### PR TITLE
fix: preserve final AI output after tool execution

### DIFF
--- a/src/aish/llm/agents.py
+++ b/src/aish/llm/agents.py
@@ -95,6 +95,10 @@ class SystemDiagnoseAgent(ToolBase):
     def get_session_output(self, result) -> str | None:
         return result.render_for_llm()
 
+    def should_stop_after_session_output(self, result) -> bool:
+        _ = result
+        return True
+
     def _create_react_system_prompt(self) -> str:
         """Generate a ReAct-style system prompt for diagnostics."""
         base_prompt = self.prompt_manager.substitute_template(

--- a/src/aish/llm/session.py
+++ b/src/aish/llm/session.py
@@ -1515,11 +1515,15 @@ class LLMSession:
                 for ctx_msg in tool_result.context_messages:
                     context_manager.add_memory(MemoryType.LLM, ctx_msg)
 
-                session_output = self.tools[tool_name].get_session_output(tool_result)
+                tool = self.tools[tool_name]
+                session_output = tool.get_session_output(tool_result)
                 if session_output is not None:
                     output = session_output
 
-                if tool_result.stop_tool_chain:
+                should_stop_after_output = tool.should_stop_after_session_output(
+                    tool_result
+                )
+                if tool_result.stop_tool_chain or should_stop_after_output:
                     tool_call_cancelled = True
                     if session_output is None:
                         output = tool_result.output
@@ -1825,6 +1829,12 @@ class LLMSession:
                             )
                         elif not has_tool_calls:
                             output += content
