### PR TITLE
fix: sanitize PyInstaller loader env for subprocesses

### DIFF
--- a/src/aish/scripts/executor.py
+++ b/src/aish/scripts/executor.py
@@ -9,6 +9,8 @@ import subprocess
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional
 
+from ..shell.environment import sanitize_subprocess_loader_env
+
 if TYPE_CHECKING:
     from ..llm import LLMSession
     from ..shell.environment import EnvironmentManager
@@ -184,7 +186,7 @@ class ScriptExecutor:
         Raises:
             ValueError: If required argument is missing.
         """
-        env = dict(os.environ)
+        env = sanitize_subprocess_loader_env(os.environ)
         env["AISH_SCRIPT_DIR"] = script.base_dir
         env["AISH_CWD"] = os.getcwd()
         env["AISH_SCRIPT_NAME"] = script.name

--- a/src/aish/shell/environment.py
+++ b/src/aish/shell/environment.py
@@ -2,7 +2,57 @@
 
 import os
 import subprocess
-from typing import Any, Dict, Optional
+import sys
+from typing import Any, Dict, Mapping, Optional
+
+
+def sanitize_subprocess_loader_env(
+    env: Mapping[str, str] | None = None,
+) -> Dict[str, str]:
+    """Return a subprocess environment with PyInstaller loader paths removed.
+
+    This preserves the caller's normal shell environment while preventing
+    PyInstaller's private library search path from leaking into system commands.
+    """
+
+    sanitized = dict(os.environ if env is None else env)
+
+    if not (getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")):
+        return sanitized
+
+    ld_library_path_orig = sanitized.get("LD_LIBRARY_PATH_ORIG")
+    if ld_library_path_orig is not None:
+        # PyInstaller keeps the pre-bootstrap loader search path here.
+        # Restoring it preserves any user-provided LD_LIBRARY_PATH entries
+        # without leaking bundle-private shared libraries into system commands.
+        if ld_library_path_orig:
+            sanitized["LD_LIBRARY_PATH"] = ld_library_path_orig
+        else:
+            sanitized.pop("LD_LIBRARY_PATH", None)
+        return sanitized
+
+    current_ld_library_path = sanitized.get("LD_LIBRARY_PATH")
+    if not current_ld_library_path:
+        return sanitized
+
+    meipass = os.path.realpath(str(getattr(sys, "_MEIPASS")))
+    filtered_paths = []
+    for path in current_ld_library_path.split(os.pathsep):
+        if not path:
+            continue
+        real_path = os.path.realpath(path)
+        # Fall back to pruning only the extracted bundle location when
+        # LD_LIBRARY_PATH_ORIG is unavailable.
+        if real_path == meipass or real_path.startswith(meipass + os.sep):
+            continue
+        filtered_paths.append(path)
+
+    if filtered_paths:
+        sanitized["LD_LIBRARY_PATH"] = os.pathsep.join(filtered_paths)
+    else:
+        sanitized.pop("LD_LIBRARY_PATH", None)
+
+    return sanitized
 
 
 class EnvironmentManager:
@@ -124,6 +174,12 @@ class EnvironmentManager:
     def get_exported_vars(self) -> Dict[str, str]:
         """Get exported environment variables only"""
         return {k: v for k, v in self._env_vars.items() if k in self._exported_vars}
+
+    def get_subprocess_env(self) -> Dict[str, str]:
+        """Get exported environment variables with loader paths sanitized."""
+        # Keep the shell's persisted exports intact while stripping only the
+        # frozen-app loader state that should not escape to child processes.
+        return sanitize_subprocess_loader_env(self.get_exported_vars())
 
     def remove_export(self, key: str) -> bool:
         """Remove export attribute from variable"""

--- a/src/aish/shell/pty/executor.py
+++ b/src/aish/shell/pty/executor.py
@@ -18,6 +18,7 @@ from anyio import to_thread
 
 from ...i18n import t
 from ...offload.pty_output_offload import PtyOutputOffload
+from ..environment import sanitize_subprocess_loader_env
 from ...tools.shell_state_capture import (apply_changes, cleanup_state_file,
                                           create_state_file, detect_changes,
                                           get_current_state, parse_state_file,
@@ -80,8 +81,12 @@ async def execute_command_with_pty(shell: Any, command: str) -> CommandResult:
     # State capture setup for cd/export support in compound commands
     state_file = create_state_file()
     env_vars = (
-        self.env_manager.get_exported_vars() if self.env_manager else dict(os.environ)
+        self.env_manager.get_subprocess_env()
+        if self.env_manager
+        else sanitize_subprocess_loader_env(dict(os.environ))
     )
+    # PTY mode launches the exact same user-facing system commands as the
+    # non-PTY executor, so it must reuse the same loader sanitization.
     old_state = get_current_state(env_vars)
 
     def build_pty_offload_payload(
@@ -345,7 +350,7 @@ async def execute_command_with_pty(shell: Any, command: str) -> CommandResult:
                 stdout=slave_fd,
                 stderr=stderr_write,  # Use pipe for stderr
                 preexec_fn=preexec_setup,
-                env=self.env_manager.get_exported_vars(),  # Use exported environment variables
+                env=env_vars,
             )
 
             # Close slave fd and stderr write end in parent

--- a/src/aish/shell/ui/editor.py
+++ b/src/aish/shell/ui/editor.py
@@ -20,6 +20,7 @@ from prompt_toolkit.key_binding.bindings.auto_suggest import (
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.shortcuts import CompleteStyle
 
+from ..environment import sanitize_subprocess_loader_env
 from .completion import ShellCompleter
 
 if TYPE_CHECKING:
@@ -240,7 +241,8 @@ class ShellPromptController:
     @staticmethod
     def _build_theme_env(cwd: str, exit_code: int, mode: str = "aish") -> dict[str, str]:
         """Build environment variables for theme script execution."""
-        env = dict(os.environ)
+        # Theme scripts and their git probes are ordinary subprocesses too.
+        env = sanitize_subprocess_loader_env(os.environ)
         env["AISH_CWD"] = cwd
         env["AISH_EXIT_CODE"] = str(exit_code)
         env["AISH_MODE"] = _normalize_prompt_mode(mode)

--- a/src/aish/tools/bash_executor.py
+++ b/src/aish/tools/bash_executor.py
@@ -15,6 +15,7 @@ import sys
 import termios
 from typing import Any, Dict, Optional, Tuple
 
+from ..shell.environment import sanitize_subprocess_loader_env
 from .shell_state_capture import (apply_changes, cleanup_state_file,
                                   create_state_file, detect_changes,
                                   get_current_state, parse_state_file,
@@ -75,10 +76,13 @@ class UnifiedBashExecutor:
         Returns:
             (success, stdout, stderr, returncode, changes)
         """
