### PR TITLE
fix: restore sandbox action i18n labels

### DIFF
--- a/src/aish/i18n/de-DE.yaml
+++ b/src/aish/i18n/de-DE.yaml
@@ -220,7 +220,9 @@ shell:
 
 security:
   sandbox_off_action:
+    allow: "Direkt erlauben"
     confirm: "Bestätigung verlangen"
+    block: "Blockieren"
   sandbox_unavailable:
     title: "⚠️ Sandbox nicht verfügbar"
     line1: "Die Sandbox ist nicht verfügbar; das Befehlsrisiko kann nicht bewertet werden."

--- a/src/aish/i18n/en-US.yaml
+++ b/src/aish/i18n/en-US.yaml
@@ -28,9 +28,7 @@ cli:
     free_key_location_overseas: "Global"
     free_key_registering: "Registering free API key..."
     free_key_success: "Free API key acquired"
-    free_key_missing_key: "Registration succeeded but no API key was returned"
     free_key_already_registered: "This device has already registered a free key"
-    free_key_fingerprint_failed: "Unable to collect device information for fingerprint"
     free_key_failed_with_reason: "Free API key registration failed: {reason}"
     free_key_provider_label: "Free API"
     free_key_privacy_title: "Privacy Notice"
@@ -116,7 +114,6 @@ cli:
     action_retry_api_key: "Re-enter API Key"
     action_retry_free_key: "Retry free key registration"
     action_fallback_manual: "Switch to manual setup"
-    action_use_existing_key: "Use existing key"
     action_use_free_key: "Use free API key"
     action_manual_setup: "Manual provider setup"
     action_change_provider: "Change provider"
@@ -274,7 +271,9 @@ shell:
 
 security:
   sandbox_off_action:
+    allow: "Allow"
     confirm: "Require confirmation"
+    block: "Block"
 
   sandbox_unavailable:
     title: "⚠️ Sandbox Unavailable"

--- a/src/aish/i18n/es-ES.yaml
+++ b/src/aish/i18n/es-ES.yaml
@@ -220,7 +220,9 @@ shell:
 
 security:
   sandbox_off_action:
+    allow: "Permitir directamente"
     confirm: "Requerir confirmación"
+    block: "Bloquear"
   sandbox_unavailable:
     title: "⚠️ Sandbox no disponible"
     line1: "El sandbox no está disponible; no se puede evaluar el riesgo del comando."

--- a/src/aish/i18n/fr-FR.yaml
+++ b/src/aish/i18n/fr-FR.yaml
@@ -220,7 +220,9 @@ shell:
 
 security:
   sandbox_off_action:
+    allow: "Autoriser directement"
     confirm: "Demander confirmation"
+    block: "Bloquer"
   sandbox_unavailable:
     title: "⚠️ Sandbox indisponible"
     line1: "Le sandbox est indisponible ; le risque de la commande ne peut pas etre evalue."

--- a/src/aish/i18n/ja-JP.yaml
+++ b/src/aish/i18n/ja-JP.yaml
@@ -220,7 +220,9 @@ shell:
 
 security:
   sandbox_off_action:
+    allow: "そのまま許可"
     confirm: "確認を求める"
+    block: "ブロック"
   sandbox_unavailable:
     title: "⚠️ サンドボックスを利用できません"
     line1: "サンドボックスを利用できないため、コマンドのリスクを評価できません。"

--- a/src/aish/i18n/zh-CN.yaml
+++ b/src/aish/i18n/zh-CN.yaml
@@ -28,9 +28,7 @@ cli:
     free_key_location_overseas: "国际节点"
     free_key_registering: "正在注册免费 API Key..."
     free_key_success: "已获取免费 API Key"
-    free_key_missing_key: "注册成功，但服务端未返回 API Key"
     free_key_already_registered: "该设备已注册过免费Key"
-    free_key_fingerprint_failed: "无法采集设备信息，指纹生成失败"
     free_key_failed_with_reason: "免费 API Key 注册失败：{reason}"
     free_key_provider_label: "免费 API"
     free_key_privacy_title: "隐私声明"
@@ -116,7 +114,6 @@ cli:
     action_retry_api_key: "重新输入 API Key"
     action_retry_free_key: "重试免费 Key 注册"
     action_fallback_manual: "切换到手动配置"
-    action_use_existing_key: "使用已有的 Key"
     action_use_free_key: "使用免费 API Key"
     action_manual_setup: "手动配置 Provider"
     action_change_provider: "更换 Provider"
@@ -274,7 +271,9 @@ shell:
 
 security:
   sandbox_off_action:
+    allow: "直接放行"
     confirm: "需要确认"
+    block: "阻断"
   sandbox_unavailable:
     title: "⚠️ 沙箱不可用"
     line1: "检测到沙箱不可用，无法评估命令风险。"


### PR DESCRIPTION
## Summary
- restore missing top-level `security.sandbox_off_action.allow` and `block` labels across locales
- fix runtime sandbox-unavailable prompts showing raw i18n keys under `uv run aish`
- remove a few confirmed-unused setup i18n entries from en-US and zh-CN

## Testing
- pytest tests/test_i18n_help.py tests/test_cli.py tests/test_output_language_config.py