### PR TITLE
fix(plan): use Shift+Tab and Ctrl+X P toggle

### DIFF
--- a/src/aish/shell/ui/editor.py
+++ b/src/aish/shell/ui/editor.py
@@ -115,7 +115,8 @@ class ShellPromptController:
     def _build_key_bindings(self):
         bindings = KeyBindings()
 
-        @bindings.add(Keys.F2, eager=True)
+        @bindings.add(Keys.BackTab, eager=True)
+        @bindings.add(Keys.ControlX, "p", eager=True)
         def _toggle_plan_mode(event) -> None:
             self._handle_mode_toggle()
             event.app.invalidate()

--- a/tests/shell/ui/test_shell_editor.py
+++ b/tests/shell/ui/test_shell_editor.py
@@ -79,16 +79,17 @@ def test_shell_prompt_controller_handle_mode_toggle_calls_handler():
     toggle_handler.assert_called_once_with()
 
 
-def test_shell_prompt_controller_registers_f2_mode_toggle_shortcut():
+def test_shell_prompt_controller_registers_plan_mode_toggle_shortcuts():
     controller = ShellPromptController()
 
     bindings = {
-        tuple(binding.keys)
+        tuple(str(key) for key in binding.keys)
         for binding in controller._build_key_bindings().bindings
         if binding.handler.__name__ == "_toggle_plan_mode"
     }
 
-    assert any(str(key) == "Keys.F2" for group in bindings for key in group)
+    assert ("Keys.BackTab",) in bindings
+    assert ("Keys.ControlX", "p") in bindings
 
 
 def test_shell_prompt_controller_render_theme_preserves_trailing_space(monkeypatch):


### PR DESCRIPTION
## Summary
This PR updates the interactive plan-mode toggle shortcuts in the shell editor so plan mode no longer depends on F2.

## What Changed
- Replaced the plan-mode toggle key binding in the shell editor with `Shift+Tab`
- Added `Ctrl+X`, then `P` as a fallback toggle sequence
- Updated the editor-level shortcut test to assert both bindings are registered
- Left the actual toggle behavior unchanged; this only changes how the existing toggle is invoked

## Notes
- `CHANGELOG.md` is intentionally not updated in this PR. We will record this in the next version release work.
- The plan-mode runtime behavior and state transitions are unchanged by this diff.

## Validation
- Ran `pytest tests/shell/ui/test_shell_editor.py tests/shell/runtime/test_shell_pty_core.py`
- Result: 69 tests passed

## Files Touched
- `src/aish/shell/ui/editor.py`
- `tests/shell/ui/test_shell_editor.py`