### PR TITLE
Make langfuse optional and add skip_reasoning for error correction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ requires-python = ">=3.10"
 dependencies = [
     "anyio>=4.9.0",
     "httpx[socks]>=0.24.0",
-    "langfuse==2.60.3",
     "litellm==1.74.3",
     "prompt-toolkit>=3.0.51",
     "pydantic>=2.0.0",
@@ -20,6 +19,9 @@ dependencies = [
     "watchfiles>=0.22.0",
     "wcwidth>=0.2.13",
 ]
+
+[project.optional-dependencies]
+langfuse = ["langfuse>=4.0.0"]
 
 [project.scripts]
 aish = "aish.cli:main"

--- a/src/aish/llm.py
+++ b/src/aish/llm.py
@@ -19,7 +19,7 @@ from aish.exception import is_litellm_exception, redact_secrets
 from aish.interaction import InteractionRequest, InteractionResponse, InteractionStatus
 from aish.interruption import ShellState
 from aish.litellm_loader import load_litellm
-from aish.providers.registry import get_provider_for_model
+from aish.providers.registry import get_provider_for_model, get_reasoning_disable_kwargs
 from aish.prompts import PromptManager
 from aish.skills import SkillManager
 from aish.tools.base import (
@@ -154,9 +154,10 @@ def _stream_coerce_message(response: object) -> dict:
 class _LLMEventEmitter:
     """Build and emit structured LLM events with minimal callsite noise."""
 
-    def __init__(self, session: "LLMSession", emit_events: bool):
+    def __init__(self, session: "LLMSession", emit_events: bool, skip_reasoning: bool = False):
         self._session = session
         self._enabled = bool(emit_events)
+        self._skip_reasoning = skip_reasoning
         self.operation: str | None = None
         self.turn_id: str | None = None
         self.generation_id: str | None = None
@@ -204,15 +205,15 @@ class _LLMEventEmitter:
 
     def emit_generation_start(self, *, generation_type: str, stream: bool) -> str:
         self.generation_id = f"gen-{uuid.uuid4().hex[:12]}"
-        self._emit(
-            LLMEventType.GENERATION_START,
-            {
-                "turn_id": self.turn_id,
-                "generation_id": self.generation_id,
-                "generation_type": generation_type,
-                "stream": stream,
-            },
-        )
+        payload: dict = {
+            "turn_id": self.turn_id,
+            "generation_id": self.generation_id,
+            "generation_type": generation_type,
+            "stream": stream,
+        }
+        if self._skip_reasoning:
+            payload["skip_reasoning"] = True
+        self._emit(LLMEventType.GENERATION_START, payload)
         return self.generation_id
 
     def emit_generation_end(
@@ -252,7 +253,7 @@ class _LLMEventEmitter:
         )
 
     def emit_reasoning_start(self) -> None:
-        if self._reasoning_started or not self.generation_id:
+        if self._skip_reasoning or self._reasoning_started or not self.generation_id:
             return
         self._reasoning_started = True
         self._emit(
@@ -261,7 +262,7 @@ class _LLMEventEmitter:
         )
 
     def emit_reasoning_delta(self, *, delta: str, accumulated: str) -> None:
-        if not self.generation_id:
+        if self._skip_reasoning or not self.generation_id:
             return
         if not self._reasoning_started:
             self.emit_reasoning_start()
@@ -276,7 +277,7 @@ class _LLMEventEmitter:
         )
 
     def emit_reasoning_end(self) -> None:
-        if not self._reasoning_started or not self.generation_id:
+        if self._skip_reasoning or not self._reasoning_started or not self.generation_id:
             return
         self._reasoning_started = False
         self._emit(
@@ -418,16 +419,24 @@ class LLMSession:
         self.user_id = "aish-user"  # Can be made configurable later
         self.conversation_count = 0
 
-        # Set up Langfuse callbacks only if enabled in config
+        # Set up Langfuse callbacks only if enabled in config and langfuse is installed
         if self.langfuse_enabled:
             try:
+                import langfuse as _langfuse  # noqa: F401
+
                 litellm = self._get_litellm()
                 if litellm is not None:
                     litellm.success_callback = ["langfuse"]
                     litellm.failure_callback = ["langfuse"]
+            except ImportError:
+                self.langfuse_enabled = False
+                logger.warning(
+                    "Langfuse is enabled but not installed. "
+                    "Install it with: pip install aish[langfuse]"
+                )
             except Exception:
-                # Silently fail if langfuse is not available
-                pass
+                self.langfuse_enabled = False
+                logger.warning("Langfuse initialization failed, disabling langfuse")
 
     def _get_litellm(self):
         """延迟加载 litellm 模块，只在首次使用时导入"""
@@ -1230,12 +1239,13 @@ class LLMSession:
         history: Optional[list[dict]] = None,
         emit_events: bool = True,
         stream: bool = False,
+        skip_reasoning: bool = False,
         **kwargs,
     ) -> str:
         # 确保在首次调用前完成初始化（使用重试机制处理循环导入）
         await self._ensure_initialized_with_retry()
 
-        events = _LLMEventEmitter(self, emit_events)
+        events = _LLMEventEmitter(self, emit_events, skip_reasoning=skip_reasoning)
         events.emit_op_start(operation="process_input", prompt=prompt, stream=stream)
 
         # Add user prompt to context manager first
@@ -1248,6 +1258,13 @@ class LLMSession:
         has_tool_calls = False
         tool_call_count = 0
         output = ""
+
+        # Inject provider-specific kwargs to disable reasoning when requested
+        if skip_reasoning:
+            reasoning_kwargs = get_reasoning_disable_kwargs(self.model)
+            # Drop unsupported params gracefully (e.g. reasoning_effort on
+            # non-reasoning models like GLM routed through openai provider)
+            kwargs = {**reasoning_kwargs, "drop_params": True, **kwargs}
 
         try:
             while True:

--- a/src/aish/providers/registry.py
+++ b/src/aish/providers/registry.py
@@ -233,6 +233,30 @@ def list_auth_capable_provider_ids() -> tuple[str, ...]:
     )
 
 
