### PR TITLE
Integrate live smoke into release preparation

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -23,8 +23,7 @@ jobs:
   live-smoke:
     name: Run live smoke tests
     runs-on: ubuntu-latest
-    environment:
-      name: live-smoke
+    environment: live-smoke
 
     steps:
       - name: Checkout repository
@@ -69,6 +68,7 @@ jobs:
           AISH_LIVE_SMOKE_MODEL: ${{ secrets.AISH_LIVE_SMOKE_MODEL }}
         run: |
           set -euo pipefail
+          mkdir -p build
           uv run --group dev python -m pytest tests/live_smoke -v -m live_smoke --run-live-smoke --basetemp build/pytest-live-smoke
 
       - name: Upload live smoke diagnostics

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -8,6 +8,12 @@ on:
         required: false
         default: main
         type: string
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref to validate
+        required: false
+        type: string
 
 concurrency:
   group: "live-smoke-${{ github.workflow }}-${{ inputs.ref || github.ref }}"
@@ -29,7 +35,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -87,7 +93,7 @@ jobs:
           cat <<EOF >> "$GITHUB_STEP_SUMMARY"
           # Live Smoke Summary
 
-          - Ref: ${{ inputs.ref }}
+          - Ref: ${{ inputs.ref || github.sha }}
           - Model: ${LIVE_MODEL:-<missing>}
           - Diagnostics artifact: live-smoke-diagnostics-${{ github.run_id }}
 

--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -120,12 +120,23 @@ jobs:
           path: artifacts/${{ matrix.arch }}/*
           if-no-files-found: error
 
+  live-smoke-validation:
+    name: Live smoke validation
+    needs:
+      - release-meta
+      - dry-run-package-validation
+    uses: ./.github/workflows/live-smoke.yml
+    with:
+      ref: ${{ github.sha }}
+    secrets: inherit
+
   release-preparation-summary:
     name: Summarize release preparation validation
     needs:
       - release-meta
       - prepare-release
       - dry-run-package-validation
+      - live-smoke-validation
     runs-on: ubuntu-latest
     steps:
       - name: Write final summary
@@ -137,5 +148,5 @@ jobs:
           - Tag: ${{ needs.release-meta.outputs.tag }}
           - Previous stable tag: ${{ needs.release-meta.outputs.previous_stable_tag || 'none' }}
 
-          Release metadata artifacts and dry-run bundle artifacts have been uploaded for review.
+          Release metadata artifacts, dry-run bundle artifacts, and live smoke validation have completed successfully.
           EOF

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Welcome to make Shell smarter!
 - `Auto response` is the repository's community bot for Issues and PRs. Reply text lives in `.github/auto-response-config.json`, and runtime logic lives in `.github/scripts/auto-response.cjs`.
 - `Release Metadata` is the shared release action that normalizes stable version inputs, validates repository version state, and uploads both markdown and JSON metadata artifacts.
 - `make prepare-release-files VERSION=X.Y.Z [DATE=YYYY-MM-DD]` updates `pyproject.toml`, `src/aish/__init__.py`, `uv.lock`, and inserts a dated release section at the top of `CHANGELOG.md`.
-- Prepare release files locally in a normal PR, merge that PR into `main`, then run `Release Preparation` as the preflight validation for the target stable version.
+- Prepare release files locally in a normal PR, merge that PR into `main`, then run `Release Preparation` as the single preflight validation for the target stable version. It now includes release metadata checks, bundle dry-run validation, and live smoke validation with real provider credentials.
 - `Release Preparation` validates the target stable version, generates a release summary from the versioned changelog section, builds dry-run bundles, and runs install smoke checks before publication.
 - `Release` is triggered by pushing a stable tag `vX.Y.Z`. It validates the tag against repository metadata, verifies that the tagged commit is on `main`, waits on the protected `release` environment approval gate, creates the GitHub Release entry with generated notes, and uploads bundle assets.
 - Configure the GitHub Environment named `release` with required reviewers if you want manual approval before production publishing.


### PR DESCRIPTION
## Summary
- make the live smoke workflow reusable via workflow_call while keeping manual dispatch
- invoke live smoke as part of Release Preparation after dry-run package validation
- update repository guidance so Release Preparation becomes the single preflight gate before tagging

## Validation
- `python -m pytest tests/live_smoke/test_live_smoke.py -q`

## Notes
- local operator notes in `release-manual.local.md` were updated separately and are not part of this repository PR