### PR TITLE
feat: add multilingual locale support

### DIFF
--- a/src/aish/i18n/__init__.py
+++ b/src/aish/i18n/__init__.py
@@ -16,6 +16,15 @@ _UI_LOCALE: str | None = None
 _MESSAGES: dict[str, Any] | None = None
 _MESSAGES_EN: dict[str, Any] | None = None
 
+_LANG_PREFIX_TO_UI_LOCALE = {
+    "zh": "zh-CN",
+    "de": "de-DE",
+    "es": "es-ES",
+    "fr": "fr-FR",
+    "ja": "ja-JP",
+    "en": "en-US",
+}
+
 
 def _normalize_lang_to_ui_locale(lang_value: str | None) -> str:
     if not lang_value:
@@ -28,10 +37,10 @@ def _normalize_lang_to_ui_locale(lang_value: str | None) -> str:
     # Common formats: zh_CN.UTF-8, en_US.UTF-8, zh_CN, en_US
     main = raw.split(".", 1)[0]
     main = main.split("@", 1)[0]
+    normalized = main.replace("_", "-").lower()
+    lang_prefix = normalized.split("-", 1)[0]
 
-    if main.lower().startswith("zh"):
-        return "zh-CN"
-    return "en-US"
+    return _LANG_PREFIX_TO_UI_LOCALE.get(lang_prefix, "en-US")
 
 
 def get_ui_locale() -> str:
@@ -74,10 +83,12 @@ def _ensure_messages_loaded() -> None:
 
     _MESSAGES_EN = _load_yaml_resource("en-US.yaml")
     ui_locale = get_ui_locale()
-    if ui_locale == "zh-CN":
-        _MESSAGES = _load_yaml_resource("zh-CN.yaml")
-    else:
+    if ui_locale == "en-US":
         _MESSAGES = _MESSAGES_EN
+        return
+
+    localized_messages = _load_yaml_resource(f"{ui_locale}.yaml")
+    _MESSAGES = localized_messages or _MESSAGES_EN
 
 
 def _lookup(messages: dict[str, Any], dotted_key: str) -> str | None:

