### PR TITLE
Remove unreleased changelog flow

### DIFF
--- a/.github/actions/release-metadata/action.yml
+++ b/.github/actions/release-metadata/action.yml
@@ -27,7 +27,7 @@ outputs:
     description: Most recent stable git tag
     value: ${{ steps.metadata.outputs.previous_stable_tag }}
   release_notes:
-    description: Unreleased changelog notes
+    description: Release changelog notes
     value: ${{ steps.metadata.outputs.release_notes }}
 
 runs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,32 +7,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-
-- TBD
-
-### Changed
-
-- TBD
-
-### Deprecated
-
-- TBD
-
-### Removed
-
-- TBD
-
-### Fixed
-
-- TBD
-
-### Security
-
-- TBD
-
 ## [0.1.2] - 2026-03-14
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Welcome to make Shell smarter!
 - Code PRs run lint, tests, and cross-platform smoke checks.
 - Packaging-related PRs additionally run Linux bundle build and install smoke checks.
 - `Release Metadata` is the shared release action that normalizes stable version inputs, validates repository version state, and uploads both markdown and JSON metadata artifacts.
-- `make prepare-release-files VERSION=X.Y.Z [DATE=YYYY-MM-DD]` updates `pyproject.toml`, `src/aish/__init__.py`, and moves the current `CHANGELOG.md` `Unreleased` section into a dated release section.
+- `make prepare-release-files VERSION=X.Y.Z [DATE=YYYY-MM-DD]` updates `pyproject.toml`, `src/aish/__init__.py`, `uv.lock`, and inserts a dated release section at the top of `CHANGELOG.md`.
 - Prepare release files locally in a normal PR, merge that PR into `main`, then run `Release Preparation` as the preflight validation for the target stable version.
 - `Release Preparation` validates the target stable version, generates a release summary from the versioned changelog section, builds dry-run bundles, and runs install smoke checks before publication.
 - `Release` is triggered by pushing a stable tag `vX.Y.Z`. It validates the tag against repository metadata, verifies that the tagged commit is on `main`, waits on the protected `release` environment approval gate, creates the GitHub Release entry with generated notes, and uploads bundle assets.

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ help:
 	@echo "  make build          Build Python wheel"
 	@echo "  make build-binary   Build standalone binaries"
 	@echo "  make build-bundle   Build release bundle archive"
-	@echo "  make prepare-release-files VERSION=X.Y.Z [DATE=YYYY-MM-DD]"
+	@echo "  make prepare-release-files VERSION=X.Y.Z [DATE=YYYY-MM-DD]  Update release versions and add a changelog section"
 	@echo "  make install        Install built artifacts into DESTDIR/PREFIX"
 	@echo "  make clean          Clean build artifacts"
 

--- a/packaging/scripts/release_metadata.py
+++ b/packaging/scripts/release_metadata.py
@@ -67,7 +67,14 @@ def _extract_changelog_section(section_name: str) -> str:
 def _extract_release_notes(version: str | None) -> str:
     if version:
         return _extract_changelog_section(version)
-    return _extract_changelog_section("Unreleased")
+
+    lines = CHANGELOG_PATH.read_text(encoding="utf-8").splitlines()
+    for line in lines:
+        match = re.match(r"^## \[(\d+\.\d+\.\d+)\]", line)
+        if match:
+            return _extract_changelog_section(match.group(1))
+
+    raise ValueError(f"Could not find any versioned changelog sections in {CHANGELOG_PATH}")
 
 
 def _normalize_version(raw_version: str) -> str:

--- a/packaging/scripts/update_release_files.py
+++ b/packaging/scripts/update_release_files.py
@@ -11,36 +11,14 @@ ROOT_DIR = Path(__file__).resolve().parents[2]
 PYPROJECT_PATH = ROOT_DIR / "pyproject.toml"
 RUNTIME_VERSION_PATH = ROOT_DIR / "src" / "aish" / "__init__.py"
 CHANGELOG_PATH = ROOT_DIR / "CHANGELOG.md"
+UV_LOCK_PATH = ROOT_DIR / "uv.lock"
 VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
 PYPROJECT_VERSION_RE = re.compile(r'^(version\s*=\s*")([^"]+)("\s*)$', re.MULTILINE)
 RUNTIME_VERSION_RE = re.compile(r'^(__version__\s*=\s*")([^"]+)("\s*)$', re.MULTILINE)
