### PR TITLE
fix: preserve prompt hook trailing spaces

### DIFF
--- a/src/aish/scripts/executor.py
+++ b/src/aish/scripts/executor.py
@@ -140,7 +140,7 @@ class ScriptExecutor:
                 timeout=timeout,
             )
 
-            output = result.stdout.strip()
+            output = result.stdout.rstrip("\r\n")
             error = result.stderr.strip() if result.returncode != 0 else ""
 
             # Parse state changes from output

--- a/src/aish/scripts/hooks.py
+++ b/src/aish/scripts/hooks.py
@@ -60,7 +60,7 @@ class HookManager:
         result = self.executor.execute_sync(hook, args=[], env=env)
 
         if result.success and result.output:
-            return result.output.strip()
+            return result.output
         if result.error:
             logger.warning("Prompt hook failed: %s", result.error)
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -404,6 +404,22 @@ class TestHookManager:
             prompt = manager.run_prompt_hook()
             assert "custom" in prompt
 
+    def test_run_prompt_hook_preserves_trailing_space(self) -> None:
+        """Prompt hook should preserve trailing space for cursor separation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "aish_prompt.aish").write_text(
+                'printf "prompt > "', encoding="utf-8"
+            )
+
+            registry = ScriptRegistry(scripts_dir=Path(tmpdir))
+            registry.load_all_scripts()
+
+            executor = ScriptExecutor()
+            manager = HookManager(registry, executor)
+
+            prompt = manager.run_prompt_hook()
+            assert prompt == "prompt > "
+
 
 class TestScriptHotReloadService:
     """Tests for script hot reload service."""


### PR DESCRIPTION
## Summary
- preserve trailing spaces in synchronous script output so prompt hooks keep cursor separation
- stop stripping prompt hook output a second time in the hook manager
- add a regression test covering a prompt hook that intentionally ends with a space

## Testing
- pytest tests/test_scripts.py -q