### PR TITLE
input is required; press Enter to correct the error.

### DIFF
--- a/src/aish/i18n/de-DE.yaml
+++ b/src/aish/i18n/de-DE.yaml
@@ -169,7 +169,7 @@ shell:
 
   command_cancelled: "Befehl abgebrochen"
   error_correction:
-    press_semicolon_hint: "Die Befehlsausführung ist fehlgeschlagen. Drücken Sie ;, um automatisch zu analysieren und zu reparieren, oder geben Sie direkt den nächsten Befehl ein."
+    press_semicolon_hint: "Die Befehlsausführung ist fehlgeschlagen. Geben Sie ; ein und drücken Sie Enter für automatische Analyse und Reparatur, oder geben Sie den nächsten Befehl ein."
     corrected_command_label: "Vorgeschlagene Korrektur:"
   error:
     execution_error: "❌ Fehler während der Ausführung: {error}"

--- a/src/aish/i18n/en-US.yaml
+++ b/src/aish/i18n/en-US.yaml
@@ -212,7 +212,7 @@ shell:
   command_cancelled: "Command cancelled"
 
   error_correction:
-    press_semicolon_hint: "Command execution failed. Press ; to automatically analyze and repair, or enter the next command directly."
+    press_semicolon_hint: "Command execution failed. Type ; and press Enter to auto-analyze and fix, or enter the next command directly."
     corrected_command_label: "Suggested fix:"
 
   error:

--- a/src/aish/i18n/es-ES.yaml
+++ b/src/aish/i18n/es-ES.yaml
@@ -169,7 +169,7 @@ shell:
 
   command_cancelled: "Comando cancelado"
   error_correction:
-    press_semicolon_hint: "La ejecución del comando falló. Pulsa ; para analizar y reparar automáticamente, o introduce el siguiente comando."
+    press_semicolon_hint: "La ejecución del comando falló. Escribe ; y pulsa Enter para analizar y reparar automáticamente, o introduce el siguiente comando."
     corrected_command_label: "Corrección sugerida:"
   error:
     execution_error: "❌ Error durante la ejecución: {error}"

--- a/src/aish/i18n/fr-FR.yaml
+++ b/src/aish/i18n/fr-FR.yaml
@@ -169,7 +169,7 @@ shell:
 
   command_cancelled: "Commande annulee"
   error_correction:
-    press_semicolon_hint: "L'execution de la commande a echoue. Appuyez sur ; pour analyser et reparer automatiquement, ou saisissez directement la commande suivante."
+    press_semicolon_hint: "L'execution de la commande a echoue. Tapez ; puis Enter pour analyser et reparer automatiquement, ou saisissez la commande suivante."
     corrected_command_label: "Correction suggeree :"
   error:
     execution_error: "❌ Erreur pendant l'execution : {error}"

--- a/src/aish/i18n/ja-JP.yaml
+++ b/src/aish/i18n/ja-JP.yaml
@@ -169,7 +169,7 @@ shell:
 
   command_cancelled: "コマンドをキャンセルしました"
   error_correction:
-    press_semicolon_hint: "コマンド実行に失敗しました。; を押して自動解析・修復するか、そのまま次のコマンドを入力してください。"
+    press_semicolon_hint: "コマンド実行に失敗しました。; を入力して Enter で自動解析・修復、または次のコマンドを入力してください。"
     corrected_command_label: "修正候補:"
   error:
     execution_error: "❌ 実行中にエラーが発生しました: {error}"

--- a/src/aish/i18n/zh-CN.yaml
+++ b/src/aish/i18n/zh-CN.yaml
@@ -212,7 +212,7 @@ shell:
   command_cancelled: "命令已取消"
 
   error_correction:
-    press_semicolon_hint: "命令执行失败。按 ; 自动分析修复，或直接输入下一条命令。"
+    press_semicolon_hint: "命令执行失败。输入 ; 后按 Enter 自动分析修复，或直接输入下一条命令。"
     corrected_command_label: "修复建议:"
 
   error:

--- a/src/aish/shell.py
+++ b/src/aish/shell.py
@@ -3396,11 +3396,11 @@ class AIShell:
                                 # Get first line of input
                                 first_input = await self.get_user_input(prompt_text)
 