--- a/src/aish/i18n/de-DE.yaml
+++ b/src/aish/i18n/de-DE.yaml
@@ -1,0 +1,519 @@
+cli:
+  app_help: "AI Shell - Eine Shell mit integrierten LLM-Funktionen"
+  help_option_help: "Diese Hilfe anzeigen und beenden."
+  run_command_help: "AI Shell starten"
+  info_command_help: "Informationen zu AI Shell anzeigen"
+  check_langfuse_command_help: "Langfuse-Konfiguration prüfen"
+  setup_command_help: "Interaktive Einrichtung ausführen und beenden"
+  check_tool_support_command_help: "Live-Prüfung der Tool-Call-Unterstützung debuggen"
+
+  option:
+    model: "Zu verwendendes LLM-Modell; kann auch über AISH_MODEL oder die Konfigurationsdatei gesetzt werden."
+    api_key: "API-Schlüssel für den LLM-Anbieter; kann auch über AISH_API_KEY oder Anbieter-Umgebungsvariablen gesetzt werden."
+    api_base: "API-Basis-URL für den LLM-Anbieter; kann auch über AISH_API_BASE oder die Konfigurationsdatei gesetzt werden."
+    config: "Pfad zur Konfigurationsdatei (Standard: ~/.config/aish/config.yaml)."
+
+  setup:
+    step_provider: "Schritt 1/3: Anbieter wählen"
+    step_provider_endpoint: "Schritt 1.5/3: Endpunkt wählen"
+    step_key: "Schritt 2/3: API-Schlüssel eingeben"
+    step_model: "Schritt 3/3: Modell wählen"
+    provider_header: "Anbieter wählen (zum Filtern tippen)"
+    provider_filter_prompt: "Filter:"
+    provider_filter_hint: "Zum Filtern tippen, mit ↑/↓ wählen, mit Enter bestätigen, mit Esc abbrechen."
+    provider_selected_label: "Anbieter"
+    provider_endpoint_selected_label: "Endpunkt"
+    provider_endpoint_header: "API-Endpunkt für {provider} wählen"
+    model_selected_label: "Modell"
+    provider_custom_note: "OpenAI-kompatibel"
+    provider_preset_base: "Voreingestellte API-Basis"
+    custom_api_base_title: "API-Basis-URL"
+    custom_api_base_header: "API-Basis-URL eingeben."
+    provider_custom_api_base: "API-Basis-URL"
+    provider_custom_api_base_required: "API-Basis ist erforderlich"
+    provider_custom_api_base_invalid: "Ungültige API-Basis-URL"
+    provider_custom_default: "Benutzerdefiniert"
+    invalid_choice: "Ungültige Auswahl"
+    filter_no_results: "Keine Treffer. Erneut versuchen oder Enter drücken, um alle anzuzeigen."
+    api_key_header: "API-Schlüssel eingeben (wird in der Konfiguration gespeichert)"
+    api_key_env_found: "Erkannt {env_key}: {masked}"
+    api_key_env_hint: "Mit Enter den erkannten Schlüssel verwenden oder einen neuen eingeben."
+    api_key_prompt: "API-Schlüssel"
+    api_key_required: "API-Schlüssel ist erforderlich"
+    model_header: "Anbieter: {provider}"
+    model_prompt: "Modellname (back eingeben, um den Anbieter zu wechseln)"
+    model_hint_openrouter: "OpenRouter benötigt ein Anbieterpräfix, z. B. openai/gpt-4o. Fehlt es, wird standardmäßig openai/ verwendet."
+    model_hint_custom: "Benutzerdefinierte Anbieter werden als OpenAI-kompatibel behandelt. Ohne Präfix wird openai/<model> gespeichert."
+    model_hint_provider: "Empfohlen: {default}"
+    model_list_unavailable: "Modellliste nicht verfügbar; bitte manuell eingeben"
+    model_filtering: "Modelle mit Tool-Call-Unterstützung werden gefiltert"
+    model_filter_result: "Auf {count} Tool-Call-fähige Modelle gefiltert"
+    model_filter_empty: "Kein Modell hat den Tool-Call-Filter bestanden; vollständige Liste wird angezeigt"
+    model_filter_prompt: "Filter:"
+    model_filter_hint: "Zum Filtern tippen, mit ↑/↓ wählen, mit Enter bestätigen, mit Esc zurück. Für manuelle Eingabe Benutzerdefiniertes Modell wählen."
+    model_custom_option: "Benutzerdefiniertes Modell..."
+    model_custom_required: "Modellname ist erforderlich"
+    model_custom_saved_as: "Wird gespeichert als: {model}"
+    verify_title: "Verifizierung"
+    verify_header: "Tool-Call-Unterstützung wird geprüft..."
+    verify_connectivity_in_progress: "Konnektivität wird geprüft..."
+    verify_tool_in_progress: "Tool-Unterstützung wird geprüft..."
+    verify_static_no_tool_support: "Modell unterstützt keine Tool-Aufrufe (statische Prüfung)"
+    verify_simple_success: "Verifizierung erfolgreich"
+    verify_simple_failed_with_reason: "Verifizierung fehlgeschlagen: {reason}"
+    verify_failed_unknown: "unbekannter Fehler"
+    verify_live_label: "Live-Prüfung"
+    verify_live_detail: "Details"
+    verify_timeout: "Zeitüberschreitung bei der Live-Prüfung"
+    verify_cancelled: "Live-Prüfung abgebrochen"
+    verify_no_tool_call_required: "Kein Tool-Aufruf zurückgegeben (Pflichtmodus)"
+    verify_no_tool_call_auto: "Im Automatikmodus wurde kein Tool aufgerufen"
+    debug_request_title: "Live-Anfrage ({mode})"
+    debug_response_title: "Live-Antwort ({mode})"
+    debug_error_title: "Live-Fehler ({mode})"
+    support_yes: "Unterstützt"
+    support_no: "Nicht unterstützt"
+    support_unknown: "Unbekannt"
+    litellm_missing: "litellm ist nicht installiert; Verifizierung übersprungen"
+    action_header: "Nächste Aktion:"
+    action_prompt: "Option wählen"
+    action_retry_model: "Anderes Modell wählen"
+    action_retry_api_base: "API-Basis erneut eingeben"
+    action_retry_api_key: "API-Schlüssel erneut eingeben"
+    action_change_provider: "Anbieter wechseln"
+    action_continue: "Trotzdem fortfahren (nicht empfohlen)"
+    action_exit: "Einrichtung beenden"
+    retry_api_base_prompt: "API-Basis eingeben (back zum Zurückkehren)"
+    retry_api_base_prompt_with_current: "API-Basis eingeben (aktuell: {current}, back zum Zurückkehren)"
+    retry_api_base_required: "API-Basis ist erforderlich"
+    saved: "Konfiguration gespeichert"
+    saved_with_warning: "Konfiguration gespeichert (Tool-Call nicht verifiziert)"
+    non_interactive: "Nicht-interaktive Umgebung; Einrichtung kann nicht ausgeführt werden"
+    cancelled: "Einrichtung abgebrochen"
+    required_cancelled: "Erforderliche Konfiguration fehlt; Vorgang beendet"
+
+  startup:
+    label:
+      skills: "   Skills"
+    goodbye: "👋 Auf Wiedersehen!"
+    config_file_error: "❌ Fehler in der Konfigurationsdatei: {error}"
+    config_file_hint: "💡 Mit --config einen gültigen Pfad zur Konfigurationsdatei angeben"
+
+  langfuse:
+    incomplete: "⚠️  Die Langfuse-Konfiguration ist unvollständig"
+    missing: "   Fehlt: {var}"
+    complete: "✅ Die Langfuse-Konfiguration ist vollständig"
+    script_failed: "Langfuse-Prüfskript fehlgeschlagen: {error}"
+    script_not_found: "check_langfuse.py-Skript nicht gefunden"
+    run_from_root: "Bitte diesen Befehl im Projektstamm ausführen"
+
+  parse_errors:
+    title: "Fehler"
+    option_requires_argument: "Option {option} erfordert ein Argument."
+    no_such_option: "Unbekannte Option: {option}"
+    missing_parameter: "Fehlender Parameter: {param}"
+    invalid_value_for_option: "Ungültiger Wert für {option}: {reason}"
+    generic: "Ungültige Argumente: {message}"
+
+shell:
+  welcome2:
+    header: ">_ AI Shell {version}"
+    model_hint: "(mit /model wechseln)"
+    label:
+      model: "Modell"
+      config: "Konfig"
+    quick_start:
+      title: " Schnellstart:"
+      item1_prefix: "Native Shell-Befehle: "
+      cmd_ls: "ls"
+      cmd_top: "top"
+      cmd_vim: "vim"
+      cmd_ssh: "ssh"
+      item1_suffix: " usw."
+      item2_prefix: "KI fragen: "
+      item2_example: "Mit ; beginnen, z. B. ; wie finde ich große Dateien"
+      item3_prefix: "Hilfe:"
+      item3_suffix_1: "Gib "
+      item3_keyword: "help"
+      item3_suffix_2: " ein, um integrierte Hilfe und Verwendung zu sehen."
+    risk: "Von der KI erzeugte Inhalte können riskant sein; bitte sorgfältig prüfen."
+    skills_loaded_suffix: " geladen"
+
+  security:
+    title:
+      blocked: "🛑 Sicherheitsblockierung: {tool}"
+      notice: "🔐 Sicherheitshinweis: {tool}"
+      confirm: "🔐 Bestätigung erforderlich: {tool}"
+    label:
+      description: "Beschreibung"
+      command: "Befehl"
+      target: "Ziel"
+      content_preview: "Inhaltsvorschau"
+      fallback_hint: "Hinweis"
+      risk_level: "Risikostufe"
+      reasons: "Gründe"
+      alternatives: "Alternativen"
+      impact: "Auswirkung"
+      no_additional_info: "Keine weiteren Informationen verfügbar."
+    fallback:
+      sandbox_execute_failed: "Die Vorabausführung des Befehls ist fehlgeschlagen; das Risiko kann nicht bewertet werden. Bitte vor der echten Ausführung bestätigen."
+      sandbox_timeout: "Die Vorabausführung des Befehls hat das Zeitlimit überschritten; das Risiko kann nicht bewertet werden. Bitte vor der echten Ausführung bestätigen."
+      sandbox_ipc_timeout: "Zeitüberschreitung beim Warten auf die Vorabbewertung des Befehls; das Risiko kann nicht bewertet werden. Bitte vor der echten Ausführung bestätigen."
+      generic: "Die Risikobewertung des Befehls konnte nicht abgeschlossen werden. Bitte vor der echten Ausführung bestätigen."
+    options_header: "Optionen"
+    option:
+      approve: "Genehmigen"
+      approve_remember: "Ja, und für diesen Befehl nicht erneut fragen"
+      cancel: "Abbrechen"
+    choice_prompt: "Ihre Auswahl (Standard: n): "
+
+  command_cancelled: "Befehl abgebrochen"
+  error_correction:
+    press_semicolon_hint: "Die Befehlsausführung ist fehlgeschlagen. Drücken Sie ;, um automatisch zu analysieren und zu reparieren, oder geben Sie direkt den nächsten Befehl ein."
+    corrected_command_label: "Vorgeschlagene Korrektur:"
+  error:
+    execution_error: "❌ Fehler während der Ausführung: {error}"
+    pty_decode_error: "PTY-Ausgabedekodierungsfehler abgefangen: {error}"
+    potential_error: "🚀 Mögliches Problem erkannt: {reason}, Lösung wird versucht..."
+    llm_error_title: "❌ LLM-Anfrage fehlgeschlagen"
+    llm_error_details_title: "Debug-Details"
+    tool_args_json_invalid_hint: "❌ Anfrage fehlgeschlagen, bitte erneut versuchen."
+  prompt:
+    confirm_execute: "?Diesen Befehl ausführen? [y/n]:"
+    ai_hint: "; verwenden, um die KI zu fragen"
+  model:
+    current: "Aktuelles Modell: {model}"
+    unset: "nicht gesetzt"
+    invalid: "Der Modellname darf nicht leer sein"
+    switching: "Modell wird validiert: {model}"
+    switch_same: "Modell unverändert: {model}"
+    switch_success: "Zu Modell gewechselt: {model}"
+    verify_failed: "Modellvalidierung fehlgeschlagen: {reason}"
+  setup:
+    no_config_manager: "Neukonfiguration nicht möglich: Konfigurationsmanager nicht verfügbar"
+    cancelled: "Einrichtung abgebrochen; aktuelle Einstellungen werden beibehalten"
+    applied: "Konfiguration aktualisiert, aktuelles Modell: {model}"
+  ask_user:
+    title: "Option auswählen"
+    custom_label: "Benutzerdefiniert:"
+    hint_select: "↑/↓ zum Bewegen • Enter zum Bestätigen • Esc zum Abbrechen"
+    hint_custom: "Zum Eingeben tippen • Enter zum Bestätigen • Tab zu den Optionen • Esc zum Abbrechen"
+    paused:
+      title: "⏸ Benutzereingabe erforderlich (Aufgabe pausiert)"
+      prompt: "Frage: {prompt}"
+      reason: "Grund: {reason}"
+      options_header: "Optionen:"
+      custom_input: "Sie können auch einen beliebigen benutzerdefinierten Wert eingeben."
+      how_to: "Antworten Sie mit einem Optionswert (oder einer Nummer) oder geben Sie ; continue with default ein (Standard: {default})."
+  diagnose_cancelled: "  └─ ❌ Systemdiagnose abgebrochen"
+  status:
+    thinking: "Denkt nach"
+    thinking_now: "Denkt nach"
+    processing: "Verarbeitet"
+    analyzing: "  Analysiert..."
+    system_diagnosing: "  └─ Systemdiagnose läuft"
+    system_analyzing: "  └─ Systemanalyse läuft"
+  tool:
+    prefix: "🔧 Verwende Tool"
+    prefix_diagnose: "  └─ 🔧 Diagnose-Tool"
+    done_diagnose: "  └─ ✅ Diagnose abgeschlossen"
+
+security:
+  sandbox_off_action:
+    confirm: "Bestätigung verlangen"
+  sandbox_unavailable:
+    title: "⚠️ Sandbox nicht verfügbar"
+    line1: "Die Sandbox ist nicht verfügbar; das Befehlsrisiko kann nicht bewertet werden."
+    line2: "Nachfolgende KI-generierte Befehle werden wie folgt behandelt: {action}."
+    policy_line1: "Die Sandbox ist per Richtlinie deaktiviert; es wurde kein Sandbox-Lauf ausgeführt."
+    policy_line2: "KI-generierte Befehle werden wie folgt behandelt: {action}."
+    reason: "Grund: {reason}"
+    error: "Fehler: {error}"
+    root_required: "Die Sandbox benötigt Root-Rechte"
+    ipc_unavailable: "Verbindung zum Sandbox-Dienst nicht möglich (aish-sandbox.socket läuft nicht oder ist nicht installiert)"
+    ipc_failed: "Ausführung des Sandbox-Dienstes fehlgeschlagen (aish-sandbox)"
+    sandbox_execute_failed: "Das Befehlsrisiko kann nicht bewertet werden; bitte vor der Ausführung bestätigen"
+  risk_reason:
+    sandbox_disabled_by_policy: "Die Sandbox ist per Richtlinie deaktiviert; Dateiveränderungen können für die Risikobewertung nicht geprüft werden. Aktion: {action}."
+    sandbox_disabled: "Die Sandbox ist nicht aktiviert oder ausgeschaltet; Dateiveränderungen können für die Risikobewertung nicht geprüft werden. Aktion: {action}."
+    cwd_outside_repo_root: "Das aktuelle Arbeitsverzeichnis {cwd} liegt außerhalb der Sandbox-Wurzel {root}; relative Seiteneffekte können nicht zuverlässig bewertet werden. Aktion: {action}."
+    sandbox_unavailable: "Initialisierung oder Ausführung der Sandbox fehlgeschlagen; Dateiveränderungen können für die Risikobewertung nicht geprüft werden. Aktion: {action}."
+    sandbox_exception: "Sandbox-Ausführungsfehler; Dateiveränderungen können für die Risikobewertung nicht geprüft werden. Aktion: {action}."
+    sandbox_failed: "Sandbox fehlgeschlagen; Dateiveränderungen können für die Risikobewertung nicht geprüft werden. Aktion: {action}."
+    policy_fallback_rule_match: "Bei deaktivierter Sandbox hat der Befehl {command} {count} Fallback-Regelpfade getroffen; Behandlung als {risk}-Risiko."
+  ai_risk:
+    no_fs_changes: "Die Sandbox hat keine Dateischreibvorgänge oder Löschungen erkannt."
+    high_hits: "Es wurden {count} Schreib-/Löschvorgänge erkannt, die hochriskante Regeln treffen."
+    medium_hits: "Es wurden {count} Schreib-/Löschvorgänge erkannt, die Regeln mittleren Risikos treffen."
+    low_or_unmatched_hits: "Es wurden {count} Schreib-/Löschvorgänge erkannt, die Regeln mit niedrigem Risiko treffen oder keiner Regel entsprechen."
+    preview_paths: "Beispielpfade (teilweise, können Verzeichnisse/Dateien enthalten): {paths}"
+  command_blocked: "Fehler: Befehl wurde vom Sicherheitssystem blockiert"
+  command_blocked_with_reason: "Fehler: Befehl wurde vom Sicherheitssystem blockiert: {reason}"
+
+tools:
+  smart_log:
+    description: "Ermittelt automatisch Log-Quellen, analysiert Protokolle anhand der Anfrage und gibt eine passende Zusammenfassung zurück."
+    param:
+      query: "Ihre Diagnoseanfrage, z. B. 'ist nginx korrekt konfiguriert' oder 'gibt es verdächtige Anmeldungen'."
+      path: "Optional. Log-Pfad (Datei/Verzeichnis) oder ein systemd-Unit-Name. Wenn nicht angegeben, wird er aus der Anfrage abgeleitet."
+    summary:
+      file: "[DATEI] {ident}: {matched}/{total} Zeilen passend\nBeispiel:\n{sample}"
+      dir: "[VERZ] {path}: {matched}/{total} Zeilen passend\nBeispiel:\n{sample}"
+      systemd: "[SYSTEMD] {ident}: {matched}/{total} Zeilen passend\nBeispiel:\n{sample}"
+      call_failed: "[{stype}] {ident}: Aufruf fehlgeschlagen\n{output}"
+    no_logs_found: "Keine Protokolle oder passenden Informationen gefunden."
+
+help:
+  labels:
+    usage: "Verwendung"
+    options: "Optionen"
+    examples: "Beispiele"
+    notes: "Hinweise"
+    brief_usage: "Verwendung: {usage}"
+  general:
+    title: "📖 AI Shell Hilfe"
+    markdown: |-
+      ## Verfügbare Befehle:
+
+      ### Verzeichnisnavigation
+      - `cd [-L|[-P [-e]]] [directory]` - Verzeichnis mit vollständiger Parameterunterstützung wechseln
+      - `pushd [directory]` - Verzeichnis auf den Stapel legen
+      - `popd` - Verzeichnis vom Stapel nehmen
+      - `dirs [-c]` - Verzeichnisstapel anzeigen
+
+      ### Verlauf
+      - `history [options] [n]` - Befehlsverlauf anzeigen
+      - `history -c` - Verlauf löschen
+      - `history -d offset` - Verlaufseintrag löschen
+
+      ### Umgebungsvariablen
+      - `export [-fn] [name[=value] ...]` - Umgebungsvariablen setzen oder exportieren
+      - `export -p` - Exportierte Variablen anzeigen
+      - `unset [-fv] [name ...]` - Umgebungsvariablen entfernen
+      - `pwd [-L|-P]` - Aktuelles Arbeitsverzeichnis ausgeben
+
+      ### Allgemeine Befehle
+      - `help` - Diese Hilfe anzeigen
+      - `clear` - Bildschirm löschen
+      - `exit` - Shell beenden
+      - `/model [model]` - Modell anzeigen oder wechseln
+      - `/setup` - API-Einstellungen neu konfigurieren
+
+      ### KI-Befehle
+      - `; <question>` - Den KI-Assistenten fragen
+
+      ### Funktionen
+      - ✅ Vollständige PTY-Unterstützung für alle Befehle
+      - ✅ Befehlsverlauf und KI-Kontextintegration
+      - ✅ Umfangreiche Terminalausgabe für KI-Antworten
+      - ✅ Signalbehandlung und sauberes Aufräumen
+
+      ### Weitere Hilfe
+      Verwenden Sie `<command> --help` oder `<command> -h`, um die detaillierte Hilfe für einen beliebigen Befehl anzuzeigen.
+
+      ### Beispiele
+      ```bash
+      history --help       # Detaillierte Hilfe zu history anzeigen
+      cd --help            # Detaillierte Hilfe zu cd anzeigen
+      export JAVA_HOME="/usr/lib/jvm/java-11"  # Umgebungsvariable setzen
+      unset TEMP_VAR       # Umgebungsvariable entfernen
+      ; erkläre ls -la     # KI um Erklärung eines Befehls bitten
+      ```
+
+  command:
+    history:
+      title: "📚 Verlauf"
+      description: "Befehlsverlauf anzeigen oder bearbeiten"
+      usage: "history [options] [n]"
+      options:
+        - ["--help, -h", "Diese Hilfe anzeigen"]
+        - ["-c", "Die Verlaufsliste leeren, indem alle Einträge gelöscht werden"]
+        - ["-d offset", "Den Verlaufseintrag an Position offset löschen"]
+        - ["n", "Nur die letzten n Befehle anzeigen"]
+      examples:
+        - "history              # Gesamten Befehlsverlauf anzeigen"
+        - "history 10           # Die letzten 10 Befehle anzeigen"
+        - "history -c           # Gesamten Verlauf löschen"
+        - "history -d 5         # Verlaufseintrag an Position 5 löschen"
+        - "history --help       # Diese Hilfe anzeigen"
+      notes: "Verlaufseinträge werden für alle ausgeführten Befehle und KI-Interaktionen automatisch aufgezeichnet."
+
+    cd:
+      title: "📁 Verzeichnis wechseln"
+      description: "Das aktuelle Arbeitsverzeichnis mit vollständiger Parameterunterstützung ändern"
+      usage: "cd [-L|[-P [-e]]] [directory]"
+      options:
+        - ["-L", "Symbolische Links verfolgen: Symlinks nach der Verarbeitung von '..' auflösen (Standard)"]
+        - ["-P", "Physische Verzeichnisstruktur ohne Verfolgen symbolischer Links verwenden: Symlinks vor der Verarbeitung von '..' auflösen"]
+        - ["-e", "Falls -P angegeben ist und das aktuelle Arbeitsverzeichnis nicht ermittelt werden kann, mit einem Fehlerstatus beenden"]
+        # - ["-@", "Auf Systemen mit Unterstützung Dateien mit erweiterten Attributen als Attribut-Verzeichnisse darstellen"]
+        - ["directory", "Zielpfad des Verzeichnisses (optional, standardmäßig das Home-Verzeichnis)"]
+        - ["-", "Zum vorherigen Verzeichnis zurückkehren"]
+      examples:
+        - "cd ~                 # Zum Home-Verzeichnis wechseln"
+        - "cd /tmp              # In das Verzeichnis /tmp wechseln"
+        - "cd -                 # Zum vorherigen Verzeichnis zurückkehren"
+        - "cd \"path with spaces\" # Anführungszeichen für Pfade mit Leerzeichen verwenden"
+        - "cd -P /tmp           # Physische Pfadauflösung verwenden"
+        - "cd -P -e /tmp        # Physische Pfadauflösung verwenden und bei Fehler abbrechen"
+        - "cd -L /tmp           # Symbolische Links verfolgen (Standardverhalten)"
+        # - "cd -@ /tmp           # Erweiterte Attribute anzeigen (falls unterstützt)"
+      notes: "Unterstützt Tab-Vervollständigung und den Umgang mit Pfaden mit Sonderzeichen. Das Standardverhalten folgt symbolischen Links (-L)."
+
+    pushd:
+      title: "📤 Verzeichnis auf Stack legen"
+      description: "Ein Verzeichnis auf den Stack legen und dorthin wechseln"
+      usage: "pushd [directory]"
+      options:
+        - ["directory", "Zielpfad des Verzeichnisses"]
+        - ["(no args)", "Die obersten zwei Verzeichnisse auf dem Stack tauschen"]
+      examples:
+        - "pushd /tmp           # Aktuelles Verzeichnis auf den Stack legen und nach /tmp wechseln"
+        - "pushd                # Zwischen aktuellem und vorherigem Verzeichnis wechseln"
+      notes: "Pflegt einen Verzeichnis-Stack für eine einfache Navigation zwischen mehreren Verzeichnissen."
+
+    popd:
+      title: "📥 Verzeichnis vom Stack holen"
+      description: "Ein Verzeichnis vom Stack nehmen und dorthin wechseln"
+      usage: "popd"
+      options: []
+      examples:
+        - "popd                 # Zum vorherigen Verzeichnis vom Stack zurückkehren"
+      notes: "Entfernt das oberste Verzeichnis vom Stack und wechselt dorthin."
+
+    dirs:
+      title: "📋 Verzeichnis-Stack anzeigen"
+      description: "Den Verzeichnis-Stack anzeigen"
+      usage: "dirs [-c]"
+      options:
+        - ["-c", "Den Verzeichnis-Stack leeren"]
+      examples:
+        - "dirs                 # Aktuellen Verzeichnis-Stack anzeigen"
+        - "dirs -c              # Verzeichnis-Stack leeren"
+      notes: "Zeigt alle Verzeichnisse an, die sich aktuell auf dem Navigations-Stack befinden."
+
+    help:
+      title: "❓ Hilfe"
+      description: "Verfügbare Befehle und Funktionen anzeigen"
+      usage: "help"
+      options: []
+      examples:
+        - "help                 # Allgemeine Hilfe anzeigen"
+      notes: "Gibt einen Überblick über alle verfügbaren Befehle und Shell-Funktionen."
+
+    clear:
+      title: "🧹 Bildschirm leeren"
+      description: "Den Terminalbildschirm leeren"
+      usage: "clear"
+      options: []
+      examples:
+        - "clear                # Den Terminalbildschirm leeren"
+      notes: "Entspricht dem standardmäßigen Unix-Befehl clear."
+
+    exit:
+      title: "🚪 Shell beenden"
+      description: "Die AI Shell beenden"
+      usage: "exit"
+      options: []
+      examples:
+        - "exit                 # Die Shell beenden"
+        - "quit                 # Alternative Methode zum Beenden"
+      notes: "Beendet die Shell sauber und bewahrt Sitzungsdaten."
+
+    export:
+      title: "🔧 Umgebungsvariablen exportieren"
+      description: "Umgebungsvariablen mit Export-Attribut setzen oder anzeigen"
+      usage: "export [-fn] [name[=value] ...]\nexport -p"
+      options:
+        - ["-f", "Name verweist auf eine Shell-Funktion (nicht unterstützt)"]
+        - ["-n", "Export-Attribut von jedem Namen entfernen"]
+        - ["-p", "Liste aller exportierten Variablen anzeigen"]
+        - ["--", "Weitere Optionsverarbeitung deaktivieren"]
+      examples:
+        - "export PATH=/usr/local/bin:$PATH"
+        - "export EDITOR=vim"
+        - "export -n VAR  # Export-Attribut von VAR entfernen"
+        - "export -p      # Alle exportierten Variablen anzeigen"
+        - "export JAVA_HOME=\"/usr/lib/jvm/java-11-openjdk\""
+        - "export -- -VAR  # Variable mit dem Namen -VAR setzen"
+      notes: "Mit export gesetzte Umgebungsvariablen werden an Kindprozesse weitergegeben."
+
+    unset:
+      title: "🗑️ Umgebungsvariablen entfernen"
+      description: "Shell-Variablen und Funktionen entfernen"
+      usage: "unset [-f] [-v] [-n] [name ...]"
+      options:
+        - ["-f", "Jeder Name verweist auf eine Shell-Funktion (nicht unterstützt)"]
+        - ["-v", "Jeder Name verweist auf eine Shell-Variable (Standard)"]
+        - ["-n", "Jeder Name verweist auf eine Namensreferenz (nicht unterstützt)"]
+        - ["--", "Weitere Optionsverarbeitung deaktivieren"]
+      examples:
+        - "unset TEMP_VAR"
+        - "unset -v VAR1 VAR2"
+        - "unset JAVA_HOME"
+        - "unset -- -VAR  # Variable mit dem Namen -VAR entfernen"
+      notes: "Entfernt Variablen aus der Shell-Umgebung. Nicht vorhandene Variablen werden ignoriert."
+
+    pwd:
+      title: "📍 Arbeitsverzeichnis ausgeben"
+      description: "Das aktuelle Arbeitsverzeichnis mit Symlink-Behandlung ausgeben"
+      usage: "pwd [-L|-P]"
+      options:
+        - ["-L", "Logischen Pfad anzeigen (Symlinks folgen, Standard)"]
+        - ["-P", "Physischen Pfad anzeigen (Symlinks auflösen)"]
+      examples:
+        - "pwd                  # Logisches aktuelles Verzeichnis anzeigen"
+        - "pwd -L               # Logischen Pfad anzeigen (Symlinks beachten)"
+        - "pwd -P               # Physischen Pfad anzeigen (Symlinks auflösen)"
+      notes: "Das Standardverhalten zeigt den logischen Pfad an und berücksichtigt symbolische Links."
+
+    ";":
+      title: "🤖 KI-Assistent"
+      description: "Dem KI-Assistenten eine Frage stellen"
+      usage: "; <question>"
+      options:
+        - ["question", "Ihre Frage an den KI-Assistenten"]
+      examples:
+        - "; wie finde ich große Dateien?"
+        - "; erkläre diesen Befehl: ls -la"
+        - "; schlage eine bessere Methode zum Komprimieren von Dateien vor"
+      notes: "Der KI-Assistent kann bei Befehlserklärungen, Vorschlägen und allgemeiner Shell-Nutzung helfen."
+
+    "；":
+      title: "🤖 KI-Assistent"
+      description: "Dem KI-Assistenten eine Frage stellen"
+      usage: "； <question>"
+      options:
+        - ["question", "Ihre Frage an den KI-Assistenten"]
+      examples:
+        - "； wie finde ich große Dateien?"
+        - "； erkläre diesen Befehl: ls -la"
+        - "； schlage eine bessere Methode zum Komprimieren von Dateien vor"
+      notes: "Der KI-Assistent kann bei Befehlserklärungen, Vorschlägen und allgemeiner Shell-Nutzung helfen."
+
+    "/model":
+      title: "🧠 Modell wechseln"
+      description: "Das aktuelle Modell anzeigen oder zu einem angegebenen Modell wechseln"
+      usage: "/model [model]"
+      options:
+        - ["model", "Zielmodellkennung (wird auf Tool-Call-Unterstützung geprüft)"]
+        - ["--help, -h", "Diese Hilfe anzeigen"]
+      examples:
+        - "/model               # Aktuelles Modell anzeigen"
+        - "/model gpt-4         # Zu einem Modell wechseln"
+        - "/model --help        # Hilfe anzeigen"
+      notes: "Beim Wechsel werden Konnektivität und Tool-Call-Unterstützung geprüft; bei Fehlern bleibt das aktuelle Modell erhalten."
+
+    "/setup":
+      title: "⚙️ Neu konfigurieren"
+      description: "Den interaktiven Einrichtungsassistenten erneut ausführen, um API-Einstellungen zu ändern (Provider, API-Key, Modell)"
+      usage: "/setup"
+      options:
+        - ["--help, -h", "Diese Hilfe anzeigen"]
+      examples:
+        - "/setup               # Einrichtungsassistent starten"
+        - "/setup --help        # Hilfe anzeigen"
+      notes: "Neue Einstellungen werden sofort ohne Neustart angewendet. Ein Abbruch behält die aktuelle Konfiguration bei."
+
+errors:
+  litellm_not_installed: "Das Modul litellm ist nicht installiert"