+_REASONING_DISABLE_MAP: dict[str, dict[str, Any]] = {
+    "anthropic": {"thinking": {"type": "disabled"}},
+    "deepseek": {"extra_body": {"enable_thinking": False}},
+    "qwen": {"extra_body": {"enable_thinking": False}},
+    "openai": {"reasoning_effort": "none"},
+    "gemini": {"extra_body": {"thinkingBudget": 0}},
+    "google": {"extra_body": {"thinkingBudget": 0}},
+    "xai": {"extra_body": {"enable_thinking": False}},
+}
+
+
+def get_reasoning_disable_kwargs(model: str | None) -> dict[str, Any]:
+    """Return API kwargs to disable model thinking/reasoning for a given model.
+
+    Uses the provider inferred from the model name to pick the right
+    parameter set.  Returns an empty dict when the provider has no known
+    mechanism or the provider cannot be determined.
+    """
+    provider_id = _infer_provider_id_from_model(model)
+    if provider_id is None:
+        return {}
+    return _REASONING_DISABLE_MAP.get(provider_id, {})
+
+
 def resolve_provider_metadata(
     model: str | None,
     api_base: str | None = None,

--- a/src/aish/providers/registry.py
+++ b/src/aish/providers/registry.py
@@ -243,15 +243,45 @@ _REASONING_DISABLE_MAP: dict[str, dict[str, Any]] = {
     "xai": {"extra_body": {"enable_thinking": False}},
 }
 
+# Providers that act as gateways / routers — their prefix should be stripped
+# to discover the actual upstream provider for reasoning-disable purposes.
+_GATEWAY_PROVIDER_IDS: frozenset[str] = frozenset({
+    "openrouter", "ai_gateway", "together", "huggingface",
+})
+
+
+def _resolve_upstream_provider_id(model: str | None) -> str | None:
+    """Resolve the *upstream* provider id, stripping gateway prefixes.
+
+    For ``openrouter/anthropic/claude-3.7`` this returns ``"anthropic"``;
+    for plain ``deepseek-chat`` it returns ``"deepseek"``.
+    """
+    raw = (model or "").strip().lower()
+    if not raw:
+        return None
+
+    # Check if model has a gateway prefix (e.g. "openrouter/anthropic/claude-3.7")
+    if "/" in raw:
+        parts = raw.split("/")
+        prefix = _canonicalize_provider_id(parts[0])
+        if prefix in _GATEWAY_PROVIDER_IDS and len(parts) >= 2:
+            # Re-infer from the remaining path after stripping gateway prefix
+            remainder = "/".join(parts[1:])
+            upstream = _infer_provider_id_from_model(remainder)
+            if upstream is not None:
+                return upstream
+
+    return _infer_provider_id_from_model(model)
+
 
 def get_reasoning_disable_kwargs(model: str | None) -> dict[str, Any]:
     """Return API kwargs to disable model thinking/reasoning for a given model.
 
-    Uses the provider inferred from the model name to pick the right
-    parameter set.  Returns an empty dict when the provider has no known
-    mechanism or the provider cannot be determined.
+    Resolves the upstream provider (stripping gateway prefixes like
+    ``openrouter/``) and returns the matching parameter set.  Returns an
+    empty dict when the provider has no known mechanism.
     """
-    provider_id = _infer_provider_id_from_model(model)
+    provider_id = _resolve_upstream_provider_id(model)
     if provider_id is None:
         return {}
     return _REASONING_DISABLE_MAP.get(provider_id, {})

--- a/src/aish/shell/runtime/ai.py
+++ b/src/aish/shell/runtime/ai.py
@@ -283,6 +283,7 @@ Please analyze the error and suggest a fix. Check the shell history context abov
                         context_manager=self.context_manager,
                         system_message=system_message,
                         stream=True,
+                        skip_reasoning=True,
                     )
                     return response
 