-        # Prepare environment variables
-        env_vars = os.environ.copy()
+        # Every shell command may spawn arbitrary system binaries, so this path
+        # always uses the sanitized subprocess environment instead of trying to
+        # classify commands as "internal" or "external".
         if self.env_manager:
-            env_vars.update(self.env_manager.get_exported_vars())
+            env_vars = self.env_manager.get_subprocess_env()
+        else:
+            env_vars = sanitize_subprocess_loader_env(os.environ.copy())
 
         # Get state before execution
         old_state = get_current_state(env_vars)

--- a/tests/shell/ui/test_shell_editor.py
+++ b/tests/shell/ui/test_shell_editor.py
@@ -128,6 +128,19 @@ def test_shell_prompt_controller_theme_env_includes_mode():
     assert env["AISH_MODE"] == "plan"
 
 
+def test_shell_prompt_controller_theme_env_restores_original_loader_env(monkeypatch):
+    monkeypatch.setattr("aish.shell.environment.sys.frozen", True, raising=False)
+    monkeypatch.setattr("aish.shell.environment.sys._MEIPASS", "/tmp/_MEI123", raising=False)
+    monkeypatch.setenv("LD_LIBRARY_PATH", "/tmp/_MEI123:/usr/lib/custom")
+    monkeypatch.setenv("LD_LIBRARY_PATH_ORIG", "/usr/lib/system")
+    monkeypatch.setenv("TEST_USER_VAR", "kept")
+
+    env = ShellPromptController._build_theme_env("/tmp/project", 0, "aish")
+
+    assert env["LD_LIBRARY_PATH"] == "/usr/lib/system"
+    assert env["TEST_USER_VAR"] == "kept"
+
+
 def test_shell_prompt_controller_compact_theme_has_no_leading_space(tmp_path, monkeypatch):
     controller = ShellPromptController(prompt_theme="compact")
 

