### PR TITLE
fix: move PTY command tracking off the shell input path

### DIFF
--- a/src/aish/shell/runtime/app.py
+++ b/src/aish/shell/runtime/app.py
@@ -1749,7 +1749,12 @@ class PTYAIShell:
         self._sync_backend_cwd(event.payload.get("cwd"))
 
         resolved_command_seq = None
+        has_backend_identity = False
         if self._pty_manager is not None and event.type in {"command_started", "prompt_ready"}:
+            has_backend_identity = (
+                event.payload.get("command_seq") is not None
+                or event.payload.get("submission_id") is not None
+            )
             resolved_command_seq = self._pty_manager.command_state.resolve_command_seq(
                 event.payload.get("command_seq"),
                 event.payload.get("submission_id"),
@@ -1767,14 +1772,14 @@ class PTYAIShell:
             self._shell_phase = "editing"
         elif event.type == "command_started":
             command_seq = resolved_command_seq
-            if command_seq is None:
+            if command_seq is None and not has_backend_identity:
                 command_seq = self._pending_command_seq
 
             if self._pending_command_seq is None or command_seq == self._pending_command_seq:
                 self._shell_phase = "running_passthrough"
         elif event.type == "prompt_ready":
             command_seq = resolved_command_seq
-            if command_seq is None:
+            if command_seq is None and not has_backend_identity:
                 command_seq = self._pending_command_seq
 
             if self._pending_command_seq is None or command_seq == self._pending_command_seq:

--- a/src/aish/shell/runtime/app.py
+++ b/src/aish/shell/runtime/app.py
@@ -1750,6 +1750,12 @@ class PTYAIShell:
 
         self._sync_backend_cwd(event.payload.get("cwd"))
 
+        resolved_command_seq = None
+        if self._pty_manager is not None and event.type in {"command_started", "prompt_ready"}:
+            resolved_command_seq = self._pty_manager.command_state.resolve_command_seq(
+                event.payload.get("command_seq")
+            )
+
         result = None
         if self._pty_manager is not None:
             result = self._pty_manager.handle_backend_event(event)
@@ -1761,17 +1767,15 @@ class PTYAIShell:
             self._backend_session_ready = True
             self._shell_phase = "editing"
         elif event.type == "command_started":
-            command_seq = event.payload.get("command_seq")
-            if command_seq is None and self._pending_command_seq is not None:
-                event.payload["command_seq"] = self._pending_command_seq
+            command_seq = resolved_command_seq
+            if command_seq is None:
                 command_seq = self._pending_command_seq
 
             if self._pending_command_seq is None or command_seq == self._pending_command_seq:
                 self._shell_phase = "running_passthrough"
         elif event.type == "prompt_ready":
-            command_seq = event.payload.get("command_seq")
-            if command_seq is None and self._pending_command_seq is not None:
-                event.payload["command_seq"] = self._pending_command_seq
+            command_seq = resolved_command_seq
+            if command_seq is None:
                 command_seq = self._pending_command_seq
 
             if self._pending_command_seq is None or command_seq == self._pending_command_seq:

--- a/src/aish/shell/runtime/app.py
+++ b/src/aish/shell/runtime/app.py
@@ -1721,8 +1721,6 @@ class PTYAIShell:
             if is_exit_cmd:
                 self._output_processor.set_filter_exit_echo(True)
                 self._user_requested_exit = True
-            else:
-                self._output_processor.set_waiting_for_result(True, command)
             self._output_processor.prepare_user_command_echo(backend_command, seq)
 
         self._pty_manager.send_command(backend_command, command_seq=seq, source="user")
@@ -1753,7 +1751,8 @@ class PTYAIShell:
         resolved_command_seq = None
         if self._pty_manager is not None and event.type in {"command_started", "prompt_ready"}:
             resolved_command_seq = self._pty_manager.command_state.resolve_command_seq(
-                event.payload.get("command_seq")
+                event.payload.get("command_seq"),
+                event.payload.get("submission_id"),
             )
 
         result = None

--- a/src/aish/shell/runtime/output.py
+++ b/src/aish/shell/runtime/output.py
@@ -29,7 +29,6 @@ class OutputProcessor:
         shell: Optional["PTYAIShell"] = None,
     ):
         self.pty_manager = pty_manager
-        self._waiting_for_result = False
         self._filter_exit_echo = False
         self.shell = shell
         self._current_command: str = ""
@@ -42,20 +41,9 @@ class OutputProcessor:
         #   user-typed vs backend commands and only expose failures once.
         self._suppress_error_hint: bool = False
 
-    def set_waiting_for_result(self, waiting: bool, command: str = "") -> None:
-        """Set whether we're waiting for a command result."""
-        self._waiting_for_result = waiting
-        self._suppress_error_hint = False
-        if waiting:
-            self._current_command = command
-
     def suppress_next_error_hint(self) -> None:
         """Suppress the next error correction hint (e.g., after Ctrl+C for exit)."""
         self._suppress_error_hint = True
-
-    def set_current_command(self, command: str) -> None:
-        """Set the current command being executed."""
-        self._current_command = command
 
     def prepare_user_command_echo(self, command: str, command_seq: int | None) -> None:
         """Suppress the first bash echo for a user-submitted command."""
@@ -143,7 +131,6 @@ class OutputProcessor:
         if event.type != "prompt_ready":
             return
 
-        self._waiting_for_result = False
         self._clear_pending_user_echo()
         if result is None:
             return

--- a/src/aish/shell/runtime/output.py
+++ b/src/aish/shell/runtime/output.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import shlex
+import re
 import sys
 from typing import TYPE_CHECKING, Optional
 
@@ -14,6 +14,10 @@ from ...terminal.pty.control_protocol import BackendControlEvent
 if TYPE_CHECKING:
     from ...terminal.pty import PTYManager
     from .app import PTYAIShell
+
+
+_ANSI_CSI_RE = re.compile(rb"\x1b\[[0-9;?]*[ -/]*[@-~]")
+_ANSI_OSC_RE = re.compile(rb"\x1b\].*?(?:\x07|\x1b\\)")
 
 
 class OutputProcessor:
@@ -30,6 +34,7 @@ class OutputProcessor:
         self.shell = shell
         self._current_command: str = ""
         self._pending_user_echo: bytes | None = None
+        self._pending_user_echo_buffer = bytearray()
         # Two-layer error suppression:
         # Layer 1 (here): _suppress_error_hint — UI-layer skip for one cycle
         #   (e.g., after Ctrl+C for exit, suppress the spurious hint).
@@ -56,51 +61,68 @@ class OutputProcessor:
         """Suppress the first bash echo for a user-submitted command."""
         command = str(command or "").strip()
         if not command or command_seq is None:
-            self._pending_user_echo = None
+            self._clear_pending_user_echo()
             return
-        quoted_command = shlex.quote(command)
-        self._pending_user_echo = (
-            (
-                f" __AISH_ACTIVE_COMMAND_SEQ={command_seq}; "
-                f"__AISH_ACTIVE_COMMAND_TEXT={quoted_command}; {command}"
-            ).encode("utf-8")
-        )
+        self._pending_user_echo = command.encode("utf-8")
+        self._pending_user_echo_buffer.clear()
+
+    def _clear_pending_user_echo(self) -> None:
+        self._pending_user_echo = None
+        self._pending_user_echo_buffer.clear()
+
+    @staticmethod
+    def _strip_terminal_control(data: bytes) -> bytes:
+        data = _ANSI_CSI_RE.sub(b"", data)
+        data = _ANSI_OSC_RE.sub(b"", data)
+        return data
+
+    def _line_matches_pending_user_echo(self, line: bytes) -> bool:
+        if self._pending_user_echo is None:
+            return False
+
+        normalized = self._strip_terminal_control(line).strip(b"\r\n")
+        normalized = normalized.lstrip(b"\r")
+        return normalized == self._pending_user_echo
+
+    def _buffer_might_be_pending_user_echo(self, buffer: bytes) -> bool:
+        if self._pending_user_echo is None:
+            return False
+
+        normalized = self._strip_terminal_control(buffer)
+        normalized = normalized.lstrip(b"\r")
+        return self._pending_user_echo.startswith(normalized)
 
     def _consume_pending_user_echo(self, data: bytes) -> bytes:
         if self._pending_user_echo is None:
             return data
 
-        echoed = self._pending_user_echo
-        patterns = (
-            b"\r" + echoed + b"\r\n",
-            echoed + b"\r\n",
-            b"\r" + echoed + b"\n",
-            echoed + b"\n",
-            b"\r" + echoed,
-            echoed,
-        )
+        self._pending_user_echo_buffer.extend(data)
+        rendered = bytearray()
 
-        for pattern in patterns:
-            if data.startswith(pattern):
-                self._pending_user_echo = None
-                return data[len(pattern) :]
+        while self._pending_user_echo_buffer:
+            buffered = bytes(self._pending_user_echo_buffer)
+            newline_index = buffered.find(b"\n")
 
-        index = data.find(echoed)
-        if index == -1:
-            return data
+            if newline_index == -1:
+                if self._buffer_might_be_pending_user_echo(buffered):
+                    break
+                rendered.extend(self._pending_user_echo_buffer)
+                self._pending_user_echo_buffer.clear()
+                break
 
-        start = index
-        end = index + len(echoed)
-        if start > 0 and data[start - 1 : start] == b"\r":
-            start -= 1
+            line_end = newline_index + 1
+            line = buffered[:line_end]
+            del self._pending_user_echo_buffer[:line_end]
 
-        if data[end : end + 2] == b"\r\n":
-            end += 2
-        elif data[end : end + 1] in (b"\r", b"\n"):
-            end += 1
+            if self._line_matches_pending_user_echo(line):
+                remainder = bytes(self._pending_user_echo_buffer)
+                self._clear_pending_user_echo()
+                rendered.extend(remainder)
+                break
 
-        self._pending_user_echo = None
-        return data[:start] + data[end:]
+            rendered.extend(line)
+
+        return bytes(rendered)
 
     def set_filter_exit_echo(self, filter_exit: bool) -> None:
         """Set whether to filter exit command echo."""
@@ -122,6 +144,7 @@ class OutputProcessor:
             return
 
         self._waiting_for_result = False
+        self._clear_pending_user_echo()
         if result is None:
             return
 

--- a/src/aish/terminal/pty/__init__.py
+++ b/src/aish/terminal/pty/__init__.py
@@ -1,6 +1,6 @@
 """PTY management for aish."""
 
-from .command_state import CommandResult, CommandState
+from .command_state import CommandResult, CommandState, CommandSubmission
 from .manager import PTYManager
 
-__all__ = ["PTYManager", "CommandResult", "CommandState"]
+__all__ = ["PTYManager", "CommandResult", "CommandState", "CommandSubmission"]

--- a/src/aish/terminal/pty/bash_rc_wrapper.sh
+++ b/src/aish/terminal/pty/bash_rc_wrapper.sh
@@ -56,12 +56,13 @@ __aish_emit_control_line() {
 }
 
 __aish_emit_session_ready() {
-    local ts cwd_json payload
+    local ts cwd_json ps2_json payload
     ts=$(date +%s)
     cwd_json=$(__aish_json_escape "$PWD")
+    ps2_json=$(__aish_json_escape "$PS2")
     printf -v payload \
-        '{"version":%s,"type":"session_ready","ts":%s,"shell_pid":%s,"cwd":"%s","shlvl":%s}' \
-        "$__AISH_PROTOCOL_VERSION" "$ts" "$$" "$cwd_json" "${SHLVL:-0}"
+        '{"version":%s,"type":"session_ready","ts":%s,"shell_pid":%s,"cwd":"%s","ps2":"%s","shlvl":%s}' \
+        "$__AISH_PROTOCOL_VERSION" "$ts" "$$" "$cwd_json" "$ps2_json" "${SHLVL:-0}"
     __aish_emit_control_line "$payload"
 }
 
