### PR TITLE
Validate release candidates earlier and add final release check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
     outputs:
       code: ${{ github.event_name == 'pull_request' && steps.filter.outputs.code || steps.default.outputs.code }}
       packaging: ${{ github.event_name == 'pull_request' && steps.filter.outputs.packaging || steps.default.outputs.packaging }}
+      release_candidate: ${{ github.event_name == 'pull_request' && steps.release_candidate.outputs.value || steps.default.outputs.release_candidate }}
     steps:
       - name: Default to full validation outside PRs
         id: default
@@ -37,6 +38,20 @@ jobs:
         run: |
           echo "code=true" >> "$GITHUB_OUTPUT"
           echo "packaging=true" >> "$GITHUB_OUTPUT"
+          echo "release_candidate=false" >> "$GITHUB_OUTPUT"
+
+      - name: Detect release candidate pull request
+        id: release_candidate
+        if: github.event_name == 'pull_request'
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          if [[ "$HEAD_REF" == release/* ]] || [[ ",$PR_LABELS," == *,release-candidate,* ]]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Classify pull request changes
         id: filter
@@ -64,7 +79,7 @@ jobs:
   lint-test:
     name: Lint and test
     needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.packaging == 'true'
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.packaging == 'true' || needs.changes.outputs.release_candidate == 'true'
     runs-on: ubuntu-latest
     container:
       image: rockylinux:8
@@ -103,7 +118,7 @@ jobs:
     needs:
       - changes
       - lint-test
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.packaging == 'true'
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.packaging == 'true' || needs.changes.outputs.release_candidate == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -136,7 +151,7 @@ jobs:
 
   build-bundle:
     name: Build bundle (${{ matrix.arch }})
-    if: github.event_name != 'pull_request' || needs.changes.outputs.packaging == 'true'
+    if: github.event_name != 'pull_request' || needs.changes.outputs.packaging == 'true' || needs.changes.outputs.release_candidate == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -190,6 +205,11 @@ jobs:
           test -f "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.service"
           test -f "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.socket"
           grep -q '^ExecStart=/usr/local/bin/aish-sandbox$' "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.service"
+
+      - name: Smoke test installed binary runtime
+        run: |
+          INSTALL_ROOT="$PWD/build/install-root/${{ matrix.arch }}"
+          bash ./packaging/scripts/smoke-installed-aish.sh "$INSTALL_ROOT/usr/local/bin/aish"
 
       - name: Upload bundle artifacts
         uses: actions/upload-artifact@v6

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -8,12 +8,27 @@ on:
         required: false
         default: main
         type: string
+      suite:
+        description: Live smoke suite to run
+        required: false
+        default: blocking
+        type: choice
+        options:
+          - blocking
+          - extended
+          - all
   workflow_call:
     inputs:
       ref:
         description: Git ref to validate
         required: false
         type: string
+        default: main
+      suite:
+        description: Live smoke suite to run
+        required: false
+        type: string
+        default: blocking
 
 concurrency:
   group: "live-smoke-${{ github.workflow }}-${{ inputs.ref || github.ref }}"
@@ -29,7 +44,8 @@ jobs:
   live-smoke:
     name: Run live smoke tests
     runs-on: ubuntu-latest
-    environment: live-smoke
+    environment:
+      name: live-smoke
 
     steps:
       - name: Checkout repository
@@ -50,6 +66,11 @@ jobs:
       - name: Sync development dependencies
         run: uv sync --group dev
 
+      - name: Install live smoke runtime dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap util-linux
+
       - name: Validate live smoke secrets
         env:
           AISH_LIVE_SMOKE_API_KEY: ${{ secrets.AISH_LIVE_SMOKE_API_KEY }}
@@ -67,6 +88,24 @@ jobs:
             exit 1
           fi
 
+      - name: Build and install live smoke bundle
+        run: |
+          set -euo pipefail
+          VERSION="0.0.0+${GITHUB_SHA::8}"
+          OUTPUT_DIR="$PWD/build/live-smoke-artifacts"
+          EXTRACT_DIR="$PWD/build/live-smoke-extract"
+          INSTALL_ROOT="$PWD/build/live-smoke-install-root"
+          BUNDLE="aish-${VERSION}-linux-amd64"
+
+          rm -rf "$OUTPUT_DIR" "$EXTRACT_DIR" "$INSTALL_ROOT"
+          mkdir -p "$OUTPUT_DIR" "$EXTRACT_DIR" "$INSTALL_ROOT"
+
+          VERSION="$VERSION" PLATFORM="linux" ARCH="amd64" OUTPUT_DIR="$OUTPUT_DIR" ./packaging/build_bundle.sh
+          tar -xzf "$OUTPUT_DIR/${BUNDLE}.tar.gz" -C "$EXTRACT_DIR"
+          AISH_INSTALL_ROOT="$INSTALL_ROOT" AISH_SKIP_SYSTEMD=1 "$EXTRACT_DIR/${BUNDLE}/install.sh"
+          bash ./packaging/scripts/smoke-installed-aish.sh "$INSTALL_ROOT/usr/local/bin/aish"
+          echo "AISH_LIVE_SMOKE_EXECUTABLE=$INSTALL_ROOT/usr/local/bin/aish" >> "$GITHUB_ENV"
+
       - name: Run live smoke tests
         env:
           AISH_LIVE_SMOKE_API_BASE: ${{ secrets.AISH_LIVE_SMOKE_API_BASE }}
@@ -75,7 +114,14 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p build
-          uv run --group dev python -m pytest tests/flows/live_smoke -v -m live_smoke --run-live-smoke --basetemp build/pytest-live-smoke
+          SUITE="${{ inputs.suite || 'blocking' }}"
+          MARK_EXPR="live_smoke and live_smoke_blocking"
+          if [[ "$SUITE" == "extended" ]]; then
+            MARK_EXPR="live_smoke and live_smoke_extended"
+          elif [[ "$SUITE" == "all" ]]; then
+            MARK_EXPR="live_smoke"
+          fi
+          uv run --group dev python -m pytest tests/flows/live_smoke -v -m "$MARK_EXPR" --run-live-smoke --basetemp build/pytest-live-smoke
 
       - name: Upload live smoke diagnostics
         if: always()
@@ -94,8 +140,10 @@ jobs:
           # Live Smoke Summary
 
           - Ref: ${{ inputs.ref || github.sha }}
+          - Suite: ${{ inputs.suite || 'blocking' }}
           - Model: ${LIVE_MODEL:-<missing>}
+          - Executable: ${AISH_LIVE_SMOKE_EXECUTABLE:-<missing>}
           - Diagnostics artifact: live-smoke-diagnostics-${{ github.run_id }}
 
-          This workflow runs the opt-in pytest live smoke suite with real provider credentials from the protected \`live-smoke\` environment.
+          This workflow runs the opt-in pytest live smoke suite against an installed bundle artifact with real provider credentials from the protected \`live-smoke\` environment.
           EOF

--- a/.github/workflows/release-final-check.yml
+++ b/.github/workflows/release-final-check.yml
@@ -1,0 +1,54 @@
+name: Release Final Check
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Target stable release version, for example 0.1.1"
+        required: true
+        type: string
+      ref:
+        description: "Git ref to validate on main before tagging"
+        required: false
+        default: main
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-final-check-${{ github.event.inputs.version }}-${{ github.event.inputs.ref }}
+  cancel-in-progress: true
+
+jobs:
+  final-check:
+    name: Validate merged release state
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Verify target ref is on main
+        run: |
+          git fetch origin main --depth=1
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - name: Validate release metadata
+        uses: ./.github/actions/release-metadata
+        with:
+          version: ${{ github.event.inputs.version }}
+          artifact_prefix: release-final-check
+
+      - name: Write final summary
+        run: |
+          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          # Release Final Check Complete
+
+          - Version: ${{ github.event.inputs.version }}
+          - Ref: ${{ github.event.inputs.ref }}
+
+          The target ref is on main and release metadata is consistent. This workflow is intentionally lightweight and does not rebuild artifacts.
+          EOF

--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -7,6 +7,11 @@ on:
         description: "Target stable release version, for example 0.1.1"
         required: true
         type: string
+      ref:
+        description: "Git ref to validate, for example release/v0.1.1-prep or a commit SHA"
+        required: false
+        default: main
+        type: string
 
 permissions:
   contents: read
@@ -29,6 +34,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.ref }}
 
       - name: Compute release metadata
         id: metadata
@@ -53,6 +59,7 @@ jobs:
 
           - Version: ${{ needs.release-meta.outputs.version }}
           - Tag: ${{ needs.release-meta.outputs.tag }}
+          - Ref: ${{ github.event.inputs.ref }}
           - Previous stable tag: ${{ needs.release-meta.outputs.previous_stable_tag || 'none' }}
 
           ## Release Notes
@@ -81,6 +88,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref }}
 
       - name: Set up build environment
         run: ./packaging/scripts/setup-ci-env.sh
@@ -113,6 +122,11 @@ jobs:
           test -f "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.socket"
           grep -q '^ExecStart=/usr/local/bin/aish-sandbox$' "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.service"
 
+      - name: Smoke test installed binary runtime
+        run: |
+          INSTALL_ROOT="$PWD/build/install-root/${{ matrix.arch }}"
+          bash ./packaging/scripts/smoke-installed-aish.sh "$INSTALL_ROOT/usr/local/bin/aish"
+
       - name: Upload dry-run artifacts
         uses: actions/upload-artifact@v6
         with:
@@ -127,7 +141,7 @@ jobs:
       - dry-run-package-validation
     uses: ./.github/workflows/live-smoke.yml
     with:
-      ref: ${{ github.sha }}
+      ref: ${{ github.event.inputs.ref }}
     secrets: inherit
 
   release-preparation-summary:
@@ -146,6 +160,7 @@ jobs:
 
           - Version: ${{ needs.release-meta.outputs.version }}
           - Tag: ${{ needs.release-meta.outputs.tag }}
+          - Ref: ${{ github.event.inputs.ref }}
           - Previous stable tag: ${{ needs.release-meta.outputs.previous_stable_tag || 'none' }}
 
           Release metadata artifacts, dry-run bundle artifacts, and live smoke validation have completed successfully.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,12 +41,15 @@ Welcome to make Shell smarter!
 ## CI and Release Workflows
 
 - Code PRs run lint, tests, and cross-platform smoke checks.
-- Packaging-related PRs additionally run Linux bundle build and install smoke checks.
+- Packaging-related PRs additionally run Linux bundle build, install smoke checks, and installed-binary runtime smoke checks.
+- Release-candidate PRs are treated as publishable candidates: by convention they use a head branch like `release/vX.Y.Z-prep`, or they are explicitly marked with the `release-candidate` label. These PRs must pass bundle build, bundle install, and installed-binary runtime validation before merge.
 - `Auto response` is the repository's community bot for Issues and PRs. Reply text lives in `.github/auto-response-config.json`, and runtime logic lives in `.github/scripts/auto-response.cjs`.
 - `Release Metadata` is the shared release action that normalizes stable version inputs, validates repository version state, and uploads both markdown and JSON metadata artifacts.
 - `make prepare-release-files VERSION=X.Y.Z [DATE=YYYY-MM-DD]` updates `pyproject.toml`, `src/aish/__init__.py`, `uv.lock`, and inserts a dated release section at the top of `CHANGELOG.md`.
-- Prepare release files locally in a normal PR, merge that PR into `main`, then run `Release Preparation` as the single preflight validation for the target stable version. It now includes release metadata checks, bundle dry-run validation, and live smoke validation with real provider credentials.
-- `Release Preparation` validates the target stable version, generates a release summary from the versioned changelog section, builds dry-run bundles, and runs install smoke checks before publication.
+- Prepare release files locally in a dedicated release PR. Use the standard release branch naming (`release/vX.Y.Z-prep`) when possible; if you need a different branch name, add the `release-candidate` label so CI still applies the release gate.
+- Run `Release Preparation` against the release PR ref before merge. It validates release metadata, rebuilds dry-run bundles, reruns install and installed-binary smoke checks, and runs artifact-based live smoke with real provider credentials.
+- Merge the release PR only after the release candidate gate and `Release Preparation` both pass.
+- After merge, run `Release Final Check` as the lightweight final confirmation on `main`, then push the stable tag `vX.Y.Z` to trigger `Release`.
 - `Release` is triggered by pushing a stable tag `vX.Y.Z`. It validates the tag against repository metadata, verifies that the tagged commit is on `main`, waits on the protected `release` environment approval gate, creates the GitHub Release entry with generated notes, and uploads bundle assets.
 - Configure the GitHub Environment named `release` with required reviewers if you want manual approval before production publishing.
 

--- a/build.sh
+++ b/build.sh
@@ -85,6 +85,11 @@ if [ -f "dist/aish" ] && [ -f "dist/aish-sandbox" ]; then
         else
             echo -e "${YELLOW}⚠️  Sandbox binary has some issues but was built successfully${NC}"
         fi
+        if command -v script >/dev/null 2>&1 && bash ./packaging/scripts/smoke-installed-aish.sh ./dist/aish > /dev/null 2>&1; then
+            echo -e "${GREEN}✅ Interactive binary smoke passed!${NC}"
+        else
+            echo -e "${YELLOW}⚠️  Interactive binary smoke did not complete successfully${NC}"
+        fi
     else
         echo -e "${YELLOW}⚠️  Binary has some issues but was built successfully${NC}"
         echo -e "${YELLOW}   (This may be due to LiteLLM/tiktoken packaging complexity)${NC}"

--- a/packaging/scripts/smoke-installed-aish.sh
+++ b/packaging/scripts/smoke-installed-aish.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 /path/to/aish" >&2
+    exit 1
+fi
+
+BINARY_PATH="$1"
+if [[ ! -x "$BINARY_PATH" ]]; then
+    echo "aish binary is not executable: $BINARY_PATH" >&2
+    exit 1
+fi
+
+if ! command -v script >/dev/null 2>&1; then
+    echo "Missing required command: script" >&2
+    exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+HOME_DIR="$TMP_DIR/home"
+XDG_CONFIG_HOME_DIR="$TMP_DIR/xdg-config"
+XDG_DATA_HOME_DIR="$TMP_DIR/xdg-data"
+mkdir -p "$HOME_DIR" "$XDG_CONFIG_HOME_DIR" "$XDG_DATA_HOME_DIR"
+
+INFO_OUTPUT="$({
+    env \
+        HOME="$HOME_DIR" \
+        XDG_CONFIG_HOME="$XDG_CONFIG_HOME_DIR" \
+        XDG_DATA_HOME="$XDG_DATA_HOME_DIR" \
+        "$BINARY_PATH" info
+} 2>&1)"
+
+if [[ "$INFO_OUTPUT" != *"AI Shell"* ]]; then
+    echo "Installed binary info output did not contain expected banner" >&2
+    echo "$INFO_OUTPUT" >&2
+    exit 1
+fi
+
+RUN_OUTPUT="$({
+    printf 'exit\n' | env \
+        HOME="$HOME_DIR" \
+        XDG_CONFIG_HOME="$XDG_CONFIG_HOME_DIR" \
+        XDG_DATA_HOME="$XDG_DATA_HOME_DIR" \
+        script -qec "$BINARY_PATH run --model openai/gpt-4o-mini --api-key dummy" /dev/null
+} 2>&1)"
+
+if [[ "$RUN_OUTPUT" != *"AI Shell v"* ]]; then
+    echo "Installed binary run smoke did not reach interactive shell banner" >&2
+    echo "$RUN_OUTPUT" >&2
+    exit 1
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,8 @@ markers = [
     "asyncio: tests using pytest-asyncio",
     "anyio: tests using pytest-anyio",
     "live_smoke: opt-in live smoke tests that use real provider credentials",
+    "live_smoke_blocking: low-variance artifact-based live smoke tests that gate release candidates",
+    "live_smoke_extended: higher-variance artifact-based live smoke tests for manual or scheduled validation",
     "timeout: tests with an execution time limit",
 ]
 

--- a/tests/flows/live_smoke/conftest.py
+++ b/tests/flows/live_smoke/conftest.py
@@ -69,6 +69,11 @@ _CONFIRMATION_PROMPTS = (
 )
 
 
+def _live_smoke_executable() -> str | None:
+    executable = os.environ.get("AISH_LIVE_SMOKE_EXECUTABLE", "").strip()
+    return executable or None
+
+
 def _expect_shell_prompt(child: Any) -> None:
     child.expect(list(_SHELL_PROMPT_PATTERNS))
 
@@ -127,6 +132,7 @@ def _env_summary(env: dict[str, str]) -> dict[str, str]:
         "XDG_DATA_HOME",
         "AISH_LIVE_SMOKE_MODEL",
         "AISH_LIVE_SMOKE_API_BASE",
+        "AISH_LIVE_SMOKE_EXECUTABLE",
     )
     summary: dict[str, str] = {}
     for key in keys:
@@ -168,27 +174,40 @@ def live_smoke_paths(tmp_path: Path) -> LiveSmokePaths:
 @pytest.fixture
 def live_smoke_env(live_smoke_paths: LiveSmokePaths) -> dict[str, str]:
     env = os.environ.copy()
+    executable = _live_smoke_executable()
     existing_pythonpath = env.get("PYTHONPATH", "")
-    repo_root = Path(__file__).resolve().parents[2]
-    src_path = str(repo_root / "src")
-    pythonpath_parts = [src_path]
-    if existing_pythonpath:
-        pythonpath_parts.append(existing_pythonpath)
+    pythonpath_parts: list[str] = []
+    if executable is None:
+        repo_root = Path(__file__).resolve().parents[2]
+        src_path = str(repo_root / "src")
+        pythonpath_parts.append(src_path)
+        if existing_pythonpath:
+            pythonpath_parts.append(existing_pythonpath)
 
     env.update(
         {
             "HOME": str(live_smoke_paths.home),
             "LANG": "en_US.UTF-8",
             "LC_ALL": "en_US.UTF-8",
-            "PYTHONPATH": os.pathsep.join(pythonpath_parts),
             "PYTHONUNBUFFERED": "1",
             "TERM": env.get("TERM", "xterm-256color"),
             "XDG_CONFIG_HOME": str(live_smoke_paths.xdg_config_home),
             "XDG_DATA_HOME": str(live_smoke_paths.xdg_data_home),
         }
     )
+    if pythonpath_parts:
+        env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
+    else:
+        env.pop("PYTHONPATH", None)
     env.pop("AISH_CONFIG_DIR", None)
     return env
+
+
+def _build_live_smoke_argv(*args: str) -> list[str]:
+    executable = _live_smoke_executable()
+    if executable is not None:
+        return [executable, *args]
+    return [sys.executable, "-m", "aish", *args]
 
 
 @pytest.fixture
@@ -256,7 +275,7 @@ def live_smoke_runner(
     live_smoke_artifacts: list[dict[str, Any]],
 ):
     def _run(*args: str, timeout: float = 30.0) -> LiveSmokeCommandResult:
-        argv = [sys.executable, "-m", "aish", *args]
+        argv = _build_live_smoke_argv(*args)
         start = time.monotonic()
         completed = subprocess.run(
             argv,
@@ -307,18 +326,15 @@ def live_smoke_chat_runner(
         auto_approve: bool = False,
         expected_file: Path | None = None,
     ) -> LiveSmokeChatResult:
-        argv = [
-            sys.executable,
-            "-m",
-            "aish",
+        argv = _build_live_smoke_argv(
             "run",
             "--config",
             str(live_smoke_config_file),
-        ]
+        )
         transcript = io.StringIO()
         start = time.monotonic()
         child = pexpect.spawn(
-            sys.executable,
+            argv[0],
             argv[1:],
             cwd=str(live_smoke_paths.workspace),
             env=live_smoke_env,

--- a/tests/flows/live_smoke/test_live_smoke.py
+++ b/tests/flows/live_smoke/test_live_smoke.py
@@ -8,6 +8,7 @@ def _contains_traceback(text: str) -> bool:
 
 
 @pytest.mark.live_smoke
+@pytest.mark.live_smoke_blocking
 def test_info_command_starts_cleanly(live_smoke_runner):
     result = live_smoke_runner("info")
 
@@ -17,6 +18,7 @@ def test_info_command_starts_cleanly(live_smoke_runner):
 
 
 @pytest.mark.live_smoke
+@pytest.mark.live_smoke_blocking
 def test_check_tool_support_succeeds_with_real_provider(
     live_smoke_provider_config,
     live_smoke_runner,
@@ -34,6 +36,7 @@ def test_check_tool_support_succeeds_with_real_provider(
 
 
 @pytest.mark.live_smoke
+@pytest.mark.live_smoke_blocking
 def test_interactive_shell_can_complete_one_live_round_trip(live_smoke_chat_runner):
     expected_token = "AISH_SMOKE_TEST_OK"
     prompt = (
@@ -52,6 +55,7 @@ def test_interactive_shell_can_complete_one_live_round_trip(live_smoke_chat_runn
 
 
 @pytest.mark.live_smoke
+@pytest.mark.live_smoke_extended
 def test_ai_can_use_tools_to_create_file_in_workspace(
     live_smoke_paths,
     live_smoke_chat_runner,


### PR DESCRIPTION
## Summary

This PR moves the heaviest release verification onto the release-candidate path and splits the post-merge release confirmation into a lightweight final check.

## What Changed

- Detect release-candidate PRs in CI and force them through bundle build, bundle install, and installed-binary runtime smoke validation.
- Add `packaging/scripts/smoke-installed-aish.sh` and wire it into CI and local binary build verification.
- Rework live smoke to run against an installed bundle artifact, with explicit blocking and extended suites.
- Update live smoke test helpers so they can target either the installed binary or the source-based entrypoint.
- Teach `Release Preparation` to validate an explicit `ref`, so maintainers can run the full release candidate check before merge.
- Add a new `Release Final Check` workflow that only confirms merged `main` state and release metadata before tagging.
- Update contributor-facing release guidance to match the new pre-merge preparation plus post-merge lightweight final confirmation model.

## Why

The old flow still left a gap where the release PR could merge before the repository had validated the installed artifact path that would actually be shipped. This PR closes that gap by running the heavy artifact-based validation before merge, while keeping a small post-merge confirmation step so tagging stays low-friction.

## Validation

- Verified modified workflow and documentation files with editor diagnostics; no errors reported for the changed workflow files included in this PR.
- Confirmed the new PR branch was pushed successfully and is diffed only against the intended release-flow changes.
- No runtime test suite was executed in this session.
