### PR TITLE
fix: support frozen sandbox worker entry

### DIFF
--- a/aish.spec
+++ b/aish.spec
@@ -201,6 +201,7 @@ a_sandbox = Analysis(
     datas=[],
     hiddenimports=[
         'aish.security.sandbox_daemon',
+        'aish.security.sandbox_worker',
     ],
     hookspath=[],
     hooksconfig={},

--- a/src/aish/sandboxd.py
+++ b/src/aish/sandboxd.py
@@ -14,12 +14,22 @@ def main(argv: list[str] | None = None) -> int:
         prog="aish-sandboxd", description="Privileged sandbox daemon for aish"
     )
     parser.add_argument(
+        "--sandbox-worker",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
         "--socket-path",
         default=str(DEFAULT_SANDBOX_SOCKET_PATH),
         help="Unix domain socket path (ignored when systemd socket activation is used)",
     )
 
     args = parser.parse_args(argv)
+
+    if args.sandbox_worker:
+        from aish.security import sandbox_worker
+
+        return sandbox_worker.main()
 
     if os.geteuid() != 0:
         print("aish-sandboxd must run as root", file=sys.stderr)

--- a/src/aish/security/sandbox_daemon.py
+++ b/src/aish/security/sandbox_daemon.py
@@ -31,6 +31,23 @@ _IPC_CHANGES_MAX = 10_000
 _LOG_DETAIL_MAX_CHARS = 4096
 
 
+def _build_worker_command() -> list[str]:
+    worker_cmd = [
+        "unshare",
+        "--mount",
+        "--propagation",
+        "private",
+        "--",
+        sys.executable,
+    ]
+    if getattr(sys, "frozen", False):
+        worker_cmd.append("--sandbox-worker")
+        return worker_cmd
+
+    worker_cmd.extend(["-m", "aish.security.sandbox_worker"])
+    return worker_cmd
+
+
 def _elapsed_ms(start_ts: float) -> int:
     return int((time.monotonic() - start_ts) * 1000)
 
@@ -743,16 +760,7 @@ class SandboxDaemon:
             "timeout_s": timeout_s,
         }
 
-        worker_cmd = [
-            "unshare",
-            "--mount",
-            "--propagation",
-            "private",
-            "--",
-            sys.executable,
-            "-m",
-            "aish.security.sandbox_worker",
-        ]
+        worker_cmd = _build_worker_command()
         exec_timeout: Optional[float] = None
         if timeout_s is not None:
             exec_timeout = float(timeout_s) + 10.0

--- a/tests/security/sandbox/test_daemon_isolation.py
+++ b/tests/security/sandbox/test_daemon_isolation.py
@@ -2,16 +2,53 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 from aish.security.sandbox import SandboxUnavailableError
+from aish.security import sandbox_daemon
 from aish.security.sandbox_daemon import SandboxDaemon, SandboxDaemonConfig
 
 
 def _make_daemon() -> SandboxDaemon:
     return SandboxDaemon(SandboxDaemonConfig(socket_path=Path("/tmp/aish-test.sock")))
+
+
+def test_build_worker_command_uses_module_entrypoint(monkeypatch):
+    monkeypatch.delattr(sys, "frozen", raising=False)
+    monkeypatch.setattr(sys, "executable", "/usr/bin/python3")
+
+    cmd = sandbox_daemon._build_worker_command()
+
+    assert cmd == [
+        "unshare",
+        "--mount",
+        "--propagation",
+        "private",
+        "--",
+        "/usr/bin/python3",
+        "-m",
+        "aish.security.sandbox_worker",
+    ]
+
+
+def test_build_worker_command_uses_internal_entrypoint_when_frozen(monkeypatch):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", "/usr/bin/aish-sandbox")
+
+    cmd = sandbox_daemon._build_worker_command()
+
+    assert cmd == [
+        "unshare",
+        "--mount",
+        "--propagation",
+        "private",
+        "--",
+        "/usr/bin/aish-sandbox",
+        "--sandbox-worker",
+    ]
 
 
 def test_simulate_for_user_uses_unshare_worker(monkeypatch):

--- a/tests/security/sandbox/test_sandboxd.py
+++ b/tests/security/sandbox/test_sandboxd.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from aish import sandboxd
+from aish.security import sandbox_worker
+
+
+def test_sandboxd_main_dispatches_internal_worker(monkeypatch):
+    monkeypatch.setattr(sandbox_worker, "main", lambda: 17)
+
+    assert sandboxd.main(["--sandbox-worker"]) == 17


### PR DESCRIPTION
## Summary
- route frozen sandbox worker launches through an internal daemon entrypoint instead of `sys.executable -m ...`
- keep source runs on the existing module entrypoint and include `aish.security.sandbox_worker` in the PyInstaller sandbox binary
- add regression coverage for source and frozen worker launch paths

## Problem
PyInstaller-built `aish-sandbox` binaries use the daemon executable as `sys.executable`. Launching the worker with `sys.executable -m aish.security.sandbox_worker` causes the daemon CLI to parse `-m` as its own argument and fail.

## Testing
- `/home/lixin/workspace/aish/.venv/bin/python -m pytest tests/security/sandbox/test_daemon_isolation.py tests/security/sandbox/test_sandboxd.py tests/security/sandbox/test_worker.py`