--- a/src/aish/i18n/en-US.yaml
+++ b/src/aish/i18n/en-US.yaml
@@ -33,7 +33,6 @@ cli:
     provider_custom_api_base_required: "API Base is required"
     provider_custom_api_base_invalid: "Invalid API Base URL"
     provider_custom_default: "Custom"
-    prompt_select: "Enter a number, type to filter, or q to quit"
     invalid_choice: "Invalid selection"
     filter_no_results: "No matches. Try again or press Enter to show all."
     api_key_header: "Enter your API key (it will be saved to config)"
@@ -152,12 +151,9 @@ shell:
       content_preview: "Content Preview"
       fallback_hint: "Note"
       risk_level: "Risk Level"
-      matched_rule: "Matched Rule"
-      matched_paths: "Matched Paths"
       reasons: "Reasons"
       alternatives: "Alternatives"
       impact: "Impact"
-      confirm_message: "Confirmation Message"
       no_additional_info: "No additional information provided."
 
     fallback:
@@ -234,9 +230,7 @@ shell:
 
 security:
   sandbox_off_action:
-    allow: "Allow"
     confirm: "Require confirmation"
-    block: "Block"
 
   sandbox_unavailable:
     title: "⚠️ Sandbox Unavailable"

--- a/src/aish/i18n/es-ES.yaml
+++ b/src/aish/i18n/es-ES.yaml
@@ -1,0 +1,519 @@
+cli:
+  app_help: "AI Shell - Un shell con capacidades de LLM integradas"
+  help_option_help: "Muestra este mensaje y sale."
+  run_command_help: "Ejecutar AI Shell"
+  info_command_help: "Mostrar información sobre AI Shell"
+  check_langfuse_command_help: "Comprobar la configuración de Langfuse"
+  setup_command_help: "Ejecutar la configuración interactiva y salir"
+  check_tool_support_command_help: "Depurar la comprobación en vivo de soporte de llamadas a herramientas"
+
+  option:
+    model: "Modelo LLM que se va a usar; también puede definirse mediante AISH_MODEL o el archivo de configuración."
+    api_key: "Clave API del proveedor LLM; también puede definirse mediante AISH_API_KEY o variables de entorno del proveedor."
+    api_base: "URL base de la API del proveedor LLM; también puede definirse mediante AISH_API_BASE o el archivo de configuración."
+    config: "Ruta al archivo de configuración (predeterminada: ~/.config/aish/config.yaml)."
+
+  setup:
+    step_provider: "Paso 1/3: Elegir proveedor"
+    step_provider_endpoint: "Paso 1.5/3: Elegir endpoint"
+    step_key: "Paso 2/3: Introducir la clave API"
+    step_model: "Paso 3/3: Elegir modelo"
+    provider_header: "Elige un proveedor (escribe para filtrar)"
+    provider_filter_prompt: "Filtro:"
+    provider_filter_hint: "Escribe para filtrar, usa ↑/↓ para seleccionar, Enter para confirmar y Esc para cancelar."
+    provider_selected_label: "Proveedor"
+    provider_endpoint_selected_label: "Endpoint"
+    provider_endpoint_header: "Elegir endpoint de API para {provider}"
+    model_selected_label: "Modelo"
+    provider_custom_note: "Compatible con OpenAI"
+    provider_preset_base: "API Base predefinida"
+    custom_api_base_title: "URL base de la API"
+    custom_api_base_header: "Introduce la URL base de la API."
+    provider_custom_api_base: "URL base de la API"
+    provider_custom_api_base_required: "La API Base es obligatoria"
+    provider_custom_api_base_invalid: "URL base de API no válida"
+    provider_custom_default: "Personalizado"
+    invalid_choice: "Selección no válida"
+    filter_no_results: "No hay coincidencias. Inténtalo de nuevo o pulsa Enter para mostrar todo."
+    api_key_header: "Introduce tu clave API (se guardará en la configuración)"
+    api_key_env_found: "Detectado {env_key}: {masked}"
+    api_key_env_hint: "Pulsa Enter para usar la clave detectada o escribe una nueva."
+    api_key_prompt: "Clave API"
+    api_key_required: "La clave API es obligatoria"
+    model_header: "Proveedor: {provider}"
+    model_prompt: "Nombre del modelo (escribe back para cambiar de proveedor)"
+    model_hint_openrouter: "OpenRouter requiere un prefijo de proveedor, por ejemplo openai/gpt-4o. Si se omite, se usará openai/ por defecto."
+    model_hint_custom: "Los proveedores personalizados se tratan como compatibles con OpenAI. Si omites el prefijo, se guardará como openai/<model>."
+    model_hint_provider: "Recomendado: {default}"
+    model_list_unavailable: "La lista de modelos no está disponible; introdúcela manualmente"
+    model_filtering: "Filtrando modelos con soporte para llamadas a herramientas"
+    model_filter_result: "Filtrado a {count} modelos compatibles con llamadas a herramientas"
+    model_filter_empty: "Ningún modelo superó el filtro de llamadas a herramientas; se mostrará la lista completa"
+    model_filter_prompt: "Filtro:"
+    model_filter_hint: "Escribe para filtrar, usa ↑/↓ para seleccionar, Enter para confirmar y Esc para volver. Selecciona Modelo personalizado para introducirlo manualmente."
+    model_custom_option: "Modelo personalizado..."
+    model_custom_required: "El nombre del modelo es obligatorio"
+    model_custom_saved_as: "Se guardará como: {model}"
+    verify_title: "Verificación"
+    verify_header: "Verificando el soporte de llamadas a herramientas..."
+    verify_connectivity_in_progress: "Comprobando la conectividad..."
+    verify_tool_in_progress: "Comprobando el soporte de herramientas..."
+    verify_static_no_tool_support: "El modelo no admite llamadas a herramientas (comprobación estática)"
+    verify_simple_success: "Verificación correcta"
+    verify_simple_failed_with_reason: "Verificación fallida: {reason}"
+    verify_failed_unknown: "error desconocido"
+    verify_live_label: "Comprobación en vivo"
+    verify_live_detail: "Detalles"
+    verify_timeout: "La verificación en vivo agotó el tiempo"
+    verify_cancelled: "Verificación en vivo cancelada"
+    verify_no_tool_call_required: "No se devolvió ninguna llamada a herramienta (modo obligatorio)"
+    verify_no_tool_call_auto: "El modelo no llamó a ninguna herramienta en modo automático"
+    debug_request_title: "Solicitud en vivo ({mode})"
+    debug_response_title: "Respuesta en vivo ({mode})"
+    debug_error_title: "Error en vivo ({mode})"
+    support_yes: "Compatible"
+    support_no: "No compatible"
+    support_unknown: "Desconocido"
+    litellm_missing: "litellm no está instalado; se omite la verificación"
+    action_header: "Siguiente acción:"
+    action_prompt: "Elige una opción"
+    action_retry_model: "Elegir otro modelo"
+    action_retry_api_base: "Volver a introducir la API Base"
+    action_retry_api_key: "Volver a introducir la clave API"
+    action_change_provider: "Cambiar proveedor"
+    action_continue: "Continuar de todos modos (no recomendado)"
+    action_exit: "Salir de la configuración"
+    retry_api_base_prompt: "Introduce la API Base (back para volver)"
+    retry_api_base_prompt_with_current: "Introduce la API Base (actual: {current}, back para volver)"
+    retry_api_base_required: "La API Base es obligatoria"
+    saved: "Configuración guardada"
+    saved_with_warning: "Configuración guardada (la llamada a herramientas no se verificó)"
+    non_interactive: "Entorno no interactivo; no se puede ejecutar la configuración"
+    cancelled: "Configuración cancelada"
+    required_cancelled: "Falta configuración obligatoria; saliendo"
+
+  startup:
+    label:
+      skills: "   Skills"
+    goodbye: "👋 ¡Adiós!"
+    config_file_error: "❌ Error en el archivo de configuración: {error}"
+    config_file_hint: "💡 Usa --config para indicar una ruta válida del archivo de configuración"
+
+  langfuse:
+    incomplete: "⚠️  La configuración de Langfuse está incompleta"
+    missing: "   Falta: {var}"
+    complete: "✅ La configuración de Langfuse está completa"
+    script_failed: "El script de comprobación de Langfuse falló: {error}"
+    script_not_found: "No se encontró el script check_langfuse.py"
+    run_from_root: "Asegúrate de ejecutar este comando desde la raíz del proyecto"
+
+  parse_errors:
+    title: "Error"
+    option_requires_argument: "La opción {option} requiere un argumento."
+    no_such_option: "No existe la opción: {option}"
+    missing_parameter: "Falta el parámetro: {param}"
+    invalid_value_for_option: "Valor no válido para {option}: {reason}"
+    generic: "Argumentos no válidos: {message}"
+
+shell:
+  welcome2:
+    header: ">_ AI Shell {version}"
+    model_hint: "(escribe /model para cambiar)"
+    label:
+      model: "modelo"
+      config: "config"
+    quick_start:
+      title: " Inicio rápido:"
+      item1_prefix: "Comandos nativos del shell: "
+      cmd_ls: "ls"
+      cmd_top: "top"
+      cmd_vim: "vim"
+      cmd_ssh: "ssh"
+      item1_suffix: " etc."
+      item2_prefix: "Pregunta a la IA: "
+      item2_example: "Empieza con ;, por ejemplo ; como encontrar archivos grandes"
+      item3_prefix: "Obtener ayuda:"
+      item3_suffix_1: "Escribe "
+      item3_keyword: "help"
+      item3_suffix_2: " para ver la ayuda integrada y el uso."
+    risk: "El contenido generado por IA puede ser arriesgado; verificalo con cuidado."
+    skills_loaded_suffix: " cargadas"
+
+  security:
+    title:
+      blocked: "🛑 Bloqueado por seguridad: {tool}"
+      notice: "🔐 Aviso de seguridad: {tool}"
+      confirm: "🔐 Confirmación requerida: {tool}"
+    label:
+      description: "Descripción"
+      command: "Comando"
+      target: "Objetivo"
+      content_preview: "Vista previa del contenido"
+      fallback_hint: "Nota"
+      risk_level: "Nivel de riesgo"
+      reasons: "Motivos"
+      alternatives: "Alternativas"
+      impact: "Impacto"
+      no_additional_info: "No se proporcionó información adicional."
+    fallback:
+      sandbox_execute_failed: "La preejecución del comando falló, por lo que no se puede evaluar el riesgo. Confirma antes de ejecutar el comando real."
+      sandbox_timeout: "La preejecución del comando agotó el tiempo, por lo que no se puede evaluar el riesgo. Confirma antes de ejecutar el comando real."
+      sandbox_ipc_timeout: "Se agotó el tiempo esperando la preevaluación del comando, por lo que no se puede evaluar el riesgo. Confirma antes de ejecutar el comando real."
+      generic: "No se pudo completar la evaluación de riesgo del comando. Confirma antes de ejecutar el comando real."
+    options_header: "Opciones"
+    option:
+      approve: "Aprobar"
+      approve_remember: "Sí, y no volver a preguntar por este comando"
+      cancel: "Cancelar"
+    choice_prompt: "Tu elección (predeterminado: n): "
+
+  command_cancelled: "Comando cancelado"
+  error_correction:
+    press_semicolon_hint: "La ejecución del comando falló. Pulsa ; para analizar y reparar automáticamente, o introduce el siguiente comando."
+    corrected_command_label: "Corrección sugerida:"
+  error:
+    execution_error: "❌ Error durante la ejecución: {error}"
+    pty_decode_error: "Error al decodificar la salida PTY: {error}"
+    potential_error: "🚀 Posible problema detectado: {reason}; intentando resolverlo..."
+    llm_error_title: "❌ Falló la solicitud al LLM"
+    llm_error_details_title: "Detalles de depuración"
+    tool_args_json_invalid_hint: "❌ La solicitud falló; inténtalo de nuevo."
+  prompt:
+    confirm_execute: "?¿Ejecutar este comando? [y/n]:"
+    ai_hint: "Usa ; para preguntar a la IA"
+  model:
+    current: "Modelo actual: {model}"
+    unset: "sin definir"
+    invalid: "El nombre del modelo no puede estar vacío"
+    switching: "Validando el modelo: {model}"
+    switch_same: "El modelo no ha cambiado: {model}"
+    switch_success: "Se cambió al modelo: {model}"
+    verify_failed: "Falló la validación del modelo: {reason}"
+  setup:
+    no_config_manager: "No se puede reconfigurar: el gestor de configuración no está disponible"
+    cancelled: "Configuración cancelada; se conservan los ajustes actuales"
+    applied: "Configuración actualizada; modelo actual: {model}"
+  ask_user:
+    title: "Selecciona una opción"
+    custom_label: "Personalizado:"
+    hint_select: "↑/↓ para moverte • Enter para confirmar • Esc para cancelar"
+    hint_custom: "Escribe para introducir un valor • Enter para confirmar • Tab para ir a las opciones • Esc para cancelar"
+    paused:
+      title: "⏸ Se requiere entrada del usuario (tarea en pausa)"
+      prompt: "Pregunta: {prompt}"
+      reason: "Motivo: {reason}"
+      options_header: "Opciones:"
+      custom_input: "También puedes responder con cualquier valor personalizado."
+      how_to: "Responde con un valor de opción (o un número), o escribe ; continue with default (predeterminado: {default})."
+  diagnose_cancelled: "  └─ ❌ Diagnóstico del sistema cancelado"
+  status:
+    thinking: "Pensando"
+    thinking_now: "Pensando"
+    processing: "Procesando"
+    analyzing: "  Analizando..."
+    system_diagnosing: "  └─ Diagnóstico del sistema en curso"
+    system_analyzing: "  └─ Análisis del sistema en curso"
+  tool:
+    prefix: "🔧 Usando herramienta"
+    prefix_diagnose: "  └─ 🔧 Herramienta de diagnóstico"
+    done_diagnose: "  └─ ✅ Diagnóstico completado"
+
+security:
+  sandbox_off_action:
+    confirm: "Requerir confirmación"
+  sandbox_unavailable:
+    title: "⚠️ Sandbox no disponible"
+    line1: "El sandbox no está disponible; no se puede evaluar el riesgo del comando."
+    line2: "Los comandos generados por IA a continuación se tratarán como: {action}."
+    policy_line1: "El sandbox está desactivado por política; no se realizó ninguna ejecución en sandbox."
+    policy_line2: "Los comandos generados por IA se tratarán como: {action}."
+    reason: "Motivo: {reason}"
+    error: "Error: {error}"
+    root_required: "El sandbox requiere privilegios de root"
+    ipc_unavailable: "No se puede conectar con el servicio sandbox (aish-sandbox.socket no se está ejecutando o no está instalado)"
+    ipc_failed: "Falló la ejecución del servicio sandbox (aish-sandbox)"
+    sandbox_execute_failed: "No se puede evaluar el riesgo del comando; confirma antes de ejecutarlo"
+  risk_reason:
+    sandbox_disabled_by_policy: "El sandbox está desactivado por política; no se pueden inspeccionar cambios de archivos para evaluar el riesgo. Acción: {action}."
+    sandbox_disabled: "El sandbox no está habilitado o está desactivado; no se pueden inspeccionar cambios de archivos para evaluar el riesgo. Acción: {action}."
+    cwd_outside_repo_root: "El directorio actual {cwd} está fuera de la raíz del sandbox {root}; no se pueden evaluar de forma fiable los efectos relativos. Acción: {action}."
+    sandbox_unavailable: "La inicialización o ejecución del sandbox falló; no se pueden inspeccionar cambios de archivos para evaluar el riesgo. Acción: {action}."
+    sandbox_exception: "Error de ejecución en el sandbox; no se pueden inspeccionar cambios de archivos para evaluar el riesgo. Acción: {action}."
+    sandbox_failed: "El sandbox falló; no se pueden inspeccionar cambios de archivos para evaluar el riesgo. Acción: {action}."
+    policy_fallback_rule_match: "Con el sandbox desactivado por política, el comando {command} coincidió con {count} rutas de reglas de respaldo; se tratará como riesgo {risk}."
+  ai_risk:
+    no_fs_changes: "El sandbox no detectó escrituras ni eliminaciones de archivos."
+    high_hits: "Se detectaron {count} operaciones de escritura o borrado que coinciden con reglas de alto riesgo."
+    medium_hits: "Se detectaron {count} operaciones de escritura o borrado que coinciden con reglas de riesgo medio."
+    low_or_unmatched_hits: "Se detectaron {count} operaciones de escritura o borrado con riesgo bajo o sin coincidencia."
+    preview_paths: "Rutas de ejemplo (parciales, pueden incluir directorios o archivos): {paths}"
+  command_blocked: "Error: el comando fue bloqueado por el sistema de seguridad"
+  command_blocked_with_reason: "Error: el comando fue bloqueado por el sistema de seguridad: {reason}"
+
+tools:
+  smart_log:
+    description: "Determina automáticamente las fuentes de registros, analiza los logs según la consulta y devuelve un resumen coincidente."
+    param:
+      query: "Tu consulta de diagnóstico, por ejemplo 'nginx está bien configurado' o 'hay inicios de sesión sospechosos'."
+      path: "Opcional. Ruta del log (archivo/directorio) o nombre de una unidad systemd. Si se omite, se inferirá a partir de la consulta."
+    summary:
+      file: "[ARCHIVO] {ident}: {matched}/{total} líneas coincidentes\nMuestra:\n{sample}"
+      dir: "[DIR] {path}: {matched}/{total} líneas coincidentes\nMuestra:\n{sample}"
+      systemd: "[SYSTEMD] {ident}: {matched}/{total} líneas coincidentes\nMuestra:\n{sample}"
+      call_failed: "[{stype}] {ident}: llamada fallida\n{output}"
+    no_logs_found: "No se encontraron registros ni información coincidente."
+
+help:
+  labels:
+    usage: "Uso"
+    options: "Opciones"
+    examples: "Ejemplos"
+    notes: "Notas"
+    brief_usage: "Uso: {usage}"
+  general:
+    title: "📖 Ayuda de AI Shell"
+    markdown: |-
+      ## Comandos disponibles:
+
+      ### Navegación por directorios
+      - `cd [-L|[-P [-e]]] [directory]` - Cambiar de directorio con soporte completo de parámetros
+      - `pushd [directory]` - Apilar un directorio
+      - `popd` - Sacar un directorio de la pila
+      - `dirs [-c]` - Mostrar la pila de directorios
+
+      ### Historial
+      - `history [options] [n]` - Mostrar el historial de comandos
+      - `history -c` - Borrar el historial
+      - `history -d offset` - Eliminar una entrada del historial
+
+      ### Variables de entorno
+      - `export [-fn] [name[=value] ...]` - Establecer o exportar variables de entorno
+      - `export -p` - Mostrar variables exportadas
+      - `unset [-fv] [name ...]` - Eliminar variables de entorno
+      - `pwd [-L|-P]` - Mostrar el directorio de trabajo actual
+
+      ### Comandos generales
+      - `help` - Mostrar esta ayuda
+      - `clear` - Limpiar la pantalla
+      - `exit` - Salir del shell
+      - `/model [model]` - Mostrar o cambiar el modelo
+      - `/setup` - Reconfigurar la API
+
+      ### Comandos de IA
+      - `; <question>` - Preguntar al asistente de IA
+
+      ### Funciones
+      - ✅ Soporte PTY completo para todos los comandos
+      - ✅ Integración del historial de comandos con el contexto de IA
+      - ✅ Salida enriquecida para respuestas de IA
+      - ✅ Manejo de señales y limpieza ordenada
+
+      ### Más ayuda
+      Usa `<command> --help` o `<command> -h` para ver la ayuda detallada de cualquier comando.
+
+      ### Ejemplos
+      ```bash
+      history --help       # Mostrar ayuda detallada de history
+      cd --help            # Mostrar ayuda detallada de cd
+      export JAVA_HOME="/usr/lib/jvm/java-11"  # Establecer una variable de entorno
+      unset TEMP_VAR       # Eliminar una variable de entorno
+      ; explica ls -la     # Pedir a la IA que explique un comando
+      ```
+
+  command:
+    history:
+      title: "📚 Historial"
+      description: "Mostrar o manipular el historial de comandos"
+      usage: "history [options] [n]"
+      options:
+        - ["--help, -h", "Mostrar este mensaje de ayuda"]
+        - ["-c", "Borrar la lista del historial eliminando todas las entradas"]
+        - ["-d offset", "Eliminar la entrada del historial en la posición offset"]
+        - ["n", "Mostrar solo los últimos n comandos"]
+      examples:
+        - "history              # Mostrar todo el historial de comandos"
+        - "history 10           # Mostrar los últimos 10 comandos"
+        - "history -c           # Borrar todo el historial"
+        - "history -d 5         # Eliminar la entrada del historial en la posición 5"
+        - "history --help       # Mostrar este mensaje de ayuda"
+      notes: "Las entradas del historial se registran automáticamente para todos los comandos ejecutados y las interacciones con la IA."
+
+    cd:
+      title: "📁 Cambiar directorio"
+      description: "Cambiar el directorio de trabajo actual con soporte completo de parámetros"
+      usage: "cd [-L|[-P [-e]]] [directory]"
+      options:
+        - ["-L", "Forzar el seguimiento de enlaces simbólicos: resolver enlaces simbólicos después de procesar las apariciones de '..' (predeterminado)"]
+        - ["-P", "Usar la estructura física de directorios sin seguir enlaces simbólicos: resolver enlaces simbólicos antes de procesar las apariciones de '..'"]
+        - ["-e", "Si se proporciona la opción -P y no se puede determinar el directorio de trabajo actual, salir con un estado distinto de cero"]
+        # - ["-@", "En sistemas compatibles, mostrar archivos con atributos extendidos como directorios que contienen atributos de archivo"]
+        - ["directory", "Ruta del directorio de destino (opcional; por defecto, el directorio personal)"]
+        - ["-", "Volver al directorio anterior"]
+      examples:
+        - "cd ~                 # Cambiar al directorio personal"
+        - "cd /tmp              # Cambiar al directorio /tmp"
+        - "cd -                 # Volver al directorio anterior"
+        - "cd \"path with spaces\" # Usar comillas para rutas con espacios"
+        - "cd -P /tmp           # Usar resolución física de rutas"
+        - "cd -P -e /tmp        # Usar resolución física de rutas y salir si hay error"
+        - "cd -L /tmp           # Forzar el seguimiento de enlaces simbólicos (comportamiento predeterminado)"
+        # - "cd -@ /tmp           # Mostrar atributos extendidos (si se admite)"
+      notes: "Admite autocompletado con Tab y manejo de rutas con caracteres especiales. El comportamiento predeterminado sigue enlaces simbólicos (-L)."
+
+    pushd:
+      title: "📤 Apilar directorio"
+      description: "Poner un directorio en la pila y cambiar a él"
+      usage: "pushd [directory]"
+      options:
+        - ["directory", "Ruta del directorio de destino"]
+        - ["(no args)", "Intercambiar los dos directorios superiores de la pila"]
+      examples:
+        - "pushd /tmp           # Poner el directorio actual en la pila e ir a /tmp"
+        - "pushd                # Intercambiar entre el directorio actual y el anterior"
+      notes: "Mantiene una pila de directorios para navegar con facilidad entre varios directorios."
+
+    popd:
+      title: "📥 Sacar directorio de la pila"
+      description: "Extraer un directorio de la pila y cambiar a él"
+      usage: "popd"
+      options: []
+      examples:
+        - "popd                 # Volver al directorio anterior desde la pila"
+      notes: "Elimina el directorio superior de la pila y cambia a él."
+
+    dirs:
+      title: "📋 Mostrar pila de directorios"
+      description: "Mostrar la pila de directorios"
+      usage: "dirs [-c]"
+      options:
+        - ["-c", "Borrar la pila de directorios"]
+      examples:
+        - "dirs                 # Mostrar la pila de directorios actual"
+        - "dirs -c              # Borrar la pila de directorios"
+      notes: "Muestra todos los directorios que están actualmente en la pila de navegación."
+
+    help:
+      title: "❓ Ayuda"
+      description: "Mostrar los comandos y funciones disponibles"
+      usage: "help"
+      options: []
+      examples:
+        - "help                 # Mostrar información de ayuda general"
+      notes: "Ofrece una visión general de todos los comandos y funciones disponibles del shell."
+
+    clear:
+      title: "🧹 Limpiar pantalla"
+      description: "Limpiar la pantalla del terminal"
+      usage: "clear"
+      options: []
+      examples:
+        - "clear                # Limpiar la pantalla del terminal"
+      notes: "Equivale al comando estándar clear de Unix."
+
+    exit:
+      title: "🚪 Salir del shell"
+      description: "Salir de AI Shell"
+      usage: "exit"
+      options: []
+      examples:
+        - "exit                 # Salir del shell"
+        - "quit                 # Forma alternativa de salir"
+      notes: "Sale del shell limpiamente y conserva los datos de la sesión."
+
+    export:
+      title: "🔧 Exportar variables de entorno"
+      description: "Establecer o mostrar variables de entorno con atributos de exportación"
+      usage: "export [-fn] [name[=value] ...]\nexport -p"
+      options:
+        - ["-f", "El nombre hace referencia a una función del shell (no compatible)"]
+        - ["-n", "Quitar el atributo de exportación de cada nombre"]
+        - ["-p", "Mostrar la lista de todas las variables exportadas"]
+        - ["--", "Desactivar el procesamiento posterior de opciones"]
+      examples:
+        - "export PATH=/usr/local/bin:$PATH"
+        - "export EDITOR=vim"
+        - "export -n VAR  # Quitar el atributo de exportación de VAR"
+        - "export -p      # Mostrar todas las variables exportadas"
+        - "export JAVA_HOME=\"/usr/lib/jvm/java-11-openjdk\""
+        - "export -- -VAR  # Establecer una variable llamada -VAR"
+      notes: "Las variables de entorno definidas con export se pasan a los procesos hijos."
+
+    unset:
+      title: "🗑️ Eliminar variables de entorno"
+      description: "Eliminar variables y funciones del shell"
+      usage: "unset [-f] [-v] [-n] [name ...]"
+      options:
+        - ["-f", "Cada nombre hace referencia a una función del shell (no compatible)"]
+        - ["-v", "Cada nombre hace referencia a una variable del shell (predeterminado)"]
+        - ["-n", "Cada nombre hace referencia a una referencia de nombre (no compatible)"]
+        - ["--", "Desactivar el procesamiento posterior de opciones"]
+      examples:
+        - "unset TEMP_VAR"
+        - "unset -v VAR1 VAR2"
+        - "unset JAVA_HOME"
+        - "unset -- -VAR  # Eliminar la variable llamada -VAR"
+      notes: "Elimina variables del entorno del shell. Las variables que no existen se ignoran."
+
+    pwd:
+      title: "📍 Mostrar directorio de trabajo"
+      description: "Mostrar el directorio de trabajo actual con manejo de enlaces simbólicos"
+      usage: "pwd [-L|-P]"
+      options:
+        - ["-L", "Mostrar la ruta lógica (seguir enlaces simbólicos, predeterminado)"]
+        - ["-P", "Mostrar la ruta física (resolver enlaces simbólicos)"]
+      examples:
+        - "pwd                  # Mostrar el directorio actual lógico"
+        - "pwd -L               # Mostrar la ruta lógica (respetando enlaces simbólicos)"
+        - "pwd -P               # Mostrar la ruta física (resolviendo enlaces simbólicos)"
+      notes: "El comportamiento predeterminado muestra la ruta lógica que respeta los enlaces simbólicos."
+
+    ";":
+      title: "🤖 Asistente de IA"
+      description: "Hacer una pregunta al asistente de IA"
+      usage: "; <question>"
+      options:
+        - ["question", "Tu pregunta para el asistente de IA"]
+      examples:
+        - "; como encuentro archivos grandes?"
+        - "; explica este comando: ls -la"
+        - "; sugiere una mejor forma de comprimir archivos"
+      notes: "El asistente de IA puede ayudar con explicaciones de comandos, sugerencias y uso general del shell."
+
+    "；":
+      title: "🤖 Asistente de IA"
+      description: "Hacer una pregunta al asistente de IA"
+      usage: "； <question>"
+      options:
+        - ["question", "Tu pregunta para el asistente de IA"]
+      examples:
+        - "； como encuentro archivos grandes?"
+        - "； explica este comando: ls -la"
+        - "； sugiere una mejor forma de comprimir archivos"
+      notes: "El asistente de IA puede ayudar con explicaciones de comandos, sugerencias y uso general del shell."
+
+    "/model":
+      title: "🧠 Cambiar modelo"
+      description: "Mostrar el modelo actual o cambiar a un modelo específico"
+      usage: "/model [model]"
+      options:
+        - ["model", "Identificador del modelo de destino (validado para compatibilidad con llamadas a herramientas)"]
+        - ["--help, -h", "Mostrar este mensaje de ayuda"]
+      examples:
+        - "/model               # Mostrar el modelo actual"
+        - "/model gpt-4         # Cambiar a un modelo"
+        - "/model --help        # Mostrar ayuda"
+      notes: "El cambio valida la conectividad y la compatibilidad con llamadas a herramientas; si falla, se mantiene el modelo actual."
+
+    "/setup":
+      title: "⚙️ Reconfigurar"
+      description: "Volver a ejecutar el asistente de configuración interactiva para cambiar los ajustes de la API (proveedor, clave API, modelo)"
+      usage: "/setup"
+      options:
+        - ["--help, -h", "Mostrar este mensaje de ayuda"]
+      examples:
+        - "/setup               # Iniciar el asistente de configuración"
+        - "/setup --help        # Mostrar ayuda"
+      notes: "La nueva configuración se aplica de inmediato sin reiniciar. Si se cancela, se conserva la configuración actual."
+
+errors:
+  litellm_not_installed: "El modulo litellm no está instalado"