--- a/tests/shell/ui/test_shell_editor.py
+++ b/tests/shell/ui/test_shell_editor.py
@@ -141,6 +141,40 @@ def test_shell_prompt_controller_theme_env_restores_original_loader_env(monkeypa
     assert env["TEST_USER_VAR"] == "kept"
 
 
+def test_shell_prompt_controller_theme_env_keeps_loader_path_when_not_frozen(
+    monkeypatch,
+):
+    monkeypatch.setattr("aish.shell.environment.sys.frozen", False, raising=False)
+    monkeypatch.setenv("LD_LIBRARY_PATH", "/usr/lib/custom")
+
+    env = ShellPromptController._build_theme_env("/tmp/project", 0, "aish")
+
+    assert env["LD_LIBRARY_PATH"] == "/usr/lib/custom"
+
+
+def test_shell_prompt_controller_theme_env_prunes_bundle_paths_without_orig(
+    monkeypatch,
+):
+    bundle_path = "/tmp/pyi-bundle"
+    nested_bundle_path = os.path.join(bundle_path, "nested")
+
+    monkeypatch.setattr("aish.shell.environment.sys.frozen", True, raising=False)
+    monkeypatch.setattr("aish.shell.environment.sys._MEIPASS", bundle_path, raising=False)
+    monkeypatch.setenv(
+        "LD_LIBRARY_PATH",
+        os.pathsep.join([bundle_path, "/usr/lib", nested_bundle_path, "/opt/other"]),
+    )
+    monkeypatch.delenv("LD_LIBRARY_PATH_ORIG", raising=False)
+
+    env = ShellPromptController._build_theme_env("/tmp/project", 0, "aish")
+
+    child_ld = env.get("LD_LIBRARY_PATH", "")
+    assert "/usr/lib" in child_ld
+    assert "/opt/other" in child_ld
+    assert bundle_path not in child_ld
+    assert nested_bundle_path not in child_ld
+
+
 def test_shell_prompt_controller_compact_theme_has_no_leading_space(tmp_path, monkeypatch):
     controller = ShellPromptController(prompt_theme="compact")
 

--- a/tests/tools/test_bash_executor.py
+++ b/tests/tools/test_bash_executor.py
@@ -24,6 +24,42 @@ class TestUnifiedBashExecutor:
     def executor(self, env_manager):
         return UnifiedBashExecutor(env_manager=env_manager)
 
+    @staticmethod
+    def _patch_state_capture(monkeypatch):
+        monkeypatch.setattr(
+            "aish.tools.bash_executor.get_current_state",
+            lambda env: {"pwd": "/tmp", "env": env.copy()},
+        )
+        monkeypatch.setattr(
+            "aish.tools.bash_executor.create_state_file",
+            lambda: "/tmp/fake-state",
+        )
+        monkeypatch.setattr(
+            "aish.tools.bash_executor.parse_state_file",
+            lambda path: {"pwd": "/tmp", "env": {}},
+        )
+        monkeypatch.setattr(
+            "aish.tools.bash_executor.detect_changes",
+            lambda old_state, new_state: {
+                "cwd_changed": False,
+                "new_cwd": old_state["pwd"],
+                "env_added": {},
+                "env_modified": {},
+                "env_removed": [],
+            },
+        )
+        monkeypatch.setattr(
+            "aish.tools.bash_executor.apply_changes",
+            lambda changes, env_manager: None,
+        )
+        monkeypatch.setattr(
+            "aish.tools.bash_executor.cleanup_state_file", lambda path: None
+        )
+        monkeypatch.setattr(
+            "aish.tools.bash_executor.wrap_command_with_state_capture",
+            lambda command, state_file: command,
+        )
+
     def test_simple_command(self, executor):
         """测试简单命令"""
         success, stdout, stderr, retcode, changes = executor.execute("echo hello")
@@ -158,34 +194,7 @@ class TestUnifiedBashExecutor:
         """测试执行子进程时会恢复原始 LD_LIBRARY_PATH"""
         captured = {}
 
-        monkeypatch.setattr(
-            "aish.tools.bash_executor.get_current_state",
-            lambda env: {"pwd": "/tmp", "env": env.copy()},
-        )
-        monkeypatch.setattr(
-            "aish.tools.bash_executor.create_state_file",
-            lambda: "/tmp/fake-state",
-        )
-        monkeypatch.setattr(
-            "aish.tools.bash_executor.parse_state_file",
-            lambda path: {"pwd": "/tmp", "env": {}},
-        )
-        monkeypatch.setattr(
-            "aish.tools.bash_executor.detect_changes",
-            lambda old_state, new_state: {
-                "cwd_changed": False,
-                "new_cwd": old_state["pwd"],
-                "env_added": {},
-                "env_modified": {},
-                "env_removed": [],
-            },
-        )
-        monkeypatch.setattr("aish.tools.bash_executor.apply_changes", lambda changes, env_manager: None)
-        monkeypatch.setattr("aish.tools.bash_executor.cleanup_state_file", lambda path: None)
-        monkeypatch.setattr(
-            "aish.tools.bash_executor.wrap_command_with_state_capture",
-            lambda command, state_file: command,
-        )
+        self._patch_state_capture(monkeypatch)
 
         def fake_run(*args, **kwargs):
             captured.update(kwargs["env"])
@@ -198,6 +207,69 @@ class TestUnifiedBashExecutor:
         executor.env_manager.set_var("LD_LIBRARY_PATH", "/tmp/_MEI123:/usr/lib/custom")
         executor.env_manager.set_var("LD_LIBRARY_PATH_ORIG", "/usr/lib/system")
         executor.env_manager.set_var("TEST_USER_VAR", "kept")
+
+        success, stdout, stderr, retcode, changes = executor.execute("echo ok")
+
+        assert success is True
+        assert retcode == 0
+        assert stdout == "ok\n"
+        assert captured["LD_LIBRARY_PATH"] == "/usr/lib/system"
+        assert captured["TEST_USER_VAR"] == "kept"
+
+    def test_execute_sanitizes_pyinstaller_loader_env_without_orig(
+        self, executor, monkeypatch
+    ):
+        """测试缺少 LD_LIBRARY_PATH_ORIG 时会移除 bundle 路径段"""
+        captured = {}
+        bundle_path = "/tmp/pyi-bundle"
+        nested_bundle_path = os.path.join(bundle_path, "nested")
+
+        self._patch_state_capture(monkeypatch)
+
+        def fake_run(*args, **kwargs):
+            captured["env"] = kwargs["env"].copy()
+            return SimpleNamespace(returncode=0, stdout=b"ok\n", stderr=b"")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "_MEIPASS", bundle_path, raising=False)
+
+        executor.env_manager.set_var(
+            "LD_LIBRARY_PATH",
+            os.pathsep.join([bundle_path, "/usr/lib", nested_bundle_path, "/opt/other"]),
+        )
+        executor.env_manager.unset_var("LD_LIBRARY_PATH_ORIG")
+
+        success, stdout, stderr, retcode, changes = executor.execute("echo ok")
+
+        assert success is True
+        assert retcode == 0
+        assert stdout == "ok\n"
+        child_ld = captured["env"].get("LD_LIBRARY_PATH", "")
+        assert "/usr/lib" in child_ld
+        assert "/opt/other" in child_ld
+        assert bundle_path not in child_ld
+        assert nested_bundle_path not in child_ld
+
+    def test_execute_sanitizes_pyinstaller_loader_env_without_env_manager(
+        self, monkeypatch
+    ):
+        """测试没有 env_manager 时仍会清理 PyInstaller loader 环境"""
+        captured = {}
+        executor = UnifiedBashExecutor(env_manager=None)
+
+        self._patch_state_capture(monkeypatch)
+
+        def fake_run(*args, **kwargs):
+            captured.update(kwargs["env"])
+            return SimpleNamespace(returncode=0, stdout=b"ok\n", stderr=b"")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "_MEIPASS", "/tmp/_MEI123", raising=False)
+        monkeypatch.setenv("LD_LIBRARY_PATH", "/tmp/_MEI123:/usr/lib/custom")
+        monkeypatch.setenv("LD_LIBRARY_PATH_ORIG", "/usr/lib/system")
+        monkeypatch.setenv("TEST_USER_VAR", "kept")
 
         success, stdout, stderr, retcode, changes = executor.execute("echo ok")
 

