### PR TITLE
Adjust bash and sandbox timeout defaults

### DIFF
--- a/config/security_policy.yaml
+++ b/config/security_policy.yaml
@@ -6,6 +6,8 @@
 #   - enable_sandbox: 是否启用沙箱预跑/受控执行（如实现侧支持，可映射到对应开关）。
 #   - sandbox_off_action: 当沙箱关闭、不可用或执行失败时，系统无法根据 rules 评估命令实际的文件变更，
 #     将采用该配置指定的动作进行处理：BLOCK=阻断，CONFIRM=需确认，ALLOW=直接放行。
+#   - sandbox_timeout_seconds: 沙箱预执行/预评估的超时时间（秒）。超时后不会阻止真实命令，
+#     但会降级为“无法可靠评估风险，请确认后执行”。
 #
 # - rules: 规则列表（自上而下匹配，命中第一条即生效）
 #   每条规则字段：
@@ -42,6 +44,9 @@ global:
 
   # 沙箱关闭、不可用或执行失败时的处理动作（BLOCK=阻断，CONFIRM=需确认，ALLOW=直接放行）
   sandbox_off_action: ALLOW
+
+  # 沙箱预执行超时时间（秒）
+  sandbox_timeout_seconds: 10
 
 # 规则列表：从上到下匹配，第一条命中生效
 rules:

--- a/src/aish/security/security_config.py
+++ b/src/aish/security/security_config.py
@@ -37,6 +37,8 @@ _EMPTY_POLICY_TEMPLATE_ZH = """# -AI-Shell Security Policy
 #   - enable_sandbox: 是否启用沙箱预跑/受控执行（如实现侧支持，可映射到对应开关）。
 #   - sandbox_off_action: 当沙箱关闭/不可用/执行失败时，无法根据 rules 评估命令的实际文件变更，
 #     将使用该动作作为兜底决策：BLOCK=阻断，CONFIRM=确认，ALLOW=直接放行。
+#   - sandbox_timeout_seconds: 沙箱预执行/预评估的超时时间（秒）。超时后不会阻止真实命令，
+#     但会降级为“无法可靠评估风险，请确认后执行”。
 #
 # - rules: 规则列表（自上而下匹配，命中第一条即生效）
 #   每条规则字段：
@@ -73,6 +75,9 @@ global:
 
     # 沙箱关闭/失败时的兜底动作（BLOCK=阻断，CONFIRM=确认，ALLOW=直接放行）
     sandbox_off_action: ALLOW
+
+    # 沙箱预执行超时时间（秒）
+    sandbox_timeout_seconds: 10
 
 # 规则列表：从上到下匹配，第一条命中生效
 rules:
@@ -114,6 +119,8 @@ _EMPTY_POLICY_TEMPLATE_EN = """# -AI-Shell Security Policy
 #   - enable_sandbox: enable sandbox pre-run/controlled execution (if supported by the implementation).
 #   - sandbox_off_action: when sandbox is disabled/unavailable/failed, rules cannot be evaluated (no file change list).
 #     This action is used as a fallback decision: BLOCK, CONFIRM, ALLOW.
+#   - sandbox_timeout_seconds: timeout in seconds for sandbox pre-execution/pre-evaluation.
+#     On timeout, the real command is not blocked, but risk evaluation degrades to confirmation fallback.
 #
 # - rules: rule list (top-down match; first match wins)
 #   Fields:
@@ -150,6 +157,9 @@ global:
 
     # Fallback action when sandbox is unavailable (BLOCK, CONFIRM, ALLOW)
     sandbox_off_action: ALLOW
+
+    # Sandbox pre-execution timeout in seconds
+    sandbox_timeout_seconds: 10
 
 # Rules: top-down match, first match wins
 rules:
@@ -446,6 +456,24 @@ def load_security_policy(config_path: Optional[Path] = None) -> SecurityPolicy:
                 "security_policy: invalid sandbox_off_action; falling back to ALLOW"
             )
 