--- a/src/aish/i18n/fr-FR.yaml
+++ b/src/aish/i18n/fr-FR.yaml
@@ -1,0 +1,519 @@
+cli:
+  app_help: "AI Shell - Un shell avec des capacites LLM integrees"
+  help_option_help: "Afficher ce message et quitter."
+  run_command_help: "Lancer AI Shell"
+  info_command_help: "Afficher les informations sur AI Shell"
+  check_langfuse_command_help: "Verifier la configuration de Langfuse"
+  setup_command_help: "Executer la configuration interactive et quitter"
+  check_tool_support_command_help: "Depanner la verification en direct de la prise en charge des appels d'outils"
+
+  option:
+    model: "Modele LLM a utiliser ; peut aussi etre defini via AISH_MODEL ou le fichier de configuration."
+    api_key: "Cle API du fournisseur LLM ; peut aussi etre definie via AISH_API_KEY ou les variables d'environnement du fournisseur."
+    api_base: "URL de base de l'API du fournisseur LLM ; peut aussi etre definie via AISH_API_BASE ou le fichier de configuration."
+    config: "Chemin du fichier de configuration (par defaut : ~/.config/aish/config.yaml)."
+
+  setup:
+    step_provider: "Etape 1/3 : choisir un fournisseur"
+    step_provider_endpoint: "Etape 1.5/3 : choisir un endpoint"
+    step_key: "Etape 2/3 : saisir la cle API"
+    step_model: "Etape 3/3 : choisir un modele"
+    provider_header: "Choisir un fournisseur (taper pour filtrer)"
+    provider_filter_prompt: "Filtre :"
+    provider_filter_hint: "Tapez pour filtrer, utilisez ↑/↓ pour selectionner, Enter pour confirmer et Esc pour annuler."
+    provider_selected_label: "Fournisseur"
+    provider_endpoint_selected_label: "Endpoint"
+    provider_endpoint_header: "Choisir l'endpoint API pour {provider}"
+    model_selected_label: "Modele"
+    provider_custom_note: "Compatible OpenAI"
+    provider_preset_base: "API Base predefinie"
+    custom_api_base_title: "URL API Base"
+    custom_api_base_header: "Saisissez l'URL API Base."
+    provider_custom_api_base: "URL API Base"
+    provider_custom_api_base_required: "L'API Base est obligatoire"
+    provider_custom_api_base_invalid: "URL API Base invalide"
+    provider_custom_default: "Personnalise"
+    invalid_choice: "Selection invalide"
+    filter_no_results: "Aucun resultat. Reessayez ou appuyez sur Enter pour tout afficher."
+    api_key_header: "Saisissez votre cle API (elle sera enregistree dans la configuration)"
+    api_key_env_found: "Detecte {env_key} : {masked}"
+    api_key_env_hint: "Appuyez sur Enter pour utiliser la cle detectee ou saisissez-en une nouvelle."
+    api_key_prompt: "Cle API"
+    api_key_required: "La cle API est obligatoire"
+    model_header: "Fournisseur : {provider}"
+    model_prompt: "Nom du modele (tapez back pour changer de fournisseur)"
+    model_hint_openrouter: "OpenRouter exige un prefixe de fournisseur, par exemple openai/gpt-4o. S'il est omis, openai/ sera utilise par defaut."
+    model_hint_custom: "Les fournisseurs personnalises sont traites comme compatibles OpenAI. Sans prefixe, le modele sera enregistre sous openai/<model>."
+    model_hint_provider: "Recommande : {default}"
+    model_list_unavailable: "Liste des modeles indisponible ; veuillez la saisir manuellement"
+    model_filtering: "Filtrage des modeles compatibles avec les appels d'outils"
+    model_filter_result: "Reduit a {count} modeles compatibles avec les appels d'outils"
+    model_filter_empty: "Aucun modele n'a passe le filtre d'appels d'outils ; la liste complete sera affichee"
+    model_filter_prompt: "Filtre :"
+    model_filter_hint: "Tapez pour filtrer, utilisez ↑/↓ pour selectionner, Enter pour confirmer et Esc pour revenir. Choisissez Modele personnalise pour saisir manuellement."
+    model_custom_option: "Modele personnalise..."
+    model_custom_required: "Le nom du modele est obligatoire"
+    model_custom_saved_as: "Sera enregistre sous : {model}"
+    verify_title: "Verification"
+    verify_header: "Verification de la prise en charge des appels d'outils..."
+    verify_connectivity_in_progress: "Verification de la connectivite..."
+    verify_tool_in_progress: "Verification de la prise en charge des outils..."
+    verify_static_no_tool_support: "Le modele ne prend pas en charge les appels d'outils (verification statique)"
+    verify_simple_success: "Verification reussie"
+    verify_simple_failed_with_reason: "Verification echouee : {reason}"
+    verify_failed_unknown: "erreur inconnue"
+    verify_live_label: "Verification en direct"
+    verify_live_detail: "Details"
+    verify_timeout: "La verification en direct a expire"
+    verify_cancelled: "Verification en direct annulee"
+    verify_no_tool_call_required: "Aucun appel d'outil n'a ete renvoye (mode requis)"
+    verify_no_tool_call_auto: "Le modele n'a appele aucun outil en mode automatique"
+    debug_request_title: "Requete en direct ({mode})"
+    debug_response_title: "Reponse en direct ({mode})"
+    debug_error_title: "Erreur en direct ({mode})"
+    support_yes: "Pris en charge"
+    support_no: "Non pris en charge"
+    support_unknown: "Inconnu"
+    litellm_missing: "litellm n'est pas installe ; verification ignoree"
+    action_header: "Action suivante :"
+    action_prompt: "Choisir une option"
+    action_retry_model: "Choisir un autre modele"
+    action_retry_api_base: "Ressaisir l'API Base"
+    action_retry_api_key: "Ressaisir la cle API"
+    action_change_provider: "Changer de fournisseur"
+    action_continue: "Continuer quand meme (deconseille)"
+    action_exit: "Quitter la configuration"
+    retry_api_base_prompt: "Saisissez l'API Base (back pour revenir)"
+    retry_api_base_prompt_with_current: "Saisissez l'API Base (actuelle : {current}, back pour revenir)"
+    retry_api_base_required: "L'API Base est obligatoire"
+    saved: "Configuration enregistree"
+    saved_with_warning: "Configuration enregistree (appel d'outil non verifie)"
+    non_interactive: "Environnement non interactif ; impossible d'executer la configuration"
+    cancelled: "Configuration annulee"
+    required_cancelled: "Configuration requise manquante ; fermeture"
+
+  startup:
+    label:
+      skills: "   Skills"
+    goodbye: "👋 Au revoir !"
+    config_file_error: "❌ Erreur de fichier de configuration : {error}"
+    config_file_hint: "💡 Utilisez --config pour specifier un chemin de configuration valide"
+
+  langfuse:
+    incomplete: "⚠️  La configuration Langfuse est incomplete"
+    missing: "   Manquant : {var}"
+    complete: "✅ La configuration Langfuse est complete"
+    script_failed: "Le script de verification Langfuse a echoue : {error}"
+    script_not_found: "Script check_langfuse.py introuvable"
+    run_from_root: "Veuillez executer cette commande depuis la racine du projet"
+
+  parse_errors:
+    title: "Erreur"
+    option_requires_argument: "L'option {option} requiert un argument."
+    no_such_option: "Option inconnue : {option}"
+    missing_parameter: "Parametre manquant : {param}"
+    invalid_value_for_option: "Valeur invalide pour {option} : {reason}"
+    generic: "Arguments invalides : {message}"
+
+shell:
+  welcome2:
+    header: ">_ AI Shell {version}"
+    model_hint: "(tapez /model pour changer)"
+    label:
+      model: "modele"
+      config: "config"
+    quick_start:
+      title: " Demarrage rapide :"
+      item1_prefix: "Commandes shell natives : "
+      cmd_ls: "ls"
+      cmd_top: "top"
+      cmd_vim: "vim"
+      cmd_ssh: "ssh"
+      item1_suffix: " etc."
+      item2_prefix: "Demander a l'IA : "
+      item2_example: "Commencez par ;, par exemple ; comment trouver de gros fichiers"
+      item3_prefix: "Obtenir de l'aide :"
+      item3_suffix_1: "Tapez "
+      item3_keyword: "help"
+      item3_suffix_2: " pour voir l'aide integree et l'utilisation."
+    risk: "Le contenu genere par l'IA peut etre risque ; verifiez-le attentivement."
+    skills_loaded_suffix: " charges"
+
+  security:
+    title:
+      blocked: "🛑 Blocage de securite : {tool}"
+      notice: "🔐 Avertissement de securite : {tool}"
+      confirm: "🔐 Confirmation requise : {tool}"
+    label:
+      description: "Description"
+      command: "Commande"
+      target: "Cible"
+      content_preview: "Apercu du contenu"
+      fallback_hint: "Note"
+      risk_level: "Niveau de risque"
+      reasons: "Raisons"
+      alternatives: "Alternatives"
+      impact: "Impact"
+      no_additional_info: "Aucune information supplementaire fournie."
+    fallback:
+      sandbox_execute_failed: "La pre-execution de la commande a echoue, le risque ne peut donc pas etre evalue. Veuillez confirmer avant d'executer la vraie commande."
+      sandbox_timeout: "La pre-execution de la commande a expire, le risque ne peut donc pas etre evalue. Veuillez confirmer avant d'executer la vraie commande."
+      sandbox_ipc_timeout: "Delai d'attente depasse lors de l'evaluation preliminaire de la commande ; le risque ne peut donc pas etre evalue. Veuillez confirmer avant d'executer la vraie commande."
+      generic: "L'evaluation du risque de la commande n'a pas pu etre menee a bien. Veuillez confirmer avant d'executer la vraie commande."
+    options_header: "Options"
+    option:
+      approve: "Autoriser"
+      approve_remember: "Oui, et ne plus demander pour cette commande"
+      cancel: "Annuler"
+    choice_prompt: "Votre choix (par defaut : n) : "
+
+  command_cancelled: "Commande annulee"
+  error_correction:
+    press_semicolon_hint: "L'execution de la commande a echoue. Appuyez sur ; pour analyser et reparer automatiquement, ou saisissez directement la commande suivante."
+    corrected_command_label: "Correction suggeree :"
+  error:
+    execution_error: "❌ Erreur pendant l'execution : {error}"
+    pty_decode_error: "Erreur de decodage de sortie PTY detectee : {error}"
+    potential_error: "🚀 Probleme potentiel detecte : {reason}, tentative de resolution..."
+    llm_error_title: "❌ Echec de la requete LLM"
+    llm_error_details_title: "Details de debogage"
+    tool_args_json_invalid_hint: "❌ La requete a echoue, veuillez reessayer."
+  prompt:
+    confirm_execute: "?Executer cette commande ? [y/n]:"
+    ai_hint: "Utilisez ; pour interroger l'IA"
+  model:
+    current: "Modele actuel : {model}"
+    unset: "non defini"
+    invalid: "Le nom du modele ne peut pas etre vide"
+    switching: "Validation du modele : {model}"
+    switch_same: "Modele inchange : {model}"
+    switch_success: "Modele active : {model}"
+    verify_failed: "La validation du modele a echoue : {reason}"
+  setup:
+    no_config_manager: "Reconfiguration impossible : gestionnaire de configuration indisponible"
+    cancelled: "Configuration annulee, les parametres actuels sont conserves"
+    applied: "Configuration mise a jour, modele actuel : {model}"
+  ask_user:
+    title: "Selectionnez une option"
+    custom_label: "Personnalise :"
+    hint_select: "↑/↓ pour se deplacer • Enter pour confirmer • Esc pour annuler"
+    hint_custom: "Tapez pour saisir une valeur • Enter pour confirmer • Tab pour aller aux options • Esc pour annuler"
+    paused:
+      title: "⏸ Saisie utilisateur requise (tache en pause)"
+      prompt: "Question : {prompt}"
+      reason: "Raison : {reason}"
+      options_header: "Options :"
+      custom_input: "Vous pouvez aussi repondre avec n'importe quelle valeur personnalisee."
+      how_to: "Repondez avec une valeur d'option (ou un numero) ou tapez ; continue with default (par defaut : {default})."
+  diagnose_cancelled: "  └─ ❌ Diagnostic systeme annule"
+  status:
+    thinking: "Reflexion"
+    thinking_now: "Reflexion"
+    processing: "Traitement"
+    analyzing: "  Analyse..."
+    system_diagnosing: "  └─ Diagnostic systeme en cours"
+    system_analyzing: "  └─ Analyse systeme en cours"
+  tool:
+    prefix: "🔧 Utilisation de l'outil"
+    prefix_diagnose: "  └─ 🔧 Outil de diagnostic"
+    done_diagnose: "  └─ ✅ Diagnostic termine"
+
+security:
+  sandbox_off_action:
+    confirm: "Demander confirmation"
+  sandbox_unavailable:
+    title: "⚠️ Sandbox indisponible"
+    line1: "Le sandbox est indisponible ; le risque de la commande ne peut pas etre evalue."
+    line2: "Les commandes generees par l'IA suivantes seront traitees ainsi : {action}."
+    policy_line1: "Le sandbox est desactive par politique ; aucune execution de sandbox n'a eu lieu."
+    policy_line2: "Les commandes IA seront traitees ainsi : {action}."
+    reason: "Raison : {reason}"
+    error: "Erreur : {error}"
+    root_required: "Le sandbox requiert les privileges root"
+    ipc_unavailable: "Impossible de se connecter au service sandbox (aish-sandbox.socket n'est pas en cours d'execution ou n'est pas installe)"
+    ipc_failed: "Echec de l'execution du service sandbox (aish-sandbox)"
+    sandbox_execute_failed: "Impossible d'evaluer le risque de la commande ; veuillez confirmer avant l'execution"
+  risk_reason:
+    sandbox_disabled_by_policy: "Le sandbox est desactive par politique ; les modifications de fichiers ne peuvent pas etre inspectees pour l'evaluation du risque. Action : {action}."
+    sandbox_disabled: "Le sandbox n'est pas active ou est desactivee ; les modifications de fichiers ne peuvent pas etre inspectees pour l'evaluation du risque. Action : {action}."
+    cwd_outside_repo_root: "Le repertoire courant {cwd} est hors de la racine du sandbox {root} ; les effets relatifs ne peuvent pas etre evalues de facon fiable. Action : {action}."
+    sandbox_unavailable: "L'initialisation ou l'execution du sandbox a echoue ; les modifications de fichiers ne peuvent pas etre inspectees pour l'evaluation du risque. Action : {action}."
+    sandbox_exception: "Erreur d'execution du sandbox ; les modifications de fichiers ne peuvent pas etre inspectees pour l'evaluation du risque. Action : {action}."
+    sandbox_failed: "Echec du sandbox ; les modifications de fichiers ne peuvent pas etre inspectees pour l'evaluation du risque. Action : {action}."
+    policy_fallback_rule_match: "Avec le sandbox desactive par politique, la commande {command} a correspondu a {count} chemins de regles de secours ; traitement comme risque {risk}."
+  ai_risk:
+    no_fs_changes: "Le sandbox n'a detecte aucune ecriture ou suppression de fichier."
+    high_hits: "{count} operations d'ecriture ou de suppression correspondant a des regles a haut risque ont ete detectees."
+    medium_hits: "{count} operations d'ecriture ou de suppression correspondant a des regles a risque moyen ont ete detectees."
+    low_or_unmatched_hits: "{count} operations d'ecriture ou de suppression a faible risque ou sans correspondance ont ete detectees."
+    preview_paths: "Exemples de chemins (partiels, pouvant inclure des fichiers ou repertoires) : {paths}"
+  command_blocked: "Erreur : commande bloquee par le systeme de securite"
+  command_blocked_with_reason: "Erreur : commande bloquee par le systeme de securite : {reason}"
+
+tools:
+  smart_log:
+    description: "Determine automatiquement les sources de journaux, analyse les logs selon la requete et renvoie un resume correspondant."
+    param:
+      query: "Votre requete de diagnostic, par exemple 'nginx est-il correctement configure' ou 'y a-t-il des connexions suspectes'."
+      path: "Optionnel. Chemin du journal (fichier/repertoire) ou nom d'une unite systemd. S'il est omis, il sera deduit de la requete."
+    summary:
+      file: "[FICHIER] {ident} : {matched}/{total} lignes correspondantes\nExemple :\n{sample}"
+      dir: "[REP] {path} : {matched}/{total} lignes correspondantes\nExemple :\n{sample}"
+      systemd: "[SYSTEMD] {ident} : {matched}/{total} lignes correspondantes\nExemple :\n{sample}"
+      call_failed: "[{stype}] {ident} : appel echoue\n{output}"
+    no_logs_found: "Aucun journal ou aucune information correspondante trouve(e)."
+
+help:
+  labels:
+    usage: "Utilisation"
+    options: "Options"
+    examples: "Exemples"
+    notes: "Notes"
+    brief_usage: "Utilisation : {usage}"
+  general:
+    title: "📖 Aide AI Shell"
+    markdown: |-
+      ## Commandes disponibles :
+
+      ### Navigation dans les repertoires
+      - `cd [-L|[-P [-e]]] [directory]` - Changer de repertoire avec prise en charge complete des parametres
+      - `pushd [directory]` - Empiler un repertoire
+      - `popd` - Depiler un repertoire
+      - `dirs [-c]` - Afficher la pile de repertoires
+
+      ### Historique
+      - `history [options] [n]` - Afficher l'historique des commandes
+      - `history -c` - Effacer l'historique
+      - `history -d offset` - Supprimer une entree de l'historique
+
+      ### Variables d'environnement
+      - `export [-fn] [name[=value] ...]` - Definir ou exporter des variables d'environnement
+      - `export -p` - Afficher les variables exportees
+      - `unset [-fv] [name ...]` - Supprimer des variables d'environnement
+      - `pwd [-L|-P]` - Afficher le repertoire courant
+
+      ### Commandes generales
+      - `help` - Afficher cette aide
+      - `clear` - Effacer l'ecran
+      - `exit` - Quitter le shell
+      - `/model [model]` - Afficher ou changer le modele
+      - `/setup` - Reconfigurer les parametres API
+
+      ### Commandes IA
+      - `; <question>` - Interroger l'assistant IA
+
+      ### Fonctionnalites
+      - ✅ Prise en charge PTY complete pour toutes les commandes
+      - ✅ Integration de l'historique des commandes et du contexte IA
+      - ✅ Sortie terminal enrichie pour les reponses IA
+      - ✅ Gestion des signaux et nettoyage propre
+
+      ### Obtenir plus d'aide
+      Utilisez `<command> --help` ou `<command> -h` pour afficher l'aide detaillee de n'importe quelle commande.
+
+      ### Exemples
+      ```bash
+      history --help       # Afficher l'aide detaillee de history
+      cd --help            # Afficher l'aide detaillee de cd
+      export JAVA_HOME="/usr/lib/jvm/java-11"  # Definir une variable d'environnement
+      unset TEMP_VAR       # Supprimer une variable d'environnement
+      ; explique ls -la    # Demander a l'IA d'expliquer une commande
+      ```
+
+  command:
+    history:
+      title: "📚 Historique"
+      description: "Afficher ou manipuler l'historique des commandes"
+      usage: "history [options] [n]"
+      options:
+        - ["--help, -h", "Afficher ce message d'aide"]
+        - ["-c", "Effacer la liste d'historique en supprimant toutes les entrees"]
+        - ["-d offset", "Supprimer l'entree d'historique a la position offset"]
+        - ["n", "Afficher seulement les n dernieres commandes"]
+      examples:
+        - "history              # Afficher tout l'historique des commandes"
+        - "history 10           # Afficher les 10 dernieres commandes"
+        - "history -c           # Effacer tout l'historique"
+        - "history -d 5         # Supprimer l'entree d'historique a la position 5"
+        - "history --help       # Afficher ce message d'aide"
+      notes: "Les entrees d'historique sont enregistrees automatiquement pour toutes les commandes executees et les interactions avec l'IA."
+
+    cd:
+      title: "📁 Changer de repertoire"
+      description: "Changer le repertoire de travail courant avec prise en charge complete des parametres"
+      usage: "cd [-L|[-P [-e]]] [directory]"
+      options:
+        - ["-L", "Forcer le suivi des liens symboliques : resoudre les liens symboliques apres le traitement des occurrences de '..' (par defaut)"]
+        - ["-P", "Utiliser la structure physique des repertoires sans suivre les liens symboliques : resoudre les liens symboliques avant le traitement des occurrences de '..'"]
+        - ["-e", "Si l'option -P est fournie et que le repertoire de travail courant ne peut pas etre determine, quitter avec un code non nul"]
+        # - ["-@", "Sur les systemes qui le prennent en charge, presenter les fichiers avec attributs etendus comme des repertoires contenant les attributs du fichier"]
+        - ["directory", "Chemin du repertoire cible (optionnel, utilise le repertoire personnel par defaut)"]
+        - ["-", "Revenir au repertoire precedent"]
+      examples:
+        - "cd ~                 # Aller au repertoire personnel"
+        - "cd /tmp              # Aller au repertoire /tmp"
+        - "cd -                 # Revenir au repertoire precedent"
+        - "cd \"path with spaces\" # Utiliser des guillemets pour les chemins contenant des espaces"
+        - "cd -P /tmp           # Utiliser la resolution de chemin physique"
+        - "cd -P -e /tmp        # Utiliser la resolution de chemin physique et quitter en cas d'erreur"
+        - "cd -L /tmp           # Forcer le suivi des liens symboliques (comportement par defaut)"
+        # - "cd -@ /tmp           # Afficher les attributs etendus (si pris en charge)"
+      notes: "Prend en charge l'autocompletion par Tab et les chemins avec caracteres speciaux. Le comportement par defaut suit les liens symboliques (-L)."
+
+    pushd:
+      title: "📤 Empiler un repertoire"
+      description: "Ajouter un repertoire a la pile et s'y deplacer"
+      usage: "pushd [directory]"
+      options:
+        - ["directory", "Chemin du repertoire cible"]
+        - ["(no args)", "Echanger les deux repertoires au sommet de la pile"]
+      examples:
+        - "pushd /tmp           # Ajouter le repertoire courant a la pile et aller a /tmp"
+        - "pushd                # Echanger entre le repertoire courant et le precedent"
+      notes: "Maintient une pile de repertoires pour naviguer facilement entre plusieurs repertoires."
+
+    popd:
+      title: "📥 Depiler un repertoire"
+      description: "Retirer un repertoire de la pile et s'y deplacer"
+      usage: "popd"
+      options: []
+      examples:
+        - "popd                 # Revenir au repertoire precedent depuis la pile"
+      notes: "Retire le repertoire au sommet de la pile et s'y deplace."
+
+    dirs:
+      title: "📋 Afficher la pile de repertoires"
+      description: "Afficher la pile de repertoires"
+      usage: "dirs [-c]"
+      options:
+        - ["-c", "Effacer la pile de repertoires"]
+      examples:
+        - "dirs                 # Afficher la pile de repertoires actuelle"
+        - "dirs -c              # Effacer la pile de repertoires"
+      notes: "Affiche tous les repertoires actuellement presents dans la pile de navigation."
+
+    help:
+      title: "❓ Aide"
+      description: "Afficher les commandes et fonctionnalites disponibles"
+      usage: "help"
+      options: []
+      examples:
+        - "help                 # Afficher l'aide generale"
+      notes: "Fournit un apercu de toutes les commandes et fonctionnalites disponibles du shell."
+
+    clear:
+      title: "🧹 Effacer l'ecran"
+      description: "Effacer l'ecran du terminal"
+      usage: "clear"
+      options: []
+      examples:
+        - "clear                # Effacer l'ecran du terminal"
+      notes: "Equivalent a la commande Unix standard clear."
+
+    exit:
+      title: "🚪 Quitter le shell"
+      description: "Quitter AI Shell"
+      usage: "exit"
+      options: []
+      examples:
+        - "exit                 # Quitter le shell"
+        - "quit                 # Methode alternative pour quitter"
+      notes: "Quitte proprement le shell en preservant les donnees de session."
+
+    export:
+      title: "🔧 Exporter les variables d'environnement"
+      description: "Definir ou afficher les variables d'environnement avec attribut d'export"
+      usage: "export [-fn] [name[=value] ...]\nexport -p"
+      options:
+        - ["-f", "Le nom fait reference a une fonction shell (non pris en charge)"]
+        - ["-n", "Retirer l'attribut d'export de chaque nom"]
+        - ["-p", "Afficher la liste de toutes les variables exportees"]
+        - ["--", "Desactiver le traitement ulterieur des options"]
+      examples:
+        - "export PATH=/usr/local/bin:$PATH"
+        - "export EDITOR=vim"
+        - "export -n VAR  # Retirer l'attribut d'export de VAR"
+        - "export -p      # Afficher toutes les variables exportees"
+        - "export JAVA_HOME=\"/usr/lib/jvm/java-11-openjdk\""
+        - "export -- -VAR  # Definir une variable nommee -VAR"
+      notes: "Les variables d'environnement definies avec export sont transmises aux processus enfants."
+
+    unset:
+      title: "🗑️ Supprimer les variables d'environnement"
+      description: "Supprimer les variables et fonctions du shell"
+      usage: "unset [-f] [-v] [-n] [name ...]"
+      options:
+        - ["-f", "Chaque nom fait reference a une fonction shell (non pris en charge)"]
+        - ["-v", "Chaque nom fait reference a une variable shell (par defaut)"]
+        - ["-n", "Chaque nom fait reference a une reference de nom (non pris en charge)"]
+        - ["--", "Desactiver le traitement ulterieur des options"]
+      examples:
+        - "unset TEMP_VAR"
+        - "unset -v VAR1 VAR2"
+        - "unset JAVA_HOME"
+        - "unset -- -VAR  # Supprimer la variable nommee -VAR"
+      notes: "Retire les variables de l'environnement du shell. Les variables inexistantes sont ignorees."
+
+    pwd:
+      title: "📍 Afficher le repertoire courant"
+      description: "Afficher le repertoire de travail courant avec gestion des liens symboliques"
+      usage: "pwd [-L|-P]"
+      options:
+        - ["-L", "Afficher le chemin logique (suivre les liens symboliques, par defaut)"]
+        - ["-P", "Afficher le chemin physique (resoudre les liens symboliques)"]
+      examples:
+        - "pwd                  # Afficher le repertoire courant logique"
+        - "pwd -L               # Afficher le chemin logique (respecte les liens symboliques)"
+        - "pwd -P               # Afficher le chemin physique (resout les liens symboliques)"
+      notes: "Le comportement par defaut affiche le chemin logique en respectant les liens symboliques."
+
+    ";":
+      title: "🤖 Assistant IA"
+      description: "Poser une question a l'assistant IA"
+      usage: "; <question>"
+      options:
+        - ["question", "Votre question pour l'assistant IA"]
+      examples:
+        - "; comment trouver de gros fichiers ?"
+        - "; explique cette commande : ls -la"
+        - "; suggere une meilleure facon de compresser des fichiers"
+      notes: "L'assistant IA peut aider avec les explications de commandes, les suggestions et l'usage general du shell."
+
+    "；":
+      title: "🤖 Assistant IA"
+      description: "Poser une question a l'assistant IA"
+      usage: "； <question>"
+      options:
+        - ["question", "Votre question pour l'assistant IA"]
+      examples:
+        - "； comment trouver de gros fichiers ?"
+        - "； explique cette commande : ls -la"
+        - "； suggere une meilleure facon de compresser des fichiers"
+      notes: "L'assistant IA peut aider avec les explications de commandes, les suggestions et l'usage general du shell."
+
+    "/model":
+      title: "🧠 Changer de modele"
+      description: "Afficher le modele actuel ou passer a un modele specifie"
+      usage: "/model [model]"
+      options:
+        - ["model", "Identifiant du modele cible (verifie pour la prise en charge des appels d'outils)"]
+        - ["--help, -h", "Afficher ce message d'aide"]
+      examples:
+        - "/model               # Afficher le modele actuel"
+        - "/model gpt-4         # Passer a un modele"
+        - "/model --help        # Afficher l'aide"
+      notes: "Le changement verifie la connectivite et la prise en charge des appels d'outils ; en cas d'echec, le modele actuel est conserve."
+
+    "/setup":
+      title: "⚙️ Reconfigurer"
+      description: "Relancer l'assistant de configuration interactif pour modifier les parametres d'API (fournisseur, cle API, modele)"
+      usage: "/setup"
+      options:
+        - ["--help, -h", "Afficher ce message d'aide"]
+      examples:
+        - "/setup               # Lancer l'assistant de configuration"
+        - "/setup --help        # Afficher l'aide"
+      notes: "Les nouveaux parametres sont appliques immediatement sans redemarrage. Une annulation conserve la configuration actuelle."
+
+errors:
+  litellm_not_installed: "Le module litellm n'est pas installe"

