### PR TITLE
fix: include bash_rc_wrapper.sh in PyInstaller bundle

### DIFF
--- a/aish.spec
+++ b/aish.spec
@@ -106,6 +106,7 @@ a = Analysis(
         ('src/aish/i18n', 'aish/i18n'),
         ('src/aish/scripts/prompts', 'aish/scripts/prompts'),
         ('src/aish/scripts/templates', 'aish/scripts/templates'),
+        ('src/aish/pty/bash_rc_wrapper.sh', 'aish/pty'),
     ] + tiktoken_datas + litellm_datas + litellm_json_datas + skills_datas,
     hiddenimports=[
         'aish.prompts',


### PR DESCRIPTION
## Summary
- Add `bash_rc_wrapper.sh` to PyInstaller `datas` in `aish.spec`

The rcfile was missing from the packaged build, causing bash to start without the control channel setup. This broke prompt suppression (PS1=''), cwd tracking, prompt_ready events, and proper exit handling.

## Test plan
- [ ] Rebuild with `pyinstaller aish.spec` and verify the packaged aish shows the compact theme prompt correctly
- [ ] Verify `cd` changes the directory and the prompt updates
- [ ] Verify `exit` properly exits the shell