+                            if generation_type == "tool_call":
+                                events.emit_content_delta(
+                                    delta=content,
+                                    accumulated=content,
+                                    is_final=True,
+                                )
                     else:
                         if has_tool_calls:
                             events.emit_content_delta(

--- a/src/aish/shell/runtime/ai.py
+++ b/src/aish/shell/runtime/ai.py
@@ -430,7 +430,7 @@ Please analyze the error and suggest a fix. Check the shell history context abov
                 return
 
             if response:
-                if shell.content_was_streamed:
+                if self._response_already_rendered(shell, response):
                     corrected_cmd = response.strip() if response else None
                 else:
                     corrected_cmd = self._display_ai_response(response)
@@ -487,9 +487,7 @@ Please analyze the error and suggest a fix. Check the shell history context abov
                 return
 
             if response:
-                # Skip the Rich Panel display when content was already
-                # streamed to the terminal via handle_content_delta.
-                if not shell.content_was_streamed:
+                if not self._response_already_rendered(shell, response):
                     self._display_ai_response(response)
                 self._auto_retain_memory(question, response)
 
@@ -504,6 +502,16 @@ Please analyze the error and suggest a fix. Check the shell history context abov
 
         self.console = Console(force_terminal=True)
         return self.console
+
+    @staticmethod
+    def _response_already_rendered(shell, response: str) -> bool:
+        if not getattr(shell, "content_was_streamed", False):
+            return False
+
+        streamed = str(getattr(shell, "last_final_streamed_content", "") or "").strip()
+        if not streamed:
+            return False
+        return streamed == str(response or "").strip()
 
     def _display_ai_response(self, response: str) -> Optional[str]:
         """Display AI response, handling JSON command format."""

--- a/src/aish/shell/runtime/app.py
+++ b/src/aish/shell/runtime/app.py
@@ -199,6 +199,7 @@ class PTYAIShell:
         self._reasoning_max_lines: int = 2
         self._last_reasoning_render_lines: list[str] = []
         self._last_streaming_accumulated: str = ""
+        self._last_final_streamed_content: str = ""
         self.current_live: Optional[Any] = None
         self._content_preview_active: bool = False
         self._content_streamed_to_terminal: bool = False
@@ -362,6 +363,7 @@ class PTYAIShell:
         self._ttft_recorded = False
         self._ttft = 0.0
         self._content_streamed_to_terminal = False
+        self._last_final_streamed_content = ""
         return None
 
     def handle_op_end(self, event) -> None:
@@ -603,9 +605,15 @@ class PTYAIShell:
         if not content:
             return None
 
+        is_final = bool(event.data.get("is_final"))
+        if is_final:
+            self._content_streamed_to_terminal = True
+            self._last_final_streamed_content = str(
+                event.data.get("accumulated") or event.data.get("delta") or ""
+            )
+
         if not self._content_preview_active:
             self._content_preview_active = True
-            self._content_streamed_to_terminal = True
             content = f"🤖 {content}"
 
         self.console.print(Text(content, style="bold grey50"), end="")
@@ -851,8 +859,13 @@ class PTYAIShell:
 
     @property
     def content_was_streamed(self) -> bool:
-        """Whether content was streamed to the terminal during this operation."""
+        """Whether the final assistant response was already rendered inline."""
         return self._content_streamed_to_terminal
+
+    @property
+    def last_final_streamed_content(self) -> str:
+        """Return the last final response content rendered inline for this turn."""
+        return self._last_final_streamed_content
 
     def _finalize_content_preview(self) -> None:
         if not self._content_preview_active:

--- a/src/aish/tools/base.py
+++ b/src/aish/tools/base.py
@@ -113,6 +113,11 @@ class ToolBase(BaseModel):
         """Optionally expose a tool result as the session's fallback output."""
         return None
 
+    def should_stop_after_session_output(self, result: ToolResult) -> bool:
+        """Whether exposing session output should also end the current turn."""
+        _ = result
+        return False
+
     def _build_panel_from_legacy(
         self, tool_args: dict[str, Any], info: object
     ) -> ToolPanelSpec:

--- a/tests/llm/test_llm_events.py
+++ b/tests/llm/test_llm_events.py
@@ -196,6 +196,137 @@ async def test_process_input_tool_call_content_is_marked_non_final():
 
 
 @pytest.mark.anyio
+async def test_process_input_streaming_final_answer_after_tool_calls_emits_final_content():
+    config = ConfigModel(model="test-model", api_key="test-key")
+    session = LLMSession(config=config, skill_manager=SkillManager())
+
+    events = []
+
+    def event_callback(event):
+        events.append(event)
+        return LLMCallbackResult.CONTINUE
+
+    session.event_callback = event_callback
+
+    async def first_stream():
+        yield {
+            "choices": [
+                {
+                    "delta": {
+                        "content": "I will inspect the workspace.",
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "read_file",
+                                    "arguments": '{"file_path":"README.md"}',
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ]
+        }
+
+    async def second_stream():
+        yield {
+            "choices": [
+                {
+                    "delta": {"content": "Inspection complete."},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+
+    responses = [first_stream(), second_stream()]
+
+    async def fake_create_completion_response(**kwargs):
+        _ = kwargs
+        return responses.pop(0)
+
+    def fake_stream_chunk_builder(*, chunks, messages):
+        _ = messages
+        first_delta = chunks[0]["choices"][0]["delta"]
+        tool_calls = first_delta.get("tool_calls")
+        if tool_calls:
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "I will inspect the workspace.",
+                            "tool_calls": [
+                                {
+                                    "id": "call_1",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "read_file",
+                                        "arguments": '{"file_path":"README.md"}',
+                                    },
+                                }
+                            ],
+                        }
+                    }
+                ]
+            }
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "Inspection complete.",
+                    }
+                }
+            ]
+        }
+
+    context_manager = ContextManager()
+
+    with (
+        patch.object(
+            session,
+            "_ensure_initialized_with_retry",
+            new=AsyncMock(return_value=None),
+        ),
+        patch.object(
+            session,
+            "_create_completion_response",
+            side_effect=fake_create_completion_response,
+        ),
+        patch.object(session, "_trim_messages", side_effect=lambda msgs: msgs),
+        patch.object(session, "_get_tools_spec", return_value=[]),
+        patch.object(session, "_get_litellm", return_value=object()),
+        patch.object(
+            session,
+            "_get_stream_chunk_builder",
+            return_value=fake_stream_chunk_builder,
+        ),
+        patch.object(
+            session, "_handle_tool_calls", new_callable=AsyncMock
+        ) as mock_tool,
+    ):
+        mock_tool.return_value = (False, "", [])
+        result = await session.process_input(
+            prompt="hi",
+            context_manager=context_manager,
+            system_message="sys",
+            stream=True,
+        )
+
+    assert result == "Inspection complete."
+
+    content_events = [e for e in events if e.event_type == LLMEventType.CONTENT_DELTA]
+    assert len(content_events) == 2
+    assert content_events[0].data.get("delta") == "I will inspect the workspace."
+    assert content_events[0].data.get("is_final") is False
+    assert content_events[1].data.get("delta") == "Inspection complete."
+    assert content_events[1].data.get("is_final") is True
+
+
+@pytest.mark.anyio
 async def test_process_input_litellm_error_uses_raw_message():
     config = ConfigModel(model="test-model", api_key="test-key")
     session = LLMSession(config=config, skill_manager=SkillManager())

--- a/tests/shell/runtime/test_shell_pty_core.py
+++ b/tests/shell/runtime/test_shell_pty_core.py
@@ -102,6 +102,7 @@ def _make_ai_handler() -> tuple[AIHandler, Mock]:
     shell.submit_backend_command = Mock()
     shell.submit_ai_backend_command = Mock(return_value=True)
     shell.content_was_streamed = False
+    shell.last_final_streamed_content = ""
     shell.operation_in_progress = False
     handler.shell = shell
     return handler, shell
@@ -155,6 +156,44 @@ def test_ai_handler_executes_corrected_command_via_security_submission():
     assert result is True
     shell.submit_ai_backend_command.assert_called_once_with("rm -rf /tmp/demo")
     shell.submit_backend_command.assert_not_called()