@@ -82,7 +83,7 @@ __aish_load_command_metadata_from_fd() {
         return 1
     fi
 
-    IFS= read -r -t 0.001 metadata_line <&${__AISH_COMMAND_METADATA_FD} || return 1
+    IFS= read -r -t 0.001 metadata_line <&"${__AISH_COMMAND_METADATA_FD}" || return 1
     if [[ -z "$metadata_line" ]]; then
         return 1
     fi

--- a/src/aish/terminal/pty/bash_rc_wrapper.sh
+++ b/src/aish/terminal/pty/bash_rc_wrapper.sh
@@ -29,8 +29,9 @@ esac
 __aish_last_exit_code=0
 __AISH_PROTOCOL_VERSION=1
 __AISH_CONTROL_FD="${AISH_CONTROL_FD:-}"
-__AISH_COMMAND_METADATA_FILE="${AISH_COMMAND_METADATA_FILE:-}"
+__AISH_COMMAND_METADATA_FD="${AISH_COMMAND_METADATA_FD:-}"
 __AISH_AT_PROMPT=0
+__AISH_PENDING_COMMAND_ID=""
 __AISH_PENDING_COMMAND_SOURCE=""
 __AISH_PENDING_COMMAND_SEQ=""
 __AISH_PENDING_COMMAND_TEXT=""
@@ -65,36 +66,60 @@ __aish_emit_session_ready() {
 }
 
 __aish_reset_command_metadata() {
+    __AISH_PENDING_COMMAND_ID=""
     __AISH_PENDING_COMMAND_SOURCE=""
     __AISH_PENDING_COMMAND_SEQ=""
     __AISH_PENDING_COMMAND_TEXT=""
 }
 
-__aish_load_command_metadata() {
-    local metadata_file="$__AISH_COMMAND_METADATA_FILE"
+__aish_load_command_metadata_from_fd() {
+    local metadata_line=""
+    local assignments=""
+
     __aish_reset_command_metadata
 
-    if [[ -z "$metadata_file" || ! -f "$metadata_file" ]]; then
+    if [[ ! "$__AISH_COMMAND_METADATA_FD" =~ ^[0-9]+$ ]]; then
         return 1
     fi
 
-    # shellcheck disable=SC1090
-    source "$metadata_file" 2>/dev/null || return 1
-    return 0
-}
-
-__aish_clear_command_metadata_file() {
-    local metadata_file="$__AISH_COMMAND_METADATA_FILE"
-    if [[ -z "$metadata_file" ]]; then
-        return 0
+    IFS= read -r -t 0.001 metadata_line <&${__AISH_COMMAND_METADATA_FD} || return 1
+    if [[ -z "$metadata_line" ]]; then
+        return 1
     fi
 
-    : > "$metadata_file" 2>/dev/null || true
+    assignments=$(METADATA_LINE="$metadata_line" python3 <<'PY'
+import json
+import os
+import shlex
+import sys
+
+line = os.environ.get("METADATA_LINE", "")
+if not line:
+    sys.exit(1)
+
+try:
+    payload = json.loads(line)
+except json.JSONDecodeError:
+    sys.exit(1)
+
+def emit(name, value):
+    text = "" if value is None else str(value)
+    print(f"{name}={shlex.quote(text)}")
+
+emit("__AISH_PENDING_COMMAND_ID", payload.get("submission_id"))
+emit("__AISH_PENDING_COMMAND_SOURCE", payload.get("source"))
+emit("__AISH_PENDING_COMMAND_SEQ", payload.get("command_seq"))
+emit("__AISH_PENDING_COMMAND_TEXT", payload.get("original_command"))
+PY
+) || return 1
+
+    eval "$assignments"
+    return 0
 }
 
 __aish_emit_prompt_ready() {
     local exit_code="$1"
-    local ts cwd_json interrupted command_seq payload
+    local ts cwd_json interrupted command_seq submission_id source_json payload
     ts=$(date +%s)
     cwd_json=$(__aish_json_escape "$PWD")
     interrupted=false
@@ -107,15 +132,25 @@ __aish_emit_prompt_ready() {
         command_seq="$__AISH_PENDING_COMMAND_SEQ"
     fi
 
+    submission_id=null
+    if [[ -n "$__AISH_PENDING_COMMAND_ID" ]]; then
+        submission_id="\"$(__aish_json_escape "$__AISH_PENDING_COMMAND_ID")\""
+    fi
+
+    source_json=null
+    if [[ -n "$__AISH_PENDING_COMMAND_SOURCE" ]]; then
+        source_json="\"$(__aish_json_escape "$__AISH_PENDING_COMMAND_SOURCE")\""
+    fi
+
     printf -v payload \
-        '{"version":%s,"type":"prompt_ready","ts":%s,"command_seq":%s,"exit_code":%s,"cwd":"%s","shlvl":%s,"interrupted":%s}' \
-        "$__AISH_PROTOCOL_VERSION" "$ts" "$command_seq" "$exit_code" "$cwd_json" "${SHLVL:-0}" "$interrupted"
+        '{"version":%s,"type":"prompt_ready","ts":%s,"submission_id":%s,"source":%s,"command_seq":%s,"exit_code":%s,"cwd":"%s","shlvl":%s,"interrupted":%s}' \
+        "$__AISH_PROTOCOL_VERSION" "$ts" "$submission_id" "$source_json" "$command_seq" "$exit_code" "$cwd_json" "${SHLVL:-0}" "$interrupted"
     __aish_emit_control_line "$payload"
 }
 
 __aish_emit_command_started() {
     local command="$1"
-    local ts command_json command_seq payload
+    local ts command_json command_seq submission_id source_json payload
     ts=$(date +%s)
     command_json=$(__aish_json_escape "$command")
 
@@ -124,9 +159,19 @@ __aish_emit_command_started() {
         command_seq="$__AISH_PENDING_COMMAND_SEQ"
     fi
 
+    submission_id=null
+    if [[ -n "$__AISH_PENDING_COMMAND_ID" ]]; then
+        submission_id="\"$(__aish_json_escape "$__AISH_PENDING_COMMAND_ID")\""
+    fi
+
+    source_json=null
+    if [[ -n "$__AISH_PENDING_COMMAND_SOURCE" ]]; then
+        source_json="\"$(__aish_json_escape "$__AISH_PENDING_COMMAND_SOURCE")\""
+    fi
+
     printf -v payload \
-        '{"version":%s,"type":"command_started","ts":%s,"command_seq":%s,"command":"%s","cwd":"%s","shlvl":%s}' \
-        "$__AISH_PROTOCOL_VERSION" "$ts" "$command_seq" "$command_json" "$(__aish_json_escape "$PWD")" "${SHLVL:-0}"
+        '{"version":%s,"type":"command_started","ts":%s,"submission_id":%s,"source":%s,"command_seq":%s,"command":"%s","cwd":"%s","shlvl":%s}' \
+        "$__AISH_PROTOCOL_VERSION" "$ts" "$submission_id" "$source_json" "$command_seq" "$command_json" "$(__aish_json_escape "$PWD")" "${SHLVL:-0}"
     __aish_emit_control_line "$payload"
 }
 
@@ -165,13 +210,13 @@ __aish_on_debug() {
         return 0
     fi
 
-    __aish_load_command_metadata || true
-
     case "$BASH_COMMAND" in
-        __aish_prompt_command*|__aish_on_debug*|__aish_emit_*|__aish_json_escape*|trap* )
+        __aish_prompt_command*|__aish_on_debug*|__aish_emit_*|__aish_json_escape*|__aish_load_command_metadata_from_fd*|__aish_reset_command_metadata*|__aish_rewrite_last_history_entry*|trap* )
             return 0
             ;;
     esac
+
+    __aish_load_command_metadata_from_fd || true
 
     __AISH_AT_PROMPT=0
     __aish_emit_command_started "$BASH_COMMAND"
@@ -181,7 +226,6 @@ __aish_on_debug() {
 __aish_prompt_command() {
     local exit_code=$?
     __aish_last_exit_code=$exit_code
-    __aish_load_command_metadata || true
     __aish_rewrite_last_history_entry
     # Call original PROMPT_COMMAND if it exists
     if [[ -n "$__AISH_ORIGINAL_PROMPT_COMMAND" ]]; then
@@ -191,7 +235,6 @@ __aish_prompt_command() {
     PS1=''
     __AISH_AT_PROMPT=1
     __aish_emit_prompt_ready "$exit_code"
-    __aish_clear_command_metadata_file
     __aish_reset_command_metadata
 }
 

--- a/src/aish/terminal/pty/bash_rc_wrapper.sh
+++ b/src/aish/terminal/pty/bash_rc_wrapper.sh
@@ -178,6 +178,9 @@ __aish_emit_command_started() {
 __aish_rewrite_last_history_entry() {
     local source="$__AISH_PENDING_COMMAND_SOURCE"
     local original_command="$__AISH_PENDING_COMMAND_TEXT"
+    local history_line=""
+    local history_index=""
+    local history_command=""
 
     if [[ "$source" != "user" ]]; then
         return 0
@@ -185,6 +188,23 @@ __aish_rewrite_last_history_entry() {
 
     if [[ -z "$original_command" ]]; then
         return 0
+    fi
+
+    history_line=$(builtin history 1 2>/dev/null || true)
+    if [[ "$history_line" =~ ^[[:space:]]*([0-9]+)[[:space:]]+(.*)$ ]]; then
+        history_index="${BASH_REMATCH[1]}"
+        history_command="${BASH_REMATCH[2]}"
+
+        if [[ "$history_command" == "$original_command" ]]; then
+            return 0
+        fi
+
+        if [[ "$original_command" == !* ]]; then
+            builtin history -s "$original_command" 2>/dev/null || true
+            return 0
+        fi
+
+        builtin history -d "$history_index" 2>/dev/null || true
     fi
 
     builtin history -s "$original_command" 2>/dev/null || true

--- a/src/aish/terminal/pty/bash_rc_wrapper.sh
+++ b/src/aish/terminal/pty/bash_rc_wrapper.sh
@@ -29,7 +29,11 @@ esac
 __aish_last_exit_code=0
 __AISH_PROTOCOL_VERSION=1
 __AISH_CONTROL_FD="${AISH_CONTROL_FD:-}"
+__AISH_COMMAND_METADATA_FILE="${AISH_COMMAND_METADATA_FILE:-}"
 __AISH_AT_PROMPT=0
+__AISH_PENDING_COMMAND_SOURCE=""
+__AISH_PENDING_COMMAND_SEQ=""
+__AISH_PENDING_COMMAND_TEXT=""
 
 __aish_json_escape() {
     local value="$1"
@@ -60,6 +64,34 @@ __aish_emit_session_ready() {
     __aish_emit_control_line "$payload"
 }
 
+__aish_reset_command_metadata() {
+    __AISH_PENDING_COMMAND_SOURCE=""
+    __AISH_PENDING_COMMAND_SEQ=""
+    __AISH_PENDING_COMMAND_TEXT=""
+}
+
+__aish_load_command_metadata() {
+    local metadata_file="$__AISH_COMMAND_METADATA_FILE"
+    __aish_reset_command_metadata
+
+    if [[ -z "$metadata_file" || ! -f "$metadata_file" ]]; then
+        return 1
+    fi
+
+    # shellcheck disable=SC1090
+    source "$metadata_file" 2>/dev/null || return 1
+    return 0
+}
+
+__aish_clear_command_metadata_file() {
+    local metadata_file="$__AISH_COMMAND_METADATA_FILE"
+    if [[ -z "$metadata_file" ]]; then
+        return 0
+    fi
+
+    : > "$metadata_file" 2>/dev/null || true
+}
+
 __aish_emit_prompt_ready() {
     local exit_code="$1"
     local ts cwd_json interrupted command_seq payload
@@ -71,16 +103,14 @@ __aish_emit_prompt_ready() {
     fi
 
     command_seq=null
-    if [[ -n "${__AISH_ACTIVE_COMMAND_SEQ:-}" ]]; then
-        command_seq="${__AISH_ACTIVE_COMMAND_SEQ}"
+    if [[ -n "$__AISH_PENDING_COMMAND_SEQ" ]]; then
+        command_seq="$__AISH_PENDING_COMMAND_SEQ"
     fi
 
     printf -v payload \
         '{"version":%s,"type":"prompt_ready","ts":%s,"command_seq":%s,"exit_code":%s,"cwd":"%s","shlvl":%s,"interrupted":%s}' \
         "$__AISH_PROTOCOL_VERSION" "$ts" "$command_seq" "$exit_code" "$cwd_json" "${SHLVL:-0}" "$interrupted"
     __aish_emit_control_line "$payload"
-    unset __AISH_ACTIVE_COMMAND_SEQ
-    unset __AISH_ACTIVE_COMMAND_TEXT
 }
 
 __aish_emit_command_started() {
@@ -90,8 +120,8 @@ __aish_emit_command_started() {
     command_json=$(__aish_json_escape "$command")
 
     command_seq=null
-    if [[ -n "${__AISH_ACTIVE_COMMAND_SEQ:-}" ]]; then
-        command_seq="${__AISH_ACTIVE_COMMAND_SEQ}"
+    if [[ -n "$__AISH_PENDING_COMMAND_SEQ" ]]; then
+        command_seq="$__AISH_PENDING_COMMAND_SEQ"
     fi
 
     printf -v payload \
@@ -101,28 +131,10 @@ __aish_emit_command_started() {
 }
 
 __aish_rewrite_last_history_entry() {
-    local seq="${__AISH_ACTIVE_COMMAND_SEQ:-}"
-    local original_command="${__AISH_ACTIVE_COMMAND_TEXT:-}"
-    local history_line history_index history_command
+    local source="$__AISH_PENDING_COMMAND_SOURCE"
+    local original_command="$__AISH_PENDING_COMMAND_TEXT"
 
-    if [[ -z "$seq" ]]; then
-        return 0
-    fi
-
-    history_line=$(builtin history 1 2>/dev/null || true)
-    if [[ "$history_line" =~ ^[[:space:]]*([0-9]+)[[:space:]]+(.*)$ ]]; then
-        history_index="${BASH_REMATCH[1]}"
-        history_command="${BASH_REMATCH[2]}"
-
-        if [[ "$history_command" == __AISH_ACTIVE_COMMAND_SEQ=* ]]; then
-            builtin history -d "$history_index" 2>/dev/null || true
-            if [[ -z "$original_command" ]]; then
-                original_command="${history_command#*; }"
-            fi
-        fi
-    fi
-
-    if [[ "$seq" == -* ]]; then
+    if [[ "$source" != "user" ]]; then
         return 0
     fi
 
@@ -153,14 +165,10 @@ __aish_on_debug() {
         return 0
     fi
 
+    __aish_load_command_metadata || true
+
     case "$BASH_COMMAND" in
         __aish_prompt_command*|__aish_on_debug*|__aish_emit_*|__aish_json_escape*|trap* )
-            return 0
-            ;;
-        __AISH_ACTIVE_COMMAND_SEQ=* )
-            return 0
-            ;;
-        __AISH_ACTIVE_COMMAND_TEXT=* )
             return 0
             ;;
     esac
@@ -173,6 +181,7 @@ __aish_on_debug() {
 __aish_prompt_command() {
     local exit_code=$?
     __aish_last_exit_code=$exit_code
+    __aish_load_command_metadata || true
     __aish_rewrite_last_history_entry
     # Call original PROMPT_COMMAND if it exists
     if [[ -n "$__AISH_ORIGINAL_PROMPT_COMMAND" ]]; then
@@ -182,6 +191,8 @@ __aish_prompt_command() {
     PS1=''
     __AISH_AT_PROMPT=1
     __aish_emit_prompt_ready "$exit_code"
+    __aish_clear_command_metadata_file
+    __aish_reset_command_metadata
 }
 
 # Save original PROMPT_COMMAND before we override it

--- a/src/aish/terminal/pty/command_state.py
+++ b/src/aish/terminal/pty/command_state.py
@@ -202,10 +202,25 @@ class CommandState:
     ) -> int | None:
         """Resolve an event command sequence using pending submission state."""
         resolved_seq = self._coerce_command_seq(command_seq)
+        resolved_submission_id = self._coerce_submission_id(submission_id)
+
+        if resolved_seq is not None and resolved_submission_id is not None:
+            seq_submission = self._submitted_by_seq.get(resolved_seq)
+            id_submission = self._submitted_by_id.get(resolved_submission_id)
+            if (
+                seq_submission is not None
+                and id_submission is not None
+                and seq_submission is not id_submission
+            ):
+                self._record_protocol_issue(
+                    "conflicting backend identifiers for "
+                    f"submission_id={resolved_submission_id} and command_seq={resolved_seq}"
+                )
+                return None
+
         if resolved_seq is not None:
             return resolved_seq
 
-        resolved_submission_id = self._coerce_submission_id(submission_id)
         if resolved_submission_id is not None:
             submission = self._submitted_by_id.get(resolved_submission_id)
             if submission is not None:
@@ -269,7 +284,8 @@ class CommandState:
                 create_if_missing=True,
             )
             if submission is not None:
-                self._bind_submission_seq(submission, command_seq)
+                if not self._bind_submission_seq(submission, command_seq):
+                    return None
                 if command:
                     submission.observed_command = command
                 if not submission.command and command:
@@ -291,7 +307,12 @@ class CommandState:
             create_if_missing=False,
         )
         if submission is None or not submission.command:
-            if raw_command_seq is not None:
+            if submission_id is not None and raw_command_seq is not None:
+                self._record_protocol_issue(
+                    "conflicting backend identifiers for "
+                    f"submission_id={submission_id} and command_seq={raw_command_seq}"
+                )
+            elif raw_command_seq is not None:
                 self._record_protocol_issue(
                     f"prompt_ready missing matching submission for command_seq={raw_command_seq}"
                 )
@@ -301,7 +322,8 @@ class CommandState:
                 )
             return None
 
-        self._bind_submission_seq(submission, command_seq)
+        if not self._bind_submission_seq(submission, command_seq):
+            return None
         resolved_command_seq = submission.command_seq if submission.command_seq is not None else command_seq
 
         exit_code = self._coerce_exit_code(event.payload.get("exit_code"))
@@ -380,20 +402,33 @@ class CommandState:
         self,
         submission: CommandSubmission,
         command_seq: int | None,
-    ) -> None:
+    ) -> bool:
         if command_seq is None:
-            return
+            return True
 
         existing_seq = submission.command_seq
         if existing_seq == command_seq:
             self._submitted_by_seq[command_seq] = submission
-            return
+            return True
+
+        mapped_submission = self._submitted_by_seq.get(command_seq)
+        if mapped_submission is not None and mapped_submission is not submission:
+            self._record_protocol_issue(
+                "conflicting backend identifiers for "
+                f"submission_id={submission.submission_id} and command_seq={command_seq}"
+            )
+            return False
 
         if existing_seq is not None:
-            self._submitted_by_seq.pop(existing_seq, None)
+            self._record_protocol_issue(
+                "refusing to rebind submission_id="
+                f"{submission.submission_id} from command_seq={existing_seq} to {command_seq}"
+            )
+            return False
 
         submission.command_seq = command_seq
         self._submitted_by_seq[command_seq] = submission
+        return True
 
     @classmethod
     def _should_offer_error_correction(cls, *, command: str, source: str) -> bool:
@@ -507,17 +542,32 @@ class CommandState:
         command: str | None,
         create_if_missing: bool,
     ) -> CommandSubmission | None:
+        id_submission = None
         if submission_id is not None:
-            submission = self._submitted_by_id.get(submission_id)
-            if submission is not None:
-                self._active_submission = submission
-                return submission
+            id_submission = self._submitted_by_id.get(submission_id)
 
+        seq_submission = None
         if command_seq is not None:
-            submission = self._submitted_by_seq.get(command_seq)
-            if submission is not None:
-                self._active_submission = submission
-                return submission
+            seq_submission = self._submitted_by_seq.get(command_seq)
+
+        if (
+            id_submission is not None
+            and seq_submission is not None
+            and id_submission is not seq_submission
+        ):
+            self._record_protocol_issue(
+                "conflicting backend identifiers for "
+                f"submission_id={submission_id} and command_seq={command_seq}"
+            )
+            return None
+
+        if id_submission is not None:
+            self._active_submission = id_submission
+            return id_submission
+
+        if seq_submission is not None:
+            self._active_submission = seq_submission
+            return seq_submission
 
         if self._active_started_submission is not None:
             if self._submission_matches(

--- a/src/aish/terminal/pty/command_state.py
+++ b/src/aish/terminal/pty/command_state.py
@@ -131,6 +131,13 @@ class CommandState:
             submissions.append(submission)
             seen.add(submission_id)
 
+        for submission in self._submitted_by_id.values():
+            submission_obj_id = id(submission)
+            if submission_obj_id in seen:
+                continue
+            submissions.append(submission)
+            seen.add(submission_obj_id)
+
         return tuple(submissions)
 
     @property
@@ -203,12 +210,18 @@ class CommandState:
             submission = self._submitted_by_id.get(resolved_submission_id)
             if submission is not None:
                 return submission.command_seq
-
-        active_submission = self._active_started_submission or self._active_submission
-        if active_submission is None:
             return None
 
-        return active_submission.command_seq
+        if (
+            self._active_started_submission is not None
+            and self._active_submission in (None, self._active_started_submission)
+        ):
+            return self._active_started_submission.command_seq
+
+        unique_submission = self._unique_pending_submission()
+        if unique_submission is None:
+            return None
+        return unique_submission.command_seq
 
     def next_submission_id(self) -> str:
         submission_id = f"subm_{self._next_submission_id}"
@@ -530,7 +543,12 @@ class CommandState:
         if not create_if_missing:
             return None
 
-        source = "backend" if command_seq is not None else "user"
+        if submission_id is not None and command_seq is None:
+            self._record_protocol_issue(
+                f"backend event missing matching submission for submission_id={submission_id}"
+            )
+
+        source = "backend" if (submission_id is not None or command_seq is not None) else "user"
         return self._store_submission(
             command=(command or self._last_command).strip(),
             source=source,

--- a/src/aish/terminal/pty/command_state.py
+++ b/src/aish/terminal/pty/command_state.py
@@ -54,6 +54,7 @@ class CommandSubmission:
     command: str
     source: str
     command_seq: int | None = None
+    observed_command: str = ""
     error_correction_dismissed: bool = False
     allow_error_correction: bool = False
 
@@ -94,6 +95,35 @@ class CommandState:
         return self._last_result
 
     @property
+    def pending_submission(self) -> CommandSubmission | None:
+        """Return the currently active pending submission, if any."""
+        return self._active_submission
+
+    @property
+    def pending_submissions(self) -> tuple[CommandSubmission, ...]:
+        """Return the known pending submissions without duplicates."""
+        submissions: list[CommandSubmission] = []
+        seen: set[int] = set()
+
+        if self._active_submission is not None:
+            submissions.append(self._active_submission)
+            seen.add(id(self._active_submission))
+
+        for submission in self._submitted_by_seq.values():
+            submission_id = id(submission)
+            if submission_id in seen:
+                continue
+            submissions.append(submission)
+            seen.add(submission_id)
+
+        return tuple(submissions)
+
+    @property
+    def pending_submission_count(self) -> int:
+        """Return the number of tracked pending submissions."""
+        return len(self.pending_submissions)
+
+    @property
     def can_correct_last_error(self) -> bool:
         result = self._last_result
         return bool(
@@ -103,28 +133,51 @@ class CommandState:
             and not result.interrupted
         )
 
-    def register_user_command(self, command: str) -> None:
-        self.register_command(command, source="user", command_seq=None)
+    def register_user_command(self, command: str) -> CommandSubmission | None:
+        return self.register_command(command, source="user", command_seq=None)
 
     def register_backend_command(
         self, command: str, command_seq: int | None = None
-    ) -> None:
-        self.register_command(command, source="backend", command_seq=command_seq)
+    ) -> CommandSubmission | None:
+        return self.register_command(command, source="backend", command_seq=command_seq)
 
     def register_command(
         self,
         command: str,
         source: str,
         command_seq: int | None = None,
-    ) -> None:
+    ) -> CommandSubmission | None:
         command = command.strip()
         if not command:
-            return
-        self._store_submission(
+            return None
+        return self._store_submission(
             command=command,
             source=source,
             command_seq=command_seq,
         )
+
+    def get_pending_submission(
+        self, command_seq: int | None = None
+    ) -> CommandSubmission | None:
+        """Return a tracked pending submission by sequence or active state."""
+        if command_seq is None:
+            return self._active_submission
+        return self._submitted_by_seq.get(command_seq)
+
+    def has_pending_submission(self, command_seq: int | None = None) -> bool:
+        """Return whether a pending submission is currently tracked."""
+        return self.get_pending_submission(command_seq) is not None
+
+    def resolve_command_seq(self, command_seq: object) -> int | None:
+        """Resolve an event command sequence using pending submission state."""
+        resolved_seq = self._coerce_command_seq(command_seq)
+        if resolved_seq is not None:
+            return resolved_seq
+
+        if self._active_submission is None:
+            return None
+
+        return self._active_submission.command_seq
 
     def clear_error_correction(self) -> None:
         self._pending_error = None
@@ -141,22 +194,24 @@ class CommandState:
     ) -> CommandResult | None:
         if event.type == "command_started":
             command = str(event.payload.get("command") or "").strip()
-            command_seq = self._coerce_command_seq(event.payload.get("command_seq"))
+            command_seq = self.resolve_command_seq(event.payload.get("command_seq"))
             submission = self._resolve_submission(
                 command_seq=command_seq,
                 command=command,
                 create_if_missing=True,
             )
-            if submission is not None and command and (
-                not submission.command or submission.source != "user"
-            ):
-                submission.command = command
+            if submission is not None:
+                self._bind_submission_seq(submission, command_seq)
+                if command:
+                    submission.observed_command = command
+                if not submission.command and command:
+                    submission.command = command
             return None
 
         if event.type != "prompt_ready":
             return None
 
-        command_seq = self._coerce_command_seq(event.payload.get("command_seq"))
+        command_seq = self.resolve_command_seq(event.payload.get("command_seq"))
         submission = self._resolve_submission(
             command_seq=command_seq,
             command=None,
@@ -165,13 +220,16 @@ class CommandState:
         if submission is None or not submission.command:
             return None
 
+        self._bind_submission_seq(submission, command_seq)
+        resolved_command_seq = submission.command_seq if submission.command_seq is not None else command_seq
+
         exit_code = self._coerce_exit_code(event.payload.get("exit_code"))
         interrupted = bool(event.payload.get("interrupted")) or exit_code == 130
         result = CommandResult(
             command=submission.command,
             exit_code=exit_code,
             source=submission.source,
-            command_seq=command_seq,
+            command_seq=resolved_command_seq,
             interrupted=interrupted,
             allow_error_correction=submission.allow_error_correction,
         )
@@ -185,8 +243,8 @@ class CommandState:
         else:
             self._pending_error = None
 
-        if command_seq is not None:
-            self._submitted_by_seq.pop(command_seq, None)
+        if resolved_command_seq is not None:
+            self._submitted_by_seq.pop(resolved_command_seq, None)
         if self._active_submission is submission:
             self._active_submission = None
         return result
@@ -219,6 +277,25 @@ class CommandState:
         if command_seq is not None:
             self._submitted_by_seq[command_seq] = submission
         return submission
+
+    def _bind_submission_seq(
+        self,
+        submission: CommandSubmission,
+        command_seq: int | None,
+    ) -> None:
+        if command_seq is None:
+            return
+
+        existing_seq = submission.command_seq
+        if existing_seq == command_seq:
+            self._submitted_by_seq[command_seq] = submission
+            return
+
+        if existing_seq is not None:
+            self._submitted_by_seq.pop(existing_seq, None)
+
+        submission.command_seq = command_seq
+        self._submitted_by_seq[command_seq] = submission
 
     @classmethod
     def _should_offer_error_correction(cls, *, command: str, source: str) -> bool:

--- a/src/aish/terminal/pty/command_state.py
+++ b/src/aish/terminal/pty/command_state.py
@@ -51,12 +51,14 @@ _SSH_OPTIONS_WITH_VALUE = frozenset(
 class CommandSubmission:
     """Metadata for a command submitted to the backend shell."""
 
+    submission_id: str
     command: str
     source: str
     command_seq: int | None = None
     observed_command: str = ""
     error_correction_dismissed: bool = False
     allow_error_correction: bool = False
+    status: str = "submitted"
 
 
 @dataclass(slots=True)
@@ -69,6 +71,7 @@ class CommandResult:
     command_seq: int | None = None
     interrupted: bool = False
     allow_error_correction: bool = False
+    submission_id: str | None = None
 
 
 class CommandState:
@@ -76,11 +79,15 @@ class CommandState:
 
     def __init__(self) -> None:
         self._active_submission: CommandSubmission | None = None
+        self._active_started_submission: CommandSubmission | None = None
         self._submitted_by_seq: dict[int, CommandSubmission] = {}
+        self._submitted_by_id: dict[str, CommandSubmission] = {}
         self._last_command: str = ""
         self._last_exit_code: int = 0
         self._last_result: CommandResult | None = None
         self._pending_error: CommandResult | None = None
+        self._protocol_issues: list[str] = []
+        self._next_submission_id: int = 1
 
     @property
     def last_command(self) -> str:
@@ -97,6 +104,8 @@ class CommandState:
     @property
     def pending_submission(self) -> CommandSubmission | None:
         """Return the currently active pending submission, if any."""
+        if self._active_started_submission is not None:
+            return self._active_started_submission
         return self._active_submission
 
     @property
@@ -108,6 +117,12 @@ class CommandState:
         if self._active_submission is not None:
             submissions.append(self._active_submission)
             seen.add(id(self._active_submission))
+
+        if self._active_started_submission is not None:
+            started_id = id(self._active_started_submission)
+            if started_id not in seen:
+                submissions.append(self._active_started_submission)
+                seen.add(started_id)
 
         for submission in self._submitted_by_seq.values():
             submission_id = id(submission)
@@ -132,6 +147,11 @@ class CommandState:
             and result.exit_code != 0
             and not result.interrupted
         )
+
+    @property
+    def protocol_issues(self) -> tuple[str, ...]:
+        """Return collected protocol/state issues for diagnostics."""
+        return tuple(self._protocol_issues)
 
     def register_user_command(self, command: str) -> CommandSubmission | None:
         return self.register_command(command, source="user", command_seq=None)
@@ -161,23 +181,39 @@ class CommandState:
     ) -> CommandSubmission | None:
         """Return a tracked pending submission by sequence or active state."""
         if command_seq is None:
-            return self._active_submission
+            return self.pending_submission
         return self._submitted_by_seq.get(command_seq)
 
     def has_pending_submission(self, command_seq: int | None = None) -> bool:
         """Return whether a pending submission is currently tracked."""
         return self.get_pending_submission(command_seq) is not None
 
-    def resolve_command_seq(self, command_seq: object) -> int | None:
+    def resolve_command_seq(
+        self,
+        command_seq: object,
+        submission_id: object | None = None,
+    ) -> int | None:
         """Resolve an event command sequence using pending submission state."""
         resolved_seq = self._coerce_command_seq(command_seq)
         if resolved_seq is not None:
             return resolved_seq
 
-        if self._active_submission is None:
+        resolved_submission_id = self._coerce_submission_id(submission_id)
+        if resolved_submission_id is not None:
+            submission = self._submitted_by_id.get(resolved_submission_id)
+            if submission is not None:
+                return submission.command_seq
+
+        active_submission = self._active_started_submission or self._active_submission
+        if active_submission is None:
             return None
 
-        return self._active_submission.command_seq
+        return active_submission.command_seq
+
+    def next_submission_id(self) -> str:
+        submission_id = f"subm_{self._next_submission_id}"
+        self._next_submission_id += 1
+        return submission_id
 
     def clear_error_correction(self) -> None:
         self._pending_error = None
@@ -189,13 +225,32 @@ class CommandState:
         self._pending_error = None
         return result.command, result.exit_code
 
+    def consume_protocol_issues(self) -> tuple[str, ...]:
+        """Consume and clear collected protocol/state issues."""
+        issues = tuple(self._protocol_issues)
+        self._protocol_issues.clear()
+        return issues
+
     def handle_backend_event(
         self, event: BackendControlEvent
     ) -> CommandResult | None:
         if event.type == "command_started":
             command = str(event.payload.get("command") or "").strip()
-            command_seq = self.resolve_command_seq(event.payload.get("command_seq"))
+            submission_id = self._coerce_submission_id(event.payload.get("submission_id"))
+            raw_command_seq = self._coerce_command_seq(event.payload.get("command_seq"))
+            command_seq = self._coerce_command_seq(event.payload.get("command_seq"))
+
+            if (
+                raw_command_seq is not None
+                and raw_command_seq not in self._submitted_by_seq
+                and self._active_submission is None
+            ):
+                self._record_protocol_issue(
+                    f"command_started missing matching submission for command_seq={raw_command_seq}"
+                )
+
             submission = self._resolve_submission(
+                submission_id=submission_id,
                 command_seq=command_seq,
                 command=command,
                 create_if_missing=True,
@@ -206,18 +261,31 @@ class CommandState:
                     submission.observed_command = command
                 if not submission.command and command:
                     submission.command = command
+                submission.status = "started"
+                self._active_started_submission = submission
             return None
 
         if event.type != "prompt_ready":
             return None
 
-        command_seq = self.resolve_command_seq(event.payload.get("command_seq"))
+        submission_id = self._coerce_submission_id(event.payload.get("submission_id"))
+        raw_command_seq = self._coerce_command_seq(event.payload.get("command_seq"))
+        command_seq = self._coerce_command_seq(event.payload.get("command_seq"))
         submission = self._resolve_submission(
+            submission_id=submission_id,
             command_seq=command_seq,
             command=None,
             create_if_missing=False,
         )
         if submission is None or not submission.command:
+            if raw_command_seq is not None:
+                self._record_protocol_issue(
+                    f"prompt_ready missing matching submission for command_seq={raw_command_seq}"
+                )
+            else:
+                self._record_protocol_issue(
+                    "prompt_ready received without matching active submission"
+                )
             return None
 
         self._bind_submission_seq(submission, command_seq)
@@ -232,6 +300,7 @@ class CommandState:
             command_seq=resolved_command_seq,
             interrupted=interrupted,
             allow_error_correction=submission.allow_error_correction,
+            submission_id=submission.submission_id,
         )
 
         self._last_command = result.command
@@ -243,19 +312,32 @@ class CommandState:
         else:
             self._pending_error = None
 
+        submission.status = "completed"
+
         if resolved_command_seq is not None:
             self._submitted_by_seq.pop(resolved_command_seq, None)
+        self._submitted_by_id.pop(submission.submission_id, None)
         if self._active_submission is submission:
             self._active_submission = None
+        if self._active_started_submission is submission:
+            self._active_started_submission = None
         return result
 
     def reset(self) -> None:
         self._active_submission = None
+        self._active_started_submission = None
         self._submitted_by_seq.clear()
+        self._submitted_by_id.clear()
         self._last_command = ""
         self._last_exit_code = 0
         self._last_result = None
         self._pending_error = None
+        self._protocol_issues.clear()
+        self._next_submission_id = 1
+
+    def _record_protocol_issue(self, issue: str) -> None:
+        self._protocol_issues.append(issue)
+        self._protocol_issues = self._protocol_issues[-50:]
 
     def _store_submission(
         self,
@@ -263,8 +345,10 @@ class CommandState:
         command: str,
         source: str,
         command_seq: int | None,
+        submission_id: str | None = None,
     ) -> CommandSubmission:
         submission = CommandSubmission(
+            submission_id=submission_id or self.next_submission_id(),
             command=command,
             source=source,
             command_seq=command_seq,
@@ -274,6 +358,7 @@ class CommandState:
             ),
         )
         self._active_submission = submission
+        self._submitted_by_id[submission.submission_id] = submission
         if command_seq is not None:
             self._submitted_by_seq[command_seq] = submission
         return submission
@@ -404,20 +489,43 @@ class CommandState:
     def _resolve_submission(
         self,
         *,
+        submission_id: str | None,
         command_seq: int | None,
         command: str | None,
         create_if_missing: bool,
     ) -> CommandSubmission | None:
+        if submission_id is not None:
+            submission = self._submitted_by_id.get(submission_id)
+            if submission is not None:
+                self._active_submission = submission
+                return submission
+
         if command_seq is not None:
             submission = self._submitted_by_seq.get(command_seq)
             if submission is not None:
                 self._active_submission = submission
                 return submission
 
+        if self._active_started_submission is not None:
+            if self._submission_matches(
+                self._active_started_submission,
+                submission_id=submission_id,
+                command_seq=command_seq,
+            ):
+                return self._active_started_submission
+
         if self._active_submission is not None:
-            active_seq = self._active_submission.command_seq
-            if command_seq is None or active_seq is None or active_seq == command_seq:
+            if self._submission_matches(
+                self._active_submission,
+                submission_id=submission_id,
+                command_seq=command_seq,
+            ):
                 return self._active_submission
+
+        if submission_id is None and command_seq is None:
+            unique_submission = self._unique_pending_submission()
+            if unique_submission is not None:
+                return unique_submission
 
         if not create_if_missing:
             return None
@@ -427,7 +535,47 @@ class CommandState:
             command=(command or self._last_command).strip(),
             source=source,
             command_seq=command_seq,
+            submission_id=submission_id,
         )
+
+    def _unique_pending_submission(self) -> CommandSubmission | None:
+        pending = self.pending_submissions
+        if len(pending) == 1:
+            return pending[0]
+        return None
+
+    @staticmethod
+    def _submission_matches(
+        submission: CommandSubmission,
+        *,
+        submission_id: str | None,
+        command_seq: int | None,
+    ) -> bool:
+        if submission_id is not None:
+            return submission.submission_id == submission_id
+
+        if command_seq is not None:
+            submission_seq = submission.command_seq
+            return submission_seq is None or submission_seq == command_seq
+
+        return False
+
+    @staticmethod
+    def _coerce_submission_id(value: object) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, bytes):
+            try:
+                value = value.decode("utf-8")
+            except UnicodeDecodeError:
+                return None
+        if not isinstance(value, str):
+            return None
+
+        submission_id = value.strip()
+        if not submission_id or submission_id == "null":
+            return None
+        return submission_id
 
     @staticmethod
     def _coerce_command_seq(value: object) -> int | None:

--- a/src/aish/terminal/pty/manager.py
+++ b/src/aish/terminal/pty/manager.py
@@ -207,17 +207,25 @@ class PTYManager:
 
     def _wait_ready(self, timeout: float = 0.3) -> None:
         """Wait for bash to initialize."""
+        if self._control_fd is None:
+            return
+
         start = time.monotonic()
         saw_session_ready = False
         saw_startup_prompt_ready = False
+        quiet_since: float | None = None
 
         while time.monotonic() - start < timeout:
-            read_fds = [self._master_fd]
-            if self._control_fd is not None:
-                read_fds.append(self._control_fd)
-            ready, _, _ = select.select(read_fds, [], [], 0.05)
+            ready, _, _ = select.select([self._control_fd], [], [], 0.05)
             if not ready and saw_session_ready and saw_startup_prompt_ready:
-                break
+                if quiet_since is None:
+                    quiet_since = time.monotonic()
+                    continue
+                if time.monotonic() - quiet_since >= 0.05:
+                    break
+                continue
+
+            quiet_since = None
             for fd in ready:
                 try:
                     data = os.read(fd, 4096)
@@ -225,18 +233,12 @@ class PTYManager:
                     break
                 if not data:
                     continue
-                if fd == self._control_fd:
-                    events = self._dispatch_control_chunk(data)
-                    for event in events:
-                        if event.type == "session_ready":
-                            saw_session_ready = True
-                        elif event.type == "prompt_ready" and event.payload.get("command_seq") in {None, "", "null"}:
-                            saw_startup_prompt_ready = True
-
-            if saw_session_ready and saw_startup_prompt_ready:
-                extra_ready, _, _ = select.select(read_fds, [], [], 0)
-                if not extra_ready:
-                    break
+                events = self._dispatch_control_chunk(data)
+                for event in events:
+                    if event.type == "session_ready":
+                        saw_session_ready = True
+                    elif event.type == "prompt_ready" and event.payload.get("command_seq") in {None, "", "null"}:
+                        saw_startup_prompt_ready = True
 
     def _output_loop(self) -> None:
         """Background thread to read and forward PTY output."""
@@ -506,14 +508,22 @@ class PTYManager:
 
         # First, drain any existing output from PTY to avoid confusion
         # with previous command's prompt/output.
+        drain_deadline = time.monotonic() + 0.2
+        quiet_since: float | None = None
         try:
-            while True:
+            while time.monotonic() < drain_deadline:
                 read_fds = [self._master_fd]
                 if self._control_fd is not None:
                     read_fds.append(self._control_fd)
-                ready, _, _ = select.select(read_fds, [], [], 0)
+                ready, _, _ = select.select(read_fds, [], [], 0.01)
                 if not ready:
-                    break
+                    if quiet_since is None:
+                        quiet_since = time.monotonic()
+                        continue
+                    if time.monotonic() - quiet_since >= 0.05:
+                        break
+                    continue
+                quiet_since = None
                 for fd in ready:
                     try:
                         data = os.read(fd, 4096)

--- a/src/aish/terminal/pty/manager.py
+++ b/src/aish/terminal/pty/manager.py
@@ -404,17 +404,21 @@ class PTYManager:
             return text
 
         output_lines = text.split("\n")
-        if len(output_lines) < len(command_lines):
+        first_content_index = 0
+        while first_content_index < len(output_lines) and not output_lines[first_content_index].strip():
+            first_content_index += 1
+
+        if len(output_lines) - first_content_index < len(command_lines):
             return text
 
         for index, command_line in enumerate(command_lines):
-            output_line = output_lines[index].lstrip()
+            output_line = output_lines[first_content_index + index].lstrip()
             if index > 0 and output_line.startswith(">"):
                 output_line = output_line[1:].lstrip()
             if output_line.rstrip() != command_line:
                 return text
 
-        return "\n".join(output_lines[len(command_lines) :])
+        return "\n".join(output_lines[first_content_index + len(command_lines) :])
 
     @staticmethod
     def _clean_pty_output(raw: bytes, command: str) -> str:

--- a/src/aish/terminal/pty/manager.py
+++ b/src/aish/terminal/pty/manager.py
@@ -1,13 +1,12 @@
 """PTY manager using direct pty.fork() - pyxtermjs style."""
 
 import fcntl
+import json
 import os
 import pty
 import select
-import shlex
 import signal
 import struct
-import tempfile
 import termios
 import threading
 import time
@@ -58,7 +57,8 @@ class PTYManager:
         self._child_pid: Optional[int] = None
         self._control_fd: Optional[int] = None
         self._control_write_fd: Optional[int] = None
-        self._command_metadata_path: Optional[str] = None
+        self._metadata_read_fd: Optional[int] = None
+        self._metadata_write_fd: Optional[int] = None
         self._running = False
         self._output_thread: Optional[threading.Thread] = None
 
@@ -69,6 +69,7 @@ class PTYManager:
         # Event-based command lifecycle state
         self._command_state = CommandState()
         self._control_buffer = b""
+        self._protocol_issues: list[str] = []
         self._completed_results: list[CommandResult] = []
         self._completion_condition = threading.Condition()
         self._next_backend_command_seq = -1
@@ -124,9 +125,10 @@ class PTYManager:
         if self._running:
             return
 
-        self._ensure_command_metadata_file()
         self._control_fd, self._control_write_fd = os.pipe()
         os.set_inheritable(self._control_write_fd, True)
+        self._metadata_read_fd, self._metadata_write_fd = os.pipe()
+        os.set_inheritable(self._metadata_read_fd, True)
 
         self._child_pid, self._master_fd = pty.fork()
 
@@ -138,6 +140,11 @@ class PTYManager:
                     os.close(self._control_fd)
                 except OSError:
                     pass
+            if self._metadata_write_fd is not None:
+                try:
+                    os.close(self._metadata_write_fd)
+                except OSError:
+                    pass
 
             # Build environment
             env = dict(os.environ)
@@ -145,8 +152,8 @@ class PTYManager:
             env["TERM"] = "xterm-256color"
             if self._control_write_fd is not None:
                 env["AISH_CONTROL_FD"] = str(self._control_write_fd)
-            if self._command_metadata_path is not None:
-                env["AISH_COMMAND_METADATA_FILE"] = self._command_metadata_path
+            if self._metadata_read_fd is not None:
+                env["AISH_COMMAND_METADATA_FD"] = str(self._metadata_read_fd)
 
             # Use our rcfile wrapper to set up exit code tracking while preserving user's config
             rcfile_path = os.path.join(os.path.dirname(__file__), "bash_rc_wrapper.sh")
@@ -171,6 +178,12 @@ class PTYManager:
             except OSError:
                 pass
             self._control_write_fd = None
+        if self._metadata_read_fd is not None:
+            try:
+                os.close(self._metadata_read_fd)
+            except OSError:
+                pass
+            self._metadata_read_fd = None
 
         # Set non-blocking
         flags = fcntl.fcntl(self._master_fd, fcntl.F_GETFL)
@@ -184,25 +197,27 @@ class PTYManager:
 
         self._running = True
 
+        # Drain initial shell readiness before exposing the PTY to callers.
+        self._wait_ready(timeout=1.0)
+
         # Start output reader thread (optional - disabled when main loop reads directly)
         if self._use_output_thread:
             self._output_thread = threading.Thread(target=self._output_loop, daemon=True)
             self._output_thread.start()
 
-            # Wait for bash to be ready (discard initial output)
-            self._wait_ready()
-        else:
-            # When not using thread, just wait a bit for bash to start
-            time.sleep(0.1)
-
     def _wait_ready(self, timeout: float = 0.3) -> None:
         """Wait for bash to initialize."""
-        start = time.time()
-        while time.time() - start < timeout:
+        start = time.monotonic()
+        saw_session_ready = False
+        saw_startup_prompt_ready = False
+
+        while time.monotonic() - start < timeout:
             read_fds = [self._master_fd]
             if self._control_fd is not None:
                 read_fds.append(self._control_fd)
             ready, _, _ = select.select(read_fds, [], [], 0.05)
+            if not ready and saw_session_ready and saw_startup_prompt_ready:
+                break
             for fd in ready:
                 try:
                     data = os.read(fd, 4096)
@@ -211,7 +226,17 @@ class PTYManager:
                 if not data:
                     continue
                 if fd == self._control_fd:
-                    self._dispatch_control_chunk(data)
+                    events = self._dispatch_control_chunk(data)
+                    for event in events:
+                        if event.type == "session_ready":
+                            saw_session_ready = True
+                        elif event.type == "prompt_ready" and event.payload.get("command_seq") in {None, "", "null"}:
+                            saw_startup_prompt_ready = True
+
+            if saw_session_ready and saw_startup_prompt_ready:
+                extra_ready, _, _ = select.select(read_fds, [], [], 0)
+                if not extra_ready:
+                    break
 
     def _output_loop(self) -> None:
         """Background thread to read and forward PTY output."""
@@ -281,25 +306,27 @@ class PTYManager:
         lock = getattr(self, "_lock", None)
 
         if lock is None:
-            self._command_state.register_command(
+            submission = self._command_state.register_command(
                 stripped_command, source=source, command_seq=command_seq
             )
             self._write_command_metadata(
                 command=stripped_command,
                 source=source,
                 command_seq=command_seq,
+                submission_id=submission.submission_id if submission is not None else None,
             )
             self.send((command_to_send + "\n").encode())
             return
 
         with lock:
-            self._command_state.register_command(
+            submission = self._command_state.register_command(
                 stripped_command, source=source, command_seq=command_seq
             )
             self._write_command_metadata(
                 command=stripped_command,
                 source=source,
                 command_seq=command_seq,
+                submission_id=submission.submission_id if submission is not None else None,
             )
             self.send((command_to_send + "\n").encode())
 
@@ -340,8 +367,22 @@ class PTYManager:
         self._control_buffer = remainder
         return events, errors
 
+    @property
+    def protocol_issues(self) -> tuple[str, ...]:
+        """Return decoded protocol and command-state issues."""
+        return tuple(self._protocol_issues) + self._command_state.protocol_issues
+
+    def consume_protocol_issues(self) -> tuple[str, ...]:
+        """Consume and clear protocol and command-state issues."""
+        issues = tuple(self._protocol_issues)
+        self._protocol_issues.clear()
+        return issues + self._command_state.consume_protocol_issues()
+
     def _dispatch_control_chunk(self, chunk: bytes) -> list[BackendControlEvent]:
-        events, _errors = self.decode_control_events(chunk)
+        events, errors = self.decode_control_events(chunk)
+        if errors:
+            self._protocol_issues.extend(errors)
+            self._protocol_issues = self._protocol_issues[-50:]
         for event in events:
             self.handle_backend_event(event)
         return events
@@ -565,44 +606,54 @@ class PTYManager:
                 os.close(self._control_write_fd)
             except OSError:
                 pass
+        if self._metadata_read_fd is not None:
+            try:
+                os.close(self._metadata_read_fd)
+            except OSError:
+                pass
+        if self._metadata_write_fd is not None:
+            try:
+                os.close(self._metadata_write_fd)
+            except OSError:
+                pass
 
         self._master_fd = None
         self._control_fd = None
         self._control_write_fd = None
+        self._metadata_read_fd = None
+        self._metadata_write_fd = None
         self._child_pid = None
 
-        self._remove_command_metadata_file()
+    @staticmethod
+    def _serialize_command_metadata(
+        *,
+        command: str,
+        source: str,
+        command_seq: int | None,
+        submission_id: str | None = None,
+    ) -> bytes:
+        payload = {
+            "submission_id": submission_id,
+            "command_seq": command_seq,
+            "source": source,
+            "original_command": command,
+        }
+        return (json.dumps(payload, separators=(",", ":")) + "\n").encode("utf-8")
 
-    def _ensure_command_metadata_file(self) -> None:
-        if self._command_metadata_path is not None:
+    def _write_command_metadata_pipe(self, payload: bytes) -> None:
+        fd = getattr(self, "_metadata_write_fd", None)
+        if fd is None:
             return
 
-        fd, path = tempfile.mkstemp(prefix="aish_command_meta_")
-        os.close(fd)
-        self._command_metadata_path = path
-        self._clear_command_metadata_file()
-
-    def _clear_command_metadata_file(self) -> None:
-        path = getattr(self, "_command_metadata_path", None)
-        if not path:
-            return
-
-        try:
-            with open(path, "w", encoding="utf-8"):
-                pass
-        except OSError:
-            pass
-
-    def _remove_command_metadata_file(self) -> None:
-        path = getattr(self, "_command_metadata_path", None)
-        if not path:
-            return
-
-        try:
-            os.remove(path)
-        except OSError:
-            pass
-        self._command_metadata_path = None
+        view = memoryview(payload)
+        while view:
+            try:
+                written = os.write(fd, view)
+            except OSError:
+                return
+            if written <= 0:
+                return
+            view = view[written:]
 
     def _write_command_metadata(
         self,
@@ -610,29 +661,15 @@ class PTYManager:
         command: str,
         source: str,
         command_seq: int | None,
+        submission_id: str | None = None,
     ) -> None:
-        path = getattr(self, "_command_metadata_path", None)
-        if not path:
-            return
-
-        payload = "\n".join(
-            [
-                f"__AISH_PENDING_COMMAND_SOURCE={shlex.quote(source)}",
-                f"__AISH_PENDING_COMMAND_SEQ={shlex.quote('' if command_seq is None else str(command_seq))}",
-                f"__AISH_PENDING_COMMAND_TEXT={shlex.quote(command)}",
-                "",
-            ]
+        payload = self._serialize_command_metadata(
+            command=command,
+            source=source,
+            command_seq=command_seq,
+            submission_id=submission_id,
         )
-        tmp_path = f"{path}.tmp"
-        try:
-            with open(tmp_path, "w", encoding="utf-8") as handle:
-                handle.write(payload)
-            os.replace(tmp_path, path)
-        except OSError:
-            try:
-                os.remove(tmp_path)
-            except OSError:
-                pass
+        self._write_command_metadata_pipe(payload)
 
     def __enter__(self) -> "PTYManager":
         self.start()

--- a/src/aish/terminal/pty/manager.py
+++ b/src/aish/terminal/pty/manager.py
@@ -70,6 +70,7 @@ class PTYManager:
         self._command_state = CommandState()
         self._control_buffer = b""
         self._protocol_issues: list[str] = []
+        self._continuation_prompt = "> "
         self._completed_results: list[CommandResult] = []
         self._completion_condition = threading.Condition()
         self._next_backend_command_seq = -1
@@ -305,22 +306,7 @@ class PTYManager:
         """
         stripped_command = command.strip()
         command_to_send = command if source == "user" else f" {command}"
-        lock = getattr(self, "_lock", None)
-
-        if lock is None:
-            submission = self._command_state.register_command(
-                stripped_command, source=source, command_seq=command_seq
-            )
-            self._write_command_metadata(
-                command=stripped_command,
-                source=source,
-                command_seq=command_seq,
-                submission_id=submission.submission_id if submission is not None else None,
-            )
-            self.send((command_to_send + "\n").encode())
-            return
-
-        with lock:
+        with self._lock:
             submission = self._command_state.register_command(
                 stripped_command, source=source, command_seq=command_seq
             )
@@ -386,6 +372,10 @@ class PTYManager:
             self._protocol_issues.extend(errors)
             self._protocol_issues = self._protocol_issues[-50:]
         for event in events:
+            if event.type == "session_ready":
+                ps2 = event.payload.get("ps2")
+                if isinstance(ps2, str) and ps2:
+                    self._continuation_prompt = ps2
             self.handle_backend_event(event)
         return events
 
@@ -400,7 +390,26 @@ class PTYManager:
             set_winsize(self._master_fd, rows, cols)
 
     @staticmethod
-    def _strip_echoed_command(text: str, command: str) -> str:
+    def _strip_continuation_prompt(output_line: str, continuation_prompt: str | None) -> str:
+        candidates: list[str] = []
+        if continuation_prompt:
+            candidates.append(continuation_prompt)
+            stripped_prompt = continuation_prompt.rstrip()
+            if stripped_prompt and stripped_prompt != continuation_prompt:
+                candidates.append(stripped_prompt)
+        candidates.append(">")
+
+        for candidate in candidates:
+            if output_line.startswith(candidate):
+                return output_line[len(candidate) :].lstrip()
+        return output_line
+
+    @staticmethod
+    def _strip_echoed_command(
+        text: str,
+        command: str,
+        continuation_prompt: str | None = None,
+    ) -> str:
         command_lines = [line.lstrip().rstrip() for line in command.strip().splitlines()]
         if not command_lines:
             return text
@@ -415,15 +424,17 @@ class PTYManager:
 
         for index, command_line in enumerate(command_lines):
             output_line = output_lines[first_content_index + index].lstrip()
-            if index > 0 and output_line.startswith(">"):
-                output_line = output_line[1:].lstrip()
+            if index > 0:
+                output_line = PTYManager._strip_continuation_prompt(
+                    output_line,
+                    continuation_prompt,
+                )
             if output_line.rstrip() != command_line:
                 return text
 
         return "\n".join(output_lines[first_content_index + len(command_lines) :])
 
-    @staticmethod
-    def _clean_pty_output(raw: bytes, command: str) -> str:
+    def _clean_pty_output(self, raw: bytes, command: str) -> str:
         """Clean PTY output: strip ANSI, echo, prompt, exit markers."""
         import re as _re
 
@@ -436,7 +447,7 @@ class PTYManager:
         # Remove carriage returns (keep newlines)
         text = text.replace("\r\n", "\n").replace("\r", "")
 
-        text = PTYManager._strip_echoed_command(text, command)
+        text = PTYManager._strip_echoed_command(text, command, self._continuation_prompt)
 
         # Remove trailing prompt line (contains prompt symbols)
         lines = text.rstrip().split("\n")

--- a/src/aish/terminal/pty/manager.py
+++ b/src/aish/terminal/pty/manager.py
@@ -7,6 +7,7 @@ import select
 import shlex
 import signal
 import struct
+import tempfile
 import termios
 import threading
 import time
@@ -57,6 +58,7 @@ class PTYManager:
         self._child_pid: Optional[int] = None
         self._control_fd: Optional[int] = None
         self._control_write_fd: Optional[int] = None
+        self._command_metadata_path: Optional[str] = None
         self._running = False
         self._output_thread: Optional[threading.Thread] = None
 
@@ -72,7 +74,7 @@ class PTYManager:
         self._next_backend_command_seq = -1
 
         # Lock for thread-safe operations
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
 
         # exec mode: when active, output thread buffers instead of forwarding
         self._exec_mode = threading.Event()
@@ -122,6 +124,7 @@ class PTYManager:
         if self._running:
             return
 
+        self._ensure_command_metadata_file()
         self._control_fd, self._control_write_fd = os.pipe()
         os.set_inheritable(self._control_write_fd, True)
 
@@ -142,6 +145,8 @@ class PTYManager:
             env["TERM"] = "xterm-256color"
             if self._control_write_fd is not None:
                 env["AISH_CONTROL_FD"] = str(self._control_write_fd)
+            if self._command_metadata_path is not None:
+                env["AISH_COMMAND_METADATA_FILE"] = self._command_metadata_path
 
             # Use our rcfile wrapper to set up exit code tracking while preserving user's config
             rcfile_path = os.path.join(os.path.dirname(__file__), "bash_rc_wrapper.sh")
@@ -271,17 +276,32 @@ class PTYManager:
 
         Command lifecycle is tracked via the backend control channel.
         """
-        self._command_state.register_command(
-            command.strip(), source=source, command_seq=command_seq
-        )
-        command_to_send = command
-        if command_seq is not None:
-            quoted_command = shlex.quote(command)
-            command_to_send = (
-                f" __AISH_ACTIVE_COMMAND_SEQ={command_seq}; "
-                f"__AISH_ACTIVE_COMMAND_TEXT={quoted_command}; {command}"
+        stripped_command = command.strip()
+        command_to_send = command if source == "user" else f" {command}"
+        lock = getattr(self, "_lock", None)
+
+        if lock is None:
+            self._command_state.register_command(
+                stripped_command, source=source, command_seq=command_seq
             )
-        self.send((command_to_send + "\n").encode())
+            self._write_command_metadata(
+                command=stripped_command,
+                source=source,
+                command_seq=command_seq,
+            )
+            self.send((command_to_send + "\n").encode())
+            return
+
+        with lock:
+            self._command_state.register_command(
+                stripped_command, source=source, command_seq=command_seq
+            )
+            self._write_command_metadata(
+                command=stripped_command,
+                source=source,
+                command_seq=command_seq,
+            )
+            self.send((command_to_send + "\n").encode())
 
     def register_user_command(self, command: str) -> None:
         """Record a user-submitted command before it reaches bash."""
@@ -337,6 +357,25 @@ class PTYManager:
             set_winsize(self._master_fd, rows, cols)
 
     @staticmethod
+    def _strip_echoed_command(text: str, command: str) -> str:
+        command_lines = [line.lstrip().rstrip() for line in command.strip().splitlines()]
+        if not command_lines:
+            return text
+
+        output_lines = text.split("\n")
+        if len(output_lines) < len(command_lines):
+            return text
+
+        for index, command_line in enumerate(command_lines):
+            output_line = output_lines[index].lstrip()
+            if index > 0 and output_line.startswith(">"):
+                output_line = output_line[1:].lstrip()
+            if output_line.rstrip() != command_line:
+                return text
+
+        return "\n".join(output_lines[len(command_lines) :])
+
+    @staticmethod
     def _clean_pty_output(raw: bytes, command: str) -> str:
         """Clean PTY output: strip ANSI, echo, prompt, exit markers."""
         import re as _re
@@ -350,15 +389,7 @@ class PTYManager:
         # Remove carriage returns (keep newlines)
         text = text.replace("\r\n", "\n").replace("\r", "")
 
-        # Remove command echo: lines containing the command itself
-        cmd_escaped = _re.escape(command.strip())
-        text = _re.sub(
-            rf"^.*{cmd_escaped}\s*$\n?",
-            "",
-            text,
-            count=1,
-            flags=_re.MULTILINE,
-        )
+        text = PTYManager._strip_echoed_command(text, command)
 
         # Remove trailing prompt line (contains prompt symbols)
         lines = text.rstrip().split("\n")
@@ -539,6 +570,69 @@ class PTYManager:
         self._control_fd = None
         self._control_write_fd = None
         self._child_pid = None
+
+        self._remove_command_metadata_file()
+
+    def _ensure_command_metadata_file(self) -> None:
+        if self._command_metadata_path is not None:
+            return
+
+        fd, path = tempfile.mkstemp(prefix="aish_command_meta_")
+        os.close(fd)
+        self._command_metadata_path = path
+        self._clear_command_metadata_file()
+
+    def _clear_command_metadata_file(self) -> None:
+        path = getattr(self, "_command_metadata_path", None)
+        if not path:
+            return
+
+        try:
+            with open(path, "w", encoding="utf-8"):
+                pass
+        except OSError:
+            pass
+
+    def _remove_command_metadata_file(self) -> None:
+        path = getattr(self, "_command_metadata_path", None)
+        if not path:
+            return
+
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+        self._command_metadata_path = None
+
+    def _write_command_metadata(
+        self,
+        *,
+        command: str,
+        source: str,
+        command_seq: int | None,
+    ) -> None:
+        path = getattr(self, "_command_metadata_path", None)
+        if not path:
+            return
+
+        payload = "\n".join(
+            [
+                f"__AISH_PENDING_COMMAND_SOURCE={shlex.quote(source)}",
+                f"__AISH_PENDING_COMMAND_SEQ={shlex.quote('' if command_seq is None else str(command_seq))}",
+                f"__AISH_PENDING_COMMAND_TEXT={shlex.quote(command)}",
+                "",
+            ]
+        )
+        tmp_path = f"{path}.tmp"
+        try:
+            with open(tmp_path, "w", encoding="utf-8") as handle:
+                handle.write(payload)
+            os.replace(tmp_path, path)
+        except OSError:
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
 
     def __enter__(self) -> "PTYManager":
         self.start()

--- a/tests/shell/runtime/test_shell_pty_core.py
+++ b/tests/shell/runtime/test_shell_pty_core.py
@@ -518,6 +518,7 @@ def test_pty_manager_send_command_sends_plain_user_command():
     manager._completed_results = []
     manager._completion_condition = threading.Condition()
     manager._exit_code_callback = None
+    manager._lock = threading.RLock()
     sent: list[bytes] = []
 
     def _fake_send(data: bytes) -> int:
@@ -558,6 +559,7 @@ def test_pty_manager_send_command_prefixes_backend_with_space_only():
     manager._completed_results = []
     manager._completion_condition = threading.Condition()
     manager._exit_code_callback = None
+    manager._lock = threading.RLock()
     sent: list[bytes] = []
 
     def _fake_send(data: bytes) -> int:

--- a/tests/shell/runtime/test_shell_pty_core.py
+++ b/tests/shell/runtime/test_shell_pty_core.py
@@ -654,6 +654,46 @@ def test_shell_tracks_phase_without_mutating_missing_command_seq_events():
     assert "command_seq" not in ready.payload
 
 
+def test_shell_ignores_unmatched_identified_backend_events():
+    shell = object.__new__(PTYAIShell)
+    shell._pty_manager = _FakePTYManager()
+    shell._backend_protocol_events = []
+    shell._backend_protocol_errors = []
+    shell._last_backend_event = None
+    shell._backend_session_ready = False
+    shell._shell_phase = "command_submitted"
+    shell._next_command_seq = 1
+    shell._pending_command_seq = 1
+    shell._pending_command_text = "pwd"
+    shell._running = True
+    shell._output_processor = Mock()
+    shell._pty_manager.command_state.register_command("pwd", source="user", command_seq=1)
+
+    started = BackendControlEvent(
+        version=1,
+        type="command_started",
+        ts=1,
+        payload={"submission_id": "subm_missing", "command": "echo other"},
+    )
+    PTYAIShell._track_backend_event(shell, started)
+
+    assert shell._shell_phase == "command_submitted"
+    assert shell._pending_command_seq == 1
+    assert shell._pending_command_text == "pwd"
+
+    ready = BackendControlEvent(
+        version=1,
+        type="prompt_ready",
+        ts=2,
+        payload={"submission_id": "subm_missing", "exit_code": 0},
+    )
+    PTYAIShell._track_backend_event(shell, ready)
+
+    assert shell._shell_phase == "command_submitted"
+    assert shell._pending_command_seq == 1
+    assert shell._pending_command_text == "pwd"
+
+
 def test_shell_tracks_backend_cwd_from_prompt_ready(monkeypatch):
     shell = object.__new__(PTYAIShell)
     shell._pty_manager = _FakePTYManager()

--- a/tests/shell/runtime/test_shell_pty_core.py
+++ b/tests/shell/runtime/test_shell_pty_core.py
@@ -73,6 +73,10 @@ class _FakePTYManager:
     def can_correct_last_error(self) -> bool:
         return self._command_state.can_correct_last_error
 
+    @property
+    def command_state(self) -> CommandState:
+        return self._command_state
+
 
 def _make_ai_handler() -> tuple[AIHandler, Mock]:
     pty_manager = _FakePTYManager()
@@ -240,26 +244,134 @@ def test_output_processor_filters_quit_echo():
     assert processor.process(b"\rquit\r\n") == b""
 
 
-def test_output_processor_filters_prefixed_user_command_echo():
+def test_output_processor_filters_user_command_echo():
     processor = OutputProcessor(_FakePTYManager())
     processor.prepare_user_command_echo("pwd", 5)
 
-    rendered = processor.process(
-        b" __AISH_ACTIVE_COMMAND_SEQ=5; __AISH_ACTIVE_COMMAND_TEXT=pwd; pwd\r\n"
-    )
+    rendered = processor.process(b"pwd\r\n")
 
     assert rendered == b""
 
 
-def test_output_processor_filters_prefixed_user_command_echo_before_command_output():
+def test_output_processor_filters_user_command_echo_before_command_output():
     processor = OutputProcessor(_FakePTYManager())
     processor.prepare_user_command_echo("pwd", 5)
 
-    rendered = processor.process(
-        b" __AISH_ACTIVE_COMMAND_SEQ=5; __AISH_ACTIVE_COMMAND_TEXT=pwd; pwd\r\n/tmp/project\r\n"
-    )
+    rendered = processor.process(b"pwd\r\n/tmp/project\r\n")
 
     assert rendered == b"/tmp/project\r\n"
+
+
+def test_output_processor_filters_split_user_command_echo_across_chunks():
+    processor = OutputProcessor(_FakePTYManager())
+    processor.prepare_user_command_echo("pwd", 5)
+
+    first = processor.process(b"pw")
+    second = processor.process(b"d\r\n")
+
+    assert first == b""
+    assert second == b""
+
+
+def test_output_processor_filters_split_user_command_echo_before_output():
+    processor = OutputProcessor(_FakePTYManager())
+    processor.prepare_user_command_echo("pwd", 5)
+
+    first = processor.process(b"pw")
+    second = processor.process(b"d\r\n/tmp/project\r\n")
+
+    assert first == b""
+    assert second == b"/tmp/project\r\n"
+
+
+def test_output_processor_does_not_strip_nonleading_command_text():
+    processor = OutputProcessor(_FakePTYManager())
+    processor.prepare_user_command_echo("pwd", 5)
+
+    rendered = processor.process(b"status: pwd\r\n")
+
+    assert rendered == b"status: pwd\r\n"
+
+
+def test_output_processor_filters_user_command_echo_after_async_output():
+    processor = OutputProcessor(_FakePTYManager())
+    processor.prepare_user_command_echo("pwd", 5)
+
+    first = processor.process(b"[1]+ Done sleep 0.1\r\n")
+    second = processor.process(b"pwd\r\n/tmp/project\r\n")
+
+    assert first == b"[1]+ Done sleep 0.1\r\n"
+    assert second == b"/tmp/project\r\n"
+
+
+def test_output_processor_clears_pending_echo_on_prompt_ready():
+    processor = OutputProcessor(_FakePTYManager())
+    processor.prepare_user_command_echo("pwd", 5)
+
+    processor.handle_backend_event(
+        BackendControlEvent(
+            version=1,
+            type="prompt_ready",
+            ts=1,
+            payload={"exit_code": 0},
+        ),
+        result=CommandResult(command="pwd", exit_code=0, source="user"),
+    )
+
+    rendered = processor.process(b"pwd\r\n")
+
+    assert rendered == b"pwd\r\n"
+
+
+def test_pty_manager_send_command_serializes_metadata_and_pty_write():
+    manager = PTYManager()
+    manager._running = True
+    manager._master_fd = 1
+
+    events: list[tuple[str, str]] = []
+    first_metadata_written = threading.Event()
+    release_first = threading.Event()
+
+    def fake_write_command_metadata(*, command: str, source: str, command_seq: int | None) -> None:
+        _ = (source, command_seq)
+        events.append(("meta", command))
+        if command == "one":
+            first_metadata_written.set()
+            release_first.wait(timeout=1)
+
+    def fake_send(data: bytes) -> int:
+        events.append(("send", data.decode("utf-8").strip()))
+        return len(data)
+
+    manager._write_command_metadata = fake_write_command_metadata
+    manager.send = fake_send
+
+    first = threading.Thread(
+        target=manager.send_command,
+        kwargs={"command": "one", "command_seq": 1},
+    )
+    second = threading.Thread(
+        target=manager.send_command,
+        kwargs={"command": "two", "command_seq": 2},
+    )
+
+    first.start()
+    assert first_metadata_written.wait(timeout=1)
+
+    second.start()
+    threading.Event().wait(0.05)
+    assert events == [("meta", "one")]
+
+    release_first.set()
+    first.join(timeout=1)
+    second.join(timeout=1)
+
+    assert events == [
+        ("meta", "one"),
+        ("send", "one"),
+        ("meta", "two"),
+        ("send", "two"),
+    ]
 
 
 class _FakeLive:
@@ -400,7 +512,7 @@ def test_output_processor_prints_error_hint_when_command_fails(capsys):
     assert t("shell.error_correction.press_semicolon_hint") in capsys.readouterr().out
 
 
-def test_pty_manager_send_command_injects_command_seq():
+def test_pty_manager_send_command_sends_plain_user_command():
     manager = object.__new__(PTYManager)
     manager._command_state = CommandState()
     manager._completed_results = []
@@ -414,7 +526,7 @@ def test_pty_manager_send_command_injects_command_seq():
 
     manager.send = _fake_send  # type: ignore[method-assign]
 
-    PTYManager.send_command(manager, "echo hi", command_seq=7)
+    PTYManager.send_command(manager, "echo hi", command_seq=7, source="user")
     result = PTYManager.handle_backend_event(
         manager,
         BackendControlEvent(
@@ -435,11 +547,28 @@ def test_pty_manager_send_command_injects_command_seq():
         ),
     )
 
-    assert sent == [
-        b" __AISH_ACTIVE_COMMAND_SEQ=7; __AISH_ACTIVE_COMMAND_TEXT='echo hi'; echo hi\n"
-    ]
+    assert sent == [b"echo hi\n"]
     assert result is not None
     assert manager.last_command == "echo hi"
+
+
+def test_pty_manager_send_command_prefixes_backend_with_space_only():
+    manager = object.__new__(PTYManager)
+    manager._command_state = CommandState()
+    manager._completed_results = []
+    manager._completion_condition = threading.Condition()
+    manager._exit_code_callback = None
+    sent: list[bytes] = []
+
+    def _fake_send(data: bytes) -> int:
+        sent.append(data)
+        return len(data)
+
+    manager.send = _fake_send  # type: ignore[method-assign]
+
+    PTYManager.send_command(manager, "history | tail -n 5", command_seq=-1, source="backend")
+
+    assert sent == [b" history | tail -n 5\n"]
 
 
 def test_shell_tracks_command_seq_and_returns_to_editing_on_prompt_ready():
@@ -483,6 +612,46 @@ def test_shell_tracks_command_seq_and_returns_to_editing_on_prompt_ready():
     assert shell._pending_command_seq is None
     assert shell._pending_command_text is None
     assert shell._output_processor.handle_backend_event.call_count == 2
+
+
+def test_shell_tracks_phase_without_mutating_missing_command_seq_events():
+    shell = object.__new__(PTYAIShell)
+    shell._pty_manager = _FakePTYManager()
+    shell._backend_protocol_events = []
+    shell._backend_protocol_errors = []
+    shell._last_backend_event = None
+    shell._backend_session_ready = False
+    shell._shell_phase = "booting"
+    shell._next_command_seq = 1
+    shell._pending_command_seq = 1
+    shell._pending_command_text = "pwd"
+    shell._running = True
+    shell._output_processor = Mock()
+    shell._pty_manager.command_state.register_command("pwd", source="user", command_seq=1)
+
+    started = BackendControlEvent(
+        version=1,
+        type="command_started",
+        ts=1,
+        payload={"command": "pwd"},
+    )
+    PTYAIShell._track_backend_event(shell, started)
+
+    assert shell._shell_phase == "running_passthrough"
+    assert "command_seq" not in started.payload
+
+    ready = BackendControlEvent(
+        version=1,
+        type="prompt_ready",
+        ts=2,
+        payload={"exit_code": 0},
+    )
+    PTYAIShell._track_backend_event(shell, ready)
+
+    assert shell._shell_phase == "editing"
+    assert shell._pending_command_seq is None
+    assert shell._pending_command_text is None
+    assert "command_seq" not in ready.payload
 
 
 def test_shell_tracks_backend_cwd_from_prompt_ready(monkeypatch):

--- a/tests/shell/runtime/test_shell_pty_core.py
+++ b/tests/shell/runtime/test_shell_pty_core.py
@@ -332,8 +332,10 @@ def test_pty_manager_send_command_serializes_metadata_and_pty_write():
     first_metadata_written = threading.Event()
     release_first = threading.Event()
 
-    def fake_write_command_metadata(*, command: str, source: str, command_seq: int | None) -> None:
-        _ = (source, command_seq)
+    def fake_write_command_metadata(
+        *, command: str, source: str, command_seq: int | None, submission_id: str | None = None
+    ) -> None:
+        _ = (source, command_seq, submission_id)
         events.append(("meta", command))
         if command == "one":
             first_metadata_written.set()
@@ -493,7 +495,6 @@ def test_restart_notification_uses_rich_style_output(monkeypatch):
 def test_output_processor_prints_error_hint_when_command_fails(capsys):
     pty_manager = _FakePTYManager(error_info=("bad command", 1))
     processor = OutputProcessor(pty_manager)
-    processor._waiting_for_result = True
 
     rendered = processor.process(b"stderr output")
     processor.handle_backend_event(
@@ -507,7 +508,6 @@ def test_output_processor_prints_error_hint_when_command_fails(capsys):
     )
 
     assert rendered == b"stderr output"
-    assert processor._waiting_for_result is False
     pty_manager.consume_error.assert_called_once_with()
     assert t("shell.error_correction.press_semicolon_hint") in capsys.readouterr().out
 
@@ -1002,7 +1002,7 @@ def test_shell_submit_backend_command_registers_user_seq():
     assert shell._pending_command_seq == 3
     assert shell._pending_command_text == "pwd"
     assert shell._shell_phase == "command_submitted"
-    shell._output_processor.set_waiting_for_result.assert_called_once_with(True, "pwd")
+    shell._output_processor.prepare_user_command_echo.assert_called_once_with("pwd", 3)
     shell._pty_manager.send_command.assert_called_once_with(
         "pwd", command_seq=3, source="user"
     )

--- a/tests/terminal/pty/test_exit_tracker_repeat_error.py
+++ b/tests/terminal/pty/test_exit_tracker_repeat_error.py
@@ -214,6 +214,56 @@ def test_unmatched_submission_id_does_not_guess_command_seq():
 
 
 @pytest.mark.timeout(5)
+def test_conflicting_identifiers_do_not_resolve_or_rebind_submission():
+    tracker = CommandState()
+
+    first = tracker.register_backend_command("echo one", command_seq=-1)
+    second = tracker.register_backend_command("echo two", command_seq=-2)
+
+    assert first is not None
+    assert second is not None
+
+    assert tracker.resolve_command_seq(-2, first.submission_id) is None
+
+    tracker.handle_backend_event(
+        _command_started(
+            "echo unexpected",
+            command_seq=-2,
+            submission_id=first.submission_id,
+        )
+    )
+
+    assert tracker.get_pending_submission(-1) is first
+    assert tracker.get_pending_submission(-2) is second
+    assert first.status == "submitted"
+    assert second.status == "submitted"
+
+    issues = tracker.consume_protocol_issues()
+    assert any("conflicting backend identifiers" in issue for issue in issues)
+
+
+@pytest.mark.timeout(5)
+def test_submission_id_can_bind_first_command_seq_when_unclaimed():
+    tracker = CommandState()
+
+    submission = tracker.register_user_command("echo one")
+
+    assert submission is not None
+    assert submission.command_seq is None
+
+    tracker.handle_backend_event(
+        _command_started(
+            "echo one",
+            command_seq=7,
+            submission_id=submission.submission_id,
+        )
+    )
+
+    assert submission.command_seq == 7
+    assert tracker.get_pending_submission(7) is submission
+
+
+@pytest.mark.timeout(5)
 def test_missing_identifiers_do_not_guess_when_multiple_pending_submissions_exist():
     tracker = CommandState()
 

--- a/tests/terminal/pty/test_exit_tracker_repeat_error.py
+++ b/tests/terminal/pty/test_exit_tracker_repeat_error.py
@@ -44,6 +44,78 @@ def test_same_command_failure_retriggers_after_consume():
 
 
 @pytest.mark.timeout(5)
+def test_register_command_returns_pending_submission_metadata():
+    """Registering a command should expose explicit pending-submission metadata."""
+    tracker = CommandState()
+
+    submission = tracker.register_backend_command("echo hello", command_seq=-1)
+
+    assert submission is not None
+    assert submission.command == "echo hello"
+    assert submission.source == "backend"
+    assert submission.command_seq == -1
+    assert tracker.pending_submission is submission
+    assert tracker.pending_submission_count == 1
+    assert tracker.pending_submissions == (submission,)
+    assert tracker.get_pending_submission(-1) is submission
+    assert tracker.has_pending_submission(-1) is True
+
+
+@pytest.mark.timeout(5)
+def test_pending_submission_is_cleared_after_prompt_ready():
+    """Pending submissions should be removed once prompt_ready resolves them."""
+    tracker = CommandState()
+
+    tracker.register_backend_command("echo hello", command_seq=-1)
+
+    assert tracker.has_pending_submission(-1) is True
+
+    tracker.handle_backend_event(_command_started("echo hello", command_seq=-1))
+    tracker.handle_backend_event(_prompt_ready(0, command_seq=-1))
+
+    assert tracker.pending_submission is None
+    assert tracker.pending_submission_count == 0
+    assert tracker.pending_submissions == ()
+    assert tracker.get_pending_submission(-1) is None
+    assert tracker.has_pending_submission(-1) is False
+
+
+@pytest.mark.timeout(5)
+def test_prompt_ready_without_command_seq_uses_pending_submission_seq():
+    """Missing prompt_ready command_seq should still resolve and clear seq-bound submissions."""
+    tracker = CommandState()
+
+    tracker.register_backend_command("echo hello", command_seq=-1)
+    tracker.handle_backend_event(_command_started("echo hello"))
+
+    result = tracker.handle_backend_event(_prompt_ready(0))
+
+    assert result is not None
+    assert result.command == "echo hello"
+    assert result.command_seq == -1
+    assert tracker.pending_submission is None
+    assert tracker.pending_submission_count == 0
+
+
+@pytest.mark.timeout(5)
+def test_command_started_keeps_original_text_and_tracks_observed_command():
+    """Original submitted text stays authoritative while shell-observed text is retained separately."""
+    tracker = CommandState()
+
+    submission = tracker.register_command("ls", source="user", command_seq=7)
+
+    tracker.handle_backend_event(_command_started("ls --color=auto"))
+    result = tracker.handle_backend_event(_prompt_ready(0))
+
+    assert submission is not None
+    assert submission.command == "ls"
+    assert submission.observed_command == "ls --color=auto"
+    assert result is not None
+    assert result.command == "ls"
+    assert result.command_seq == 7
+
+
+@pytest.mark.timeout(5)
 def test_prompt_redraw_no_duplicate_hint():
     """Prompt redraw (same marker, no set_last_command) must not re-trigger hint."""
     tracker = CommandState()

--- a/tests/terminal/pty/test_exit_tracker_repeat_error.py
+++ b/tests/terminal/pty/test_exit_tracker_repeat_error.py
@@ -6,8 +6,15 @@ from aish.terminal.pty.command_state import CommandState
 from aish.terminal.pty.control_protocol import BackendControlEvent
 
 
-def _command_started(command: str, command_seq: int | None = None) -> BackendControlEvent:
+def _command_started(
+    command: str,
+    command_seq: int | None = None,
+    *,
+    submission_id: str | None = None,
+) -> BackendControlEvent:
     payload = {"command": command}
+    if submission_id is not None:
+        payload["submission_id"] = submission_id
     if command_seq is not None:
         payload["command_seq"] = command_seq
     return BackendControlEvent(version=1, type="command_started", ts=1, payload=payload)
@@ -18,8 +25,11 @@ def _prompt_ready(
     command_seq: int | None = None,
     *,
     interrupted: bool = False,
+    submission_id: str | None = None,
 ) -> BackendControlEvent:
     payload = {"exit_code": exit_code, "interrupted": interrupted}
+    if submission_id is not None:
+        payload["submission_id"] = submission_id
     if command_seq is not None:
         payload["command_seq"] = command_seq
     return BackendControlEvent(version=1, type="prompt_ready", ts=2, payload=payload)
@@ -51,9 +61,11 @@ def test_register_command_returns_pending_submission_metadata():
     submission = tracker.register_backend_command("echo hello", command_seq=-1)
 
     assert submission is not None
+    assert submission.submission_id.startswith("subm_")
     assert submission.command == "echo hello"
     assert submission.source == "backend"
     assert submission.command_seq == -1
+    assert submission.status == "submitted"
     assert tracker.pending_submission is submission
     assert tracker.pending_submission_count == 1
     assert tracker.pending_submissions == (submission,)
@@ -71,6 +83,9 @@ def test_pending_submission_is_cleared_after_prompt_ready():
     assert tracker.has_pending_submission(-1) is True
 
     tracker.handle_backend_event(_command_started("echo hello", command_seq=-1))
+    pending = tracker.pending_submission
+    assert pending is not None
+    assert pending.status == "started"
     tracker.handle_backend_event(_prompt_ready(0, command_seq=-1))
 
     assert tracker.pending_submission is None
@@ -93,8 +108,33 @@ def test_prompt_ready_without_command_seq_uses_pending_submission_seq():
     assert result is not None
     assert result.command == "echo hello"
     assert result.command_seq == -1
+    assert result.submission_id is not None
     assert tracker.pending_submission is None
     assert tracker.pending_submission_count == 0
+
+
+@pytest.mark.timeout(5)
+def test_prompt_ready_without_matching_submission_records_protocol_issue():
+    tracker = CommandState()
+
+    result = tracker.handle_backend_event(_prompt_ready(0, command_seq=99))
+
+    assert result is None
+    issues = tracker.consume_protocol_issues()
+    assert len(issues) == 1
+    assert "prompt_ready missing matching submission" in issues[0]
+    assert tracker.consume_protocol_issues() == ()
+
+
+@pytest.mark.timeout(5)
+def test_command_started_without_matching_submission_records_protocol_issue():
+    tracker = CommandState()
+
+    tracker.handle_backend_event(_command_started("echo unexpected", command_seq=42))
+
+    issues = tracker.consume_protocol_issues()
+    assert len(issues) == 1
+    assert "command_started missing matching submission" in issues[0]
 
 
 @pytest.mark.timeout(5)
@@ -113,6 +153,54 @@ def test_command_started_keeps_original_text_and_tracks_observed_command():
     assert result is not None
     assert result.command == "ls"
     assert result.command_seq == 7
+
+
+@pytest.mark.timeout(5)
+def test_submission_id_matches_correct_pending_submission_before_active_fallback():
+    tracker = CommandState()
+
+    first = tracker.register_backend_command("echo one", command_seq=-1)
+    second = tracker.register_backend_command("echo two", command_seq=-2)
+
+    assert first is not None
+    assert second is not None
+
+    tracker.handle_backend_event(
+        _command_started(
+            "echo one",
+            submission_id=first.submission_id,
+        )
+    )
+    result = tracker.handle_backend_event(
+        _prompt_ready(
+            0,
+            submission_id=first.submission_id,
+        )
+    )
+
+    assert result is not None
+    assert result.command == "echo one"
+    assert result.command_seq == -1
+    assert result.submission_id == first.submission_id
+    assert tracker.get_pending_submission(-1) is None
+    assert tracker.get_pending_submission(-2) is second
+    assert second.status == "submitted"
+
+
+@pytest.mark.timeout(5)
+def test_missing_identifiers_do_not_guess_when_multiple_pending_submissions_exist():
+    tracker = CommandState()
+
+    first = tracker.register_backend_command("echo one", command_seq=-1)
+    second = tracker.register_backend_command("echo two", command_seq=-2)
+
+    result = tracker.handle_backend_event(_prompt_ready(0))
+
+    assert first is not None
+    assert second is not None
+    assert result is None
+    assert tracker.get_pending_submission(-1) is first
+    assert tracker.get_pending_submission(-2) is second
 
 
 @pytest.mark.timeout(5)

--- a/tests/terminal/pty/test_exit_tracker_repeat_error.py
+++ b/tests/terminal/pty/test_exit_tracker_repeat_error.py
@@ -74,6 +74,22 @@ def test_register_command_returns_pending_submission_metadata():
 
 
 @pytest.mark.timeout(5)
+def test_pending_submissions_include_id_only_registrations():
+    tracker = CommandState()
+
+    first = tracker.register_user_command("echo one")
+    second = tracker.register_user_command("echo two")
+
+    assert first is not None
+    assert second is not None
+    assert tracker.pending_submission_count == 2
+    assert {submission.submission_id for submission in tracker.pending_submissions} == {
+        first.submission_id,
+        second.submission_id,
+    }
+
+
+@pytest.mark.timeout(5)
 def test_pending_submission_is_cleared_after_prompt_ready():
     """Pending submissions should be removed once prompt_ready resolves them."""
     tracker = CommandState()
@@ -188,6 +204,16 @@ def test_submission_id_matches_correct_pending_submission_before_active_fallback
 
 
 @pytest.mark.timeout(5)
+def test_unmatched_submission_id_does_not_guess_command_seq():
+    tracker = CommandState()
+
+    tracker.register_backend_command("echo one", command_seq=-1)
+    tracker.register_backend_command("echo two", command_seq=-2)
+
+    assert tracker.resolve_command_seq(None, "subm_missing") is None
+
+
+@pytest.mark.timeout(5)
 def test_missing_identifiers_do_not_guess_when_multiple_pending_submissions_exist():
     tracker = CommandState()
 
@@ -201,6 +227,26 @@ def test_missing_identifiers_do_not_guess_when_multiple_pending_submissions_exis
     assert result is None
     assert tracker.get_pending_submission(-1) is first
     assert tracker.get_pending_submission(-2) is second
+
+
+@pytest.mark.timeout(5)
+def test_submission_id_only_placeholder_stays_backend_sourced():
+    tracker = CommandState()
+
+    tracker.handle_backend_event(
+        _command_started(
+            "echo unexpected",
+            submission_id="subm_missing",
+        )
+    )
+
+    pending = tracker.pending_submission
+    assert pending is not None
+    assert pending.source == "backend"
+    assert pending.allow_error_correction is False
+
+    issues = tracker.consume_protocol_issues()
+    assert any("backend event missing matching submission" in issue for issue in issues)
 
 
 @pytest.mark.timeout(5)

--- a/tests/terminal/pty/test_pty_control_protocol.py
+++ b/tests/terminal/pty/test_pty_control_protocol.py
@@ -202,6 +202,17 @@ def test_pty_manager_execute_command_returns_output_without_marker():
         assert "[AISH_EXIT:" not in output
     finally:
         manager.stop()
+
+
+def test_clean_pty_output_strips_echo_after_leading_blank_line():
+    cleaned = PTYManager._clean_pty_output(
+        b"\r\n printf 'hello\\n'\r\nhello\r\n",
+        "printf 'hello\\n'",
+    )
+
+    assert cleaned == "hello"
+
+
 def test_pty_manager_execute_command_waits_without_implicit_timeout():
     manager = PTYManager(use_output_thread=False)
 

--- a/tests/terminal/pty/test_pty_control_protocol.py
+++ b/tests/terminal/pty/test_pty_control_protocol.py
@@ -5,8 +5,7 @@ import select
 import time
 from pathlib import Path
 
-import pytest
-
+from aish.terminal.pty.control_protocol import BackendControlEvent
 from aish.terminal.pty.control_protocol import decode_control_chunk
 from aish.terminal.pty.manager import PTYManager
 
@@ -74,6 +73,56 @@ def test_decode_control_chunk_reports_invalid_lines_without_dropping_valid_event
     assert len(errors) == 1
 
 
+def test_pty_manager_collects_protocol_decode_errors():
+    manager = PTYManager(use_output_thread=False)
+
+    manager._dispatch_control_chunk(b'{"version":1,"type":"session_ready","ts":1}\nnot-json\n')
+
+    issues = manager.consume_protocol_issues()
+    assert len(issues) == 1
+    assert "invalid control event JSON" in issues[0]
+    assert manager.consume_protocol_issues() == ()
+
+
+def test_pty_manager_surfaces_command_state_protocol_issues():
+    manager = PTYManager(use_output_thread=False)
+
+    result = manager.handle_backend_event(
+        BackendControlEvent(
+            version=1,
+            type="prompt_ready",
+            ts=1,
+            payload={"command_seq": 404, "exit_code": 0},
+        )
+    )
+
+    assert result is None
+    issues = manager.consume_protocol_issues()
+    assert len(issues) == 1
+    assert "prompt_ready missing matching submission" in issues[0]
+    assert manager.consume_protocol_issues() == ()
+
+
+def test_pty_manager_aggregates_decode_and_state_issues_together():
+    manager = PTYManager(use_output_thread=False)
+
+    manager._dispatch_control_chunk(b'{"version":1,"type":"session_ready","ts":1}\nnot-json\n')
+    manager.handle_backend_event(
+        BackendControlEvent(
+            version=1,
+            type="prompt_ready",
+            ts=2,
+            payload={"command_seq": 505, "exit_code": 0},
+        )
+    )
+
+    issues = manager.consume_protocol_issues()
+    assert len(issues) == 2
+    assert any("invalid control event JSON" in issue for issue in issues)
+    assert any("prompt_ready missing matching submission" in issue for issue in issues)
+    assert manager.consume_protocol_issues() == ()
+
+
 def test_pty_manager_emits_control_events_for_user_command():
     manager = PTYManager(use_output_thread=False)
 
@@ -84,6 +133,7 @@ def test_pty_manager_emits_control_events_for_user_command():
 
         saw_started = False
         saw_ready = False
+        started_submission_id = None
         deadline = time.monotonic() + 5.0
 
         while time.monotonic() < deadline and not (saw_started and saw_ready):
@@ -99,16 +149,42 @@ def test_pty_manager_emits_control_events_for_user_command():
                         result = manager.handle_backend_event(event)
                         if event.type == "command_started":
                             saw_started = event.payload.get("command") == "echo hello"
-                        if event.type == "prompt_ready":
+                            started_submission_id = event.payload.get("submission_id")
+                            if started_submission_id is not None:
+                                assert isinstance(started_submission_id, str)
+                                assert started_submission_id.startswith("subm_")
+                        if event.type == "prompt_ready" and saw_started:
                             saw_ready = event.payload.get("exit_code") == 0
                             assert result is not None
                             assert result.command == "echo hello"
+                            if started_submission_id is not None:
+                                assert event.payload.get("submission_id") == started_submission_id
+                                assert result.submission_id == started_submission_id
                 else:
                     continue
 
         assert saw_started is True
         assert saw_ready is True
         assert manager.last_command == "echo hello"
+        assert manager.last_exit_code == 0
+    finally:
+        manager.stop()
+
+
+def test_start_drains_startup_prompt_ready_in_poll_mode():
+    manager = PTYManager(use_output_thread=False)
+
+    try:
+        manager.start()
+
+        ready, _, _ = select.select([manager.control_fd], [], [], 0.1)
+        assert ready == []
+
+        manager.send_command("printf 'ready\\n'", command_seq=11, source="backend")
+        output = _wait_for_prompt_ready(manager, 11)
+
+        assert b"ready" in output
+        assert manager.last_command == "printf 'ready\\n'"
         assert manager.last_exit_code == 0
     finally:
         manager.stop()
@@ -148,6 +224,43 @@ def test_bash_history_keeps_user_command_without_internal_prefix(tmp_path: Path)
         assert history_lines[0].endswith("echo hello")
         assert all("__AISH_ACTIVE_COMMAND_SEQ" not in line for line in history_lines)
         assert all("history | tail -n 5" not in line for line in history_lines)
+    finally:
+        manager.stop()
+
+
+def test_send_command_emits_matching_submission_id_for_started_and_ready():
+    manager = PTYManager(use_output_thread=False)
+
+    try:
+        manager.start()
+        manager.send_command("echo hello", command_seq=7, source="user")
+
+        started_submission_id = None
+        saw_ready = False
+        deadline = time.monotonic() + 5.0
+
+        while time.monotonic() < deadline and not saw_ready:
+            ready, _, _ = select.select([manager.control_fd, manager._master_fd], [], [], 0.1)
+            for fd in ready:
+                data = os.read(fd, 4096)
+                if not data:
+                    continue
+                if fd != manager.control_fd:
+                    continue
+
+                events, errors = manager.decode_control_events(data)
+                assert errors == []
+                for event in events:
+                    manager.handle_backend_event(event)
+                    if event.type == "command_started" and event.payload.get("command_seq") == 7:
+                        started_submission_id = event.payload.get("submission_id")
+                    if event.type == "prompt_ready" and event.payload.get("command_seq") == 7:
+                        assert event.payload.get("submission_id") == started_submission_id
+                        saw_ready = True
+
+        assert isinstance(started_submission_id, str)
+        assert started_submission_id.startswith("subm_")
+        assert saw_ready is True
     finally:
         manager.stop()
 

--- a/tests/terminal/pty/test_pty_control_protocol.py
+++ b/tests/terminal/pty/test_pty_control_protocol.py
@@ -5,8 +5,46 @@ import select
 import time
 from pathlib import Path
 
+import pytest
+
 from aish.terminal.pty.control_protocol import decode_control_chunk
 from aish.terminal.pty.manager import PTYManager
+
+
+def _wait_for_prompt_ready(manager: PTYManager, command_seq: int, timeout: float = 5.0) -> bytes:
+    output = bytearray()
+    deadline = time.monotonic() + timeout
+
+    while time.monotonic() < deadline:
+        ready, _, _ = select.select([manager.control_fd, manager._master_fd], [], [], 0.1)
+        saw_prompt = False
+        for fd in ready:
+            data = os.read(fd, 4096)
+            if not data:
+                continue
+            if fd == manager.control_fd:
+                events, errors = manager.decode_control_events(data)
+                assert errors == []
+                for event in events:
+                    manager.handle_backend_event(event)
+                    if event.type == "prompt_ready" and event.payload.get("command_seq") == command_seq:
+                        saw_prompt = True
+            else:
+                output.extend(data)
+        if saw_prompt:
+            break
+
+    return bytes(output)
+
+
+def _drain_master_fd(manager: PTYManager) -> bytes:
+    output = bytearray()
+    while True:
+        ready, _, _ = select.select([manager._master_fd], [], [], 0)
+        if not ready:
+            break
+        output.extend(os.read(manager._master_fd, 4096))
+    return bytes(output)
 
 
 def test_decode_control_chunk_handles_partial_ndjson_frames():
@@ -90,18 +128,131 @@ def test_pty_manager_execute_command_returns_output_without_marker():
         manager.stop()
 
 
-def test_bash_history_hides_internal_command_seq_prefix_for_user_commands(tmp_path: Path):
+def test_bash_history_keeps_user_command_without_internal_prefix(tmp_path: Path):
     histfile = tmp_path / "bash_history"
     manager = PTYManager(use_output_thread=False, env={"HISTFILE": str(histfile)})
 
     try:
         manager.start()
         manager.send_command("echo hello", command_seq=7, source="user")
+        _wait_for_prompt_ready(manager, 7)
+        _drain_master_fd(manager)
 
+        output, exit_code = manager.execute_command("history | tail -n 5")
+        history_lines = [
+            line for line in output.splitlines() if line.lstrip()[:1].isdigit()
+        ]
+
+        assert exit_code == 0
+        assert len(history_lines) == 1
+        assert history_lines[0].endswith("echo hello")
+        assert all("__AISH_ACTIVE_COMMAND_SEQ" not in line for line in history_lines)
+        assert all("history | tail -n 5" not in line for line in history_lines)
+    finally:
+        manager.stop()
+
+
+def test_bash_history_excludes_backend_commands(tmp_path: Path):
+    histfile = tmp_path / "bash_history"
+    manager = PTYManager(use_output_thread=False, env={"HISTFILE": str(histfile)})
+
+    try:
+        manager.start()
+        manager.send_command("echo hello", command_seq=7, source="user")
+        _wait_for_prompt_ready(manager, 7)
+        _drain_master_fd(manager)
+
+        backend_output, backend_exit_code = manager.execute_command("printf 'backend\\n'")
+        assert backend_exit_code == 0
+        assert backend_output == "backend"
+
+        output, exit_code = manager.execute_command("history | tail -n 5")
+        history_lines = [
+            line for line in output.splitlines() if line.lstrip()[:1].isdigit()
+        ]
+
+        assert exit_code == 0
+        assert len(history_lines) == 1
+        assert history_lines[0].endswith("echo hello")
+        assert all("printf 'backend" not in line for line in history_lines)
+    finally:
+        manager.stop()
+
+
+def test_history_expansion_does_not_leak_internal_metadata(tmp_path: Path):
+    histfile = tmp_path / "bash_history"
+    manager = PTYManager(use_output_thread=False, env={"HISTFILE": str(histfile)})
+
+    try:
+        manager.start()
+        manager.send_command("echo hello", command_seq=7, source="user")
+        _wait_for_prompt_ready(manager, 7)
+        _drain_master_fd(manager)
+
+        manager.send_command("!!", command_seq=8, source="user")
+        output = _wait_for_prompt_ready(manager, 8)
+        output += _drain_master_fd(manager)
+
+        rendered = output.decode("utf-8", errors="ignore")
+        assert "__AISH_ACTIVE_COMMAND_SEQ" not in rendered
+        assert "__AISH_ACTIVE_COMMAND_TEXT" not in rendered
+
+        history_output, exit_code = manager.execute_command("history | tail -n 5")
+        history_lines = [
+            line for line in history_output.splitlines() if line.lstrip()[:1].isdigit()
+        ]
+
+        assert exit_code == 0
+        assert any(line.endswith("echo hello") for line in history_lines)
+        assert any(line.endswith("!!") for line in history_lines)
+    finally:
+        manager.stop()
+
+
+def test_pty_manager_execute_command_with_shell_metacharacters_has_no_metadata_leak():
+    manager = PTYManager(use_output_thread=False)
+
+    try:
+        manager.start()
+        output, exit_code = manager.execute_command("printf '%s\\n' 'a|b & c'")
+
+        assert exit_code == 0
+        assert output == "a|b & c"
+        assert "__AISH_ACTIVE_COMMAND_SEQ" not in output
+        assert "__AISH_ACTIVE_COMMAND_TEXT" not in output
+    finally:
+        manager.stop()
+
+
+def test_pty_manager_execute_multiline_command_has_no_metadata_leak():
+    manager = PTYManager(use_output_thread=False)
+
+    try:
+        manager.start()
+        output, exit_code = manager.execute_command("printf 'hello\\n' && \\\nprintf 'world\\n'")
+
+        assert exit_code == 0
+        assert output == "hello\nworld"
+        assert "__AISH_ACTIVE_COMMAND_SEQ" not in output
+        assert "__AISH_ACTIVE_COMMAND_TEXT" not in output
+    finally:
+        manager.stop()
+
+
+def test_pty_manager_emits_shell_exiting_event_for_exit_command():
+    manager = PTYManager(use_output_thread=False)
+
+    try:
+        manager.start()
+        manager.send_command("exit", command_seq=9, source="user")
+
+        saw_started = False
+        saw_exiting = False
+        exit_code = None
         deadline = time.monotonic() + 5.0
-        while time.monotonic() < deadline:
+
+        while time.monotonic() < deadline and not saw_exiting:
             ready, _, _ = select.select([manager.control_fd, manager._master_fd], [], [], 0.1)
-            saw_prompt = False
             for fd in ready:
                 data = os.read(fd, 4096)
                 if not data:
@@ -110,26 +261,14 @@ def test_bash_history_hides_internal_command_seq_prefix_for_user_commands(tmp_pa
                     events, errors = manager.decode_control_events(data)
                     assert errors == []
                     for event in events:
-                        manager.handle_backend_event(event)
-                        if event.type == "prompt_ready":
-                            saw_prompt = True
-            if saw_prompt:
-                break
+                        if event.type == "command_started":
+                            saw_started = event.payload.get("command_seq") == 9
+                        if event.type == "shell_exiting":
+                            saw_exiting = True
+                            exit_code = event.payload.get("exit_code")
 
-        while True:
-            ready, _, _ = select.select([manager._master_fd], [], [], 0)
-            if not ready:
-                break
-            os.read(manager._master_fd, 4096)
-
-        output, exit_code = manager.execute_command("history | tail -n 5")
-        history_lines = [
-            line for line in output.splitlines() if line.lstrip()[:1].isdigit()
-        ]
-
+        assert saw_started is True
+        assert saw_exiting is True
         assert exit_code == 0
-        assert history_lines == ["    1  echo hello"]
-        assert all("__AISH_ACTIVE_COMMAND_SEQ" not in line for line in history_lines)
-        assert all("history | tail -n 5" not in line for line in history_lines)
     finally:
         manager.stop()

--- a/tests/terminal/pty/test_pty_control_protocol.py
+++ b/tests/terminal/pty/test_pty_control_protocol.py
@@ -190,6 +190,27 @@ def test_start_drains_startup_prompt_ready_in_poll_mode():
         manager.stop()
 
 
+def test_start_preserves_startup_master_output_in_poll_mode(tmp_path: Path):
+    bashrc = tmp_path / ".bashrc"
+    bashrc.write_text("printf 'startup-marker\\n'\n", encoding="utf-8")
+    manager = PTYManager(use_output_thread=False, env={"HOME": str(tmp_path)})
+
+    try:
+        manager.start()
+
+        output = bytearray()
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline and b"startup-marker" not in output:
+            ready, _, _ = select.select([manager._master_fd], [], [], 0.1)
+            if not ready:
+                continue
+            output.extend(os.read(manager._master_fd, 4096))
+
+        assert b"startup-marker" in output
+    finally:
+        manager.stop()
+
+
 def test_pty_manager_execute_command_returns_output_without_marker():
     manager = PTYManager(use_output_thread=False)
 

--- a/tests/terminal/pty/test_pty_control_protocol.py
+++ b/tests/terminal/pty/test_pty_control_protocol.py
@@ -188,6 +188,7 @@ def test_start_drains_startup_prompt_ready_in_poll_mode():
 
         manager.send_command("printf 'ready\\n'", command_seq=11, source="backend")
         output = _wait_for_prompt_ready(manager, 11)
+        output += _drain_master_fd(manager)
 
         assert b"ready" in output
         assert manager.last_command == "printf 'ready\\n'"

--- a/tests/terminal/pty/test_pty_control_protocol.py
+++ b/tests/terminal/pty/test_pty_control_protocol.py
@@ -13,10 +13,10 @@ from aish.terminal.pty.manager import PTYManager
 def _wait_for_prompt_ready(manager: PTYManager, command_seq: int, timeout: float = 5.0) -> bytes:
     output = bytearray()
     deadline = time.monotonic() + timeout
+    saw_prompt = False
 
     while time.monotonic() < deadline:
         ready, _, _ = select.select([manager.control_fd, manager._master_fd], [], [], 0.1)
-        saw_prompt = False
         for fd in ready:
             data = os.read(fd, 4096)
             if not data:
@@ -32,6 +32,12 @@ def _wait_for_prompt_ready(manager: PTYManager, command_seq: int, timeout: float
                 output.extend(data)
         if saw_prompt:
             break
+
+    if not saw_prompt:
+        rendered = output.decode("utf-8", errors="replace")
+        raise TimeoutError(
+            f"timed out waiting for prompt_ready with command_seq={command_seq}: {rendered!r}"
+        )
 
     return bytes(output)
 
@@ -226,12 +232,27 @@ def test_pty_manager_execute_command_returns_output_without_marker():
 
 
 def test_clean_pty_output_strips_echo_after_leading_blank_line():
-    cleaned = PTYManager._clean_pty_output(
+    manager = PTYManager(use_output_thread=False)
+
+    cleaned = manager._clean_pty_output(
         b"\r\n printf 'hello\\n'\r\nhello\r\n",
         "printf 'hello\\n'",
     )
 
     assert cleaned == "hello"
+
+
+def test_execute_multiline_command_uses_reported_continuation_prompt():
+    manager = PTYManager(use_output_thread=False, env={"PS2": "cont> "})
+
+    try:
+        manager.start()
+        output, exit_code = manager.execute_command("printf 'hello\\n' && \\\nprintf 'world\\n'")
+
+        assert exit_code == 0
+        assert output == "hello\nworld"
+    finally:
+        manager.stop()
 
 
 def test_pty_manager_execute_command_waits_without_implicit_timeout():

--- a/tests/test_exit_tracker_repeat_error.py
+++ b/tests/test_exit_tracker_repeat_error.py
@@ -6,8 +6,15 @@ from aish.terminal.pty.command_state import CommandState
 from aish.terminal.pty.control_protocol import BackendControlEvent
 
 
-def _command_started(command: str, command_seq: int | None = None) -> BackendControlEvent:
+def _command_started(
+    command: str,
+    command_seq: int | None = None,
+    *,
+    submission_id: str | None = None,
+) -> BackendControlEvent:
     payload = {"command": command}
+    if submission_id is not None:
+        payload["submission_id"] = submission_id
     if command_seq is not None:
         payload["command_seq"] = command_seq
     return BackendControlEvent(version=1, type="command_started", ts=1, payload=payload)
@@ -18,8 +25,11 @@ def _prompt_ready(
     command_seq: int | None = None,
     *,
     interrupted: bool = False,
+    submission_id: str | None = None,
 ) -> BackendControlEvent:
     payload = {"exit_code": exit_code, "interrupted": interrupted}
+    if submission_id is not None:
+        payload["submission_id"] = submission_id
     if command_seq is not None:
         payload["command_seq"] = command_seq
     return BackendControlEvent(version=1, type="prompt_ready", ts=2, payload=payload)

--- a/tests/tools/test_bash_output_offload.py
+++ b/tests/tools/test_bash_output_offload.py
@@ -8,6 +8,7 @@ import pytest
 from aish.config import BashOutputOffloadSettings
 from aish.security.security_manager import SecurityDecision
 from aish.security.security_policy import RiskLevel
+from aish.terminal.pty.manager import PTYManager
 from aish.tools.code_exec import BashTool
 
 
@@ -99,6 +100,56 @@ async def test_bash_exec_offloads_large_output(tmp_path: Path):
     assert meta_path.exists()
     assert stdout_path.read_text(encoding="utf-8") == "1234567890abcdef"
     assert stderr_path.read_text(encoding="utf-8") == "err"
+
+
+@pytest.mark.asyncio
+async def test_bash_exec_uses_shared_pty_without_metadata_leak(tmp_path: Path):
+    manager = PTYManager(use_output_thread=False, env={"HISTFILE": str(tmp_path / "bash_history")})
+    tool = BashTool(
+        pty_manager=manager,
+        offload_settings=BashOutputOffloadSettings(
+            enabled=True,
+            threshold_bytes=1024,
+            preview_bytes=1024,
+        ),
+    )
+
+    manager.start()
+    try:
+        with patch.object(tool.security_manager, "decide", return_value=_allow_decision()):
+            result = await tool("printf 'hello\\n'")
+
+        assert result.ok is True
+        assert _extract_tag(result.output, "stdout") == "hello"
+        assert "__AISH_ACTIVE_COMMAND_SEQ" not in result.output
+        assert "__AISH_ACTIVE_COMMAND_TEXT" not in result.output
+    finally:
+        manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_bash_exec_uses_shared_pty_for_multiline_command_without_echo(tmp_path: Path):
+    manager = PTYManager(use_output_thread=False, env={"HISTFILE": str(tmp_path / "bash_history")})
+    tool = BashTool(
+        pty_manager=manager,
+        offload_settings=BashOutputOffloadSettings(
+            enabled=True,
+            threshold_bytes=1024,
+            preview_bytes=1024,
+        ),
+    )
+
+    manager.start()
+    try:
+        with patch.object(tool.security_manager, "decide", return_value=_allow_decision()):
+            result = await tool("printf 'hello\\n' && \\\nprintf 'world\\n'")
+
+        assert result.ok is True
+        assert _extract_tag(result.output, "stdout") == "hello\nworld"
+        assert "__AISH_ACTIVE_COMMAND_SEQ" not in result.output
+        assert "__AISH_ACTIVE_COMMAND_TEXT" not in result.output
+    finally:
+        manager.stop()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
This PR fixes PTY command metadata leakage by removing internal command-tracking metadata from the shell input stream.

Instead of injecting internal command state directly into the command text sent to bash, command association now uses Python-side pending submission state plus a shell metadata side channel. The change also preserves user and backend history semantics, improves multiline output cleanup, and hardens interactive echo suppression.

## Why
Internal metadata should never depend on shell echo behavior to stay hidden.

The old approach assumed bash would echo the submitted command in a form close enough to the original injected text for cleanup to strip it reliably. That breaks in real shell scenarios such as history expansion, quoting changes, multiline commands, and other bash rewrites, which can expose internal AISH metadata in terminal output or `bash_exec` results.

## Testing
- Ran `/home/lixin/workspace/aishell/aish/.venv/bin/python -m pytest tests/terminal/pty/test_pty_control_protocol.py tests/shell/runtime/test_shell_pty_core.py tests/tools/test_bash_output_offload.py -q`
- Result: 79 passed

## Summary by Sourcery

Remove internal PTY command-tracking metadata from the shell input stream and shift command association to a sidechannel and pending-submission state while tightening echo filtering and lifecycle tracking.

New Features:
- Expose PTY command submission metadata and pending submissions via CommandState and PTYManager for higher-level consumers.

Bug Fixes:
- Prevent internal AISH PTY command-tracking metadata from leaking into user-visible bash output, history, and tool execution results.
- Ensure user command echo suppression works across split and interleaved PTY output chunks without stripping unrelated text.
- Avoid mutating backend events that arrive without command_seq while still resolving them against pending submissions.
- Ensure bash exit commands emit a dedicated shell_exiting backend event with the correct exit code.

Enhancements:
- Route PTY command metadata through a dedicated temporary file and bash rc wrapper sidechannel instead of inline environment-variable prefixes on user commands.
- Refine PTY output cleaning to strip echoed commands more robustly, including multiline and prompt-prefixed echoes, while preserving legitimate output.
- Improve thread safety and ordering guarantees in PTYManager when writing command metadata and sending commands.
- Harden output processing by stripping ANSI control sequences when matching echoes and resetting echo suppression state on prompt_ready.
- Extend PTY command state tracking with observed-command capture, better command_seq resolution, and richer pending submission queries.
- Adjust backend commands to be prefixed only with a leading space so they do not end up in bash history while preserving user history semantics.

Tests:
- Add extensive PTY, shell, and tool tests covering echo suppression edge cases, bash history behavior for user vs. backend commands, history expansion, metadata leakage prevention, multiline commands, and shell exit signaling.
- Expand exit tracker tests to validate pending submission lifecycle, command_seq resolution from events, and separation of submitted vs. observed command text.
- Add Bash tool tests ensuring shared-PTY execution does not leak internal command metadata for single-line and multiline commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Propagates command metadata (submission IDs/metadata) to improve command/result correlation and lifecycle visibility.

* **Bug Fixes**
  * More reliable user-command echo suppression that handles chunked output and strips ANSI sequences.
  * Prevented internal metadata from appearing in command output or shell history; pending echoes cleared on prompt completion.

* **Improvements**
  * Enhanced command lifecycle tracking, protocol diagnostics, PTY readiness, and serialized metadata writes for concurrent submissions.

* **Tests**
  * Expanded coverage for echo handling, protocol issues, lifecycle resolution, history hygiene, and concurrent submission ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->