### PR TITLE
CI: Tighten live smoke tool verification

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -23,8 +23,7 @@ jobs:
   live-smoke:
     name: Run live smoke tests
     runs-on: ubuntu-latest
-    environment:
-      name: live-smoke
+    environment: live-smoke
 
     steps:
       - name: Checkout repository
@@ -69,6 +68,7 @@ jobs:
           AISH_LIVE_SMOKE_MODEL: ${{ secrets.AISH_LIVE_SMOKE_MODEL }}
         run: |
           set -euo pipefail
+          mkdir -p build
           uv run --group dev python -m pytest tests/live_smoke -v -m live_smoke --run-live-smoke --basetemp build/pytest-live-smoke
 
       - name: Upload live smoke diagnostics

--- a/src/aish/i18n/en-US.yaml
+++ b/src/aish/i18n/en-US.yaml
@@ -146,6 +146,7 @@ cli:
     verify_live_detail: "Details"
     verify_timeout: "Live verification timed out"
     verify_cancelled: "Live verification cancelled"
+    verify_model_prefix_required: "When API Base is set, the model must include a provider prefix, for example openai/{model}"
     verify_no_tool_call_required: "No tool call returned (required mode)"
     verify_no_tool_call_auto: "Model did not call tool (auto mode)"
     debug_request_title: "Live request ({mode})"

--- a/src/aish/i18n/zh-CN.yaml
+++ b/src/aish/i18n/zh-CN.yaml
@@ -146,6 +146,7 @@ cli:
     verify_live_detail: "详情"
     verify_timeout: "在线验证超时"
     verify_cancelled: "在线验证已终止"
+    verify_model_prefix_required: "设置 API Base 时，模型名必须带 provider 前缀，例如 openai/{model}"
     verify_no_tool_call_required: "强制调用未返回工具调用"
     verify_no_tool_call_auto: "自动模式未触发工具调用"
     debug_request_title: "在线请求（{mode}）"

--- a/src/aish/wizard/verification.py
+++ b/src/aish/wizard/verification.py
@@ -33,6 +33,15 @@ CONNECTIVITY_TIMEOUT = 15.0
 TOOL_CHECK_TIMEOUT = 30.0
 
 
+def _validate_model_name(model: str, api_base: Optional[str]) -> str | None:
+    trimmed = (model or "").strip()
+    if not trimmed:
+        return t("cli.setup.model_custom_required")
+    if api_base and "/" not in trimmed:
+        return t("cli.setup.verify_model_prefix_required", model=trimmed)
+    return None
+
+
 def _compact_error_message(error: object, *, max_len: int = 180) -> str:
     if error is None:
         return t("cli.setup.verify_failed_unknown")
@@ -113,6 +122,10 @@ async def _check_connectivity(
     debug: bool = False,
 ) -> ConnectivityResult:
     """Send a minimal completion request to verify the model is reachable."""
