### PR TITLE
Release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-04-16
+
+### Added
+
+- Added a dedicated `Release Final Check` workflow so maintainers can confirm merged `main` release metadata before pushing a stable tag.
+
+### Changed
+
+- Changed release candidate validation so release PRs now run installed-binary runtime smoke checks and artifact-based live smoke against the built bundle before merge.
+- Changed the plan mode keyboard toggle from `F2` to `Shift+Tab` and `Ctrl+X P`, reducing conflicts with terminal key handling.
+
+### Fixed
+
+- Fixed normal streamed conversations so the live reasoning display is no longer interrupted by partial content rendering while the model is still responding.
+
 ## [0.2.1] - 2026-04-15
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aish"
-version = "0.2.1"
+version = "0.2.2"
 description = "AI Shell - A shell with built-in LLM capabilities"
 readme = "README.md"
 authors = [{ name = "Sian Cao", email = "yinshuiboy@gmail.com" }]

--- a/src/aish/__init__.py
+++ b/src/aish/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 # Avoid importing heavy modules (and any side-effects) at package import time.
 # This matters for system services like aish-sandbox, which only need aish.sandboxd.

--- a/uv.lock
+++ b/uv.lock
@@ -146,7 +146,7 @@ wheels = [
 
 [[package]]
 name = "aish"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Prepare the 0.2.2 release candidate by updating all versioned release files and adding the final changelog entry for this stable release.

## Release Notes

### Added
- Add a dedicated `Release Final Check` workflow so maintainers can confirm merged `main` release metadata before pushing the stable tag.

### Changed
- Change release candidate validation so release PRs run installed-binary runtime smoke checks and artifact-based live smoke against the built bundle before merge.
- Change the plan mode keyboard toggle from `F2` to `Shift+Tab` and `Ctrl+X P` to avoid terminal shortcut conflicts.

### Fixed
- Fix normal streamed conversations so the live reasoning display is not interrupted by partial content rendering while the model is still responding.

## Files Updated

- `pyproject.toml`
- `src/aish/__init__.py`
- `uv.lock`
- `CHANGELOG.md`

## Local Validation

- `/home/lixin/workspace/aishell/aish/.venv/bin/python -m pytest tests/scripts/packaging/test_update_release_files.py tests/scripts/packaging/test_release_metadata.py -q`
- `make test` -> 569 passed, 15 skipped
- `make build-bundle`
- `bash packaging/scripts/smoke-installed-aish.sh ./dist/aish`

## Follow-up For Maintainers

After review, run `Release Preparation` manually with:
- `version = 0.2.2`
- `ref = release/v0.2.2-prep`

After the PR merges, run `Release Final Check` on `main` before pushing tag `v0.2.2`.