--- a/src/aish/shell/runtime/app.py
+++ b/src/aish/shell/runtime/app.py
@@ -272,7 +272,8 @@ class PTYAIShell:
         self._finalize_content_preview()
         self._reset_reasoning_state()
         self._last_streaming_accumulated = ""
-        self._reasoning_display_enabled = True
+        skip_reasoning = bool(event.data.get("skip_reasoning"))
+        self._reasoning_display_enabled = not skip_reasoning
         return self.handle_thinking_start(event)
 
     def handle_thinking_start(self, event) -> None:

--- a/tests/test_litellm_langfuse.py
+++ b/tests/test_litellm_langfuse.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import pytest
 
+langfuse = pytest.importorskip("langfuse")
+
 # 添加项目路径
 project_root = Path(__file__).parent
 sys.path.insert(0, str(project_root / "src"))

--- a/tests/test_llm_events.py
+++ b/tests/test_llm_events.py
@@ -242,3 +242,83 @@ async def test_process_input_litellm_error_uses_raw_message():
         text = str(details)
         assert "THIS_SHOULD_NOT_LEAK" not in text
         assert "sk-THIS_SHOULD_NOT_LEAK" not in text
+
+
+@pytest.mark.anyio
+async def test_process_input_skip_reasoning_injects_kwargs():
+    config = ConfigModel(model="claude-sonnet-4-6", api_key="test-key")
+    session = LLMSession(config=config, skill_manager=SkillManager())
+
+    captured_kwargs = {}
+
+    async def fake_acompletion(**kwargs):
+        captured_kwargs.update(kwargs)
+        return {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "fixed"},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+
+    context_manager = ContextManager()
+
+    with (
+        patch.object(session, "_get_acompletion", return_value=fake_acompletion),
+        patch.object(session, "_trim_messages", side_effect=lambda msgs: msgs),
+        patch.object(session, "_get_tools_spec", return_value=[]),
+    ):
+        result = await session.process_input(
+            prompt="hi",
+            context_manager=context_manager,
+            system_message="sys",
+            skip_reasoning=True,
+        )
+
+    assert result == "fixed"
+    # Verify reasoning-disable kwargs were passed through to the completion call
+    assert captured_kwargs.get("thinking") == {"type": "disabled"}
+    assert captured_kwargs.get("drop_params") is True
+
+
+@pytest.mark.anyio
+async def test_process_input_skip_reasoning_sets_generation_event_flag():
+    config = ConfigModel(model="test-model", api_key="test-key")
+    session = LLMSession(config=config, skill_manager=SkillManager())
+
+    events = []
+
+    def event_callback(event):
+        events.append(event)
+        return LLMCallbackResult.CONTINUE
+
+    session.event_callback = event_callback
+
+    async def fake_acompletion(**kwargs):
+        return {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "hello"},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+
+    context_manager = ContextManager()
+
+    with (
+        patch.object(session, "_get_acompletion", return_value=fake_acompletion),
+        patch.object(session, "_trim_messages", side_effect=lambda msgs: msgs),
+        patch.object(session, "_get_tools_spec", return_value=[]),
+    ):
+        await session.process_input(
+            prompt="hi",
+            context_manager=context_manager,
+            system_message="sys",
+            skip_reasoning=True,
+        )
+
+    gen_start_events = [e for e in events if e.event_type == LLMEventType.GENERATION_START]
+    assert len(gen_start_events) == 1
+    assert gen_start_events[0].data.get("skip_reasoning") is True

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -6,7 +6,7 @@ from aish.config import ConfigModel
 from aish.context_manager import ContextManager
 from aish.llm import LLMSession
 from aish.providers.interface import ProviderAuthConfig, ProviderMetadata