-                                # Check for semicolon key press for error correction
-                                # Only if there's pending error correction
-                                if (
-                                    self._pending_error_correction
-                                    and first_input == "__CORRECT_SEMICOLON__"
+                                # Check for semicolon input for error correction
+                                # User must press Enter after typing ";" or "；" to trigger correction
+                                if self._pending_error_correction and first_input.strip() in (
+                                    ";",
+                                    "；",
                                 ):
                                     await self._execute_error_correction()
                                     continue

--- a/src/aish/shell_enhanced/shell_prompt_io.py
+++ b/src/aish/shell_enhanced/shell_prompt_io.py
@@ -46,7 +46,6 @@ async def get_user_input(
     import threading
     import time
 
-    from prompt_toolkit.filters import Condition
     from prompt_toolkit.key_binding import KeyBindings
     from prompt_toolkit.keys import Keys
 
@@ -89,9 +88,6 @@ async def get_user_input(
     # 用于存储 app 引用和刷新控制
     app_ref = [None]
     refresh_stop_event = threading.Event()
-
-    # Track whether correction was triggered
-    correction_triggered = [False]
 
     # Create bottom toolbar for TUI mode - shows status bar at bottom
     from prompt_toolkit.application import get_app_or_none
@@ -295,40 +291,6 @@ async def get_user_input(
         if app_ref[0] is None:
             app_ref[0] = event.app
 
-    # Handle semicolon key for error correction when there's a pending correction
-    if has_pending_correction:
-        # Create a filter that checks if we still have pending correction
-        def has_correction_filter():
-            return self._pending_error_correction is not None
-
-        @kb.add(";", filter=Condition(has_correction_filter))
-        def handle_correction_key(event):
-            """Trigger error correction when semicolon is pressed at line start."""
-            if app_ref[0] is None:
-                app_ref[0] = event.app
-            # Only trigger when cursor is at line start (first character is semicolon)
-            # Does not affect semicolon input at other positions
-            buffer = event.app.current_buffer
-            if buffer.cursor_position == 0:
-                correction_triggered[0] = True
-                event.app.exit(result="__CORRECT_SEMICOLON__")
-            else:
-                # Not at line start, insert semicolon normally
-                buffer.insert_text(";")
-
-        @kb.add("；", filter=Condition(has_correction_filter))
-        def handle_correction_key_cn(event):
-            """Trigger error correction when Chinese semicolon is pressed at line start."""
-            if app_ref[0] is None:
-                app_ref[0] = event.app
-            buffer = event.app.current_buffer
-            if buffer.cursor_position == 0:
-                correction_triggered[0] = True
-                event.app.exit(result="__CORRECT_SEMICOLON__")
-            else:
-                # Not at line start, insert Chinese semicolon normally
-                buffer.insert_text("；")
-
     try:
         result = await self.session.prompt_async(
             base_prompt,
@@ -340,12 +302,12 @@ async def get_user_input(
         if result is None:
             return ""
 
-        # Check if correction was triggered (user pressed Y)
-        if correction_triggered[0]:
-            return result
-
-        # If we had pending correction but user didn't press Y, clear it
-        if self._pending_error_correction is not None:
+        # Clear pending correction if user didn't type only semicolon
+        # If they typed only ";" or "；", preserve it for shell.py to handle
+        if (
+            self._pending_error_correction is not None
+            and result.strip() not in (";", "；")
+        ):
             self._pending_error_correction = None
 
         # 检查是否在确认窗口期内按了其他键


### PR DESCRIPTION
## Summary

- Problem: After entering the wrong command, there is no need to correct the error. Instead, enter the natural language. Press; and it will automatically enter the error correction.
- Changes:
- Related Issue: #
<img width="679" height="85" alt="image" src="https://github.com/user-attachments/assets/bd0d3d7b-35ce-432b-a88b-debcdda8f7d5" />

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Other

## Scope

- [ ] Core shell / PTY
- [ ] AI agent / LLM
- [ ] Skills / Tools
- [ ] Security
- [ ] Configuration
- [ ] CLI / Interface
- [ ] Packaging / Installation
- [ ] CI/CD
- [ ] Documentation

## User-visible Changes

<!-- Describe behavior changes visible to users. Write "None" if not applicable. -->

-

## Compatibility

- Backward compatible? (Yes/No)
- Config changes? (Yes/No - if yes, describe migration)

## Testing

<!-- How to verify this change -->

-

## Checklist

- [ ] Code follows project style
- [ ] Tests added if needed
- [ ] Documentation updated if needed