--- a/tests/tools/test_bash_executor.py
+++ b/tests/tools/test_bash_executor.py
@@ -3,6 +3,7 @@
 import os
 import subprocess
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -152,6 +153,59 @@ class TestUnifiedBashExecutor:
         assert retcode == 0
         assert stdout == "ok\n"
         assert "timeout" not in captured
+
+    def test_execute_sanitizes_pyinstaller_loader_env(self, executor, monkeypatch):
+        """测试执行子进程时会恢复原始 LD_LIBRARY_PATH"""
+        captured = {}
+
+        monkeypatch.setattr(
+            "aish.tools.bash_executor.get_current_state",
+            lambda env: {"pwd": "/tmp", "env": env.copy()},
+        )
+        monkeypatch.setattr(
+            "aish.tools.bash_executor.create_state_file",
+            lambda: "/tmp/fake-state",
+        )
+        monkeypatch.setattr(
+            "aish.tools.bash_executor.parse_state_file",
+            lambda path: {"pwd": "/tmp", "env": {}},
+        )
+        monkeypatch.setattr(
+            "aish.tools.bash_executor.detect_changes",
+            lambda old_state, new_state: {
+                "cwd_changed": False,
+                "new_cwd": old_state["pwd"],
+                "env_added": {},
+                "env_modified": {},
+                "env_removed": [],
+            },
+        )
+        monkeypatch.setattr("aish.tools.bash_executor.apply_changes", lambda changes, env_manager: None)
+        monkeypatch.setattr("aish.tools.bash_executor.cleanup_state_file", lambda path: None)
+        monkeypatch.setattr(
+            "aish.tools.bash_executor.wrap_command_with_state_capture",
+            lambda command, state_file: command,
+        )
+
+        def fake_run(*args, **kwargs):
+            captured.update(kwargs["env"])
+            return SimpleNamespace(returncode=0, stdout=b"ok\n", stderr=b"")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "_MEIPASS", "/tmp/_MEI123", raising=False)
+
+        executor.env_manager.set_var("LD_LIBRARY_PATH", "/tmp/_MEI123:/usr/lib/custom")
+        executor.env_manager.set_var("LD_LIBRARY_PATH_ORIG", "/usr/lib/system")
+        executor.env_manager.set_var("TEST_USER_VAR", "kept")
+
+        success, stdout, stderr, retcode, changes = executor.execute("echo ok")
+
+        assert success is True
+        assert retcode == 0
+        assert stdout == "ok\n"
+        assert captured["LD_LIBRARY_PATH"] == "/usr/lib/system"
+        assert captured["TEST_USER_VAR"] == "kept"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
This PR sanitizes subprocess environments when AISH is running from a PyInstaller bundle.