-UNRELEASED_SECTION_RE = re.compile(
-    r"(?ms)^## \[Unreleased\]\n(?P<body>.*?)(?=^## \[|\Z)"
+UV_LOCK_VERSION_RE = re.compile(
+    r'(?ms)^(\[\[package\]\]\nname\s*=\s*"aish"\nversion\s*=\s*")([^"]+)("\s*$)'
 )
-
-UNRELEASED_TEMPLATE = """### Added
-
-- TBD
-
-### Changed
-
-- TBD
-
-### Deprecated
-
-- TBD
-
-### Removed
-
-- TBD
-
-### Fixed
-
-- TBD
-
-### Security
-
-- TBD"""
+CHANGELOG_SECTION_RE = re.compile(r"^## \[", re.MULTILINE)
 
 
 def _replace_single(pattern: re.Pattern[str], text: str, replacement_value: str) -> str:
@@ -65,27 +43,28 @@ def _update_runtime_version(version: str) -> None:
     RUNTIME_VERSION_PATH.write_text(updated, encoding="utf-8")
 
 
+def _update_uv_lock(version: str) -> None:
+    if not UV_LOCK_PATH.exists():
+        return
+
+    original = UV_LOCK_PATH.read_text(encoding="utf-8")
+    updated = _replace_single(UV_LOCK_VERSION_RE, original, version)
+    UV_LOCK_PATH.write_text(updated, encoding="utf-8")
+
+
 def _update_changelog(version: str, release_date: str) -> None:
     original = CHANGELOG_PATH.read_text(encoding="utf-8")
     if f"## [{version}] - {release_date}" in original or f"## [{version}]" in original:
         raise ValueError(f"Changelog already contains a section for version {version}")
 
-    match = UNRELEASED_SECTION_RE.search(original)
+    new_section = f"## [{version}] - {release_date}\n\n"
+    match = CHANGELOG_SECTION_RE.search(original)
     if match is None:
-        raise ValueError("Could not find the [Unreleased] section in CHANGELOG.md")
+        separator = "" if original.endswith("\n\n") else "\n\n"
+        updated = f"{original.rstrip()}{separator}{new_section}"
+    else:
+        updated = f"{original[:match.start()]}{new_section}{original[match.start():]}"
 
-    unreleased_body = match.group("body").strip("\n")
-    if not unreleased_body.strip():
-        unreleased_body = UNRELEASED_TEMPLATE
-
-    replacement = (
-        "## [Unreleased]\n\n"
-        f"{UNRELEASED_TEMPLATE}\n\n"
-        f"## [{version}] - {release_date}\n\n"
-        f"{unreleased_body}\n"
-    )
-
-    updated = original[: match.start()] + replacement + original[match.end() :]
     CHANGELOG_PATH.write_text(updated, encoding="utf-8")
 
 
@@ -94,6 +73,7 @@ def update_release_files(version: str, release_date: str) -> None:
         raise ValueError(f"Invalid version '{version}'. Expected format: X.Y.Z")
     _update_pyproject(version)
     _update_runtime_version(version)
+    _update_uv_lock(version)
     _update_changelog(version, release_date)
 
 

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -17,12 +17,6 @@ def test_extract_release_notes_uses_versioned_section(tmp_path, monkeypatch):
     changelog.write_text(
         """# Changelog
 
-## [Unreleased]
-
-### Added
-
-- Future change
-
 ## [0.1.1] - 2026-03-13
 
 ### Added
@@ -36,12 +30,12 @@ def test_extract_release_notes_uses_versioned_section(tmp_path, monkeypatch):
     assert release_metadata._extract_release_notes("0.1.1") == "### Added\n\n- Stable release note"
 
 
-def test_extract_release_notes_uses_unreleased_without_expected_version(tmp_path, monkeypatch):
+def test_extract_release_notes_uses_latest_version_without_expected_version(tmp_path, monkeypatch):
     changelog = tmp_path / "CHANGELOG.md"
     changelog.write_text(
         """# Changelog
 
-## [Unreleased]
+## [0.1.1] - 2026-03-13
 
 ### Fixed
 

--- a/tests/test_update_release_files.py
+++ b/tests/test_update_release_files.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "packaging" / "scripts" / "update_release_files.py"
+SPEC = importlib.util.spec_from_file_location("update_release_files", MODULE_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+update_release_files = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(update_release_files)
+
+
+def test_update_release_files_updates_uv_lock_package_version(tmp_path, monkeypatch):
+    pyproject = tmp_path / "pyproject.toml"
+    runtime = tmp_path / "__init__.py"
+    changelog = tmp_path / "CHANGELOG.md"
+    uv_lock = tmp_path / "uv.lock"
+
+    pyproject.write_text('[project]\nversion = "0.1.0"\n', encoding="utf-8")
+    runtime.write_text('__version__ = "0.1.0"\n', encoding="utf-8")
+    changelog.write_text(
+        """# Changelog
+
+## [0.1.1] - 2026-03-13
+
+### Added
+
+- Previous release note
+""",
+        encoding="utf-8",
+    )
+    uv_lock.write_text(
+        """version = 1
+
+[[package]]
+name = "aish"
+version = "0.1.0"
+source = { editable = "." }
+
+[[package]]
+name = "other"
+version = "0.1.0"
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(update_release_files, "PYPROJECT_PATH", pyproject)
+    monkeypatch.setattr(update_release_files, "RUNTIME_VERSION_PATH", runtime)
+    monkeypatch.setattr(update_release_files, "CHANGELOG_PATH", changelog)
+    monkeypatch.setattr(update_release_files, "UV_LOCK_PATH", uv_lock)
+
+    update_release_files.update_release_files("0.1.2", "2026-03-16")
+
+    assert 'version = "0.1.2"' in uv_lock.read_text(encoding="utf-8")
+    assert 'name = "other"\nversion = "0.1.0"' in uv_lock.read_text(encoding="utf-8")
+    assert "## [0.1.2] - 2026-03-16\n\n## [0.1.1] - 2026-03-13" in changelog.read_text(encoding="utf-8")
+
+
+def test_update_uv_lock_is_noop_when_lockfile_missing(tmp_path, monkeypatch):
+    pyproject = tmp_path / "pyproject.toml"
+    runtime = tmp_path / "__init__.py"
+    changelog = tmp_path / "CHANGELOG.md"
+    missing_lock = tmp_path / "missing.lock"
+
+    pyproject.write_text('[project]\nversion = "0.1.0"\n', encoding="utf-8")
+    runtime.write_text('__version__ = "0.1.0"\n', encoding="utf-8")
+    changelog.write_text(
+        """# Changelog
+
+## [0.1.1] - 2026-03-13
+
+### Added
+
+- Previous release note
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(update_release_files, "PYPROJECT_PATH", pyproject)
+    monkeypatch.setattr(update_release_files, "RUNTIME_VERSION_PATH", runtime)
+    monkeypatch.setattr(update_release_files, "CHANGELOG_PATH", changelog)
+    monkeypatch.setattr(update_release_files, "UV_LOCK_PATH", missing_lock)
+
+    update_release_files.update_release_files("0.1.2", "2026-03-16")
+
+    assert not missing_lock.exists()
+
+
+def test_update_release_files_rejects_existing_version_section(tmp_path, monkeypatch):
+    pyproject = tmp_path / "pyproject.toml"
+    runtime = tmp_path / "__init__.py"
+    changelog = tmp_path / "CHANGELOG.md"
+    uv_lock = tmp_path / "uv.lock"
+
+    pyproject.write_text('[project]\nversion = "0.1.0"\n', encoding="utf-8")
+    runtime.write_text('__version__ = "0.1.0"\n', encoding="utf-8")
+    changelog.write_text(
+        """# Changelog
+
+## [0.1.2] - 2026-03-16
+
+### Added
+
+- Existing notes
+""",
+        encoding="utf-8",
+    )
+    uv_lock.write_text(
+        """version = 1
+
+[[package]]
+name = "aish"
+version = "0.1.0"
+source = { editable = "." }
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(update_release_files, "PYPROJECT_PATH", pyproject)
+    monkeypatch.setattr(update_release_files, "RUNTIME_VERSION_PATH", runtime)
+    monkeypatch.setattr(update_release_files, "CHANGELOG_PATH", changelog)
+    monkeypatch.setattr(update_release_files, "UV_LOCK_PATH", uv_lock)
+
+    try:
+        update_release_files.update_release_files("0.1.2", "2026-03-16")
+    except ValueError as exc:
+        assert "already contains a section" in str(exc)
+    else:
+        raise AssertionError("Expected duplicate changelog version section to be rejected")
+
+
+def test_update_release_files_inserts_new_version_section(tmp_path, monkeypatch):
+    pyproject = tmp_path / "pyproject.toml"
+    runtime = tmp_path / "__init__.py"
+    changelog = tmp_path / "CHANGELOG.md"
+    uv_lock = tmp_path / "uv.lock"
+
+    pyproject.write_text('[project]\nversion = "0.1.0"\n', encoding="utf-8")
+    runtime.write_text('__version__ = "0.1.0"\n', encoding="utf-8")
+    changelog.write_text(
+        """# Changelog
+
+## [0.1.1] - 2026-03-13
+
+### Added
+
+- Previous release note
+""",
+        encoding="utf-8",
+    )
+    uv_lock.write_text(
+        """version = 1
+
+[[package]]
+name = "aish"
+version = "0.1.0"
+source = { editable = "." }
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(update_release_files, "PYPROJECT_PATH", pyproject)
+    monkeypatch.setattr(update_release_files, "RUNTIME_VERSION_PATH", runtime)
+    monkeypatch.setattr(update_release_files, "CHANGELOG_PATH", changelog)
+    monkeypatch.setattr(update_release_files, "UV_LOCK_PATH", uv_lock)
+
+    update_release_files.update_release_files("0.1.2", "2026-03-16")
+
+    changelog_text = changelog.read_text(encoding="utf-8")
+    assert "## [0.1.2] - 2026-03-16" in changelog_text
+    assert "## [0.1.2] - 2026-03-16\n\n## [0.1.1] - 2026-03-13" in changelog_text

--- a/uv.lock
+++ b/uv.lock
@@ -146,7 +146,7 @@ wheels = [
 
 [[package]]
 name = "aish"
-version = "0.1.0"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary
- remove the changelog Unreleased section and stop release scripts from depending on it
- make release metadata read versioned changelog notes consistently
- document the updated release prep behavior and add regression tests

## Testing
- /home/lixin/workspace/aish/.venv/bin/python -m pytest tests/test_update_release_files.py tests/test_release_metadata.py -q