+    raw_sandbox_timeout = (
+        global_cfg.get("sandbox_timeout_seconds")
+        if isinstance(global_cfg, dict)
+        else None
+    )
+    if raw_sandbox_timeout is None:
+        sandbox_timeout_seconds = 10.0
+    else:
+        try:
+            sandbox_timeout_seconds = float(raw_sandbox_timeout)
+            if sandbox_timeout_seconds <= 0:
+                raise ValueError("sandbox_timeout_seconds must be > 0")
+        except Exception:
+            sandbox_timeout_seconds = 10.0
+            _LOGGER.warning(
+                "security_policy: invalid sandbox_timeout_seconds; falling back to 10.0"
+            )
+
     # Backward compatibility: support the old key sandbox_fallback_risk (LOW/MEDIUM/HIGH)
     # and map it to sandbox_off_action (ALLOW/CONFIRM/BLOCK).
     if (
@@ -501,6 +529,7 @@ def load_security_policy(config_path: Optional[Path] = None) -> SecurityPolicy:
         enable_sandbox=enable_sandbox,
         rules=rules,
         sandbox_off_action=sandbox_off_action,
+        sandbox_timeout_seconds=sandbox_timeout_seconds,
         default_risk_level=default_risk,
         audit_enabled=audit_cfg.enabled,
         audit_log_path=audit_cfg.log_path,

--- a/src/aish/security/security_manager.py
+++ b/src/aish/security/security_manager.py
@@ -75,6 +75,7 @@ class SimpleSecurityManager:
                 repo_root=self._repo_root,
                 enabled=True,
                 socket_path=socket_path,
+                timeout_s=self._policy.sandbox_timeout_seconds,
             )
 
         self._ai_engine = AiRiskEngine(self._policy)

--- a/src/aish/security/security_policy.py
+++ b/src/aish/security/security_policy.py
@@ -83,6 +83,7 @@ class SecurityPolicy:
     # 此时将依据 sandbox_off_action 配置决定执行阻断、确认还是直接放行。
     # 默认为放行
     sandbox_off_action: SandboxOffAction = SandboxOffAction.ALLOW
+    sandbox_timeout_seconds: float = 10.0
 
     default_risk_level: RiskLevel = RiskLevel.LOW
     audit_enabled: bool = False
@@ -95,6 +96,7 @@ class SecurityPolicy:
         return SecurityPolicy(
             enable_sandbox=False,
             rules=list(_DEFAULT_RULES),
+            sandbox_timeout_seconds=10.0,
             invalid_fallback_rules=[],
             validation_issues=[],
         )

--- a/src/aish/tools/bash_executor.py
+++ b/src/aish/tools/bash_executor.py
@@ -58,7 +58,7 @@ class UnifiedBashExecutor:
         self,
         command: str,
         source: str = "ai",
-        timeout: int = 30,
+        timeout: Optional[int] = None,
         use_pty: bool = False,
         cancel_event: Optional[Any] = None,
     ) -> Tuple[bool, str, str, int, Dict]:
@@ -68,7 +68,7 @@ class UnifiedBashExecutor:
         Args:
             command: Shell command to execute
             source: Command source ("ai" or "user")
-            timeout: Timeout in seconds
+            timeout: Optional timeout in seconds; None disables timeout
             use_pty: Whether to use PTY (for interactive commands)
             cancel_event: Cancellation event (PTY mode only)
 
@@ -122,21 +122,26 @@ class UnifiedBashExecutor:
         state_file: str,
         cwd: str,
         env_vars: Dict[str, str],
-        timeout: int,
+        timeout: Optional[int],
     ) -> Tuple[bool, str, str, int]:
         """Normal execution using subprocess.run."""
         wrapped_command = wrap_command_with_state_capture(command, state_file)
 
         try:
+            run_kwargs: Dict[str, Any] = {
+                "args": wrapped_command,
+                "shell": True,
+                "executable": "/bin/bash",
+                "capture_output": True,
+                "text": False,
+                "cwd": cwd,
+                "env": env_vars,
+            }
+            if timeout is not None:
+                run_kwargs["timeout"] = timeout
+
             result = subprocess.run(
-                wrapped_command,
-                shell=True,
-                executable="/bin/bash",
-                capture_output=True,
-                text=False,
-                timeout=timeout,
-                cwd=cwd,
-                env=env_vars,
+                **run_kwargs,
             )
 
             stdout = (result.stdout or b"").decode("utf-8", errors="replace")

--- a/tests/security/policy/test_fallback_risk.py
+++ b/tests/security/policy/test_fallback_risk.py
@@ -31,6 +31,21 @@ def test_load_security_policy_parses_sandbox_off_action(tmp_path: Path):
     assert policy.sandbox_off_action == SandboxOffAction.BLOCK
 
 
+def test_load_security_policy_parses_sandbox_timeout_seconds(tmp_path: Path):
+    policy_path = tmp_path / "security_policy.yaml"
+    policy_path.write_text(
+        "global:\n"
+        "  enable_sandbox: true\n"
+        "  sandbox_timeout_seconds: 10\n"
+        "rules: []\n",
+        encoding="utf-8",
+    )
+
+    policy = load_security_policy(config_path=policy_path)
+    assert policy.enable_sandbox is True
+    assert policy.sandbox_timeout_seconds == 10.0
+
+
 def test_sandbox_fallback_high_blocks_ai_command():
     policy = SecurityPolicy(
         enable_sandbox=False,

--- a/tests/security/sandbox/test_ipc.py
+++ b/tests/security/sandbox/test_ipc.py
@@ -118,7 +118,7 @@ def test_sandbox_ipc_protocol_error_on_invalid_json(tmp_path: Path):
 
 def test_security_manager_uses_ipc_when_enabled(monkeypatch, tmp_path: Path):
     monkeypatch.setattr("aish.security.security_manager.os.geteuid", lambda: 0)
-    policy = SecurityPolicy(enable_sandbox=True, rules=[])
+    policy = SecurityPolicy(enable_sandbox=True, rules=[], sandbox_timeout_seconds=10.0)
 
     manager = SimpleSecurityManager(
         repo_root=tmp_path,
@@ -127,6 +127,7 @@ def test_security_manager_uses_ipc_when_enabled(monkeypatch, tmp_path: Path):
     )
 
     assert isinstance(manager._sandbox_security, SandboxSecurityIpc)
+    assert manager._sandbox_security._client._timeout_s == 10.0
 
 
 def test_security_manager_uses_fallback_when_ipc_is_unavailable(tmp_path: Path):

--- a/tests/test_bash_executor.py
+++ b/tests/test_bash_executor.py
@@ -1,6 +1,7 @@
 """测试统一 Bash 执行器"""
 
 import os
+import subprocess
 import sys
 
 import pytest
@@ -121,6 +122,28 @@ class TestUnifiedBashExecutor:
         assert success is True
         assert "Error: 'utf-8' codec can't decode" not in stderr
         assert stdout != ""
+
+    def test_default_execute_does_not_pass_timeout(self, executor, monkeypatch):
+        """测试默认执行不向 subprocess 传递 timeout"""
+        captured = {}
+
+        def fake_run(*args, **kwargs):
+            captured.update(kwargs)
+            return subprocess.CompletedProcess(
+                args=kwargs.get("args") or args[0],
+                returncode=0,
+                stdout=b"ok\n",
+                stderr=b"",
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        success, stdout, stderr, retcode, changes = executor.execute("echo ok")
+
+        assert success is True
+        assert retcode == 0
+        assert stdout == "ok\n"
+        assert "timeout" not in captured
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove the default execution timeout from bash_exec so shell commands are not cut off after 30 seconds
- add a configurable sandbox pre-execution timeout with a 10 second default
- update security policy templates and tests to cover the new timeout behavior

## Testing
- /home/lixin/workspace/aish/.venv/bin/python -m pytest tests/test_bash_executor.py tests/security/policy/test_fallback_risk.py tests/security/sandbox/test_ipc.py -q