### PR TITLE
ci: fix release PR changelog extraction

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -54,29 +54,35 @@ jobs:
           VERSION: ${{ github.event.inputs.version }}
           BASE_BRANCH: ${{ github.event.inputs.base_branch }}
         run: |
-          heading=$(grep -E "^## \[$VERSION\]( - [0-9]{4}-[0-9]{2}-[0-9]{2})?$" CHANGELOG.md | head -n1 || true)
-          if [ -z "$heading" ]; then
-            echo "Could not find release section for version $VERSION in CHANGELOG.md" >&2
-            exit 1
-          fi
+          python3 - <<'PY'
+          import os
+          import pathlib
+          import re
+          import sys
 
-          release_date=$(printf '%s\n' "$heading" | sed -E 's/^## \[[^]]+\]( - )?//')
-          if [ -z "$release_date" ] || [ "$release_date" = "$heading" ]; then
-            release_date="TBD"
-          fi
+          version = os.environ["VERSION"]
+          changelog = pathlib.Path("CHANGELOG.md").read_text(encoding="utf-8")
+          pattern = re.compile(
+              rf"(?ms)^## \[{re.escape(version)}\](?: - (?P<date>\d{{4}}-\d{{2}}-\d{{2}}))?\n(?P<body>.*?)(?=^## \[|\Z)"
+          )
+          match = pattern.search(changelog)
+          if match is None:
+              print(f"Could not find release section for version {version} in CHANGELOG.md", file=sys.stderr)
+              raise SystemExit(1)
+
+          release_date = match.group("date") or "TBD"
+          release_body = match.group("body").strip()
+          if not release_body:
+              print(f"Release section for version {version} is empty", file=sys.stderr)
+              raise SystemExit(1)
+
+          pathlib.Path("release-date.txt").write_text(f"{release_date}\n", encoding="utf-8")
+          pathlib.Path("release-pr-notes.md").write_text(f"{release_body}\n", encoding="utf-8")
+          PY
+
+          release_date=$(cat release-date.txt)
 
           previous_stable_tag=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -vx "v$VERSION" | sort -V | tail -n1 || true)
-
-          awk -v version="$VERSION" '
-            $0 ~ "^## \\\\[" version "\\\\]( - .*)?$" { capture=1; next }
-            /^## \[/ && capture { exit }
-            capture { print }
-          ' CHANGELOG.md | sed '/^$/N;/^\n$/D' > release-pr-notes.md
-
-          if [ ! -s release-pr-notes.md ]; then
-            echo "Release section for version $VERSION is empty" >&2
-            exit 1
-          fi
 
           {
             echo "# Release $VERSION"


### PR DESCRIPTION
## Summary
- replace the release PR changelog extraction shell snippet with a Python parser
- correctly capture the generated version section and its body from CHANGELOG.md
- avoid false empty-section failures during the Release PR workflow

## Testing
- not run locally
- validated workflow file syntax in editor