### PR TITLE
Release v0.2.1

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p build
-          uv run --group dev python -m pytest tests/live_smoke -v -m live_smoke --run-live-smoke --basetemp build/pytest-live-smoke
+          uv run --group dev python -m pytest tests/flows/live_smoke -v -m live_smoke --run-live-smoke --basetemp build/pytest-live-smoke
 
       - name: Upload live smoke diagnostics
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-04-15
+
+### Added
+
+- Added an interactive plan mode for non-trivial tasks, including persisted plan artifacts, review and approval flow, and an explicit transition back into execution. Enter plan mode with `/plan` or `F2`, then leave it with `/plan exit` or `F2` when you want to return to normal shell execution.
+- Added persistent long-term memory backed by Markdown storage, with memory recall and store tooling that can carry forward user preferences and project context across sessions.
+- Added `aish update` and `aish uninstall` commands so archive, pip, and system-package installs have a built-in path for upgrade and removal.
+
+### Changed
+
+- Changed the terminal UI to show a visible thinking timer while the model is working, making longer requests easier to track.
+- Changed startup and session wiring so plan mode, memory, and the new CLI management flows are initialized more consistently from the current package layout.
+
+### Fixed
+
+- Fixed the interactive shell so `quit` works again as an exit alias.
+- Fixed compact prompt theme spacing and related prompt rendering regressions in the shell UI.
+- Fixed release automation paths so preparation and publishing workflows target the current repository layout.
+
 ## [0.2.0] - 2026-04-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aish"
-version = "0.2.0"
+version = "0.2.1"
 description = "AI Shell - A shell with built-in LLM capabilities"
 readme = "README.md"
 authors = [{ name = "Sian Cao", email = "yinshuiboy@gmail.com" }]

--- a/src/aish/__init__.py
+++ b/src/aish/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 # Avoid importing heavy modules (and any side-effects) at package import time.
 # This matters for system services like aish-sandbox, which only need aish.sandboxd.

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -93,7 +93,7 @@ def test_check_for_updates_available(
         result = update_manager.check_for_updates()
 
     assert result is not None
-    assert result["current_version"] == "0.2.0"
+    assert result["current_version"] == __version__
     assert result["latest_version"] == "0.3.0"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -146,7 +146,7 @@ wheels = [
 
 [[package]]
 name = "aish"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Release Notes

This PR prepares aish v0.2.1 for release.

### Added
- Added an interactive plan mode for non-trivial tasks, including persisted plan artifacts, review and approval flow, and an explicit transition back into execution.
- Enter plan mode with `/plan` or `F2`.
- Leave plan mode with `/plan exit` or `F2` again to return to normal shell execution.
- Added persistent long-term memory backed by Markdown storage, with memory recall and store tooling that can carry forward user preferences and project context across sessions.
- Added `aish update` and `aish uninstall` commands so archive, pip, and system-package installs have a built-in path for upgrade and removal.

### Changed
- Changed the terminal UI to show a visible thinking timer while the model is working, making longer requests easier to track.
- Changed startup and session wiring so plan mode, memory, and the new CLI management flows are initialized more consistently from the current package layout.

### Fixed
- Fixed the interactive shell so `quit` works again as an exit alias.
- Fixed compact prompt theme spacing and related prompt rendering regressions in the shell UI.
- Fixed release automation paths so preparation and publishing workflows target the current repository layout.
- Fixed the update-manager test so release version bumps do not break the suite with a hard-coded version assertion.

### Release Files
- Bumped version to `0.2.1` in `pyproject.toml`, `src/aish/__init__.py`, and `uv.lock`.
- Added the `0.2.1` changelog section.