+    model_error = _validate_model_name(model, api_base)
+    if model_error:
+        return ConnectivityResult(ok=False, error=model_error)
+
     messages = [{"role": "user", "content": CONNECTIVITY_PROMPT}]
     kwargs = dict(
         model=model,
@@ -255,6 +268,9 @@ async def _check_tool_support(
     debug: bool = False,
 ) -> ToolSupportResult:
     """Live tool-call probe: send a ping tool and see if the model invokes it."""
+    model_error = _validate_model_name(model, api_base)
+    if model_error:
+        return ToolSupportResult(supports=None, error=model_error)
 
     # Quick static pre-check – if litellm metadata says "no", skip the live call.
     static = _quick_static_check(litellm, model)
@@ -323,13 +339,12 @@ async def _check_tool_support(
             )
         return response
 
-    required_choice = {"type": "function", "function": {"name": "ping"}}
-
-    # Try with tool_choice=required first
+    # Runtime uses tool_choice=auto. Verify the same path instead of a stricter
+    # mode that some gateways do not implement consistently.
     try:
         with anyio.fail_after(timeout_seconds):
-            response = await _call(required_choice, "required")
-        return _parse(response, strict=True)
+            response = await _call(None, "auto")
+        return _parse(response, strict=False)
     except TimeoutError:
         return ToolSupportResult(
             supports=None,
@@ -341,37 +356,12 @@ async def _check_tool_support(
         message = _compact_error_message(raw_message)
         if debug:
             _print_debug_block(
-                t("cli.setup.debug_error_title", mode="required"),
+                t("cli.setup.debug_error_title", mode="auto"),
                 message,
                 border_style="red",
             )
         if _error_indicates_no_tool_support(raw_message):
             return ToolSupportResult(supports=False, error=message)
-
-        # Fallback: some models reject tool_choice but support tools via auto
-        if _error_indicates_tool_choice_unsupported(raw_message):
-            try:
-                with anyio.fail_after(timeout_seconds):
-                    response = await _call(None, "auto")
-                return _parse(response, strict=False)
-            except TimeoutError:
-                return ToolSupportResult(
-                    supports=None,
-                    timed_out=True,
-                    error=t("cli.setup.verify_timeout"),
-                )
-            except Exception as fallback_exc:
-                fb_raw = str(fallback_exc)
-                fb_msg = _compact_error_message(fb_raw)
-                if debug:
-                    _print_debug_block(
-                        t("cli.setup.debug_error_title", mode="auto"),
-                        fb_msg,
-                        border_style="red",
-                    )
-                if _error_indicates_no_tool_support(fb_raw):
-                    return ToolSupportResult(supports=False, error=fb_msg)
-                return ToolSupportResult(supports=None, error=fb_msg)
 
         return ToolSupportResult(supports=None, error=message)
 

--- a/tests/live_smoke/conftest.py
+++ b/tests/live_smoke/conftest.py
@@ -201,6 +201,11 @@ def live_smoke_provider_config() -> LiveSmokeProviderConfig:
         pytest.skip("missing AISH_LIVE_SMOKE_MODEL for live smoke test")
     if not api_key:
         pytest.skip("missing AISH_LIVE_SMOKE_API_KEY for live smoke test")
+    if api_base and "/" not in model:
+        pytest.fail(
+            "AISH_LIVE_SMOKE_MODEL must include a provider prefix when AISH_LIVE_SMOKE_API_BASE is set, "
+            f"for example openai/{model}"
+        )
 
     return LiveSmokeProviderConfig(model=model, api_key=api_key, api_base=api_base)
 

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+
+from aish.wizard.verification import _check_tool_support
+
+
+class _AutoOnlyToolLiteLLM:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def supports_function_calling(self, *, model: str):
+        return None
+
+    def get_supported_openai_params(self, model: str):
+        return None
+
+    async def acompletion(self, **kwargs):
+        self.calls.append(kwargs)
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "id": "call_123",
+                                "type": "function",
+                                "function": {"name": "ping", "arguments": "{}"},
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+
+
+@pytest.mark.anyio
+async def test_check_tool_support_uses_auto_mode_only():
+    litellm = _AutoOnlyToolLiteLLM()
+
+    result = await _check_tool_support(
+        litellm,
+        model="openai/gpt-5.1",
+        api_base="http://gateway.example/v1",
+        api_key="test-key",
+        timeout_seconds=0.1,
+    )
+
+    assert result.supports is True
+    assert [call.get("model") for call in litellm.calls] == ["openai/gpt-5.1"]
+    assert "tool_choice" not in litellm.calls[0]
+
+
+@pytest.mark.anyio
+async def test_check_tool_support_returns_clear_error_for_bare_model_with_api_base():
+    litellm = _AutoOnlyToolLiteLLM()
+
+    result = await _check_tool_support(
+        litellm,
+        model="gpt-5.1",
+        api_base="http://gateway.example/v1",
+        api_key="test-key",
+        timeout_seconds=0.1,
+    )
+
+    assert result.supports is None
+    assert result.error is not None
+    assert "openai/gpt-5.1" in result.error
+    assert "provider" in result.error.lower() or "前缀" in result.error
+    assert litellm.calls == []


### PR DESCRIPTION
## Summary
- make live smoke fail fast when a custom API base is paired with a bare model name
- align check-tool-support with the runtime auto tool-calling path instead of probing required mode
- add regression coverage for the verification behavior

## Testing
- /home/lixin/workspace/aishell/aish/.venv/bin/python -m pytest tests/test_verification.py tests/live_smoke/conftest.py -q
- /home/lixin/workspace/aishell/aish/.venv/bin/python -m pytest tests/test_provider_registry.py tests/test_cli.py tests/test_verification.py -q
- AISH_LIVE_SMOKE_MODEL=openai/gpt-5.1 AISH_LIVE_SMOKE_API_BASE=http://www.aishell.ai:8080/aitest/v1 AISH_LIVE_SMOKE_API_KEY=*** make test-live-smoke