--- a/src/aish/i18n/ja-JP.yaml
+++ b/src/aish/i18n/ja-JP.yaml
@@ -1,0 +1,519 @@
+cli:
+  app_help: "AI Shell - LLM 機能を内蔵した対話型シェル"
+  help_option_help: "このメッセージを表示して終了します。"
+  run_command_help: "AI Shell を起動します"
+  info_command_help: "AI Shell の情報を表示します"
+  check_langfuse_command_help: "Langfuse の設定を確認します"
+  setup_command_help: "対話式セットアップを実行して終了します"
+  check_tool_support_command_help: "ツール呼び出しのライブ検証をデバッグします"
+
+  option:
+    model: "使用する LLM モデル。AISH_MODEL または設定ファイルでも指定できます。"
+    api_key: "LLM プロバイダーの API キー。AISH_API_KEY または各プロバイダーの環境変数でも指定できます。"
+    api_base: "LLM プロバイダーの API ベース URL。AISH_API_BASE または設定ファイルでも指定できます。"
+    config: "設定ファイルのパス（既定値: ~/.config/aish/config.yaml）。"
+
+  setup:
+    step_provider: "ステップ 1/3: プロバイダーを選択"
+    step_provider_endpoint: "ステップ 1.5/3: エンドポイントを選択"
+    step_key: "ステップ 2/3: API キーを入力"
+    step_model: "ステップ 3/3: モデルを選択"
+    provider_header: "プロバイダーを選択（入力で絞り込み）"
+    provider_filter_prompt: "フィルター:"
+    provider_filter_hint: "入力して絞り込み、↑/↓ で選択、Enter で確定、Esc でキャンセルします。"
+    provider_selected_label: "プロバイダー"
+    provider_endpoint_selected_label: "エンドポイント"
+    provider_endpoint_header: "{provider} の API エンドポイントを選択"
+    model_selected_label: "モデル"
+    provider_custom_note: "OpenAI 互換"
+    provider_preset_base: "既定の API Base"
+    custom_api_base_title: "API Base URL"
+    custom_api_base_header: "API Base URL を入力してください。"
+    provider_custom_api_base: "API Base URL"
+    provider_custom_api_base_required: "API Base は必須です"
+    provider_custom_api_base_invalid: "無効な API Base URL です"
+    provider_custom_default: "カスタム"
+    invalid_choice: "無効な選択です"
+    filter_no_results: "一致する項目がありません。再入力するか Enter ですべて表示します。"
+    api_key_header: "API キーを入力してください（設定に保存されます）"
+    api_key_env_found: "{env_key} を検出: {masked}"
+    api_key_env_hint: "Enter で検出されたキーを使うか、新しいキーを入力してください。"
+    api_key_prompt: "API キー"
+    api_key_required: "API キーは必須です"
+    model_header: "プロバイダー: {provider}"
+    model_prompt: "モデル名（プロバイダーを変更するには back と入力）"
+    model_hint_openrouter: "OpenRouter では openai/gpt-4o のようなプロバイダープレフィックスが必要です。省略した場合は openai/ が既定で使われます。"
+    model_hint_custom: "カスタムプロバイダーは OpenAI 互換として扱われます。プレフィックスを省略すると openai/<model> として保存されます。"
+    model_hint_provider: "推奨: {default}"
+    model_list_unavailable: "モデル一覧を取得できません。手動で入力してください"
+    model_filtering: "ツール呼び出しに対応したモデルを絞り込んでいます"
+    model_filter_result: "ツール呼び出し対応モデル {count} 件に絞り込みました"
+    model_filter_empty: "ツール呼び出し対応モデルが見つからなかったため、一覧全体を表示します"
+    model_filter_prompt: "フィルター:"
+    model_filter_hint: "入力して絞り込み、↑/↓ で選択、Enter で確定、Esc で戻ります。手動入力するにはカスタムモデルを選択してください。"
+    model_custom_option: "カスタムモデル..."
+    model_custom_required: "モデル名は必須です"
+    model_custom_saved_as: "保存名: {model}"
+    verify_title: "検証"
+    verify_header: "ツール呼び出し対応を検証しています..."
+    verify_connectivity_in_progress: "接続性を確認しています..."
+    verify_tool_in_progress: "ツール対応を確認しています..."
+    verify_static_no_tool_support: "このモデルはツール呼び出しをサポートしていません（静的判定）"
+    verify_simple_success: "検証に成功しました"
+    verify_simple_failed_with_reason: "検証に失敗しました: {reason}"
+    verify_failed_unknown: "不明なエラー"
+    verify_live_label: "ライブ検証"
+    verify_live_detail: "詳細"
+    verify_timeout: "ライブ検証がタイムアウトしました"
+    verify_cancelled: "ライブ検証を中止しました"
+    verify_no_tool_call_required: "ツール呼び出しが返されませんでした（必須モード）"
+    verify_no_tool_call_auto: "自動モードでツール呼び出しが発生しませんでした"
+    debug_request_title: "ライブリクエスト ({mode})"
+    debug_response_title: "ライブレスポンス ({mode})"
+    debug_error_title: "ライブエラー ({mode})"
+    support_yes: "対応"
+    support_no: "非対応"
+    support_unknown: "不明"
+    litellm_missing: "litellm がインストールされていないため検証をスキップしました"
+    action_header: "次の操作:"
+    action_prompt: "オプションを選択してください"
+    action_retry_model: "別のモデルを選択"
+    action_retry_api_base: "API Base を再入力"
+    action_retry_api_key: "API キーを再入力"
+    action_change_provider: "プロバイダーを変更"
+    action_continue: "このまま続行（非推奨）"
+    action_exit: "セットアップを終了"
+    retry_api_base_prompt: "API Base を入力してください（戻るには back）"
+    retry_api_base_prompt_with_current: "API Base を入力してください（現在: {current}、戻るには back）"
+    retry_api_base_required: "API Base は必須です"
+    saved: "設定を保存しました"
+    saved_with_warning: "設定を保存しました（ツール呼び出しは未検証です）"
+    non_interactive: "非対話環境ではセットアップを実行できません"
+    cancelled: "セットアップをキャンセルしました"
+    required_cancelled: "必須設定が不足しているため終了します"
+
+  startup:
+    label:
+      skills: "   Skills"
+    goodbye: "👋 終了します"
+    config_file_error: "❌ 設定ファイルエラー: {error}"
+    config_file_hint: "💡 --config で有効な設定ファイルパスを指定してください"
+
+  langfuse:
+    incomplete: "⚠️  Langfuse の設定が不完全です"
+    missing: "   不足: {var}"
+    complete: "✅ Langfuse の設定は完全です"
+    script_failed: "Langfuse 確認スクリプトが失敗しました: {error}"
+    script_not_found: "check_langfuse.py スクリプトが見つかりません"
+    run_from_root: "このコマンドはプロジェクトのルートで実行してください"
+
+  parse_errors:
+    title: "エラー"
+    option_requires_argument: "オプション {option} には引数が必要です。"
+    no_such_option: "そのようなオプションはありません: {option}"
+    missing_parameter: "不足しているパラメーター: {param}"
+    invalid_value_for_option: "{option} の値が無効です: {reason}"
+    generic: "無効な引数です: {message}"
+
+shell:
+  welcome2:
+    header: ">_ AI Shell {version}"
+    model_hint: "(/model で切り替え)"
+    label:
+      model: "モデル"
+      config: "設定"
+    quick_start:
+      title: " クイックスタート:"
+      item1_prefix: "ネイティブなシェルコマンド: "
+      cmd_ls: "ls"
+      cmd_top: "top"
+      cmd_vim: "vim"
+      cmd_ssh: "ssh"
+      item1_suffix: " など"
+      item2_prefix: "AI に質問: "
+      item2_example: "; で始めます。例: ; 大きなファイルを探す方法"
+      item3_prefix: "ヘルプを見る:"
+      item3_suffix_1: ""
+      item3_keyword: "help"
+      item3_suffix_2: " を入力すると組み込みヘルプを表示します。"
+    risk: "AI が生成した内容にはリスクがあるため、必ず注意して確認してください。"
+    skills_loaded_suffix: " 件読み込み済み"
+
+  security:
+    title:
+      blocked: "🛑 セキュリティによりブロック: {tool}"
+      notice: "🔐 セキュリティ通知: {tool}"
+      confirm: "🔐 確認が必要です: {tool}"
+    label:
+      description: "説明"
+      command: "コマンド"
+      target: "対象"
+      content_preview: "内容プレビュー"
+      fallback_hint: "注意"
+      risk_level: "リスクレベル"
+      reasons: "理由"
+      alternatives: "代替案"
+      impact: "影響"
+      no_additional_info: "追加情報はありません。"
+    fallback:
+      sandbox_execute_failed: "コマンドの事前実行に失敗したため、リスクを評価できません。本実行前に確認してください。"
+      sandbox_timeout: "コマンドの事前実行がタイムアウトしたため、リスクを評価できません。本実行前に確認してください。"
+      sandbox_ipc_timeout: "コマンドの事前評価待機がタイムアウトしたため、リスクを評価できません。本実行前に確認してください。"
+      generic: "コマンドのリスク評価を完了できませんでした。本実行前に確認してください。"
+    options_header: "オプション"
+    option:
+      approve: "許可"
+      approve_remember: "はい。このコマンドでは今後確認しない"
+      cancel: "キャンセル"
+    choice_prompt: "選択してください（既定: n）: "
+
+  command_cancelled: "コマンドをキャンセルしました"
+  error_correction:
+    press_semicolon_hint: "コマンド実行に失敗しました。; を押して自動解析・修復するか、そのまま次のコマンドを入力してください。"
+    corrected_command_label: "修正候補:"
+  error:
+    execution_error: "❌ 実行中にエラーが発生しました: {error}"
+    pty_decode_error: "PTY 出力のデコードエラーを検出しました: {error}"
+    potential_error: "🚀 問題の可能性を検出しました: {reason}。解決を試みます..."
+    llm_error_title: "❌ LLM リクエストに失敗しました"
+    llm_error_details_title: "デバッグ詳細"
+    tool_args_json_invalid_hint: "❌ リクエストに失敗しました。再試行してください。"
+  prompt:
+    confirm_execute: "?このコマンドを実行しますか? [y/n]:"
+    ai_hint: "; で AI に質問"
+  model:
+    current: "現在のモデル: {model}"
+    unset: "未設定"
+    invalid: "モデル名は空にできません"
+    switching: "モデルを検証しています: {model}"
+    switch_same: "モデルは変更されていません: {model}"
+    switch_success: "モデルを切り替えました: {model}"
+    verify_failed: "モデル検証に失敗しました: {reason}"
+  setup:
+    no_config_manager: "再設定できません: 設定マネージャーを利用できません"
+    cancelled: "セットアップをキャンセルしました。現在の設定を維持します"
+    applied: "設定を更新しました。現在のモデル: {model}"
+  ask_user:
+    title: "オプションを選択"
+    custom_label: "カスタム:"
+    hint_select: "↑/↓ で移動 • Enter で確定 • Esc でキャンセル"
+    hint_custom: "入力して値を指定 • Enter で確定 • Tab で選択肢へ移動 • Esc でキャンセル"
+    paused:
+      title: "⏸ ユーザー入力が必要です（タスクは一時停止中）"
+      prompt: "質問: {prompt}"
+      reason: "理由: {reason}"
+      options_header: "選択肢:"
+      custom_input: "任意の値を自由入力することもできます。"
+      how_to: "選択肢の値（または番号）で返信するか、; continue with default と入力してください（既定値: {default}）。"
+  diagnose_cancelled: "  └─ ❌ システム診断をキャンセルしました"
+  status:
+    thinking: "考え中"
+    thinking_now: "考え中"
+    processing: "処理中"
+    analyzing: "  解析中..."
+    system_diagnosing: "  └─ システム診断中"
+    system_analyzing: "  └─ システム解析中"
+  tool:
+    prefix: "🔧 ツールを使用中"
+    prefix_diagnose: "  └─ 🔧 診断ツール"
+    done_diagnose: "  └─ ✅ 診断完了"
+
+security:
+  sandbox_off_action:
+    confirm: "確認を求める"
+  sandbox_unavailable:
+    title: "⚠️ サンドボックスを利用できません"
+    line1: "サンドボックスを利用できないため、コマンドのリスクを評価できません。"
+    line2: "以後の AI 生成コマンドは次の方針で扱われます: {action}。"
+    policy_line1: "ポリシーによりサンドボックスが無効化されているため、サンドボックス実行は行われませんでした。"
+    policy_line2: "AI 生成コマンドは次の方針で扱われます: {action}。"
+    reason: "理由: {reason}"
+    error: "エラー: {error}"
+    root_required: "サンドボックスには root 権限が必要です"
+    ipc_unavailable: "サンドボックスサービスに接続できません（aish-sandbox.socket が起動していないか未インストールです）"
+    ipc_failed: "サンドボックスサービスの実行に失敗しました（aish-sandbox）"
+    sandbox_execute_failed: "コマンドのリスクを評価できません。実行前に確認してください"
+  risk_reason:
+    sandbox_disabled_by_policy: "ポリシーによりサンドボックスが無効です。ファイル変更を検査してリスク評価できません。処理方針: {action}。"
+    sandbox_disabled: "サンドボックスが有効でないか無効化されています。ファイル変更を検査してリスク評価できません。処理方針: {action}。"
+    cwd_outside_repo_root: "現在の作業ディレクトリ {cwd} はサンドボックスルート {root} の外にあるため、相対パスの副作用を信頼して評価できません。処理方針: {action}。"
+    sandbox_unavailable: "サンドボックスの初期化または実行に失敗したため、ファイル変更を検査してリスク評価できません。処理方針: {action}。"
+    sandbox_exception: "サンドボックス実行エラーのため、ファイル変更を検査してリスク評価できません。処理方針: {action}。"
+    sandbox_failed: "サンドボックスが失敗したため、ファイル変更を検査してリスク評価できません。処理方針: {action}。"
+    policy_fallback_rule_match: "ポリシーによりサンドボックス無効時、コマンド {command} が {count} 件のフォールバックルールに一致しました。{risk} リスクとして扱います。"
+  ai_risk:
+    no_fs_changes: "サンドボックスはファイルの書き込みや削除を検出しませんでした。"
+    high_hits: "高リスクルールに一致する書き込みまたは削除を {count} 件検出しました。"
+    medium_hits: "中リスクルールに一致する書き込みまたは削除を {count} 件検出しました。"
+    low_or_unmatched_hits: "低リスクまたは未一致の書き込みまたは削除を {count} 件検出しました。"
+    preview_paths: "対象パスの例（一部のみ。ディレクトリやファイルを含む場合があります）: {paths}"
+  command_blocked: "エラー: コマンドはセキュリティシステムによりブロックされました"
+  command_blocked_with_reason: "エラー: コマンドはセキュリティシステムによりブロックされました: {reason}"
+
+tools:
+  smart_log:
+    description: "ログソースを自動判定し、問い合わせに基づいてログを解析し、一致する要約を返します。"
+    param:
+      query: "診断したい内容。例: nginx は正しく設定されているか、怪しいログインはあるか。"
+      path: "任意。ログパス（ファイルまたはディレクトリ）または systemd ユニット名。省略時は問い合わせから推定します。"
+    summary:
+      file: "[FILE] {ident}: 一致 {matched}/{total} 行\nサンプル:\n{sample}"
+      dir: "[DIR] {path}: 一致 {matched}/{total} 行\nサンプル:\n{sample}"
+      systemd: "[SYSTEMD] {ident}: 一致 {matched}/{total} 行\nサンプル:\n{sample}"
+      call_failed: "[{stype}] {ident}: 呼び出し失敗\n{output}"
+    no_logs_found: "ログまたは一致する情報は見つかりませんでした。"
+
+help:
+  labels:
+    usage: "使い方"
+    options: "オプション"
+    examples: "例"
+    notes: "補足"
+    brief_usage: "使い方: {usage}"
+  general:
+    title: "📖 AI Shell ヘルプ"
+    markdown: |-
+      ## 利用可能なコマンド:
+
+      ### ディレクトリ操作
+      - `cd [-L|[-P [-e]]] [directory]` - 完全なパラメーター対応でディレクトリを変更
+      - `pushd [directory]` - ディレクトリをスタックに積む
+      - `popd` - ディレクトリをスタックから取り出す
+      - `dirs [-c]` - ディレクトリスタックを表示
+
+      ### 履歴管理
+      - `history [options] [n]` - コマンド履歴を表示
+      - `history -c` - 履歴を消去
+      - `history -d offset` - 履歴エントリーを削除
+
+      ### 環境変数
+      - `export [-fn] [name[=value] ...]` - 環境変数を設定または export
+      - `export -p` - export 済み変数を表示
+      - `unset [-fv] [name ...]` - 環境変数を解除
+      - `pwd [-L|-P]` - 現在の作業ディレクトリを表示
+
+      ### 一般コマンド
+      - `help` - このヘルプを表示
+      - `clear` - 画面を消去
+      - `exit` - シェルを終了
+      - `/model [model]` - モデルを表示または切り替え
+      - `/setup` - API 設定を再構成
+
+      ### AI コマンド
+      - `; <question>` - AI アシスタントに質問
+
+      ### 機能
+      - ✅ すべてのコマンドで完全な PTY サポート
+      - ✅ コマンド履歴と AI コンテキストの統合
+      - ✅ AI 応答のリッチなターミナル表示
+      - ✅ シグナル処理と適切なクリーンアップ
+
+      ### さらに詳しいヘルプ
+      任意のコマンドで `<command> --help` または `<command> -h` を使うと詳細ヘルプを表示できます。
+
+      ### 例
+      ```bash
+      history --help       # history の詳細ヘルプを表示
+      cd --help            # cd の詳細ヘルプを表示
+      export JAVA_HOME="/usr/lib/jvm/java-11"  # 環境変数を設定
+      unset TEMP_VAR       # 環境変数を削除
+      ; ls -la を説明して   # AI にコマンド説明を依頼
+      ```
+
+  command:
+    history:
+      title: "📚 履歴"
+      description: "コマンド履歴を表示または操作します"
+      usage: "history [options] [n]"
+      options:
+        - ["--help, -h", "このヘルプメッセージを表示します"]
+        - ["-c", "すべての項目を削除して履歴一覧を消去します"]
+        - ["-d offset", "位置 offset の履歴項目を削除します"]
+        - ["n", "直近 n 件のコマンドのみ表示します"]
+      examples:
+        - "history              # すべてのコマンド履歴を表示します"
+        - "history 10           # 直近 10 件のコマンドを表示します"
+        - "history -c           # すべての履歴を消去します"
+        - "history -d 5         # 位置 5 の履歴項目を削除します"
+        - "history --help       # このヘルプメッセージを表示します"
+      notes: "実行したすべてのコマンドと AI との対話は自動的に履歴へ記録されます。"
+
+    cd:
+      title: "📁 ディレクトリ移動"
+      description: "完全な引数サポート付きで現在の作業ディレクトリを変更します"
+      usage: "cd [-L|[-P [-e]]] [directory]"
+      options:
+        - ["-L", "シンボリックリンクをたどります: '..' を処理した後にリンクを解決します（既定）"]
+        - ["-P", "シンボリックリンクをたどらず物理ディレクトリ構造を使います: '..' を処理する前にリンクを解決します"]
+        - ["-e", "-P が指定され、現在の作業ディレクトリを判定できない場合は非ゼロ終了します"]
+        # - ["-@", "対応システムでは、拡張属性を持つファイルを属性を含むディレクトリとして表示します"]
+        - ["directory", "移動先ディレクトリのパス（省略時はホームディレクトリ）"]
+        - ["-", "前のディレクトリに戻ります"]
+      examples:
+        - "cd ~                 # ホームディレクトリへ移動します"
+        - "cd /tmp              # /tmp ディレクトリへ移動します"
+        - "cd -                 # 前のディレクトリに戻ります"
+        - "cd \"path with spaces\" # スペースを含むパスでは引用符を使います"
+        - "cd -P /tmp           # 物理パス解決を使います"
+        - "cd -P -e /tmp        # 物理パス解決を使い、エラー時に終了します"
+        - "cd -L /tmp           # シンボリックリンクをたどります（既定動作）"
+        # - "cd -@ /tmp           # 拡張属性を表示します（対応時）"
+      notes: "Tab 補完と特殊文字を含むパスの処理に対応しています。既定ではシンボリックリンクをたどります（-L）。"
+
+    pushd:
+      title: "📤 ディレクトリをスタックに追加"
+      description: "ディレクトリをスタックに積み、その場所へ移動します"
+      usage: "pushd [directory]"
+      options:
+        - ["directory", "移動先ディレクトリのパス"]
+        - ["(no args)", "スタック先頭の 2 つのディレクトリを入れ替えます"]
+      examples:
+        - "pushd /tmp           # 現在のディレクトリをスタックに積み、/tmp へ移動します"
+        - "pushd                # 現在と直前のディレクトリを入れ替えます"
+      notes: "複数のディレクトリ間を簡単に移動できるよう、ディレクトリスタックを維持します。"
+
+    popd:
+      title: "📥 ディレクトリをスタックから取り出す"
+      description: "スタックからディレクトリを取り出し、その場所へ移動します"
+      usage: "popd"
+      options: []
+      examples:
+        - "popd                 # スタックから前のディレクトリへ戻ります"
+      notes: "スタック先頭のディレクトリを取り除き、その場所へ移動します。"
+
+    dirs:
+      title: "📋 ディレクトリスタック表示"
+      description: "ディレクトリスタックを表示します"
+      usage: "dirs [-c]"
+      options:
+        - ["-c", "ディレクトリスタックを消去します"]
+      examples:
+        - "dirs                 # 現在のディレクトリスタックを表示します"
+        - "dirs -c              # ディレクトリスタックを消去します"
+      notes: "現在ナビゲーションスタックにあるすべてのディレクトリを表示します。"
+
+    help:
+      title: "❓ ヘルプ"
+      description: "利用可能なコマンドと機能を表示します"
+      usage: "help"
+      options: []
+      examples:
+        - "help                 # 一般的なヘルプ情報を表示します"
+      notes: "利用可能なすべてのコマンドとシェル機能の概要を表示します。"
+
+    clear:
+      title: "🧹 画面クリア"
+      description: "ターミナル画面を消去します"
+      usage: "clear"
+      options: []
+      examples:
+        - "clear                # ターミナル画面を消去します"
+      notes: "標準的な Unix の clear コマンドと同等です。"
+
+    exit:
+      title: "🚪 シェル終了"
+      description: "AI Shell を終了します"
+      usage: "exit"
+      options: []
+      examples:
+        - "exit                 # シェルを終了します"
+        - "quit                 # 別の終了方法です"
+      notes: "セッションデータを保持したままシェルを正常終了します。"
+
+    export:
+      title: "🔧 環境変数を export"
+      description: "export 属性付きで環境変数を設定または表示します"
+      usage: "export [-fn] [name[=value] ...]\nexport -p"
+      options:
+        - ["-f", "名前はシェル関数を指します（未対応）"]
+        - ["-n", "各名前から export 属性を削除します"]
+        - ["-p", "export 済み変数の一覧を表示します"]
+        - ["--", "以降のオプション処理を無効にします"]
+      examples:
+        - "export PATH=/usr/local/bin:$PATH"
+        - "export EDITOR=vim"
+        - "export -n VAR  # VAR から export 属性を削除します"
+        - "export -p      # export 済み変数をすべて表示します"
+        - "export JAVA_HOME=\"/usr/lib/jvm/java-11-openjdk\""
+        - "export -- -VAR  # -VAR という名前の変数を設定します"
+      notes: "export で設定した環境変数は子プロセスへ引き継がれます。"
+
+    unset:
+      title: "🗑️ 環境変数を解除"
+      description: "シェル変数と関数を削除します"
+      usage: "unset [-f] [-v] [-n] [name ...]"
+      options:
+        - ["-f", "各名前はシェル関数を指します（未対応）"]
+        - ["-v", "各名前はシェル変数を指します（既定）"]
+        - ["-n", "各名前は名前参照を指します（未対応）"]
+        - ["--", "以降のオプション処理を無効にします"]
+      examples:
+        - "unset TEMP_VAR"
+        - "unset -v VAR1 VAR2"
+        - "unset JAVA_HOME"
+        - "unset -- -VAR  # -VAR という名前の変数を削除します"
+      notes: "シェル環境から変数を削除します。存在しない変数は無視されます。"
+
+    pwd:
+      title: "📍 作業ディレクトリ表示"
+      description: "シンボリックリンク処理付きで現在の作業ディレクトリを表示します"
+      usage: "pwd [-L|-P]"
+      options:
+        - ["-L", "論理パスを表示します（シンボリックリンクをたどる、既定）"]
+        - ["-P", "物理パスを表示します（シンボリックリンクを解決する）"]
+      examples:
+        - "pwd                  # 論理的な現在ディレクトリを表示します"
+        - "pwd -L               # 論理パスを表示します（シンボリックリンクを考慮）"
+        - "pwd -P               # 物理パスを表示します（シンボリックリンクを解決）"
+      notes: "既定ではシンボリックリンクを考慮した論理パスを表示します。"
+
+    ";":
+      title: "🤖 AI アシスタント"
+      description: "AI アシスタントに質問します"
+      usage: "; <question>"
+      options:
+        - ["question", "AI アシスタントへの質問"]
+      examples:
+        - "; 大きいファイルを見つけるには？"
+        - "; このコマンドを説明して: ls -la"
+        - "; ファイルを圧縮するもっと良い方法を提案して"
+      notes: "AI アシスタントは、コマンドの説明、提案、一般的なシェルの使い方を支援できます。"
+
+    "；":
+      title: "🤖 AI アシスタント"
+      description: "AI アシスタントに質問します"
+      usage: "； <question>"
+      options:
+        - ["question", "AI アシスタントへの質問"]
+      examples:
+        - "； 大きいファイルを見つけるには？"
+        - "； このコマンドを説明して: ls -la"
+        - "； ファイルを圧縮するもっと良い方法を提案して"
+      notes: "AI アシスタントは、コマンドの説明、提案、一般的なシェルの使い方を支援できます。"
+
+    "/model":
+      title: "🧠 モデル切替"
+      description: "現在のモデルを表示するか、指定したモデルへ切り替えます"
+      usage: "/model [model]"
+      options:
+        - ["model", "切り替え先のモデル識別子（ツール呼び出し対応を検証します）"]
+        - ["--help, -h", "このヘルプメッセージを表示します"]
+      examples:
+        - "/model               # 現在のモデルを表示します"
+        - "/model gpt-4         # モデルを切り替えます"
+        - "/model --help        # ヘルプを表示します"
+      notes: "切り替え時には接続性とツール呼び出し対応を検証し、失敗した場合は現在のモデルを維持します。"
+
+    "/setup":
+      title: "⚙️ 再設定"
+      description: "対話型セットアップウィザードを再実行し、API 設定（プロバイダー、API キー、モデル）を変更します"
+      usage: "/setup"
+      options:
+        - ["--help, -h", "このヘルプメッセージを表示します"]
+      examples:
+        - "/setup               # セットアップウィザードを起動します"
+        - "/setup --help        # ヘルプを表示します"
+      notes: "新しい設定は再起動なしで直ちに適用されます。キャンセルした場合は現在の設定が維持されます。"
+
+errors:
+  litellm_not_installed: "litellm モジュールがインストールされていません"