+
+
+def test_ai_handler_renders_response_when_streamed_content_mismatches_final_response():
+    handler, shell = _make_ai_handler()
+
+    def _complete_operation(coro, shell, history_entry=None):
+        _ = (shell, history_entry)
+        coro.close()
+        return ("final-response", False)
+
+    handler._execute_ai_operation = Mock(side_effect=_complete_operation)
+    handler._display_ai_response = Mock()
+    handler._auto_retain_memory = Mock()
+    shell.content_was_streamed = True
+    shell.last_final_streamed_content = "preview-only"
+
+    handler.handle_question("hello")
+
+    handler._display_ai_response.assert_called_once_with("final-response")
+
+
+def test_ai_handler_skips_duplicate_render_when_streamed_content_matches_final_response():
+    handler, shell = _make_ai_handler()
+
+    def _complete_operation(coro, shell, history_entry=None):
+        _ = (shell, history_entry)
+        coro.close()
+        return ("final-response", False)
+
+    handler._execute_ai_operation = Mock(side_effect=_complete_operation)
+    handler._display_ai_response = Mock()
+    handler._auto_retain_memory = Mock()
+    shell.content_was_streamed = True
+    shell.last_final_streamed_content = "final-response"
+
+    handler.handle_question("hello")
+
+    handler._display_ai_response.assert_not_called()
 
 
 def test_ai_handler_marks_cancelled_operation_and_notifies_shell():
@@ -1175,6 +1214,35 @@ def test_ttft_timing_preserves_state_across_generations(monkeypatch):
     assert shell._thinking_start_time == start_time
     assert shell._ttft == first_ttft
     assert shell._ttft_recorded is True
+
+
+def test_non_final_content_preview_does_not_mark_response_as_streamed():
+    shell = object.__new__(PTYAIShell)
+    shell.console = Mock()
+    shell._stop_animation = Mock()
+    shell._reset_reasoning_state = Mock()
+    shell.current_live = None
+    shell._thinking_start_time = 0.0
+    shell._ttft = 0.0
+    shell._ttft_recorded = False
+    shell._last_streaming_accumulated = ""
+    shell._content_preview_active = False
+    shell._content_streamed_to_terminal = False
+    shell._at_line_start = True
+
+    PTYAIShell.handle_content_delta(
+        shell,
+        Mock(data={"delta": "Preparing diagnosis", "is_final": False}),
+    )
+
+    assert shell.content_was_streamed is False
+
+    PTYAIShell.handle_content_delta(
+        shell,
+        Mock(data={"delta": "Final diagnosis summary", "is_final": True}),
+    )
+
+    assert shell.content_was_streamed is True
 
 
 def test_ttft_timing_summary_renders_at_op_end_not_generation_end():

--- a/tests/test_ask_user_tool.py
+++ b/tests/test_ask_user_tool.py
@@ -404,7 +404,7 @@ async def test_handle_tool_calls_system_diagnose_agent_sets_session_output():
             output="",
         )
 
-    assert tool_call_cancelled is False
+    assert tool_call_cancelled is True
     assert output == "diagnostic result"
 
 

--- a/tests/tools/test_ask_user_tool.py
+++ b/tests/tools/test_ask_user_tool.py
@@ -403,7 +403,7 @@ async def test_handle_tool_calls_system_diagnose_agent_sets_session_output():
             output="",
         )
 
-    assert tool_call_cancelled is False
+    assert tool_call_cancelled is True
     assert output == "diagnostic result"
 
 


### PR DESCRIPTION
## Summary
This PR fixes final-answer handoff after tool execution so tool-driven turns reliably surface their final natural-language response.

`LLMSession` now emits a final content event for post-tool generations, and tools can explicitly mark session output as the final answer for the current turn. On the shell side, final streamed content is tracked separately from preview content so fallback rendering only happens when it is actually needed.

## Why
Tool execution introduced ambiguity between preview content, streamed content, and the actual final answer.

In some cases that caused the shell to miss the final response. In others it could render a fallback panel even though the final answer had already been streamed. The turn lifecycle needs a clear distinction between non-final preview output and the real final assistant response.

## Testing
- Ran `/home/lixin/workspace/aishell/aish/.venv/bin/python -m pytest tests/llm/test_llm_events.py tests/test_ask_user_tool.py tests/tools/test_ask_user_tool.py tests/shell/runtime/test_shell_pty_core.py -k "tool_call_content_is_marked_non_final or streaming_final_answer_after_tool_calls_emits_final_content or system_diagnose_agent_sets_session_output or handle_tool_execution or ai_handler or non_final_content_preview_does_not_mark_response_as_streamed or ttft_timing" -q`
- Result: 22 passed, 76 deselected

## Summary by Sourcery

Ensure final assistant responses after tool execution are correctly surfaced and not duplicated between the LLM session and shell UI.

New Features:
- Allow tools to declare that their session output should end the current LLM turn and be used as the final answer.

Bug Fixes:
- Emit a final content event for post-tool streaming generations so the final answer is preserved after tool calls.
- Prevent the shell from treating non-final preview content as the final streamed response.
- Avoid re-rendering AI responses in the shell when the final streamed content already matches the returned response.
- Ensure diagnostic ask-user tool turns stop after providing their session output.

Enhancements:
- Track the last final streamed assistant content in the shell to differentiate between preview and final output when deciding what to render.

Tests:
- Add LLM session tests validating final content emission after tool-call streaming.
- Extend PTY shell tests to cover preview vs final streaming semantics and duplicate-render avoidance.
- Update ask-user tool tests to reflect that diagnostic tool output now ends the turn.