### PR TITLE
feat: add built-in OpenAI Codex OAuth support

### DIFF
--- a/src/aish/cli.py
+++ b/src/aish/cli.py
@@ -1,7 +1,10 @@
 """CLI entry point for AI Shell."""
 
 import os
+import shutil
+import subprocess
 import sys
+from enum import Enum
 from typing import Optional
 
 import anyio
@@ -14,6 +17,12 @@ from .config import Config, ConfigModel
 from .i18n import t
 from .i18n.typer import I18nTyperCommand, I18nTyperGroup
 from .logging_utils import init_logging
+from .openai_codex import (OPENAI_CODEX_DEFAULT_CALLBACK_PORT,
+                           OPENAI_CODEX_DEFAULT_MODEL,
+                           OpenAICodexAuthError,
+                           load_openai_codex_auth,
+                           login_openai_codex_with_browser,
+                           login_openai_codex_with_device_code)
 from .shell import AIShell
 from .skills import SkillManager
 from .wizard.setup_wizard import (needs_interactive_setup,
@@ -29,6 +38,16 @@ app = typer.Typer(
 )
 
 console = Console()
+models_app = typer.Typer(help="Manage models and provider auth", cls=I18nTyperGroup)
+models_auth_app = typer.Typer(help="Manage provider login state", cls=I18nTyperGroup)
+models_app.add_typer(models_auth_app, name="auth")
+app.add_typer(models_app, name="models")
+
+
+class OpenAICodexAuthFlow(str, Enum):
+    BROWSER = "browser"
+    DEVICE_CODE = "device-code"
+    CODEX_CLI = "codex-cli"
 
 
 def _load_raw_yaml_config(config_file: str | os.PathLike[str]) -> dict:
@@ -70,6 +89,10 @@ def get_effective_config(
     api_key_env = os.getenv("AISH_API_KEY")
     if api_key_env:
         config_data["api_key"] = api_key_env
+
+    codex_auth_path_env = os.getenv("AISH_CODEX_AUTH_PATH")
+    if codex_auth_path_env:
+        config_data["codex_auth_path"] = codex_auth_path_env
 
     # Override with command line arguments (highest priority)
     if model is not None:
@@ -222,6 +245,136 @@ def setup(
         sys.exit(1)
 
 
+@models_auth_app.command("login", cls=I18nTyperCommand)
+def models_auth_login(
+    provider: str = typer.Option(
+        ...,
+        "--provider",
+        help="Provider id to log in (currently only openai-codex).",
+    ),
+    model: str = typer.Option(
+        OPENAI_CODEX_DEFAULT_MODEL,
+        "--model",
+        help="Default OpenAI Codex model to store in config after login.",
+    ),
+    set_default: bool = typer.Option(
+        True,
+        "--set-default/--no-set-default",
+        help="Update the config model to the OpenAI Codex model after login.",
+    ),
+    auth_flow: OpenAICodexAuthFlow = typer.Option(
+        OpenAICodexAuthFlow.BROWSER,
+        "--auth-flow",
+        help="Auth flow to use: browser, device-code, or codex-cli.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force/--no-force",
+        help="Force a fresh OpenAI Codex login even if local auth already exists.",
+    ),
+    open_browser: bool = typer.Option(
+        True,
+        "--open-browser/--no-open-browser",
+        help="Open the browser automatically for browser auth.",
+    ),
+    callback_port: int = typer.Option(
+        OPENAI_CODEX_DEFAULT_CALLBACK_PORT,
+        "--callback-port",
+        min=0,
+        max=65535,
+        help="Local callback port for browser auth. Use 0 for an ephemeral port.",
+    ),
+    config_file: Optional[str] = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help=t("cli.option.config"),
+    ),
+):
+    normalized_provider = provider.strip().lower().replace("_", "-")
+    if normalized_provider != "openai-codex":
+        console.print(
+            "Only `--provider openai-codex` is supported right now.",
+            style="red",
+        )
+        raise typer.Exit(1)
+
+    try:
+        config = Config(config_file_path=config_file)
+    except FileNotFoundError as exc:
+        console.print(t("cli.startup.config_file_error", error=str(exc)), style="red")
+        console.print(t("cli.startup.config_file_hint"), style="dim")
+        raise typer.Exit(1) from exc
+
+    auth_path = getattr(config.model_config, "codex_auth_path", None)
+    auth_state = None
+    if not force:
+        try:
+            auth_state = load_openai_codex_auth(auth_path)
+        except OpenAICodexAuthError:
+            auth_state = None
+
+    if auth_state is None:
+        try:
+            if auth_flow == OpenAICodexAuthFlow.BROWSER:
+                auth_state = login_openai_codex_with_browser(
+                    auth_path=auth_path,
+                    open_browser=open_browser,
+                    callback_port=callback_port,
+                    notify=lambda message: console.print(message, style="dim"),
+                )
+            elif auth_flow == OpenAICodexAuthFlow.DEVICE_CODE:
+                auth_state = login_openai_codex_with_device_code(
+                    auth_path=auth_path,
+                    notify=lambda message: console.print(message, style="dim"),
+                )
+            else:
+                codex_bin = shutil.which("codex")
+                if not codex_bin:
+                    console.print(
+                        "The `codex` CLI is not installed. Install `@openai/codex` or use "
+                        "`--auth-flow browser` / `--auth-flow device-code`.",
+                        style="red",
+                    )
+                    raise typer.Exit(1)
+
+                try:
+                    subprocess.run([codex_bin, "login"], check=True)
+                except subprocess.CalledProcessError as exc:
+                    console.print(
+                        f"`codex login` failed with exit code {exc.returncode}.",
+                        style="red",
+                    )
+                    raise typer.Exit(exc.returncode or 1) from exc
+                except KeyboardInterrupt as exc:
+                    raise typer.Exit(1) from exc
+
+                auth_state = load_openai_codex_auth(auth_path)
+        except OpenAICodexAuthError as exc:
+            console.print(str(exc), style="red")
+            raise typer.Exit(1) from exc
+
+    config_data = config.model_config.model_dump()
+    config_data["codex_auth_path"] = str(auth_state.auth_path)
+    if set_default:
+        config_data["model"] = f"openai-codex/{model.strip() or OPENAI_CODEX_DEFAULT_MODEL}"
+        config_data["api_key"] = None
+    config.config_model = ConfigModel.model_validate(config_data)
+    config.save_config()
+
+    console.print(
+        f"OpenAI Codex auth ready: {auth_state.auth_path}",
+        style="green",
+    )
+    if set_default:
+        console.print(f"Default model set to {config.config_model.model}", style="green")
+    else:
+        console.print(
+            f"OpenAI Codex model available: openai-codex/{model.strip() or OPENAI_CODEX_DEFAULT_MODEL}",
+            style="dim",
+        )
+
+
 @app.command(help=t("cli.check_tool_support_command_help"), cls=I18nTyperCommand)
 def check_tool_support(
     model: str = typer.Option(
@@ -337,6 +490,12 @@ aish run
 
 # Check Langfuse configuration
 aish check-langfuse
+
+# Log into OpenAI Codex account auth
+aish models auth login --provider openai-codex
+
+# Use built-in device-code auth on headless servers
+aish models auth login --provider openai-codex --auth-flow device-code
 
 # Use config file
 cat > ~/.config/aish/config.yaml << EOF

--- a/src/aish/config.py
+++ b/src/aish/config.py
@@ -143,6 +143,13 @@ class ConfigModel(BaseModel):
         default=None, description="Custom API base URL (e.g., for OpenRouter)"
     )
     api_key: Optional[str] = Field(default=None, description="API key for the service")
+    codex_auth_path: Optional[str] = Field(
+        default=None,
+        description=(
+            "Path to OpenAI Codex auth.json. Defaults to $AISH_CODEX_AUTH_PATH, "
+            "$CODEX_HOME/auth.json, or ~/.codex/auth.json"
+        ),
+    )
     temperature: float = Field(
         default=0.7, ge=0.0, le=2.0, description="Temperature for LLM responses"
     )

--- a/src/aish/llm.py
+++ b/src/aish/llm.py
@@ -17,6 +17,8 @@ from aish.exception import is_litellm_exception, redact_secrets
 from aish.i18n import t
 from aish.interruption import ShellState
 from aish.litellm_loader import load_litellm
+from aish.openai_codex import (create_openai_codex_chat_completion,
+                               is_openai_codex_model)
 from aish.prompts import PromptManager
 from aish.skills import SkillManager
 from aish.tools.base import ToolBase
@@ -445,6 +447,39 @@ class LLMSession:
             self._stream_chunk_builder_func = litellm.stream_chunk_builder
         return self._stream_chunk_builder_func
 
+    def _uses_openai_codex(self) -> bool:
+        return is_openai_codex_model(self.model)
+
+    async def _create_completion_response(
+        self,
+        *,
+        messages: list[dict],
+        stream: bool,
+        tools: Optional[list[dict]] = None,
+        tool_choice: str = "auto",
+        **kwargs,
+    ):
+        if self._uses_openai_codex():
+            return await create_openai_codex_chat_completion(
+                model=self.model,
+                messages=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                api_base=self.api_base,
+                auth_path=getattr(self.config, "codex_auth_path", None),
+                timeout=float(kwargs.get("timeout", 300)),
+            )
+
+        acompletion = self._get_acompletion()
+        return await acompletion(
+            model=self.model,
+            api_base=self.api_base,
+            api_key=self.api_key,
+            messages=messages,
+            stream=stream,
+            **kwargs,
+        )
+
     def update_model(
         self,
         model: str,
@@ -469,6 +504,9 @@ class LLMSession:
 
     async def _background_initialize(self):
         """后台初始化 litellm 模块，使用独立线程避免阻塞事件循环"""
+        if self._uses_openai_codex():
+            return
+
         async with self._init_lock:
             if self._initialized:
                 return
@@ -533,6 +571,9 @@ class LLMSession:
 
     async def _ensure_initialized(self):
         """确保 litellm 已初始化，等待后台初始化完成"""
+        if self._uses_openai_codex():
+            return
+
         # 如果已经初始化完成，直接返回
         if self._initialized:
             return
@@ -575,7 +616,7 @@ class LLMSession:
             max_retries: 最大重试次数，默认 5 次
             retry_delay: 重试间隔（秒），默认 0.5 秒
         """
-        if self._initialized:
+        if self._uses_openai_codex() or self._initialized:
             return
 
         last_error = None
@@ -1064,7 +1105,8 @@ class LLMSession:
 
     def _trim_messages(self, messages: list[dict]) -> list[dict]:
         """Trim messages to keep under token limit"""
-        # return messages
+        if self._uses_openai_codex():
+            return messages
         old_size = len(messages)
         trim_messages = self._get_trim_messages()
         new_messages = trim_messages(messages, model=self.model)
@@ -1320,9 +1362,10 @@ class LLMSession:
                         stream = bool(merged_kwargs.pop("stream"))
                     except Exception:
                         merged_kwargs.pop("stream")
+                actual_stream = stream and not self._uses_openai_codex()
 
                 events.emit_generation_start(
-                    generation_type=generation_type, stream=stream
+                    generation_type=generation_type, stream=actual_stream
                 )
 
                 # Get Langfuse metadata
@@ -1347,19 +1390,15 @@ class LLMSession:
                         ):
                             raise anyio.get_cancelled_exc_class()
 
-                        acompletion = self._get_acompletion()
-                        response = await acompletion(
-                            model=self.model,
-                            api_base=self.api_base,
-                            api_key=self.api_key,
+                        response = await self._create_completion_response(
                             messages=messages,
                             tools=tools_spec,
                             tool_choice="auto",
-                            stream=stream,
+                            stream=actual_stream,
                             **merged_kwargs,
                         )
 
-                        if stream:
+                        if actual_stream:
                             content_acc = ""
                             reasoning_acc = ""
                             stream_chunks: list[object] = []
@@ -1543,7 +1582,7 @@ class LLMSession:
 
                 content = msg.get("content")
                 if content:
-                    if stream:
+                    if actual_stream:
                         if has_tool_calls and not content_preview_started:
                             events.emit_content_delta(
                                 delta=content, accumulated=content, is_final=False
@@ -1573,7 +1612,7 @@ class LLMSession:
                         tool_calls, context_manager, system_message, output
                     )
 
-                if not stream:
+                if not actual_stream:
                     events.emit_generation_end(
                         status="success", finish_reason=finish_reason
                     )
@@ -1643,7 +1682,10 @@ class LLMSession:
         elif langfuse_metadata:
             merged_kwargs["metadata"] = langfuse_metadata
 
-        events.emit_generation_start(generation_type=generation_type, stream=stream)
+        actual_stream = stream and not self._uses_openai_codex()
+        events.emit_generation_start(
+            generation_type=generation_type, stream=actual_stream
+        )
 
         result = ""
         try:
@@ -1651,17 +1693,13 @@ class LLMSession:
             if self.cancellation_token and self.cancellation_token.is_cancelled():
                 raise anyio.get_cancelled_exc_class()
 
-            acompletion = self._get_acompletion()
-            response = await acompletion(
-                model=self.model,
-                api_base=self.api_base,
-                api_key=self.api_key,
+            response = await self._create_completion_response(
                 messages=messages,
-                stream=stream,
+                stream=actual_stream,
                 **merged_kwargs,
             )
 
-            if stream:
+            if actual_stream:
                 reasoning_acc = ""
                 finish_reason = None
                 generation_status = "success"

--- a/src/aish/openai_codex.py
+++ b/src/aish/openai_codex.py
@@ -1,0 +1,1503 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import platform
+import secrets
+import threading
+import time
+import webbrowser
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Callable, Optional
+from urllib.parse import parse_qs, urlencode, urlsplit
+
+import httpx
+
+OPENAI_CODEX_PROVIDER = "openai-codex"
+OPENAI_CODEX_DEFAULT_MODEL = "gpt-5.4"
+OPENAI_CODEX_DEFAULT_BASE_URL = "https://chatgpt.com/backend-api/codex"
+OPENAI_CODEX_AUTH_ISSUER = "https://auth.openai.com"
+OPENAI_CODEX_AUTHORIZE_URL = f"{OPENAI_CODEX_AUTH_ISSUER}/oauth/authorize"
+OPENAI_CODEX_REFRESH_URL = f"{OPENAI_CODEX_AUTH_ISSUER}/oauth/token"
+OPENAI_CODEX_DEVICE_AUTH_BASE_URL = f"{OPENAI_CODEX_AUTH_ISSUER}/api/accounts"
+OPENAI_CODEX_DEVICE_VERIFICATION_URL = f"{OPENAI_CODEX_AUTH_ISSUER}/codex/device"
+OPENAI_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+OPENAI_CODEX_OAUTH_SCOPE = (
+    "openid profile email offline_access api.connectors.read api.connectors.invoke"
+)
+OPENAI_CODEX_ORIGINATOR = "codex_cli_rs"
+OPENAI_CODEX_USER_AGENT = (
+    f"{OPENAI_CODEX_ORIGINATOR}/0.0.0 "
+    f"(aish; Python/{platform.python_version()}; "
+    f"{platform.system()} {platform.machine() or 'unknown'})"
+)
+OPENAI_CODEX_REFRESH_LEEWAY_SECONDS = 60
+OPENAI_CODEX_DEFAULT_CALLBACK_PORT = 1455
+OPENAI_CODEX_BROWSER_LOGIN_TIMEOUT_SECONDS = 300.0
+OPENAI_CODEX_DEVICE_CODE_TIMEOUT_SECONDS = 900.0
+
+_LOGIN_SUCCESS_HTML = """<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>OpenAI Codex Login Complete</title>
+  <style>
+    body { font-family: sans-serif; margin: 3rem; color: #111; }
+    code { background: #f3f4f6; padding: 0.1rem 0.3rem; }
+  </style>
+</head>
+<body>
+  <h1>Sign-in complete</h1>
+  <p>You can close this tab and return to <code>aish</code>.</p>
+</body>
+</html>
+"""
+
+_LOGIN_ERROR_HTML_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>OpenAI Codex Login Failed</title>
+  <style>
+    body { font-family: sans-serif; margin: 3rem; color: #111; }
+    pre { background: #f3f4f6; padding: 1rem; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <h1>Sign-in failed</h1>
+  <pre>{message}</pre>
+</body>
+</html>
+"""
+
+
+class OpenAICodexAuthError(RuntimeError):
+    pass
+
+
+@dataclass
+class OpenAICodexAuthState:
+    auth_path: Path
+    access_token: str
+    refresh_token: str | None
+    account_id: str
+    expires_at: int | None
+
+    def needs_refresh(
+        self, *, leeway_seconds: int = OPENAI_CODEX_REFRESH_LEEWAY_SECONDS
+    ) -> bool:
+        if self.expires_at is None:
+            return False
+        return int(time.time()) >= (self.expires_at - leeway_seconds)
+
+
+@dataclass
+class OpenAICodexPkceCodes:
+    code_verifier: str
+    code_challenge: str
+
+
+@dataclass
+class OpenAICodexOAuthTokens:
+    id_token: str
+    access_token: str
+    refresh_token: str
+
+
+@dataclass
+class OpenAICodexDeviceCode:
+    verification_url: str
+    user_code: str
+    device_auth_id: str
+    interval: float
+
+
+@dataclass
+class OpenAICodexDeviceCodeAuthorization:
+    authorization_code: str
+    code_verifier: str
+    code_challenge: str
+
+
+@dataclass
+class OpenAICodexBrowserCallbackResult:
+    code: str | None = None
+    error: str | None = None
+    error_description: str | None = None
+
+
+class _OpenAICodexCallbackServer(ThreadingHTTPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+    def __init__(self, server_address: tuple[str, int], expected_state: str):
+        super().__init__(server_address, _OpenAICodexCallbackHandler)
+        self.expected_state = expected_state
+        self.callback_event = threading.Event()
+        self.callback_result: OpenAICodexBrowserCallbackResult | None = None
+
+    def set_callback_result(self, result: OpenAICodexBrowserCallbackResult) -> None:
+        if self.callback_event.is_set():
+            return
+        self.callback_result = result
+        self.callback_event.set()
+
+
+class _OpenAICodexCallbackHandler(BaseHTTPRequestHandler):
+    server: _OpenAICodexCallbackServer
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlsplit(self.path)
+        if parsed.path == "/auth/callback":
+            self._handle_auth_callback(parsed)
+            return
+        if parsed.path == "/cancel":
+            self.server.set_callback_result(
+                OpenAICodexBrowserCallbackResult(error="cancelled")
+            )
+            self._send_response(
+                200,
+                "text/plain; charset=utf-8",
+                "Login cancelled.".encode("utf-8"),
+            )
+            self._shutdown_async()
+            return
+        self._send_response(404, "text/plain; charset=utf-8", b"Not Found")
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+    def _handle_auth_callback(self, parsed) -> None:
+        params = parse_qs(parsed.query, keep_blank_values=False)
+        state = _first_query_value(params, "state")
+        if state != self.server.expected_state:
+            message = "State mismatch during OpenAI Codex OAuth callback."
+            self.server.set_callback_result(
+                OpenAICodexBrowserCallbackResult(
+                    error="state_mismatch",
+                    error_description=message,
+                )
+            )
+            self._send_response(
+                400,
+                "text/html; charset=utf-8",
+                _LOGIN_ERROR_HTML_TEMPLATE.format(message=message).encode("utf-8"),
+            )
+            self._shutdown_async()
+            return
+
+        error = _first_query_value(params, "error")
+        error_description = _first_query_value(params, "error_description")
+        if error:
+            message = _format_oauth_callback_error(error, error_description)
+            self.server.set_callback_result(
+                OpenAICodexBrowserCallbackResult(
+                    error=error,
+                    error_description=error_description,
+                )
+            )
+            self._send_response(
+                200,
+                "text/html; charset=utf-8",
+                _LOGIN_ERROR_HTML_TEMPLATE.format(message=message).encode("utf-8"),
+            )
+            self._shutdown_async()
+            return
+
+        code = _first_query_value(params, "code")
+        if not code:
+            message = "Missing authorization code in OpenAI Codex OAuth callback."
+            self.server.set_callback_result(
+                OpenAICodexBrowserCallbackResult(
+                    error="missing_authorization_code",
+                    error_description=message,
+                )
+            )
+            self._send_response(
+                400,
+                "text/html; charset=utf-8",
+                _LOGIN_ERROR_HTML_TEMPLATE.format(message=message).encode("utf-8"),
+            )
+            self._shutdown_async()
+            return
+
+        self.server.set_callback_result(OpenAICodexBrowserCallbackResult(code=code))
+        self._send_response(
+            200,
+            "text/html; charset=utf-8",
+            _LOGIN_SUCCESS_HTML.encode("utf-8"),
+        )
+        self._shutdown_async()
+
+    def _shutdown_async(self) -> None:
+        threading.Thread(target=self.server.shutdown, daemon=True).start()
+
+    def _send_response(
+        self, status_code: int, content_type: str, body: bytes
+    ) -> None:
+        self.send_response(status_code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def is_openai_codex_model(model: str | None) -> bool:
+    return bool(
+        model and model.strip().lower().startswith(f"{OPENAI_CODEX_PROVIDER}/")
+    )
+
+
+def strip_openai_codex_prefix(model: str) -> str:
+    if is_openai_codex_model(model):
+        return model.split("/", 1)[1].strip()
+    return model.strip()
+
+
+def resolve_openai_codex_base_url(api_base: str | None) -> str:
+    trimmed = (api_base or "").strip().rstrip("/")
+    if not trimmed:
+        return OPENAI_CODEX_DEFAULT_BASE_URL
+
+    parsed = urlsplit(trimmed)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return OPENAI_CODEX_DEFAULT_BASE_URL
+
+    host = parsed.netloc.lower()
+    if host not in {"chatgpt.com", "chat.openai.com"}:
+        return OPENAI_CODEX_DEFAULT_BASE_URL
+
+    return f"{parsed.scheme}://{parsed.netloc}/backend-api/codex"
+
+
+def resolve_openai_codex_auth_path(
+    explicit_path: str | os.PathLike[str] | None = None,
+) -> Path:
+    if explicit_path:
+        return Path(explicit_path).expanduser()
+
+    env_path = os.getenv("AISH_CODEX_AUTH_PATH")
+    if env_path:
+        return Path(env_path).expanduser()
+
+    codex_home = os.getenv("CODEX_HOME")
+    if codex_home:
+        return Path(codex_home).expanduser() / "auth.json"
+
+    return Path.home() / ".codex" / "auth.json"
+
+
+def load_openai_codex_auth(
+    auth_path: str | os.PathLike[str] | None = None,
+) -> OpenAICodexAuthState:
+    path = resolve_openai_codex_auth_path(auth_path)
+    if not path.exists():
+        raise OpenAICodexAuthError(
+            "OpenAI Codex auth not found. Run `aish models auth login --provider openai-codex` first."
+        )
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise OpenAICodexAuthError(f"Failed to read Codex auth file: {path}") from exc
+
+    tokens = payload.get("tokens")
+    if not isinstance(tokens, dict):
+        raise OpenAICodexAuthError(
+            "Codex auth file does not contain ChatGPT OAuth tokens. Re-run "
+            "`aish models auth login --provider openai-codex`."
+        )
+
+    access_token = _coerce_str(tokens.get("access_token"))
+    refresh_token = _coerce_str(tokens.get("refresh_token")) or None
+    access_token_claims = _decode_jwt_claims(access_token)
+    id_token_claims = _coerce_id_token_claims(tokens.get("id_token"))
+
+    account_id = (
+        _coerce_str(tokens.get("account_id"))
+        or _extract_account_id_from_claims(id_token_claims)
+        or _extract_account_id_from_claims(access_token_claims)
+    )
+    if not access_token or not account_id:
+        raise OpenAICodexAuthError(
+            "Codex auth is incomplete. Re-run `aish models auth login --provider openai-codex`."
+        )
+
+    expires_at = _coerce_int(access_token_claims.get("exp")) or _coerce_int(
+        id_token_claims.get("exp")
+    )
+    return OpenAICodexAuthState(
+        auth_path=path,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        account_id=account_id,
+        expires_at=expires_at,
+    )
+
+
+def generate_openai_codex_pkce() -> OpenAICodexPkceCodes:
+    verifier = base64.urlsafe_b64encode(os.urandom(64)).rstrip(b"=").decode("utf-8")
+    challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode("utf-8")).digest()
+    ).rstrip(b"=").decode("utf-8")
+    return OpenAICodexPkceCodes(
+        code_verifier=verifier,
+        code_challenge=challenge,
+    )
+
+
+def generate_openai_codex_state() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def build_openai_codex_authorize_url(
+    *,
+    redirect_uri: str,
+    code_challenge: str,
+    state: str,
+    issuer: str = OPENAI_CODEX_AUTH_ISSUER,
+    client_id: str = OPENAI_CODEX_CLIENT_ID,
+    allowed_workspace_id: str | None = None,
+) -> str:
+    query: list[tuple[str, str]] = [
+        ("response_type", "code"),
+        ("client_id", client_id),
+        ("redirect_uri", redirect_uri),
+        ("scope", OPENAI_CODEX_OAUTH_SCOPE),
+        ("code_challenge", code_challenge),
+        ("code_challenge_method", "S256"),
+        ("id_token_add_organizations", "true"),
+        ("codex_cli_simplified_flow", "true"),
+        ("state", state),
+        ("originator", OPENAI_CODEX_ORIGINATOR),
+    ]
+    if allowed_workspace_id:
+        query.append(("allowed_workspace_id", allowed_workspace_id))
+    return f"{issuer.rstrip('/')}/oauth/authorize?{urlencode(query)}"
+
+
+def exchange_openai_codex_code_for_tokens(
+    *,
+    code: str,
+    redirect_uri: str,
+    pkce: OpenAICodexPkceCodes,
+    issuer: str = OPENAI_CODEX_AUTH_ISSUER,
+    client_id: str = OPENAI_CODEX_CLIENT_ID,
+    client: httpx.Client | None = None,
+) -> OpenAICodexOAuthTokens:
+    owns_client = client is None
+    if client is None:
+        client = httpx.Client(timeout=30.0)
+
+    try:
+        response = client.post(
+            f"{issuer.rstrip('/')}/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "client_id": client_id,
+                "code_verifier": pkce.code_verifier,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+    except Exception as exc:
+        raise OpenAICodexAuthError(
+            f"OpenAI Codex token exchange failed: {exc}"
+        ) from exc
+    finally:
+        if owns_client:
+            client.close()
+
+    if response.is_error:
+        detail = _extract_http_error_message(response)
+        raise OpenAICodexAuthError(
+            f"OpenAI Codex token exchange failed: {response.status_code} {detail}"
+        )
+
+    try:
+        payload = response.json()
+    except Exception as exc:
+        raise OpenAICodexAuthError(
+            "OpenAI Codex token exchange returned invalid JSON."
+        ) from exc
+
+    id_token = _coerce_str(payload.get("id_token"))
+    access_token = _coerce_str(payload.get("access_token"))
+    refresh_token = _coerce_str(payload.get("refresh_token"))
+    if not id_token or not access_token or not refresh_token:
+        raise OpenAICodexAuthError(
+            "OpenAI Codex token exchange returned incomplete credentials."
+        )
+
+    return OpenAICodexOAuthTokens(
+        id_token=id_token,
+        access_token=access_token,
+        refresh_token=refresh_token,
+    )
+
+
+def request_openai_codex_device_code(
+    *,
+    issuer: str = OPENAI_CODEX_AUTH_ISSUER,
+    client_id: str = OPENAI_CODEX_CLIENT_ID,
+    client: httpx.Client | None = None,
+) -> OpenAICodexDeviceCode:
+    owns_client = client is None
+    if client is None:
+        client = httpx.Client(timeout=30.0)
+
+    try:
+        response = client.post(
+            f"{issuer.rstrip('/')}/api/accounts/deviceauth/usercode",
+            json={"client_id": client_id},
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        raise OpenAICodexAuthError(
+            f"OpenAI Codex device code request failed: {exc}"
+        ) from exc
+    finally:
+        if owns_client:
+            client.close()
+
+    if response.status_code == httpx.codes.NOT_FOUND:
+        raise OpenAICodexAuthError(
+            "OpenAI Codex device-code login is not available on this auth server."
+        )
+    if response.is_error:
+        detail = _extract_http_error_message(response)
+        raise OpenAICodexAuthError(
+            f"OpenAI Codex device code request failed: {response.status_code} {detail}"
+        )
+
+    try:
+        payload = response.json()
+    except Exception as exc:
+        raise OpenAICodexAuthError(
+            "OpenAI Codex device code request returned invalid JSON."
+        ) from exc
+
+    user_code = _coerce_str(payload.get("user_code") or payload.get("usercode"))
+    device_auth_id = _coerce_str(payload.get("device_auth_id"))
+    interval = _coerce_non_negative_float(payload.get("interval"), default=5.0)
+    if not user_code or not device_auth_id:
+        raise OpenAICodexAuthError(
+            "OpenAI Codex device code request returned incomplete data."
+        )
+
+    return OpenAICodexDeviceCode(
+        verification_url=f"{issuer.rstrip('/')}/codex/device",
+        user_code=user_code,
+        device_auth_id=device_auth_id,
+        interval=interval,
+    )
+
+
+def poll_openai_codex_device_code_authorization(
+    *,
+    device_code: OpenAICodexDeviceCode,
+    timeout: float = OPENAI_CODEX_DEVICE_CODE_TIMEOUT_SECONDS,
+    issuer: str = OPENAI_CODEX_AUTH_ISSUER,
+    client: httpx.Client | None = None,
+) -> OpenAICodexDeviceCodeAuthorization:
+    owns_client = client is None
+    if client is None:
+        client = httpx.Client(timeout=30.0)
+
+    deadline = time.monotonic() + timeout
+    try:
+        while True:
+            if time.monotonic() >= deadline:
+                raise OpenAICodexAuthError(
+                    "Timed out waiting for OpenAI Codex device-code approval."
+                )
+
+            try:
+                response = client.post(
+                    f"{issuer.rstrip('/')}/api/accounts/deviceauth/token",
+                    json={
+                        "device_auth_id": device_code.device_auth_id,
+                        "user_code": device_code.user_code,
+                    },
+                    headers={"Content-Type": "application/json"},
+                )
+            except Exception as exc:
+                raise OpenAICodexAuthError(
+                    f"OpenAI Codex device-code polling failed: {exc}"
+                ) from exc
+
+            if response.is_success:
+                try:
+                    payload = response.json()
+                except Exception as exc:
+                    raise OpenAICodexAuthError(
+                        "OpenAI Codex device-code polling returned invalid JSON."
+                    ) from exc
+
+                authorization_code = _coerce_str(payload.get("authorization_code"))
+                code_verifier = _coerce_str(payload.get("code_verifier"))
+                code_challenge = _coerce_str(payload.get("code_challenge"))
+                if authorization_code and code_verifier and code_challenge:
+                    return OpenAICodexDeviceCodeAuthorization(
+                        authorization_code=authorization_code,
+                        code_verifier=code_verifier,
+                        code_challenge=code_challenge,
+                    )
+                raise OpenAICodexAuthError(
+                    "OpenAI Codex device-code polling returned incomplete data."
+                )
+
+            if response.status_code not in {
+                httpx.codes.FORBIDDEN,
+                httpx.codes.NOT_FOUND,
+            }:
+                detail = _extract_http_error_message(response)
+                raise OpenAICodexAuthError(
+                    f"OpenAI Codex device-code polling failed: {response.status_code} {detail}"
+                )
+
+            sleep_for = min(device_code.interval, max(0.0, deadline - time.monotonic()))
+            if sleep_for > 0:
+                time.sleep(sleep_for)
+    finally:
+        if owns_client:
+            client.close()
+
+
+def login_openai_codex_with_browser(
+    *,
+    auth_path: str | os.PathLike[str] | None = None,
+    issuer: str = OPENAI_CODEX_AUTH_ISSUER,
+    client_id: str = OPENAI_CODEX_CLIENT_ID,
+    callback_port: int = OPENAI_CODEX_DEFAULT_CALLBACK_PORT,
+    timeout: float = OPENAI_CODEX_BROWSER_LOGIN_TIMEOUT_SECONDS,
+    open_browser: bool = True,
+    notify: Callable[[str], None] | None = None,
+) -> OpenAICodexAuthState:
+    notify = notify or print
+    resolved_auth_path = resolve_openai_codex_auth_path(auth_path)
+    pkce = generate_openai_codex_pkce()
+    state = generate_openai_codex_state()
+    server = _bind_openai_codex_callback_server(state, callback_port)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    redirect_uri = (
+        f"http://localhost:{server.server_address[1]}/auth/callback"
+    )
+    auth_url = build_openai_codex_authorize_url(
+        redirect_uri=redirect_uri,
+        code_challenge=pkce.code_challenge,
+        state=state,
+        issuer=issuer,
+        client_id=client_id,
+    )
+
+    notify(f"Open this URL to sign in with OpenAI Codex:\n{auth_url}")
+    if open_browser:
+        try:
+            opened = webbrowser.open(auth_url)
+        except Exception as exc:
+            opened = False
+            notify(f"Could not open a browser automatically: {exc}")
+        if not opened:
+            notify("Browser auto-open failed. Open the URL above manually.")
+
+    try:
+        result = _wait_for_openai_codex_browser_callback(server, timeout=timeout)
+        if result.error:
+            raise OpenAICodexAuthError(
+                _format_oauth_callback_error(result.error, result.error_description)
+            )
+
+        if not result.code:
+            raise OpenAICodexAuthError(
+                "OpenAI Codex browser login did not return an authorization code."
+            )
+
+        with httpx.Client(timeout=30.0) as client:
+            tokens = exchange_openai_codex_code_for_tokens(
+                code=result.code,
+                redirect_uri=redirect_uri,
+                pkce=pkce,
+                issuer=issuer,
+                client_id=client_id,
+                client=client,
+            )
+            persist_openai_codex_tokens(
+                resolved_auth_path,
+                tokens=tokens,
+            )
+        return load_openai_codex_auth(resolved_auth_path)
+    finally:
+        _stop_openai_codex_callback_server(server, server_thread)
+
+
+def login_openai_codex_with_device_code(
+    *,
+    auth_path: str | os.PathLike[str] | None = None,
+    issuer: str = OPENAI_CODEX_AUTH_ISSUER,
+    client_id: str = OPENAI_CODEX_CLIENT_ID,
+    timeout: float = OPENAI_CODEX_DEVICE_CODE_TIMEOUT_SECONDS,
+    notify: Callable[[str], None] | None = None,
+) -> OpenAICodexAuthState:
+    notify = notify or print
+    resolved_auth_path = resolve_openai_codex_auth_path(auth_path)
+
+    with httpx.Client(timeout=30.0) as client:
+        device_code = request_openai_codex_device_code(
+            issuer=issuer,
+            client_id=client_id,
+            client=client,
+        )
+        notify(
+            "OpenAI Codex device-code login\n"
+            f"1. Open: {device_code.verification_url}\n"
+            f"2. Enter code: {device_code.user_code}\n"
+            "3. Return here after approving access."
+        )
+        authorization = poll_openai_codex_device_code_authorization(
+            device_code=device_code,
+            timeout=timeout,
+            issuer=issuer,
+            client=client,
+        )
+        tokens = exchange_openai_codex_code_for_tokens(
+            code=authorization.authorization_code,
+            redirect_uri=f"{issuer.rstrip('/')}/deviceauth/callback",
+            pkce=OpenAICodexPkceCodes(
+                code_verifier=authorization.code_verifier,
+                code_challenge=authorization.code_challenge,
+            ),
+            issuer=issuer,
+            client_id=client_id,
+            client=client,
+        )
+
+    persist_openai_codex_tokens(
+        resolved_auth_path,
+        tokens=tokens,
+    )
+    return load_openai_codex_auth(resolved_auth_path)
+
+
+async def refresh_openai_codex_auth(
+    auth: OpenAICodexAuthState,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> OpenAICodexAuthState:
+    if not auth.refresh_token:
+        raise OpenAICodexAuthError(
+            "OpenAI Codex session expired and no refresh token is available. "
+            "Re-run `aish models auth login --provider openai-codex`."
+        )
+
+    owns_client = client is None
+    if client is None:
+        client = httpx.AsyncClient(timeout=30.0)
+
+    try:
+        response = await client.post(
+            OPENAI_CODEX_REFRESH_URL,
+            json={
+                "client_id": OPENAI_CODEX_CLIENT_ID,
+                "grant_type": "refresh_token",
+                "refresh_token": auth.refresh_token,
+            },
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        raise OpenAICodexAuthError(
+            f"Failed to refresh OpenAI Codex session: {exc}"
+        ) from exc
+    finally:
+        if owns_client:
+            await client.aclose()
+
+    if response.status_code == httpx.codes.UNAUTHORIZED:
+        raise OpenAICodexAuthError(
+            "OpenAI Codex session is no longer valid. Re-run "
+            "`aish models auth login --provider openai-codex`."
+        )
+    if response.is_error:
+        raise OpenAICodexAuthError(
+            f"Failed to refresh OpenAI Codex session: {response.status_code} {response.text}"
+        )
+
+    try:
+        refresh_payload = response.json()
+    except Exception as exc:
+        raise OpenAICodexAuthError(
+            "OpenAI Codex refresh returned invalid JSON."
+        ) from exc
+
+    access_token = _coerce_str(refresh_payload.get("access_token"))
+    if not access_token:
+        raise OpenAICodexAuthError(
+            "OpenAI Codex refresh did not return an access token."
+        )
+
+    refresh_token = _coerce_str(refresh_payload.get("refresh_token")) or auth.refresh_token
+    id_token_claims = _coerce_id_token_claims(refresh_payload.get("id_token"))
+    account_id = (
+        _extract_account_id_from_claims(id_token_claims)
+        or _extract_account_id_from_claims(_decode_jwt_claims(access_token))
+        or auth.account_id
+    )
+    expires_at = _coerce_int(_decode_jwt_claims(access_token).get("exp"))
+    _persist_openai_codex_auth(
+        auth.auth_path,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        account_id=account_id,
+        id_token=refresh_payload.get("id_token"),
+    )
+    return OpenAICodexAuthState(
+        auth_path=auth.auth_path,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        account_id=account_id,
+        expires_at=expires_at,
+    )
+
+
+def build_openai_codex_request(
+    *,
+    model: str,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None,
+    tool_choice: str = "auto",
+) -> dict[str, Any]:
+    instructions: list[str] = []
+    input_items: list[dict[str, Any]] = []
+
+    for message in messages:
+        role = str(message.get("role") or "").strip().lower()
+        if role == "system":
+            content = _coerce_message_text(message.get("content"))
+            if content:
+                instructions.append(content)
+            continue
+
+        if role == "user":
+            content = _coerce_message_text(message.get("content"))
+            if content:
+                input_items.append(
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": content}],
+                    }
+                )
+            continue
+
+        if role == "assistant":
+            content = _coerce_message_text(message.get("content"))
+            if content:
+                input_items.append(
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": content}],
+                    }
+                )
+
+            for tool_call in message.get("tool_calls") or []:
+                if not isinstance(tool_call, dict):
+                    continue
+                function = tool_call.get("function") or {}
+                if not isinstance(function, dict):
+                    continue
+                name = _coerce_str(function.get("name"))
+                call_id = _coerce_str(tool_call.get("id"))
+                arguments = function.get("arguments")
+                if not name or not call_id:
+                    continue
+                if not isinstance(arguments, str):
+                    arguments = json.dumps(arguments or {}, ensure_ascii=False)
+                input_items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": call_id,
+                        "name": name,
+                        "arguments": arguments,
+                    }
+                )
+            continue
+
+        if role == "tool":
+            tool_call_id = _coerce_str(message.get("tool_call_id"))
+            if not tool_call_id:
+                continue
+            content = _coerce_message_text(message.get("content"))
+            input_items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": tool_call_id,
+                    "output": content,
+                }
+            )
+
+    return {
+        "model": strip_openai_codex_prefix(model),
+        "instructions": "\n\n".join(part for part in instructions if part).strip(),
+        "input": input_items,
+        "tools": _convert_tools_for_openai_codex(tools or []),
+        "tool_choice": tool_choice,
+        "parallel_tool_calls": True,
+        "store": False,
+        "stream": True,
+        "include": [],
+    }
+
+
+def convert_openai_codex_response_to_chat_completion(
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    output = payload.get("output")
+    if not isinstance(output, list):
+        output = []
+
+    content_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+
+    for item in output:
+        if not isinstance(item, dict):
+            continue
+        item_type = str(item.get("type") or "").strip().lower()
+        if item_type == "message":
+            text = _extract_response_message_text(item.get("content"))
+            if text:
+                content_parts.append(text)
+            continue
+        if item_type == "function_call":
+            name = _coerce_str(item.get("name"))
+            call_id = _coerce_str(item.get("call_id")) or _coerce_str(item.get("id"))
+            arguments = item.get("arguments")
+            if not name or not call_id:
+                continue
+            if not isinstance(arguments, str):
+                arguments = json.dumps(arguments or {}, ensure_ascii=False)
+            tool_calls.append(
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "arguments": arguments,
+                    },
+                }
+            )
+
+    message: dict[str, Any] = {
+        "role": "assistant",
+        "content": "\n".join(part for part in content_parts if part) or "",
+    }
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+
+    return {
+        "choices": [
+            {
+                "message": message,
+                "finish_reason": "tool_calls" if tool_calls else "stop",
+            }
+        ]
+    }
+
+
+async def create_openai_codex_chat_completion(
+    *,
+    model: str,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: str = "auto",
+    api_base: str | None = None,
+    auth_path: str | os.PathLike[str] | None = None,
+    timeout: float = 300.0,
+) -> dict[str, Any]:
+    url = f"{resolve_openai_codex_base_url(api_base)}/responses"
+    request_body = build_openai_codex_request(
+        model=model,
+        messages=messages,
+        tools=tools,
+        tool_choice=tool_choice,
+    )
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        auth = load_openai_codex_auth(auth_path)
+        if auth.needs_refresh() and auth.refresh_token:
+            auth = await refresh_openai_codex_auth(auth, client=client)
+
+        for attempt in range(2):
+            async with client.stream(
+                "POST",
+                url,
+                json=request_body,
+                headers=_build_headers(auth),
+            ) as response:
+                if (
+                    response.status_code == httpx.codes.UNAUTHORIZED
+                    and auth.refresh_token
+                    and attempt == 0
+                ):
+                    auth = await refresh_openai_codex_auth(auth, client=client)
+                    continue
+                if response.is_error:
+                    await response.aread()
+                    detail = _extract_http_error_message(response)
+                    raise OpenAICodexAuthError(
+                        f"OpenAI Codex request failed: {response.status_code} {detail}"
+                    )
+
+                content_type = _coerce_str(response.headers.get("content-type")).lower()
+                if not content_type or "text/event-stream" in content_type:
+                    payload = await _collect_openai_codex_stream_response(response)
+                else:
+                    raw_body = await response.aread()
+                    body_text = raw_body.decode("utf-8", errors="replace")
+                    if _looks_like_sse_text(body_text):
+                        payload = _collect_openai_codex_stream_text(body_text)
+                        return convert_openai_codex_response_to_chat_completion(payload)
+                    try:
+                        payload = json.loads(body_text)
+                    except Exception as exc:
+                        raise OpenAICodexAuthError(
+                            "OpenAI Codex returned invalid JSON."
+                        ) from exc
+                return convert_openai_codex_response_to_chat_completion(payload)
+
+    raise OpenAICodexAuthError(
+        "OpenAI Codex request failed after token refresh."
+    )
+
+
+def persist_openai_codex_tokens(
+    auth_path: str | os.PathLike[str],
+    *,
+    tokens: OpenAICodexOAuthTokens,
+) -> None:
+    account_id = (
+        _extract_account_id_from_claims(_decode_jwt_claims(tokens.id_token))
+        or _extract_account_id_from_claims(_decode_jwt_claims(tokens.access_token))
+    )
+    if not account_id:
+        raise OpenAICodexAuthError(
+            "OpenAI Codex login succeeded, but the account id was missing from the returned tokens."
+        )
+
+    _persist_openai_codex_auth(
+        Path(auth_path),
+        access_token=tokens.access_token,
+        refresh_token=tokens.refresh_token,
+        account_id=account_id,
+        id_token=tokens.id_token,
+    )
+
+
+def _bind_openai_codex_callback_server(
+    expected_state: str, callback_port: int
+) -> _OpenAICodexCallbackServer:
+    ports = [callback_port]
+    if callback_port != 0:
+        ports.append(0)
+
+    last_error: OSError | None = None
+    for port in ports:
+        try:
+            return _OpenAICodexCallbackServer(("127.0.0.1", port), expected_state)
+        except OSError as exc:
+            last_error = exc
+
+    raise OpenAICodexAuthError(
+        f"Failed to bind OpenAI Codex callback server: {last_error}"
+    ) from last_error
+
+
+def _wait_for_openai_codex_browser_callback(
+    server: _OpenAICodexCallbackServer, *, timeout: float
+) -> OpenAICodexBrowserCallbackResult:
+    if not server.callback_event.wait(timeout):
+        raise OpenAICodexAuthError(
+            "Timed out waiting for the OpenAI Codex browser callback."
+        )
+
+    result = server.callback_result
+    if result is None:
+        raise OpenAICodexAuthError(
+            "OpenAI Codex browser login ended without a callback result."
+        )
+    return result
+
+
+def _stop_openai_codex_callback_server(
+    server: _OpenAICodexCallbackServer, server_thread: threading.Thread
+) -> None:
+    try:
+        server.shutdown()
+    except Exception:
+        pass
+    try:
+        server.server_close()
+    except Exception:
+        pass
+    server_thread.join(timeout=2.0)
+
+
+def _extract_http_error_message(response: httpx.Response) -> str:
+    content_type = _coerce_str(response.headers.get("content-type")).lower()
+    text = response.text.strip()
+    if _looks_like_html_error(content_type, text):
+        detail = _summarize_html_error(text)
+        return _append_http_error_metadata(detail, response)
+
+    try:
+        payload = response.json()
+    except Exception:
+        return _append_http_error_metadata(text or "unknown error", response)
+
+    if isinstance(payload, dict):
+        error_description = _coerce_str(payload.get("error_description"))
+        if error_description:
+            return error_description
+        error_value = payload.get("error")
+        if isinstance(error_value, dict):
+            error_message = _coerce_str(error_value.get("message"))
+            error_code = _coerce_str(error_value.get("code"))
+            if error_message:
+                return error_message
+            if error_code:
+                return error_code
+        error_text = _coerce_str(error_value)
+        if error_text:
+            return error_text
+
+    return _append_http_error_metadata(text or "unknown error", response)
+
+
+async def _collect_openai_codex_stream_response(
+    response: httpx.Response,
+) -> dict[str, Any]:
+    events: list[tuple[str, dict[str, Any]]] = []
+    async for event_type, payload in _iter_openai_codex_sse_events(response):
+        events.append((event_type, payload))
+    return _build_openai_codex_stream_payload(events)
+
+
+def _collect_openai_codex_stream_text(text: str) -> dict[str, Any]:
+    event_type: str | None = None
+    data_lines: list[str] = []
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip("\r")
+        if not line:
+            parsed = _parse_openai_codex_sse_event(event_type, data_lines)
+            if parsed is not None:
+                events.append(parsed)
+            event_type = None
+            data_lines = []
+            continue
+
+        if line.startswith(":"):
+            continue
+
+        field, separator, value = line.partition(":")
+        if not separator:
+            continue
+        value = value.lstrip()
+        if field == "event":
+            event_type = value
+        elif field == "data":
+            data_lines.append(value)
+
+    parsed = _parse_openai_codex_sse_event(event_type, data_lines)
+    if parsed is not None:
+        events.append(parsed)
+
+    return _build_openai_codex_stream_payload(events)
+
+
+def _build_openai_codex_stream_payload(
+    events: list[tuple[str, dict[str, Any]]]
+) -> dict[str, Any]:
+    output_items: list[dict[str, Any]] = []
+    text_deltas: list[str] = []
+    response_id: str | None = None
+    usage: Any = None
+    completed = False
+
+    for event_type, payload in events:
+        if event_type == "response.output_item.done":
+            item = payload.get("item")
+            if isinstance(item, dict):
+                output_items.append(item)
+            continue
+
+        if event_type == "response.output_text.delta":
+            delta = _coerce_str(payload.get("delta"))
+            if delta:
+                text_deltas.append(delta)
+            continue
+
+        if event_type == "response.failed":
+            raise OpenAICodexAuthError(
+                _extract_openai_codex_stream_failure_message(payload)
+            )
+
+        if event_type == "response.incomplete":
+            reason = (
+                payload.get("response", {})
+                if isinstance(payload.get("response"), dict)
+                else {}
+            )
+            incomplete_details = (
+                reason.get("incomplete_details")
+                if isinstance(reason.get("incomplete_details"), dict)
+                else {}
+            )
+            incomplete_reason = _coerce_str(incomplete_details.get("reason")) or "unknown"
+            raise OpenAICodexAuthError(
+                f"OpenAI Codex returned an incomplete response: {incomplete_reason}"
+            )
+
+        if event_type == "response.completed":
+            response_payload = payload.get("response")
+            if isinstance(response_payload, dict):
+                response_id = _coerce_str(response_payload.get("id")) or response_id
+                usage = response_payload.get("usage")
+                if not output_items:
+                    completed_output = response_payload.get("output")
+                    if isinstance(completed_output, list):
+                        output_items = [
+                            item for item in completed_output if isinstance(item, dict)
+                        ]
+            completed = True
+            break
+
+    if not completed:
+        raise OpenAICodexAuthError(
+            "OpenAI Codex stream ended before response.completed."
+        )
+
+    if not output_items and text_deltas:
+        output_items.append(
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "output_text", "text": "".join(text_deltas)},
+                ],
+            }
+        )
+
+    payload: dict[str, Any] = {"output": output_items}
+    if response_id:
+        payload["id"] = response_id
+    if usage is not None:
+        payload["usage"] = usage
+    return payload
+
+
+def _looks_like_sse_text(text: str) -> bool:
+    stripped = text.lstrip()
+    return stripped.startswith("event: ") or "\nevent: " in stripped
+
+
+async def _iter_openai_codex_sse_events(
+    response: httpx.Response,
+):
+    event_type: str | None = None
+    data_lines: list[str] = []
+
+    async for raw_line in response.aiter_lines():
+        line = raw_line.rstrip("\r")
+        if not line:
+            parsed = _parse_openai_codex_sse_event(event_type, data_lines)
+            if parsed is not None:
+                yield parsed
+            event_type = None
+            data_lines = []
+            continue
+
+        if line.startswith(":"):
+            continue
+
+        field, separator, value = line.partition(":")
+        if not separator:
+            continue
+        value = value.lstrip()
+        if field == "event":
+            event_type = value
+        elif field == "data":
+            data_lines.append(value)
+
+    parsed = _parse_openai_codex_sse_event(event_type, data_lines)
+    if parsed is not None:
+        yield parsed
+
+
+def _parse_openai_codex_sse_event(
+    event_type: str | None, data_lines: list[str]
+) -> tuple[str, dict[str, Any]] | None:
+    if not data_lines:
+        return None
+
+    data = "\n".join(data_lines).strip()
+    if not data or data == "[DONE]":
+        return None
+
+    try:
+        payload = json.loads(data)
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    resolved_type = _coerce_str(payload.get("type")) or _coerce_str(event_type)
+    if not resolved_type:
+        return None
+    return resolved_type, payload
+
+
+def _extract_openai_codex_stream_failure_message(payload: dict[str, Any]) -> str:
+    response_payload = payload.get("response")
+    if isinstance(response_payload, dict):
+        error = response_payload.get("error")
+        if isinstance(error, dict):
+            message = _coerce_str(error.get("message"))
+            if message:
+                return message
+            code = _coerce_str(error.get("code"))
+            if code:
+                return code
+    return "OpenAI Codex stream failed."
+
+
+def _format_oauth_callback_error(
+    error_code: str, error_description: str | None
+) -> str:
+    if (
+        error_code == "access_denied"
+        and error_description
+        and "missing_codex_entitlement" in error_description.lower()
+    ):
+        return (
+            "Codex is not enabled for this workspace. Ask the workspace administrator "
+            "to grant Codex access."
+        )
+    if error_description:
+        return f"OpenAI Codex sign-in failed: {error_description}"
+    return f"OpenAI Codex sign-in failed: {error_code}"
+
+
+def _coerce_message_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        chunks: list[str] = []
+        for item in value:
+            if isinstance(item, str):
+                chunks.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text") or item.get("content")
+                if isinstance(text, str):
+                    chunks.append(text)
+        return "\n".join(chunk for chunk in chunks if chunk)
+    return str(value)
+
+
+def _extract_response_message_text(content: Any) -> str:
+    if not isinstance(content, list):
+        return ""
+    chunks: list[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        item_type = str(item.get("type") or "").strip().lower()
+        if item_type in {"output_text", "input_text"}:
+            text = item.get("text")
+            if isinstance(text, str) and text:
+                chunks.append(text)
+    return "\n".join(chunks)
+
+
+def _convert_tools_for_openai_codex(
+    tools: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    converted: list[dict[str, Any]] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        if tool.get("type") != "function":
+            continue
+        function = tool.get("function")
+        if not isinstance(function, dict):
+            continue
+        name = _coerce_str(function.get("name"))
+        if not name:
+            continue
+        converted.append(
+            {
+                "type": "function",
+                "name": name,
+                "description": _coerce_str(function.get("description")),
+                "parameters": function.get("parameters")
+                or {"type": "object", "properties": {}},
+            }
+        )
+    return converted
+
+
+def _build_headers(auth: OpenAICodexAuthState) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {auth.access_token}",
+        "ChatGPT-Account-ID": auth.account_id,
+        "Content-Type": "application/json",
+        "User-Agent": OPENAI_CODEX_USER_AGENT,
+        "originator": OPENAI_CODEX_ORIGINATOR,
+    }
+
+
+def _decode_jwt_claims(token: str) -> dict[str, Any]:
+    parts = token.split(".")
+    if len(parts) < 2:
+        return {}
+    payload = parts[1]
+    padding = "=" * (-len(payload) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(f"{payload}{padding}".encode("utf-8"))
+        claims = json.loads(decoded.decode("utf-8"))
+    except Exception:
+        return {}
+    return claims if isinstance(claims, dict) else {}
+
+
+def _coerce_id_token_claims(value: Any) -> dict[str, Any]:
+    if isinstance(value, str):
+        return _decode_jwt_claims(value)
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _extract_account_id_from_claims(claims: dict[str, Any]) -> str:
+    auth_claims = claims.get("https://api.openai.com/auth")
+    if not isinstance(auth_claims, dict):
+        auth_claims = {}
+    return (
+        _coerce_str(claims.get("chatgpt_account_id"))
+        or _coerce_str(claims.get("account_id"))
+        or _coerce_str(auth_claims.get("chatgpt_account_id"))
+        or _coerce_str(auth_claims.get("account_id"))
+    )
+
+
+def _looks_like_html_error(content_type: str, body: str) -> bool:
+    if "text/html" in content_type:
+        return True
+    lowered = body.lstrip().lower()
+    return lowered.startswith("<!doctype html") or lowered.startswith("<html")
+
+
+def _summarize_html_error(body: str) -> str:
+    lowered = body.lower()
+    if (
+        "cloudflare" in lowered
+        or "enable javascript and cookies to continue" in lowered
+        or "_cf_chl_opt" in lowered
+        or "challenge-platform" in lowered
+    ):
+        return (
+            "Cloudflare blocked the OpenAI Codex request. "
+            "This usually means the wrong ChatGPT endpoint was used or "
+            "this network/region requires an interactive challenge."
+        )
+    return "OpenAI Codex returned an HTML error page instead of JSON."
+
+
+def _append_http_error_metadata(detail: str, response: httpx.Response) -> str:
+    metadata: list[str] = []
+    for header_name in ("cf-ray", "x-request-id", "request-id"):
+        header_value = _coerce_str(response.headers.get(header_name))
+        if header_value:
+            metadata.append(f"{header_name}: {header_value}")
+    if metadata:
+        return f"{detail} ({', '.join(metadata)})"
+    return detail
+
+
+def _persist_openai_codex_auth(
+    auth_path: Path,
+    *,
+    access_token: str,
+    refresh_token: str | None,
+    account_id: str,
+    id_token: Any,
+) -> None:
+    try:
+        payload = json.loads(auth_path.read_text(encoding="utf-8"))
+    except Exception:
+        payload = {}
+
+    payload["auth_mode"] = "chatgpt"
+    payload.pop("OPENAI_API_KEY", None)
+
+    tokens = payload.get("tokens")
+    if not isinstance(tokens, dict):
+        tokens = {}
+        payload["tokens"] = tokens
+
+    tokens["access_token"] = access_token
+    if refresh_token:
+        tokens["refresh_token"] = refresh_token
+    tokens["account_id"] = account_id
+
+    if isinstance(id_token, str) and id_token.strip():
+        tokens["id_token"] = id_token.strip()
+    elif id_token is not None:
+        tokens["id_token"] = id_token
+
+    payload["last_refresh"] = datetime.now(timezone.utc).isoformat()
+    auth_path.parent.mkdir(parents=True, exist_ok=True)
+    auth_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _first_query_value(params: dict[str, list[str]], key: str) -> str | None:
+    values = params.get(key)
+    if not values:
+        return None
+    value = values[0].strip()
+    return value or None
+
+
+def _coerce_str(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _coerce_non_negative_float(value: Any, *, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 0 else default

--- a/src/aish/shell.py
+++ b/src/aish/shell.py
@@ -47,6 +47,8 @@ from .interruption import (InterruptionManager, PromptConfig,
                            ShellState)
 from .llm import LLMCallbackResult, LLMEvent, LLMEventType, LLMSession
 from .logging_utils import set_session_uuid
+from .openai_codex import (OpenAICodexAuthError, is_openai_codex_model,
+                           load_openai_codex_auth)
 from .prompts import PromptManager
 from .security.security_manager import SimpleSecurityManager
 from .session_store import SessionRecord, SessionStore
@@ -1486,19 +1488,26 @@ class AIShell:
             return
 
         self.console.print(t("shell.model.switching", model=new_model), style="dim")
-        from aish.wizard.verification import (build_failure_reason,
-                                              run_verification_async)
+        if is_openai_codex_model(new_model):
+            try:
+                load_openai_codex_auth(getattr(self.config, "codex_auth_path", None))
+            except OpenAICodexAuthError as exc:
+                await report_model_error(str(exc))
+                return
+        else:
+            from aish.wizard.verification import (build_failure_reason,
+                                                  run_verification_async)
 
-        connectivity, tool_support = await run_verification_async(
-            model=new_model,
-            api_base=self.config.api_base,
-            api_key=self.config.api_key,
-        )
-        if not connectivity.ok or tool_support.supports is not True:
-            reason = build_failure_reason(connectivity, tool_support)
-            message = t("shell.model.verify_failed", reason=reason)
-            await report_model_error(message)
-            return
+            connectivity, tool_support = await run_verification_async(
+                model=new_model,
+                api_base=self.config.api_base,
+                api_key=self.config.api_key,
+            )
+            if not connectivity.ok or tool_support.supports is not True:
+                reason = build_failure_reason(connectivity, tool_support)
+                message = t("shell.model.verify_failed", reason=reason)
+                await report_model_error(message)
+                return
 
         self.llm_session.update_model(
             new_model,

--- a/src/aish/wizard/setup_wizard.py
+++ b/src/aish/wizard/setup_wizard.py
@@ -22,6 +22,7 @@ from rich.table import Table
 from ..config import Config, ConfigModel
 from ..i18n import t
 from ..litellm_loader import load_litellm, preload_litellm
+from ..openai_codex import is_openai_codex_model
 from .constants import (_HUGGINGFACE_DEFAULT_MODEL,
                         _KILOCODE_DEFAULT_MODEL, _MISTRAL_DEFAULT_MODEL,
                         _OLLAMA_DEFAULT_MODEL, _QIANFAN_MODELS,
@@ -1494,9 +1495,14 @@ def needs_interactive_setup(
     model_arg: Optional[str],
     api_key_arg: Optional[str],
 ) -> bool:
-    if model_arg is None and _is_blank(raw_config.get("model")):
+    effective_model = model_arg if model_arg is not None else raw_config.get("model")
+    if model_arg is None and _is_blank(effective_model):
         return True
-    if api_key_arg is None and _is_blank(raw_config.get("api_key")):
+    if (
+        api_key_arg is None
+        and _is_blank(raw_config.get("api_key"))
+        and not is_openai_codex_model(str(effective_model or ""))
+    ):
         return True
     return False
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for CLI functionality."""
 
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 from typer.testing import CliRunner
@@ -7,6 +8,7 @@ from typer.testing import CliRunner
 from aish.cli import app, run
 from aish.config import ConfigModel
 from aish.i18n import t
+from aish.openai_codex import OpenAICodexAuthError
 
 
 class TestCLI:
@@ -208,3 +210,125 @@ class TestCLI:
         assert t("cli.setup.cancelled") in result.output
         mock_config_class.assert_called_once()
         mock_run_interactive_setup.assert_called_once_with(mock_config)
+
+    @patch("aish.cli.Config")
+    @patch("aish.cli.load_openai_codex_auth")
+    def test_models_auth_login_sets_default_openai_codex_model(
+        self, mock_load_openai_codex_auth, mock_config_class
+    ):
+        """Codex auth login should persist auth path and default model."""
+        mock_config = Mock()
+        mock_config.model_config = ConfigModel(model="openai/gpt-4o", api_key="k")
+        mock_config_class.return_value = mock_config
+        mock_load_openai_codex_auth.return_value = Mock(
+            auth_path=Path("/tmp/codex-auth.json")
+        )
+
+        result = self.runner.invoke(
+            app,
+            ["models", "auth", "login", "--provider", "openai-codex"],
+        )
+
+        assert result.exit_code == 0
+        assert mock_config.config_model.model == "openai-codex/gpt-5.4"
+        assert mock_config.config_model.api_key is None
+        assert mock_config.config_model.codex_auth_path == "/tmp/codex-auth.json"
+        mock_config.save_config.assert_called_once()
+
+    @patch("aish.cli.Config")
+    @patch("aish.cli.load_openai_codex_auth")
+    def test_models_auth_login_without_default_keeps_existing_api_key(
+        self, mock_load_openai_codex_auth, mock_config_class
+    ):
+        """Codex auth login should not clear the current provider config when not switching defaults."""
+        mock_config = Mock()
+        mock_config.model_config = ConfigModel(model="openai/gpt-4o", api_key="k")
+        mock_config_class.return_value = mock_config
+        mock_load_openai_codex_auth.return_value = Mock(
+            auth_path=Path("/tmp/codex-auth.json")
+        )
+
+        result = self.runner.invoke(
+            app,
+            [
+                "models",
+                "auth",
+                "login",
+                "--provider",
+                "openai-codex",
+                "--no-set-default",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert mock_config.config_model.model == "openai/gpt-4o"
+        assert mock_config.config_model.api_key == "k"
+        assert mock_config.config_model.codex_auth_path == "/tmp/codex-auth.json"
+        mock_config.save_config.assert_called_once()
+
+    @patch("aish.cli.Config")
+    @patch("aish.cli.login_openai_codex_with_browser")
+    @patch("aish.cli.load_openai_codex_auth")
+    def test_models_auth_login_uses_builtin_browser_flow_by_default(
+        self,
+        mock_load_openai_codex_auth,
+        mock_login_browser,
+        mock_config_class,
+    ):
+        """Codex auth login should use the built-in browser flow by default."""
+        mock_config = Mock()
+        mock_config.model_config = ConfigModel(model="openai/gpt-4o", api_key="k")
+        mock_config_class.return_value = mock_config
+        mock_load_openai_codex_auth.side_effect = OpenAICodexAuthError("missing")
+        mock_login_browser.return_value = Mock(auth_path=Path("/tmp/codex-auth.json"))
+
+        result = self.runner.invoke(
+            app,
+            [
+                "models",
+                "auth",
+                "login",
+                "--provider",
+                "openai-codex",
+                "--no-open-browser",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_login_browser.assert_called_once()
+        assert mock_login_browser.call_args.kwargs["open_browser"] is False
+        assert mock_login_browser.call_args.kwargs["auth_path"] is None
+
+    @patch("aish.cli.Config")
+    @patch("aish.cli.login_openai_codex_with_device_code")
+    @patch("aish.cli.load_openai_codex_auth")
+    def test_models_auth_login_supports_device_code_flow(
+        self,
+        mock_load_openai_codex_auth,
+        mock_login_device_code,
+        mock_config_class,
+    ):
+        """Codex auth login should support the built-in device-code flow."""
+        mock_config = Mock()
+        mock_config.model_config = ConfigModel(model="openai/gpt-4o", api_key="k")
+        mock_config_class.return_value = mock_config
+        mock_load_openai_codex_auth.side_effect = OpenAICodexAuthError("missing")
+        mock_login_device_code.return_value = Mock(
+            auth_path=Path("/tmp/codex-auth.json")
+        )
+
+        result = self.runner.invoke(
+            app,
+            [
+                "models",
+                "auth",
+                "login",
+                "--provider",
+                "openai-codex",
+                "--auth-flow",
+                "device-code",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_login_device_code.assert_called_once()

--- a/tests/test_openai_codex.py
+++ b/tests/test_openai_codex.py
@@ -1,0 +1,474 @@
+import base64
+import json
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from aish.config import ConfigModel
+from aish.context_manager import ContextManager
+from aish.llm import LLMSession
+from aish.openai_codex import (_collect_openai_codex_stream_response,
+                               _extract_http_error_message,
+                               OpenAICodexDeviceCode,
+                               OpenAICodexOAuthTokens,
+                               OpenAICodexPkceCodes,
+                               build_openai_codex_authorize_url,
+                               build_openai_codex_request,
+                               convert_openai_codex_response_to_chat_completion,
+                               exchange_openai_codex_code_for_tokens,
+                               load_openai_codex_auth,
+                               persist_openai_codex_tokens,
+                               poll_openai_codex_device_code_authorization,
+                               request_openai_codex_device_code,
+                               resolve_openai_codex_base_url)
+from aish.skills import SkillManager
+
+
+def _make_jwt(payload: dict) -> str:
+    def encode_part(value: dict) -> str:
+        raw = json.dumps(value, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("utf-8")
+
+    header = {"alg": "none", "typ": "JWT"}
+    return f"{encode_part(header)}.{encode_part(payload)}.sig"
+
+
+def test_load_openai_codex_auth_extracts_account_id_from_official_id_token_shape(
+    tmp_path,
+):
+    auth_path = tmp_path / "auth.json"
+    id_token = _make_jwt(
+        {
+            "exp": 2_000_000_000,
+            "https://api.openai.com/auth": {"chatgpt_account_id": "acct_123"},
+        }
+    )
+    auth_path.write_text(
+        json.dumps(
+            {
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "id_token": id_token,
+                    "access_token": _make_jwt({"exp": 2_000_000_100}),
+                    "refresh_token": "refresh_123",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    auth = load_openai_codex_auth(auth_path)
+
+    assert auth.auth_path == auth_path
+    assert auth.account_id == "acct_123"
+    assert auth.refresh_token == "refresh_123"
+    assert auth.expires_at == 2_000_000_100
+
+
+def test_build_openai_codex_authorize_url_includes_pkce_and_originator():
+    url = build_openai_codex_authorize_url(
+        redirect_uri="http://localhost:1455/auth/callback",
+        code_challenge="challenge_123",
+        state="state_123",
+    )
+
+    assert "response_type=code" in url
+    assert "client_id=app_EMoamEEZ73f0CkXaXp7hrann" in url
+    assert "redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback" in url
+    assert "code_challenge=challenge_123" in url
+    assert "code_challenge_method=S256" in url
+    assert "originator=codex_cli_rs" in url
+    assert "codex_cli_simplified_flow=true" in url
+
+
+@pytest.mark.parametrize(
+    ("api_base", "expected"),
+    [
+        (None, "https://chatgpt.com/backend-api/codex"),
+        ("https://chatgpt.com", "https://chatgpt.com/backend-api/codex"),
+        (
+            "https://chatgpt.com/backend-api",
+            "https://chatgpt.com/backend-api/codex",
+        ),
+        (
+            "https://chatgpt.com/backend-api/responses",
+            "https://chatgpt.com/backend-api/codex",
+        ),
+        (
+            "https://chat.openai.com/backend-api",
+            "https://chat.openai.com/backend-api/codex",
+        ),
+        (
+            "https://example.com/backend-api",
+            "https://chatgpt.com/backend-api/codex",
+        ),
+    ],
+)
+def test_resolve_openai_codex_base_url_normalizes_official_codex_backend(
+    api_base, expected
+):
+    assert resolve_openai_codex_base_url(api_base) == expected
+
+
+def test_persist_openai_codex_tokens_writes_chatgpt_auth_json(tmp_path):
+    auth_path = tmp_path / "auth.json"
+    id_token = _make_jwt(
+        {
+            "https://api.openai.com/auth": {"chatgpt_account_id": "acct_123"},
+        }
+    )
+
+    persist_openai_codex_tokens(
+        auth_path,
+        tokens=OpenAICodexOAuthTokens(
+            id_token=id_token,
+            access_token=_make_jwt({"exp": 2_000_000_000}),
+            refresh_token="refresh_123",
+        ),
+    )
+
+    payload = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert payload["auth_mode"] == "chatgpt"
+    assert "OPENAI_API_KEY" not in payload
+    assert payload["tokens"]["id_token"] == id_token
+    assert payload["tokens"]["account_id"] == "acct_123"
+
+    auth = load_openai_codex_auth(auth_path)
+    assert auth.account_id == "acct_123"
+
+
+def test_request_openai_codex_device_code_parses_response():
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "device_auth_id": "device-auth-123",
+                "user_code": "CODE-12345",
+                "interval": "0",
+            },
+        )
+    )
+    with httpx.Client(transport=transport) as client:
+        device_code = request_openai_codex_device_code(client=client)
+
+    assert device_code == OpenAICodexDeviceCode(
+        verification_url="https://auth.openai.com/codex/device",
+        user_code="CODE-12345",
+        device_auth_id="device-auth-123",
+        interval=0.0,
+    )
+
+
+def test_poll_openai_codex_device_code_authorization_retries_until_success():
+    responses = iter(
+        [
+            httpx.Response(404),
+            httpx.Response(
+                200,
+                json={
+                    "authorization_code": "auth-code-123",
+                    "code_verifier": "verifier-123",
+                    "code_challenge": "challenge-123",
+                },
+            ),
+        ]
+    )
+    transport = httpx.MockTransport(lambda request: next(responses))
+    with httpx.Client(transport=transport) as client:
+        authorization = poll_openai_codex_device_code_authorization(
+            device_code=OpenAICodexDeviceCode(
+                verification_url="https://auth.openai.com/codex/device",
+                user_code="CODE-12345",
+                device_auth_id="device-auth-123",
+                interval=0.0,
+            ),
+            timeout=1.0,
+            client=client,
+        )
+
+    assert authorization.authorization_code == "auth-code-123"
+    assert authorization.code_verifier == "verifier-123"
+    assert authorization.code_challenge == "challenge-123"
+
+
+def test_exchange_openai_codex_code_for_tokens_uses_form_post():
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = request.content.decode("utf-8")
+        assert "grant_type=authorization_code" in body
+        assert "code=code-123" in body
+        assert "client_id=app_EMoamEEZ73f0CkXaXp7hrann" in body
+        assert "code_verifier=verifier-123" in body
+        return httpx.Response(
+            200,
+            json={
+                "id_token": "id-token-123",
+                "access_token": "access-token-123",
+                "refresh_token": "refresh-token-123",
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as client:
+        tokens = exchange_openai_codex_code_for_tokens(
+            code="code-123",
+            redirect_uri="http://localhost:1455/auth/callback",
+            pkce=OpenAICodexPkceCodes(
+                code_verifier="verifier-123",
+                code_challenge="challenge-123",
+            ),
+            client=client,
+        )
+
+    assert tokens.id_token == "id-token-123"
+    assert tokens.access_token == "access-token-123"
+    assert tokens.refresh_token == "refresh-token-123"
+
+
+def test_extract_http_error_message_simplifies_cloudflare_html():
+    response = httpx.Response(
+        403,
+        headers={"content-type": "text/html", "cf-ray": "ray-123"},
+        text=(
+            "<html><body>"
+            "Enable JavaScript and cookies to continue"
+            "<script>window._cf_chl_opt = {}</script>"
+            "</body></html>"
+        ),
+    )
+
+    detail = _extract_http_error_message(response)
+
+    assert "Cloudflare blocked the OpenAI Codex request" in detail
+    assert "cf-ray: ray-123" in detail
+
+
+def test_build_openai_codex_request_converts_chat_messages_and_tools():
+    request = build_openai_codex_request(
+        model="openai-codex/gpt-5.4",
+        messages=[
+            {"role": "system", "content": "Follow repo conventions."},
+            {"role": "user", "content": "Inspect the workspace."},
+            {
+                "role": "assistant",
+                "content": "I will call a tool.",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "bash_exec",
+                            "arguments": '{"command":"pwd"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "name": "bash_exec",
+                "content": "/home/hao/CCC/aish",
+            },
+        ],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "bash_exec",
+                    "description": "Run a shell command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string"}},
+                    },
+                },
+            }
+        ],
+    )
+
+    assert request["model"] == "gpt-5.4"
+    assert request["instructions"] == "Follow repo conventions."
+    assert request["stream"] is True
+    assert request["input"][0]["role"] == "user"
+    assert request["input"][0]["content"][0]["type"] == "input_text"
+    assert request["input"][1]["role"] == "assistant"
+    assert request["input"][2] == {
+        "type": "function_call",
+        "call_id": "call_1",
+        "name": "bash_exec",
+        "arguments": '{"command":"pwd"}',
+    }
+    assert request["input"][3] == {
+        "type": "function_call_output",
+        "call_id": "call_1",
+        "output": "/home/hao/CCC/aish",
+    }
+    assert request["tools"] == [
+        {
+            "type": "function",
+            "name": "bash_exec",
+            "description": "Run a shell command",
+            "parameters": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+            },
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_collect_openai_codex_stream_response_aggregates_sse_items():
+    response = httpx.Response(
+        200,
+        headers={"content-type": "text/event-stream"},
+        text=(
+            'event: response.output_item.done\n'
+            'data: {"type":"response.output_item.done","item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hello"}]}}\n'
+            "\n"
+            'event: response.completed\n'
+            'data: {"type":"response.completed","response":{"id":"resp_123"}}\n'
+            "\n"
+        ),
+    )
+
+    payload = await _collect_openai_codex_stream_response(response)
+
+    assert payload["id"] == "resp_123"
+    assert payload["output"] == [
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Hello"}],
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_create_openai_codex_chat_completion_accepts_sse_without_content_type(
+    tmp_path,
+):
+    auth_path = tmp_path / "auth.json"
+    id_token = _make_jwt(
+        {
+            "https://api.openai.com/auth": {"chatgpt_account_id": "acct_123"},
+        }
+    )
+    persist_openai_codex_tokens(
+        auth_path,
+        tokens=OpenAICodexOAuthTokens(
+            id_token=id_token,
+            access_token=_make_jwt({"exp": 2_000_000_000}),
+            refresh_token="refresh_123",
+        ),
+    )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"transfer-encoding": "chunked"},
+            text=(
+                'event: response.output_item.done\n'
+                'data: {"type":"response.output_item.done","item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"你好"}]}}\n'
+                "\n"
+                'event: response.completed\n'
+                'data: {"type":"response.completed","response":{"id":"resp_123"}}\n'
+                "\n"
+            ),
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    with patch(
+        "aish.openai_codex.httpx.AsyncClient",
+        side_effect=lambda *args, **kwargs: real_async_client(transport=transport),
+    ):
+        from aish.openai_codex import create_openai_codex_chat_completion
+
+        result = await create_openai_codex_chat_completion(
+            model="openai-codex/gpt-5.4",
+            messages=[{"role": "user", "content": "你好"}],
+            auth_path=auth_path,
+        )
+
+    assert result["choices"][0]["message"]["content"] == "你好"
+
+
+def test_convert_openai_codex_response_to_chat_completion_maps_tool_calls():
+    response = convert_openai_codex_response_to_chat_completion(
+        {
+            "output": [
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "Checking now."}],
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "bash_exec",
+                    "arguments": '{"command":"pwd"}',
+                },
+            ]
+        }
+    )
+
+    choice = response["choices"][0]
+    assert choice["finish_reason"] == "tool_calls"
+    assert choice["message"]["content"] == "Checking now."
+    assert choice["message"]["tool_calls"] == [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {
+                "name": "bash_exec",
+                "arguments": '{"command":"pwd"}',
+            },
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_process_input_uses_openai_codex_path_when_stream_requested():
+    session = LLMSession(
+        config=ConfigModel(
+            model="openai-codex/gpt-5.4",
+            codex_auth_path="/tmp/codex-auth.json",
+        ),
+        skill_manager=SkillManager(),
+    )
+    context_manager = ContextManager()
+
+    with (
+        patch.object(
+            session,
+            "_get_acompletion",
+            side_effect=AssertionError("LiteLLM should not be used for openai-codex"),
+        ),
+        patch.object(session, "_get_tools_spec", return_value=[]),
+        patch(
+            "aish.llm.create_openai_codex_chat_completion",
+            new=AsyncMock(
+                return_value={
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": "hello from codex",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ]
+                }
+            ),
+        ) as mock_create,
+    ):
+        result = await session.process_input(
+            prompt="hi",
+            context_manager=context_manager,
+            system_message="sys",
+            stream=True,
+        )
+
+    assert result == "hello from codex"
+    assert mock_create.await_count == 1
+    assert mock_create.await_args.kwargs["model"] == "openai-codex/gpt-5.4"
+    assert mock_create.await_args.kwargs["auth_path"] == "/tmp/codex-auth.json"

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -143,6 +143,30 @@ class TestAIShell:
 
         assert shell.llm_session.model == "test-model"
 
+    @pytest.mark.asyncio
+    async def test_model_command_switches_to_openai_codex_without_verification(self):
+        """/model should allow OpenAI Codex after local auth validation."""
+        config = ConfigModel(
+            model="test-model",
+            api_key="test-key",
+            codex_auth_path="/tmp/codex-auth.json",
+        )
+        shell = make_shell(config)
+
+        with (
+            patch("aish.shell.load_openai_codex_auth", return_value=Mock()),
+            patch(
+                "aish.wizard.verification.run_verification_async",
+                new_callable=AsyncMock,
+            ) as mock_verify,
+        ):
+            await shell.handle_model_command("/model openai-codex/gpt-5.4")
+
+        assert shell.llm_session.model == "openai-codex/gpt-5.4"
+        assert shell.context_manager.model == "openai-codex/gpt-5.4"
+        assert shell.config.model == "openai-codex/gpt-5.4"
+        mock_verify.assert_not_called()
+
     def test_init_creates_session_record(self, tmp_path):
         """Each shell start should create a new persisted session record."""
         db_path = tmp_path / "sessions.db"


### PR DESCRIPTION
## Summary
- add built-in OpenAI Codex account auth to aish, without requiring a traditional API key
- support browser PKCE login, device-code login, and optional `codex-cli` compatibility fallback
- wire `openai-codex/*` models into the existing config, setup, shell, and LLM runtime paths
- handle the official Codex backend stream format and token refresh flow, with regression tests

## Usage
Login with built-in browser OAuth:

```bash
aish models auth login --provider openai-codex
```

Login on a headless server:

```bash
aish models auth login --provider openai-codex --auth-flow device-code
```

Optional fallback using the local `codex` CLI:

```bash
aish models auth login --provider openai-codex --auth-flow codex-cli
```

Use an account-scoped model after login:

```bash
aish run --model openai-codex/gpt-5.4
```

Or switch inside the shell:

```text
/model openai-codex/gpt-5.4
```

Notes:
- `openai-codex/*` does not require `api_key`
- auth file resolution supports `AISH_CODEX_AUTH_PATH`, `codex_auth_path`, `$CODEX_HOME/auth.json`, and `~/.codex/auth.json`

## Testing
- `.venv/bin/pytest -q tests/test_openai_codex.py tests/test_cli.py tests/test_shell.py`
- `67 passed`
