### PR TITLE
Release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2026-03-19
+
+### Added
+
+- Added shell prompt scripting support with built-in templates, examples, and hot reload so prompts can be customized without modifying core code.
+- Added full localized interface coverage for German, Spanish, French, Japanese, and Chinese alongside the existing English experience.
+
+### Changed
+
+- Changed the setup wizard to better guide provider configuration with clearer loading feedback during key assignment and verification.
+- Changed assistant response rendering to use a more compact message box layout for long replies in the terminal UI.
+
+### Fixed
+
+- Fixed transient OpenAI Codex request failures by retrying temporary upstream errors during provider requests.
+- Fixed sandbox startup and IPC routing so sandboxed execution remains reliable in both normal and frozen binary environments.
+- Fixed missing localized labels for sandbox approval actions in non-English interfaces.
+
 ## [0.1.2] - 2026-03-14
 
 ### Added
@@ -46,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Linux bundle smoke tests to match the installer layout used by release artifacts.
 - Fixed startup welcome screen rendering regressions.
 - Fixed official website redirection failures.
+
 ## [0.1.0] - 2025-12-29
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aish"
-version = "0.1.2"
+version = "0.1.3"
 description = "AI Shell - A shell with built-in LLM capabilities"
 readme = "README.md"
 authors = [{ name = "Sian Cao", email = "yinshuiboy@gmail.com" }]

--- a/src/aish/__init__.py
+++ b/src/aish/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 # Avoid importing heavy modules (and any side-effects) at package import time.
 # This matters for system services like aish-sandbox, which only need aish.sandboxd.

--- a/uv.lock
+++ b/uv.lock
@@ -146,7 +146,7 @@ wheels = [
 
 [[package]]
 name = "aish"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary
- prepare release v0.1.3 metadata and version files
- add the 0.1.3 changelog section for scripts, localization, wizard UX, and stability fixes
- update lockfile package version to keep release metadata validation consistent

## Changelog Highlights
- Added shell prompt scripting support with templates, examples, and hot reload
- Added localized interface coverage for German, Spanish, French, Japanese, and Chinese
- Improved setup wizard feedback and compact AI response rendering
- Fixed transient OpenAI Codex retries, sandbox startup and IPC reliability, and non-English sandbox approval labels

## Validation
- /home/lixin/workspace/aish/.venv/bin/python -m pytest tests/test_update_release_files.py tests/test_release_metadata.py -q
- make test