--- a/src/aish/i18n/zh-CN.yaml
+++ b/src/aish/i18n/zh-CN.yaml
@@ -33,7 +33,6 @@ cli:
     provider_custom_api_base_required: "API Base 不能为空"
     provider_custom_api_base_invalid: "API Base 无效，请输入完整 URL"
     provider_custom_default: "Custom"
-    prompt_select: "输入序号，或输入关键词过滤，或输入 q 退出"
     invalid_choice: "选择无效，请重试"
     filter_no_results: "没有匹配项，请重新输入或回车显示全部"
     api_key_header: "请输入 API Key（将保存到配置文件）"
@@ -152,12 +151,9 @@ shell:
       content_preview: "内容预览"
       fallback_hint: "提示"
       risk_level: "风险等级"
-      matched_rule: "命中规则"
-      matched_paths: "命中路径"
       reasons: "原因"
       alternatives: "替代方案"
       impact: "影响"
-      confirm_message: "确认提示"
       no_additional_info: "未提供更多信息。"
 
     fallback:
@@ -234,10 +230,7 @@ shell:
 
 security:
   sandbox_off_action:
-    allow: "直接放行"
     confirm: "需要确认"
-    block: "阻断"
-
   sandbox_unavailable:
     title: "⚠️ 沙箱不可用"
     line1: "检测到沙箱不可用，无法评估命令风险。"
