### PR TITLE
fix(llm): avoid interrupting reasoning display with streamed content

### DIFF
--- a/src/aish/llm/session.py
+++ b/src/aish/llm/session.py
@@ -1637,6 +1637,7 @@ class LLMSession:
                             generation_status = "success"
                             generation_error_message = None
                             content_preview_started = False
+                            tool_calls_seen = False
 
                             async for chunk in response:
                                 try:
@@ -1664,20 +1665,37 @@ class LLMSession:
                                     if content_delta:
                                         content_acc += str(content_delta)
 
-                                    # Emit CONTENT_DELTA for all content
-                                    if content_acc and not content_preview_started:
-                                        content_preview_started = True
-                                        events.emit_content_delta(
-                                            delta=content_acc,
-                                            accumulated=content_acc,
-                                            is_final=False,
-                                        )
-                                    elif content_preview_started and content_delta:
-                                        events.emit_content_delta(
-                                            delta=str(content_delta),
-                                            accumulated=content_acc,
-                                            is_final=False,
-                                        )
+                                    tool_calls_delta = _stream_get_delta_value(
+                                        delta, "tool_calls"
+                                    )
+                                    if tool_calls_delta:
+                                        tool_calls_seen = True
+
+                                    function_call_delta = _stream_get_delta_value(
+                                        delta, "function_call"
+                                    )
+                                    if function_call_delta and not tool_calls_delta:
+                                        tool_calls_seen = True
+
+                                    # Only emit content during streaming when tool
+                                    # calls are present.  For plain conversations the
+                                    # response is rendered by the caller after the
+                                    # operation completes, which avoids interrupting
+                                    # the reasoning Live display.
+                                    if tool_calls_seen:
+                                        if content_acc and not content_preview_started:
+                                            content_preview_started = True
+                                            events.emit_content_delta(
+                                                delta=content_acc,
+                                                accumulated=content_acc,
+                                                is_final=False,
+                                            )
+                                        elif content_preview_started and content_delta:
+                                            events.emit_content_delta(
+                                                delta=str(content_delta),
+                                                accumulated=content_acc,
+                                                is_final=False,
+                                            )
 
                                     finish_reason = (
                                         choice.get("finish_reason")
@@ -1807,11 +1825,6 @@ class LLMSession:
                             )
                         elif not has_tool_calls:
                             output += content
-                            events.emit_content_delta(
-                                delta=content,
-                                accumulated=output,
-                                is_final=True,
-                            )
                     else:
                         if has_tool_calls:
                             events.emit_content_delta(

--- a/src/aish/shell/runtime/ai.py
+++ b/src/aish/shell/runtime/ai.py
@@ -430,7 +430,10 @@ Please analyze the error and suggest a fix. Check the shell history context abov
                 return
 
             if response:
-                corrected_cmd = self._display_ai_response(response)
+                if shell.content_was_streamed:
+                    corrected_cmd = response.strip() if response else None
+                else:
+                    corrected_cmd = self._display_ai_response(response)
                 if corrected_cmd:
                     self._ask_execute_command(corrected_cmd)
 
@@ -484,7 +487,10 @@ Please analyze the error and suggest a fix. Check the shell history context abov
                 return
 
             if response:
-                self._display_ai_response(response)
+                # Skip the Rich Panel display when content was already
+                # streamed to the terminal via handle_content_delta.
+                if not shell.content_was_streamed:
+                    self._display_ai_response(response)
                 self._auto_retain_memory(question, response)
 
         except Exception as error:

--- a/src/aish/shell/runtime/app.py
+++ b/src/aish/shell/runtime/app.py
@@ -201,6 +201,7 @@ class PTYAIShell:
         self._last_streaming_accumulated: str = ""
         self.current_live: Optional[Any] = None
         self._content_preview_active: bool = False
+        self._content_streamed_to_terminal: bool = False
         self._at_line_start: bool = True
 
         self._current_op_scope: Optional[Any] = None
@@ -360,6 +361,7 @@ class PTYAIShell:
         self._thinking_start_time = time.monotonic()
         self._ttft_recorded = False
         self._ttft = 0.0
+        self._content_streamed_to_terminal = False
         return None
 
     def handle_op_end(self, event) -> None:
@@ -603,6 +605,7 @@ class PTYAIShell:
 
         if not self._content_preview_active:
             self._content_preview_active = True
+            self._content_streamed_to_terminal = True
             content = f"🤖 {content}"
 
         self.console.print(Text(content, style="bold grey50"), end="")
@@ -845,6 +848,11 @@ class PTYAIShell:
         self._reasoning_partial = ""
         self._reasoning_lines = []
         self._last_reasoning_render_lines = []
+
+    @property
+    def content_was_streamed(self) -> bool:
+        """Whether content was streamed to the terminal during this operation."""
+        return self._content_streamed_to_terminal
 
     def _finalize_content_preview(self) -> None:
         if not self._content_preview_active:

--- a/tests/shell/runtime/test_shell_pty_core.py
+++ b/tests/shell/runtime/test_shell_pty_core.py
@@ -101,6 +101,7 @@ def _make_ai_handler() -> tuple[AIHandler, Mock]:
     shell._on_interrupt_requested = Mock()
     shell.submit_backend_command = Mock()
     shell.submit_ai_backend_command = Mock(return_value=True)
+    shell.content_was_streamed = False
     shell.operation_in_progress = False
     handler.shell = shell
     return handler, shell


### PR DESCRIPTION
## Summary
- Only emit `content_delta` events during streaming when tool calls are present, preventing the reasoning Live display from being disrupted in plain conversations
- Expose `content_was_streamed` property on `PTYAIShell` for clean cross-object access, replacing `getattr` on private attributes
- Remove redundant `emit_content_delta(is_final=True)` in non-streaming path without tool calls

## Test plan
- [ ] Verify plain conversation (no tool calls) does not stream content to terminal during LLM response
- [ ] Verify tool-call conversations still display streamed content correctly
- [ ] Verify error fix and question flows render responses properly in both modes