-from aish.providers.registry import resolve_provider_metadata
+from aish.providers.registry import get_reasoning_disable_kwargs, resolve_provider_metadata
 from aish.skills import SkillManager
 
 
@@ -115,3 +115,42 @@ def test_resolve_provider_metadata_uses_configured_api_base_for_local_provider()
     assert metadata.provider_id == "ollama"
     assert metadata.display_name == "Ollama"
     assert metadata.dashboard_url == "http://192.168.1.20:11434"
+
+
+# --- get_reasoning_disable_kwargs ---
+
+
+def test_reasoning_disable_direct_model():
+    assert get_reasoning_disable_kwargs("deepseek-chat") == {
+        "extra_body": {"enable_thinking": False}
+    }
+    assert get_reasoning_disable_kwargs("claude-sonnet-4-6") == {
+        "thinking": {"type": "disabled"}
+    }
+    assert get_reasoning_disable_kwargs("qwen-plus") == {
+        "extra_body": {"enable_thinking": False}
+    }
+
+
+def test_reasoning_disable_gateway_strips_prefix():
+    # openrouter routing anthropic → should use anthropic's params
+    result = get_reasoning_disable_kwargs("openrouter/anthropic/claude-3.7")
+    assert result == {"thinking": {"type": "disabled"}}
+
+    # openrouter routing deepseek → should use deepseek's params
+    result = get_reasoning_disable_kwargs("openrouter/deepseek/deepseek-r1")
+    assert result == {"extra_body": {"enable_thinking": False}}
+
+    # openrouter routing openai model
+    result = get_reasoning_disable_kwargs("openrouter/openai/o3-mini")
+    assert result == {"reasoning_effort": "none"}
+
+
+def test_reasoning_disable_unknown_model_returns_empty():
+    assert get_reasoning_disable_kwargs("unknown-model") == {}
+    assert get_reasoning_disable_kwargs(None) == {}
+
+
+def test_reasoning_disable_non_gateway_prefix_unchanged():
+    # A non-gateway prefix like "ollama/llama3" should infer normally
+    assert get_reasoning_disable_kwargs("ollama/llama3") == {}