@@ -538,12 +531,3 @@ help:
 
 errors:
   litellm_not_installed: "litellm 模块未安装"
-  security_blocked_task: "任务未完成。由于系统安全限制，该操作已被阻断。"
-  llm:
-    auth: "认证失败：请检查 API_Key 是否正确。"
-    rate_limit: "请求过于频繁：已触发限流，请稍后重试。"
-    invalid_request: "请求参数无效：请检查模型名称/接口地址（API Base）以及请求参数。"
-    timeout: "请求超时：请检查网络连接或稍后重试。"
-    service_unavailable: "服务暂不可用：请稍后重试，或更换模型/Provider。"
-    context_length: "上下文过长：请清理对话历史或缩短输入内容。"
-    unknown: "调用大模型失败：{message}"

--- a/tests/test_i18n_help.py
+++ b/tests/test_i18n_help.py
@@ -1,34 +1,84 @@
 import os
+import subprocess
+import sys
+from pathlib import Path
 
-from typer.testing import CliRunner
+import pytest
 
-from aish.cli import app
-from aish.i18n import reset_i18n_for_tests
-
-
-def test_help_is_localized_by_lang_env_zh_cn():
-    runner = CliRunner()
-
-    reset_i18n_for_tests()
-    result = runner.invoke(app, ["--help"])
-
-    assert result.exit_code == 0
-    lang = os.getenv("LANG", "")
-    if lang.lower().startswith("zh"):
-        assert "内置大模型能力" in result.output
-    else:
-        assert "A shell with built-in LLM capabilities" in result.output
+from aish.i18n import _normalize_lang_to_ui_locale
 
 
-def test_help_falls_back_to_english_for_non_zh():
-    runner = CliRunner()
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
 
