### PR TITLE
docs: align bundle install guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,27 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- TBD
+- Added built-in OpenAI Codex OAuth support.
+- Added a manual Release PR workflow to prepare version bumps and release notes before publication.
+- Added a unified Release Preparation workflow that validates the target version and dry-runs release bundles before the final release.
 
 ### Changed
 
-- TBD
-
-### Deprecated
-
-- TBD
+- Changed the release pipeline to publish Linux binary bundles for amd64 and arm64, with install and smoke-test verification in CI.
+- Changed release metadata handling so version normalization, changelog extraction, and previous-tag discovery are generated consistently for release workflows.
 
 ### Removed
 
-- TBD
+- Removed Debian package publishing from the release path; new releases should be installed from the published binary bundle instead of a .deb package.
 
 ### Fixed
 
-- TBD
-
-### Security
-
-- TBD
+- Fixed bundle install and uninstall scripts so packaged binaries, services, and install layout are handled consistently.
+- Fixed Linux bundle smoke tests to match the installer layout used by release artifacts.
+- Fixed startup welcome screen rendering regressions.
+- Fixed official website redirection failures.
 
 ## [0.1.0] - 2025-12-29
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -2,19 +2,23 @@
 
 ## 🚀 Installation
 
-### Method 1: Package Installation (Recommended)
+### Method 1: One-line Install (Recommended)
 
-**Debian/Ubuntu:**
 ```bash
-sudo dpkg -i aish_<version>_<arch>.deb
+curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-**Or use the installation script:**
+### Method 2: Manual Bundle Install
+
+Download the matching `aish-<version>-linux-<arch>.tar.gz` bundle from the official release directory, then run:
+
 ```bash
-curl -fsSL https://github.com/AI-Shell-Team/aish/blob/main/install.sh | bash
+tar -xzf aish-<version>-linux-<arch>.tar.gz
+cd aish-<version>-linux-<arch>
+sudo ./install.sh
 ```
 
-### Method 2: Run from Source
+### Method 3: Run from Source
 
 ```bash
 cd /path/to/aish

--- a/README.md
+++ b/README.md
@@ -73,16 +73,20 @@ Empower the Shell to think. Evolve Operations.
 
 ### 1) Install and Launch
 
-**Option 1: One-line install (Recommended)**
+#### Option 1: One-line install (Recommended)
 
 ```bash
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-**Option 2: Install from .deb package**
+#### Option 2: Manual bundle install
+
+Download the matching `aish-<version>-linux-<arch>.tar.gz` bundle from the official release directory, then run:
 
 ```bash
-sudo dpkg -i aish_<version>_<arch>.deb
+tar -xzf aish-<version>-linux-<arch>.tar.gz
+cd aish-<version>-linux-<arch>
+sudo ./install.sh
 ```
 
 Then launch:
@@ -114,11 +118,13 @@ aish> ;explain this command: tar -czf a.tgz ./dir
 
 ## Installation
 
-### Debian/Ubuntu Distributions
+### Linux Release Bundle
 
 ```bash
-sudo dpkg -i aish_<version>_<arch>.deb
+curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
+
+The installer resolves the latest release directory under `https://www.aishell.ai/repo`, downloads the matching bundle for your architecture, and installs `aish`, `aish-sandbox`, and `aish-uninstall` into `/usr/local/bin`.
 
 ### Run from Source (Development/Trial)
 
@@ -136,13 +142,13 @@ python -m aish
 Uninstall (keep configuration files):
 
 ```bash
-sudo dpkg -r aish
+sudo aish-uninstall
 ```
 
 Complete uninstallation (also removes system-level security policies):
 
 ```bash
-sudo dpkg -P aish
+sudo aish-uninstall --purge-config
 ```
 
 Optional: Clean user-level configuration (will clear model/API keys etc.):

--- a/README_CN.md
+++ b/README_CN.md
@@ -70,16 +70,20 @@
 
 ### 1) 安装并启动
 
-**方式一：一键安装（推荐）**
+#### 方式一：一键安装（推荐）
 
 ```bash
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-**方式二：从 .deb 包安装**
+#### 方式二：手动安装二进制 bundle
+
+先从官方发布目录下载对应架构的 `aish-<version>-linux-<arch>.tar.gz`，然后执行：
 
 ```bash
-sudo dpkg -i aish_<version>_<arch>.deb
+tar -xzf aish-<version>-linux-<arch>.tar.gz
+cd aish-<version>-linux-<arch>
+sudo ./install.sh
 ```
 
 然后启动：
@@ -111,11 +115,13 @@ aish> ;解释一下这个命令：tar -czf a.tgz ./dir
 
 ## 安装
 
-### Debian/Ubuntu 等 发行版
+### Linux 二进制 Bundle
 
 ```bash
-sudo dpkg -i aish_<version>_<arch>.deb
+curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
+
+该安装器会在 `https://www.aishell.ai/repo` 下解析最新发布目录，下载与你当前架构匹配的 bundle，并把 `aish`、`aish-sandbox` 和 `aish-uninstall` 安装到 `/usr/local/bin`。
 
 ### 从源码运行（开发/试用）
 
@@ -133,13 +139,13 @@ python -m aish
 卸载（保留配置文件）：
 
 ```bash
-sudo dpkg -r aish
+sudo aish-uninstall
 ```
 
 彻底卸载（同时删除系统级安全策略）：
 
 ```bash
-sudo dpkg -P aish
+sudo aish-uninstall --purge-config
 ```
 
 可选：清理用户级配置（会清空模型/API Key 等）：

--- a/packaging/scripts/install-bundle.sh
+++ b/packaging/scripts/install-bundle.sh
@@ -196,6 +196,7 @@ BIN_DIR="$(binary_target_dir)"
 
 install_file "$ROOTFS_DIR/usr/bin/aish" "${BIN_DIR}/aish" 0755
 install_file "$ROOTFS_DIR/usr/bin/aish-sandbox" "${BIN_DIR}/aish-sandbox" 0755
+install_file "$SCRIPT_DIR/uninstall.sh" "${BIN_DIR}/aish-uninstall" 0755
 install_config "$ROOTFS_DIR/etc/aish/security_policy.yaml" "/etc/aish/security_policy.yaml"
 if [[ -z "$INSTALL_PREFIX" ]]; then
 	install_systemd_unit "$ROOTFS_DIR/lib/systemd/system/aish-sandbox.service" "/etc/systemd/system/aish-sandbox.service"

--- a/packaging/scripts/uninstall-bundle.sh
+++ b/packaging/scripts/uninstall-bundle.sh
@@ -74,7 +74,7 @@ disable_services
 
 BIN_DIR="$(binary_target_dir)"
 
-rm -f "$(target_path "${BIN_DIR}/aish")" "$(target_path "${BIN_DIR}/aish-sandbox")"
+rm -f "$(target_path "${BIN_DIR}/aish")" "$(target_path "${BIN_DIR}/aish-sandbox")" "$(target_path "${BIN_DIR}/aish-uninstall")"
 
 if [[ -z "$INSTALL_PREFIX" ]]; then
 	rm -f "$(target_path "/etc/systemd/system/aish-sandbox.service")" "$(target_path "/etc/systemd/system/aish-sandbox.socket")"


### PR DESCRIPTION
## Summary
- update release notes draft for 0.1.1
- switch user-facing install docs from deb packages to bundle installs
- install aish-uninstall from the bundle so docs match actual behavior

## Testing
- not run (docs and installer script path updates only)