The change removes bundle-private loader paths before launching child processes, while preserving the user's normal shell environment as much as possible. When PyInstaller provides the original loader path state, the subprocess environment restores that directly; otherwise it falls back to pruning only the extracted bundle path.

## Why
System commands launched from the packaged app should not inherit AISH's private runtime loader configuration.

Without this cleanup, subprocesses can observe a modified library search path that differs from the user's real environment. That makes shell execution under the frozen build less predictable and can cause linkage behavior that only exists inside the packaged app.

## Testing
- Ran `/home/lixin/workspace/aishell/aish/.venv/bin/python -m pytest tests/shell/ui/test_shell_editor.py tests/tools/test_bash_executor.py -q`
- Result: 28 passed

## Summary by Sourcery

Sanitize subprocess environments to strip PyInstaller-specific loader paths while preserving user environment variables across shell, PTY, and script executors.

Bug Fixes:
- Prevent child processes from inheriting PyInstaller bundle-private LD_LIBRARY_PATH settings that can alter system command behavior.

Enhancements:
- Introduce a shared helper for building sanitized subprocess environments and integrate it into environment management, bash execution, PTY execution, script runtime, and shell theme scripts.

Tests:
- Add tests to verify that shell executors and prompt theme environments restore the original loader environment and retain user-defined variables under PyInstaller.