-    reset_i18n_for_tests()
-    result = runner.invoke(app, ["--help"])
 
-    assert result.exit_code == 0
-    # This project currently supports only zh-CN/en-US; non-zh locales fall back to English.
-    # If LANG starts with zh, help may render in Chinese.
-    lang = os.getenv("LANG", "")
-    if not lang.lower().startswith("zh"):
-        assert "A shell with built-in LLM capabilities" in result.output
+def _build_subprocess_env(lang: str) -> dict[str, str]:
+    env = dict(os.environ)
+    env["LANG"] = lang
+    python_path = str(SRC_ROOT)
+    existing_python_path = env.get("PYTHONPATH")
+    if existing_python_path:
+        python_path = f"{python_path}{os.pathsep}{existing_python_path}"
+    env["PYTHONPATH"] = python_path
+    return env
+
+
+@pytest.mark.parametrize(
+    ("lang", "expected_locale"),
+    [
+        ("zh_CN.UTF-8", "zh-CN"),
+        ("de_DE.UTF-8", "de-DE"),
+        ("es_ES.UTF-8", "es-ES"),
+        ("fr_FR.UTF-8", "fr-FR"),
+        ("ja_JP.UTF-8", "ja-JP"),
+        ("en_US.UTF-8", "en-US"),
+        ("pt_BR.UTF-8", "en-US"),
+        ("C", "en-US"),
+        (None, "en-US"),
+    ],
+)
+def test_normalize_lang_to_ui_locale(lang, expected_locale):
+    assert _normalize_lang_to_ui_locale(lang) == expected_locale
+
+
+@pytest.mark.parametrize(
+    ("lang", "expected_text"),
+    [
+        ("zh_CN.UTF-8", "内置大模型能力"),
+        ("de_DE.UTF-8", "integrierten LLM-Funktionen"),
+        ("es_ES.UTF-8", "capacidades de LLM integradas"),
+        ("fr_FR.UTF-8", "capacites LLM integrees"),
+        ("ja_JP.UTF-8", "LLM 機能を内蔵"),
+        ("en_US.UTF-8", "A shell with built-in LLM capabilities"),
+    ],
+)
+def test_help_is_localized_by_lang_env(lang, expected_text):
+    env = _build_subprocess_env(lang)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "aish.cli", "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=PROJECT_ROOT,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert expected_text in result.stdout
+
+
+def test_help_falls_back_to_english_for_unsupported_locale():
+    env = _build_subprocess_env("pt_BR.UTF-8")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "aish.cli", "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=PROJECT_ROOT,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "A shell with built-in LLM capabilities" in result.stdout


### PR DESCRIPTION
## Summary
- remove unused i18n keys from existing locales
- add German, Spanish, French, and Japanese locale support
- localize command help text and extend LANG-based locale normalization
- add runtime help localization coverage in tests

## Testing
- pytest tests/test_i18n_help.py tests/test_cli.py tests/test_output_language_config.py