--- a/uv.lock
+++ b/uv.lock
@@ -151,7 +151,6 @@ source = { editable = "." }
 dependencies = [
     { name = "anyio" },
     { name = "httpx", extra = ["socks"] },
-    { name = "langfuse" },
     { name = "litellm" },
     { name = "prompt-toolkit" },
     { name = "pydantic" },
@@ -162,6 +161,11 @@ dependencies = [
     { name = "typer" },
     { name = "watchfiles" },
     { name = "wcwidth" },
+]
+
+[package.optional-dependencies]
+langfuse = [
+    { name = "langfuse" },
 ]
 
 [package.dev-dependencies]
@@ -181,7 +185,7 @@ dev = [
 requires-dist = [
     { name = "anyio", specifier = ">=4.9.0" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.24.0" },
-    { name = "langfuse", specifier = "==2.60.3" },
+    { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=4.0.0" },
     { name = "litellm", specifier = "==1.74.3" },
     { name = "prompt-toolkit", specifier = ">=3.0.51" },
     { name = "pydantic", specifier = ">=2.0.0" },
@@ -193,6 +197,7 @@ requires-dist = [
     { name = "watchfiles", specifier = ">=0.22.0" },
     { name = "wcwidth", specifier = ">=0.2.13" },
 ]
+provides-extras = ["langfuse"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -726,6 +731,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.74.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/18/a746c8344152d368a5aac738d4c857012f2c5d1fd2eac7e17b647a7861bd/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1", size = 151254, upload-time = "2026-04-02T21:23:26.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/b0/be5d3329badb9230b765de6eea66b73abd5944bdeb5afb3562ddcd80ae84/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5", size = 300743, upload-time = "2026-04-02T21:22:49.108Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -996,21 +1013,21 @@ wheels = [
 
 [[package]]
 name = "langfuse"
-version = "2.60.3"
+version = "4.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
     { name = "backoff" },
     { name = "httpx" },
-    { name = "idna" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
     { name = "packaging" },
     { name = "pydantic" },
-    { name = "requests" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/7a/a998b48823a609af8f5096cb322a4ddfded01d565509cd6b511a2e5891ca/langfuse-2.60.3.tar.gz", hash = "sha256:171c0caf07a26282bd0403c6c15886ef1f447def42d6570684c94d6d9ae61d6e", size = 152467, upload-time = "2025-04-15T17:01:15.973Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/d0/6d79ed5614f86f27f5df199cf10c6facf6874ff6f91b828ae4dad90aa86d/langfuse-4.0.6.tar.gz", hash = "sha256:83a6f8cc8f1431fa2958c91e2673bc4179f993297e9b1acd1dbf001785e6cf83", size = 274094, upload-time = "2026-04-01T20:04:15.153Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/6b/4d3bdea30ceb3e4cf3ac1a2f104ffc20b6caa636549874262b2fa8cedaec/langfuse-2.60.3-py3-none-any.whl", hash = "sha256:2b866c44f24d5f06b617d7f14f75a2e42577538b530e4e26dc6ad770d6d1399e", size = 275008, upload-time = "2025-04-15T17:01:13.799Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b4/088048e37b6d7ec1b52c6a11bc33101454285a22eaab8303dcccfd78344d/langfuse-4.0.6-py3-none-any.whl", hash = "sha256:0562b1dcf83247f9d8349f0f755eaed9a7f952fee67e66580970f0738bf3adbf", size = 472841, upload-time = "2026-04-01T20:04:16.451Z" },
 ]
 
 [[package]]
@@ -1451,6 +1468,88 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/1d/4049a9e8698361cc1a1aa03a6c59e4fa4c71e0c0f94a30f988a6876a2ae6/opentelemetry_api-1.40.0.tar.gz", hash = "sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f", size = 70851, upload-time = "2026-03-04T14:17:21.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/bf/93795954016c522008da367da292adceed71cca6ee1717e1d64c83089099/opentelemetry_api-1.40.0-py3-none-any.whl", hash = "sha256:82dd69331ae74b06f6a874704be0cfaa49a1650e1537d4a813b86ecef7d0ecf9", size = 68676, upload-time = "2026-03-04T14:17:01.24Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/bc/1559d46557fe6eca0b46c88d4c2676285f1f3be2e8d06bb5d15fbffc814a/opentelemetry_exporter_otlp_proto_common-1.40.0.tar.gz", hash = "sha256:1cbee86a4064790b362a86601ee7934f368b81cd4cc2f2e163902a6e7818a0fa", size = 20416, upload-time = "2026-03-04T14:17:23.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ca/8f122055c97a932311a3f640273f084e738008933503d0c2563cd5d591fc/opentelemetry_exporter_otlp_proto_common-1.40.0-py3-none-any.whl", hash = "sha256:7081ff453835a82417bf38dccf122c827c3cbc94f2079b03bba02a3165f25149", size = 18369, upload-time = "2026-03-04T14:17:04.796Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/fa/73d50e2c15c56be4d000c98e24221d494674b0cc95524e2a8cb3856d95a4/opentelemetry_exporter_otlp_proto_http-1.40.0.tar.gz", hash = "sha256:db48f5e0f33217588bbc00274a31517ba830da576e59503507c839b38fa0869c", size = 17772, upload-time = "2026-03-04T14:17:25.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/3a/8865d6754e61c9fb170cdd530a124a53769ee5f740236064816eb0ca7301/opentelemetry_exporter_otlp_proto_http-1.40.0-py3-none-any.whl", hash = "sha256:a8d1dab28f504c5d96577d6509f80a8150e44e8f45f82cdbe0e34c99ab040069", size = 19960, upload-time = "2026-03-04T14:17:07.153Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/77/dd38991db037fdfce45849491cb61de5ab000f49824a00230afb112a4392/opentelemetry_proto-1.40.0.tar.gz", hash = "sha256:03f639ca129ba513f5819810f5b1f42bcb371391405d99c168fe6937c62febcd", size = 45667, upload-time = "2026-03-04T14:17:31.194Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/b2/189b2577dde745b15625b3214302605b1353436219d42b7912e77fa8dc24/opentelemetry_proto-1.40.0-py3-none-any.whl", hash = "sha256:266c4385d88923a23d63e353e9761af0f47a6ed0d486979777fe4de59dc9b25f", size = 72073, upload-time = "2026-03-04T14:17:16.673Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/fd/3c3125b20ba18ce2155ba9ea74acb0ae5d25f8cd39cfd37455601b7955cc/opentelemetry_sdk-1.40.0.tar.gz", hash = "sha256:18e9f5ec20d859d268c7cb3c5198c8d105d073714db3de50b593b8c1345a48f2", size = 184252, upload-time = "2026-03-04T14:17:31.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/c5/6a852903d8bfac758c6dc6e9a68b015d3c33f2f1be5e9591e0f4b69c7e0a/opentelemetry_sdk-1.40.0-py3-none-any.whl", hash = "sha256:787d2154a71f4b3d81f20524a8ce061b7db667d24e46753f32a7bc48f1c1f3f1", size = 141951, upload-time = "2026-03-04T14:17:17.961Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/c0/4ae7973f3c2cfd2b6e321f1675626f0dab0a97027cc7a297474c9c8f3d04/opentelemetry_semantic_conventions-0.61b0.tar.gz", hash = "sha256:072f65473c5d7c6dc0355b27d6c9d1a679d63b6d4b4b16a9773062cb7e31192a", size = 145755, upload-time = "2026-03-04T14:17:32.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/37/cc6a55e448deaa9b27377d087da8615a3416d8ad523d5960b78dbeadd02a/opentelemetry_semantic_conventions-0.61b0-py3-none-any.whl", hash = "sha256:fa530a96be229795f8cef353739b618148b0fe2b4b3f005e60e262926c4d38e2", size = 231621, upload-time = "2026-03-04T14:17:19.33Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "24.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1631,6 +1730,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Move langfuse from required to optional dependency (`pip install aish[langfuse]`), with graceful ImportError handling and warning logs
- Add `skip_reasoning` parameter to disable model thinking during error analysis for faster responses
- Centralize provider-specific reasoning disable params in `providers/registry.py` using existing `_infer_provider_id_from_model`
- Add `drop_params=True` to handle non-reasoning models gracefully (e.g. GLM routed through openai provider)
- Protect test file with `pytest.importorskip("langfuse")`

## Test plan

- [ ] Verify `uv sync` works without langfuse installed (base install)
- [ ] Verify `uv sync --extra langfuse` installs langfuse>=4.0.0
- [ ] Run `pytest tests/test_litellm_langfuse.py` — should be skipped when langfuse not installed
- [ ] Test error correction with a reasoning model (e.g. deepseek, claude) — response should be faster, no reasoning displayed
- [ ] Test error correction with a non-reasoning model (e.g. GLM) — should not throw UnsupportedParamsError