### PR TITLE
fix: retry transient OpenAI Codex request failures

### DIFF
--- a/src/aish/providers/openai_codex.py
+++ b/src/aish/providers/openai_codex.py
@@ -71,6 +71,10 @@ class OpenAICodexAuthError(RuntimeError):
     pass
 
 
+class _OpenAICodexRetryableRequestError(OpenAICodexAuthError):
+    pass
+
+
 @dataclass
 class OpenAICodexAuthState:
     auth_path: Path
@@ -768,23 +772,32 @@ async def create_openai_codex_chat_completion(
                     if response.is_error:
                         await response.aread()
                         detail = _extract_http_error_message(response)
-                        raise OpenAICodexAuthError(
+                        message = (
                             f"OpenAI Codex request failed: {response.status_code} {detail}"
                         )
+                        raise _build_openai_codex_request_error(message)
 
                     content_type = _coerce_str(response.headers.get("content-type")).lower()
                     if not content_type or "text/event-stream" in content_type:
-                        payload = await _collect_openai_codex_stream_response(response)
+                        try:
+                            payload = await _collect_openai_codex_stream_response(response)
+                        except OpenAICodexAuthError as exc:
+                            raise _build_openai_codex_request_error(str(exc)) from exc
                     else:
                         raw_body = await response.aread()
                         body_text = raw_body.decode("utf-8", errors="replace")
                         if _looks_like_sse_text(body_text):
-                            payload = _collect_openai_codex_stream_text(body_text)
+                            try:
+                                payload = _collect_openai_codex_stream_text(body_text)
+                            except OpenAICodexAuthError as exc:
+                                raise _build_openai_codex_request_error(
+                                    str(exc)
+                                ) from exc
                         else:
                             try:
                                 payload = json.loads(body_text)
                             except Exception as exc:
-                                raise OpenAICodexAuthError(
+                                raise _OpenAICodexRetryableRequestError(
                                     "OpenAI Codex returned invalid JSON."
                                 ) from exc
                     return convert_openai_codex_response_to_chat_completion(payload)
@@ -793,13 +806,10 @@ async def create_openai_codex_chat_completion(
                 if attempt + 1 >= OPENAI_CODEX_MAX_REQUEST_ATTEMPTS:
                     break
                 continue
-            except OpenAICodexAuthError as exc:
-                if (
-                    attempt + 1 < OPENAI_CODEX_MAX_REQUEST_ATTEMPTS
-                    and _is_retryable_openai_codex_failure_message(str(exc))
-                ):
-                    continue
-                raise
+            except _OpenAICodexRetryableRequestError:
+                if attempt + 1 >= OPENAI_CODEX_MAX_REQUEST_ATTEMPTS:
+                    raise
+                continue
 
     if last_transport_error is not None:
         raise OpenAICodexAuthError(
@@ -1077,6 +1087,12 @@ def _is_retryable_openai_codex_failure_message(message: str) -> bool:
         "returned an incomplete response",
     )
     return any(marker in lowered for marker in retryable_markers)
+
+
+def _build_openai_codex_request_error(message: str) -> OpenAICodexAuthError:
+    if _is_retryable_openai_codex_failure_message(message):
+        return _OpenAICodexRetryableRequestError(message)
+    return OpenAICodexAuthError(message)
 
 
 def _format_oauth_callback_error(

--- a/tests/test_openai_codex.py
+++ b/tests/test_openai_codex.py
@@ -470,6 +470,66 @@ async def test_create_openai_codex_chat_completion_retries_transient_backend_fai
 
 
 @pytest.mark.anyio
+async def test_create_openai_codex_chat_completion_does_not_retry_refresh_failures(
+    tmp_path,
+):
+    auth_path = tmp_path / "auth.json"
+    id_token = _make_jwt(
+        {
+            "https://api.openai.com/auth": {"chatgpt_account_id": "acct_123"},
+        }
+    )
+    persist_openai_codex_tokens(
+        auth_path,
+        tokens=OpenAICodexOAuthTokens(
+            id_token=id_token,
+            access_token=_make_jwt({"exp": 2_000_000_000}),
+            refresh_token="refresh_123",
+        ),
+    )
+
+    attempts = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx.Response(
+            401,
+            headers={"content-type": "application/json"},
+            json={"error": {"message": "unauthorized"}},
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    with (
+        patch(
+            "aish.providers.openai_codex.httpx.AsyncClient",
+            side_effect=lambda *args, **kwargs: real_async_client(transport=transport),
+        ),
+        patch(
+            "aish.providers.openai_codex.refresh_openai_codex_auth",
+            new=AsyncMock(
+                side_effect=OpenAICodexAuthError(
+                    "OpenAI Codex returned invalid JSON."
+                )
+            ),
+        ) as mock_refresh,
+    ):
+        from aish.providers.openai_codex import create_openai_codex_chat_completion
+
+        with pytest.raises(OpenAICodexAuthError, match="returned invalid JSON"):
+            await create_openai_codex_chat_completion(
+                model="openai-codex/gpt-5.4",
+                messages=[{"role": "user", "content": "你好"}],
+                auth_path=auth_path,
+            )
+
+    assert attempts == 1
+    assert mock_refresh.await_count == 1
+
+
+@pytest.mark.anyio
 async def test_create_openai_codex_chat_completion_retries_transport_errors_up_to_five_attempts(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- retry transient OpenAI Codex backend failures instead of failing on the first malformed/incomplete response
- retry transport-level request errors up to five attempts while keeping token refresh single-shot
- add coverage for transient backend failures, transport timeouts, and retry exhaustion

## Testing
- .venv/bin/pytest -q tests/test_openai_codex.py