### PR TITLE
fix(diagnose): propagate sub-session events and handle final_answer tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/aish-cli/Cargo.toml
+++ b/crates/aish-cli/Cargo.toml
@@ -21,3 +21,4 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 dirs.workspace = true
 reqwest.workspace = true
+sha2.workspace = true

--- a/crates/aish-cli/src/uninstall.rs
+++ b/crates/aish-cli/src/uninstall.rs
@@ -79,8 +79,9 @@ fn detect_installation_method() -> InstallMethod {
 
     // 4. System package: dpkg or rpm
     if is_command_available("dpkg") {
-        if let Ok(output) =
-            std::process::Command::new("dpkg").args(["-s", "aish"]).output()
+        if let Ok(output) = std::process::Command::new("dpkg")
+            .args(["-s", "aish"])
+            .output()
         {
             if output.status.success() {
                 return InstallMethod::System;
@@ -89,8 +90,9 @@ fn detect_installation_method() -> InstallMethod {
     }
 
     if is_command_available("rpm") {
-        if let Ok(output) =
-            std::process::Command::new("rpm").args(["-q", "aish"]).output()
+        if let Ok(output) = std::process::Command::new("rpm")
+            .args(["-q", "aish"])
+            .output()
         {
             if output.status.success() {
                 return InstallMethod::System;
@@ -149,7 +151,11 @@ fn uninstall_archive(purge: bool) -> Result<(), AishError> {
         let binary = PathBuf::from(ARCHIVE_BIN_DIR).join(name);
         if binary.exists() {
             if let Err(e) = run_sudo(&["rm", "-f", binary.to_str().unwrap_or("")]) {
-                eprintln!("\x1b[31mFailed to remove {}: {}\x1b[0m", binary.display(), e);
+                eprintln!(
+                    "\x1b[31mFailed to remove {}: {}\x1b[0m",
+                    binary.display(),
+                    e
+                );
                 success = false;
             }
         }
@@ -158,7 +164,11 @@ fn uninstall_archive(purge: bool) -> Result<(), AishError> {
     let share_dir = PathBuf::from(ARCHIVE_SHARE_DIR);
     if share_dir.exists() {
         if let Err(e) = run_sudo(&["rm", "-rf", share_dir.to_str().unwrap_or("")]) {
-            eprintln!("\x1b[31mFailed to remove {}: {}\x1b[0m", share_dir.display(), e);
+            eprintln!(
+                "\x1b[31mFailed to remove {}: {}\x1b[0m",
+                share_dir.display(),
+                e
+            );
             success = false;
         }
     }
@@ -282,8 +292,7 @@ fn get_data_directories() -> Vec<(String, PathBuf)> {
 /// "aish", and requires at least 2 path components.
 fn is_safe_purge_path(path: &Path) -> bool {
     let critical_prefixes: &[&str] = &[
-        "/etc", "/usr", "/boot", "/dev", "/proc", "/sys", "/lib", "/lib64",
-        "/bin", "/sbin", "/opt",
+        "/etc", "/usr", "/boot", "/dev", "/proc", "/sys", "/lib", "/lib64", "/bin", "/sbin", "/opt",
     ];
 
     let lexical = match path.strip_prefix("~") {
@@ -303,7 +312,7 @@ fn is_safe_purge_path(path: &Path) -> bool {
     }
 
     // Must not be root or a system-critical directory
-    if lexical == PathBuf::from("/") {
+    if lexical == std::path::Path::new("/") {
         return false;
     }
     for prefix in critical_prefixes {
@@ -314,9 +323,10 @@ fn is_safe_purge_path(path: &Path) -> bool {
     }
 
     // At least 2 path components
-    let parts: Vec<_> = lexical.components().filter(|c| {
-        matches!(c, std::path::Component::Normal(_))
-    }).collect();
+    let parts: Vec<_> = lexical
+        .components()
+        .filter(|c| matches!(c, std::path::Component::Normal(_)))
+        .collect();
     parts.len() >= 2
 }
 
@@ -330,7 +340,10 @@ fn purge_data() -> Result<(), AishError> {
             continue;
         }
         if !is_safe_purge_path(path) {
-            eprintln!("\x1b[31mRefusing to delete {}: unsafe path\x1b[0m", path.display());
+            eprintln!(
+                "\x1b[31mRefusing to delete {}: unsafe path\x1b[0m",
+                path.display()
+            );
             success = false;
             continue;
         }
@@ -346,7 +359,9 @@ fn purge_data() -> Result<(), AishError> {
     if success {
         Ok(())
     } else {
-        Err(AishError::Config("Some directories could not be removed".into()))
+        Err(AishError::Config(
+            "Some directories could not be removed".into(),
+        ))
     }
 }
 
@@ -469,7 +484,9 @@ mod tests {
 
     #[test]
     fn test_is_safe_purge_path_rejects_wrong_name() {
-        assert!(!is_safe_purge_path(&PathBuf::from("/home/user/.config/other")));
+        assert!(!is_safe_purge_path(&PathBuf::from(
+            "/home/user/.config/other"
+        )));
     }
 
     #[test]

--- a/crates/aish-cli/src/uninstall.rs
+++ b/crates/aish-cli/src/uninstall.rs
@@ -1,54 +1,358 @@
-//! Uninstall aish binary and optionally purge data.
+//! Uninstall aish binary, supporting multiple installation methods.
+//!
+//! Detects how aish was installed (archive, cargo, pip, system package)
+//! and runs the appropriate uninstall procedure. With `--purge`, also
+//! removes user config/data/cache and system-level config files.
 
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use aish_core::AishError;
 
-pub fn detect_installation_method() -> String {
-    let exe = std::env::current_exe().unwrap_or_default();
-    let exe_str = exe.to_string_lossy();
+// Paths used by the archive/script installer (install.sh)
+const ARCHIVE_BIN_DIR: &str = "/usr/local/bin";
+const ARCHIVE_BINARY_NAMES: &[&str] = &["aish", "aish-sandbox", "aish-uninstall"];
+const ARCHIVE_SHARE_DIR: &str = "/usr/local/share/aish";
+const SYSTEM_CONFIG_DIR: &str = "/etc/aish";
 
-    if exe_str.contains("/.local/bin/") || exe_str.contains("/usr/local/bin/") {
-        "archive".to_string()
-    } else if exe_str.contains("/.cargo/bin/") {
-        "cargo".to_string()
-    } else {
-        "unknown".to_string()
-    }
+// ---------------------------------------------------------------------------
+// Installation method detection
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InstallMethod {
+    Archive,
+    Cargo,
+    Pip,
+    System,
+    Unknown,
 }
 
-pub fn get_purge_paths() -> Vec<PathBuf> {
-    let mut paths = Vec::new();
-    if let Some(config_dir) = dirs::config_dir() {
-        paths.push(config_dir.join("aish"));
-    }
-    if let Some(data_dir) = dirs::data_dir() {
-        paths.push(data_dir.join("aish"));
-    }
-    paths
-}
-
-fn remove_binary() -> Result<(), AishError> {
-    let exe = std::env::current_exe()
-        .map_err(|e| AishError::Config(format!("Cannot determine binary path: {e}")))?;
-    if exe.exists() {
-        std::fs::remove_file(&exe)
-            .map_err(|e| AishError::Config(format!("Failed to remove binary: {e}")))?;
-    }
-    Ok(())
-}
-
-fn purge_data() -> Result<(), AishError> {
-    for path in get_purge_paths() {
-        if path.exists() {
-            std::fs::remove_dir_all(&path).map_err(|e| {
-                AishError::Config(format!("Failed to remove {}: {e}", path.display()))
-            })?;
+impl std::fmt::Display for InstallMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Archive => write!(f, "archive"),
+            Self::Cargo => write!(f, "cargo"),
+            Self::Pip => write!(f, "pip"),
+            Self::System => write!(f, "system"),
+            Self::Unknown => write!(f, "unknown"),
         }
     }
+}
+
+/// Check if a file starts with the ELF magic bytes.
+fn is_elf_binary(path: &Path) -> bool {
+    match std::fs::read(path) {
+        Ok(bytes) => bytes.len() >= 4 && bytes[..4] == [0x7f, b'E', b'L', b'F'],
+        Err(_) => false,
+    }
+}
+
+/// Detect how aish was installed.
+fn detect_installation_method() -> InstallMethod {
+    // 1. Archive install: ELF binary in /usr/local/bin/aish
+    let archive_bin = PathBuf::from(ARCHIVE_BIN_DIR).join("aish");
+    if archive_bin.exists() && is_elf_binary(&archive_bin) {
+        return InstallMethod::Archive;
+    }
+
+    // 2. Cargo install: binary under ~/.cargo/bin/
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(path_str) = exe.to_str() {
+            if path_str.contains("/.cargo/bin/") {
+                return InstallMethod::Cargo;
+            }
+        }
+    }
+
+    // 3. Pip install: check `pip show aish`
+    if is_command_available("pip") {
+        if let Ok(output) = std::process::Command::new("pip")
+            .args(["show", "aish"])
+            .output()
+        {
+            if output.status.success() {
+                return InstallMethod::Pip;
+            }
+        }
+    }
+
+    // 4. System package: dpkg or rpm
+    if is_command_available("dpkg") {
+        if let Ok(output) =
+            std::process::Command::new("dpkg").args(["-s", "aish"]).output()
+        {
+            if output.status.success() {
+                return InstallMethod::System;
+            }
+        }
+    }
+
+    if is_command_available("rpm") {
+        if let Ok(output) =
+            std::process::Command::new("rpm").args(["-q", "aish"]).output()
+        {
+            if output.status.success() {
+                return InstallMethod::System;
+            }
+        }
+    }
+
+    InstallMethod::Unknown
+}
+
+fn is_command_available(cmd: &str) -> bool {
+    which_exists(cmd)
+}
+
+fn which_exists(cmd: &str) -> bool {
+    std::process::Command::new("which")
+        .arg(cmd)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+// ---------------------------------------------------------------------------
+// Uninstall by method
+// ---------------------------------------------------------------------------
+
+fn run_sudo(args: &[&str]) -> Result<(), AishError> {
+    let output = std::process::Command::new("sudo")
+        .args(args)
+        .output()
+        .map_err(|e| AishError::Config(format!("Failed to run sudo: {e}")))?;
+    if !output.status.success() {
+        return Err(AishError::Config(format!(
+            "Command failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
     Ok(())
 }
+
+fn uninstall_archive(purge: bool) -> Result<(), AishError> {
+    // Prefer bundled uninstall script
+    let uninstall_script = PathBuf::from(ARCHIVE_BIN_DIR).join("aish-uninstall");
+    if uninstall_script.exists() {
+        let mut args = vec![uninstall_script.to_str().unwrap_or("")];
+        if purge {
+            args.push("--purge-config");
+        }
+        return run_sudo(&args);
+    }
+
+    // Fallback: remove files manually
+    let mut success = true;
+
+    for name in ARCHIVE_BINARY_NAMES {
+        let binary = PathBuf::from(ARCHIVE_BIN_DIR).join(name);
+        if binary.exists() {
+            if let Err(e) = run_sudo(&["rm", "-f", binary.to_str().unwrap_or("")]) {
+                eprintln!("\x1b[31mFailed to remove {}: {}\x1b[0m", binary.display(), e);
+                success = false;
+            }
+        }
+    }
+
+    let share_dir = PathBuf::from(ARCHIVE_SHARE_DIR);
+    if share_dir.exists() {
+        if let Err(e) = run_sudo(&["rm", "-rf", share_dir.to_str().unwrap_or("")]) {
+            eprintln!("\x1b[31mFailed to remove {}: {}\x1b[0m", share_dir.display(), e);
+            success = false;
+        }
+    }
+
+    if purge {
+        purge_system_config();
+    }
+
+    if success {
+        Ok(())
+    } else {
+        Err(AishError::Config("Some files could not be removed".into()))
+    }
+}
+
+fn uninstall_cargo() -> Result<(), AishError> {
+    let output = std::process::Command::new("cargo")
+        .args(["uninstall", "aish"])
+        .output()
+        .map_err(|e| AishError::Config(format!("Failed to run cargo: {e}")))?;
+    if !output.status.success() {
+        return Err(AishError::Config(format!(
+            "cargo uninstall failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+fn uninstall_pip() -> Result<(), AishError> {
+    let output = std::process::Command::new("pip")
+        .args(["uninstall", "-y", "aish"])
+        .output()
+        .map_err(|e| AishError::Config(format!("Failed to run pip: {e}")))?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    // Retry with --break-system-packages for externally-managed environments
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.contains("externally-managed-environment") {
+        let retry = std::process::Command::new("pip")
+            .args(["uninstall", "-y", "--break-system-packages", "aish"])
+            .output()
+            .map_err(|e| AishError::Config(format!("Failed to run pip: {e}")))?;
+        if retry.status.success() {
+            return Ok(());
+        }
+        return Err(AishError::Config(format!(
+            "pip uninstall failed: {}",
+            String::from_utf8_lossy(&retry.stderr).trim()
+        )));
+    }
+
+    Err(AishError::Config(format!(
+        "pip uninstall failed: {}",
+        stderr.trim()
+    )))
+}
+
+fn uninstall_system(purge: bool) -> Result<(), AishError> {
+    if which_exists("dpkg") {
+        let output = std::process::Command::new("sudo")
+            .args(["apt-get", "remove", "-y", "aish"])
+            .output()
+            .map_err(|e| AishError::Config(format!("Failed to run apt-get: {e}")))?;
+        if output.status.success() {
+            if purge {
+                purge_system_config();
+            }
+            return Ok(());
+        }
+    }
+
+    if which_exists("dnf") {
+        let output = std::process::Command::new("sudo")
+            .args(["dnf", "remove", "-y", "aish"])
+            .output()
+            .map_err(|e| AishError::Config(format!("Failed to run dnf: {e}")))?;
+        if output.status.success() {
+            if purge {
+                purge_system_config();
+            }
+            return Ok(());
+        }
+    }
+
+    Err(AishError::Config(
+        "Could not uninstall via system package manager".into(),
+    ))
+}
+
+fn purge_system_config() {
+    let etc_aish = Path::new(SYSTEM_CONFIG_DIR);
+    if etc_aish.exists() {
+        let _ = run_sudo(&["rm", "-rf", etc_aish.to_str().unwrap_or("")]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// User data directories (XDG)
+// ---------------------------------------------------------------------------
+
+fn get_data_directories() -> Vec<(String, PathBuf)> {
+    let mut dirs = Vec::new();
+    if let Some(d) = dirs::config_dir() {
+        dirs.push(("config".into(), d.join("aish")));
+    }
+    if let Some(d) = dirs::data_dir() {
+        dirs.push(("data".into(), d.join("aish")));
+    }
+    if let Some(d) = dirs::cache_dir() {
+        dirs.push(("cache".into(), d.join("aish")));
+    }
+    dirs
+}
+
+/// Validate a path is safe to recursively delete.
+///
+/// Rejects system-critical directories, requires the leaf to be named
+/// "aish", and requires at least 2 path components.
+fn is_safe_purge_path(path: &Path) -> bool {
+    let critical_prefixes: &[&str] = &[
+        "/etc", "/usr", "/boot", "/dev", "/proc", "/sys", "/lib", "/lib64",
+        "/bin", "/sbin", "/opt",
+    ];
+
+    let lexical = match path.strip_prefix("~") {
+        Ok(rest) => dirs::home_dir()
+            .map(|h| h.join(rest))
+            .unwrap_or_else(|| path.to_path_buf()),
+        Err(_) => path.to_path_buf(),
+    };
+
+    if !lexical.is_absolute() {
+        return false;
+    }
+
+    // Must end in "aish"
+    if lexical.file_name().map(|n| n != "aish").unwrap_or(true) {
+        return false;
+    }
+
+    // Must not be root or a system-critical directory
+    if lexical == PathBuf::from("/") {
+        return false;
+    }
+    for prefix in critical_prefixes {
+        let prefix_path = Path::new(prefix);
+        if lexical == *prefix_path || lexical.starts_with(prefix_path) {
+            return false;
+        }
+    }
+
+    // At least 2 path components
+    let parts: Vec<_> = lexical.components().filter(|c| {
+        matches!(c, std::path::Component::Normal(_))
+    }).collect();
+    parts.len() >= 2
+}
+
+/// Remove all user config/data/cache directories.
+fn purge_data() -> Result<(), AishError> {
+    let dirs = get_data_directories();
+    let mut success = true;
+
+    for (name, path) in &dirs {
+        if !path.exists() {
+            continue;
+        }
+        if !is_safe_purge_path(path) {
+            eprintln!("\x1b[31mRefusing to delete {}: unsafe path\x1b[0m", path.display());
+            success = false;
+            continue;
+        }
+        match std::fs::remove_dir_all(path) {
+            Ok(()) => println!("\x1b[32mRemoved {}: {}\x1b[0m", name, path.display()),
+            Err(e) => {
+                eprintln!("\x1b[31mFailed to remove {}: {}\x1b[0m", path.display(), e);
+                success = false;
+            }
+        }
+    }
+
+    if success {
+        Ok(())
+    } else {
+        Err(AishError::Config("Some directories could not be removed".into()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
 
 pub fn run_uninstall(purge: bool, yes: bool) {
     println!("\x1b[1;36mAI Shell Uninstall\x1b[0m\n");
@@ -57,10 +361,10 @@ pub fn run_uninstall(purge: bool, yes: bool) {
     println!("\x1b[2mInstallation method: {}\x1b[0m", method);
 
     if purge {
-        println!("\x1b[1;33m--purge: ALL config and data files will be removed.\x1b[0m");
-        for p in get_purge_paths() {
-            if p.exists() {
-                println!("  \x1b[2m{}\x1b[0m", p.display());
+        println!("\x1b[1;33m--purge: ALL config, data and cache files will be removed.\x1b[0m");
+        for (_, path) in get_data_directories() {
+            if path.exists() {
+                println!("  \x1b[2m{}\x1b[0m", path.display());
             }
         }
     }
@@ -77,18 +381,114 @@ pub fn run_uninstall(purge: bool, yes: bool) {
     }
 
     println!("Uninstalling...");
-    if let Err(e) = remove_binary() {
-        eprintln!("\x1b[31mFailed to remove binary: {}\x1b[0m", e);
+
+    let result = match method {
+        InstallMethod::Archive => uninstall_archive(purge),
+        InstallMethod::Cargo => uninstall_cargo(),
+        InstallMethod::Pip => uninstall_pip(),
+        InstallMethod::System => uninstall_system(purge),
+        InstallMethod::Unknown => {
+            eprintln!("\x1b[33mCould not detect installation method.\x1b[0m");
+            eprintln!("\x1b[2mAttempting to remove current binary...\x1b[0m");
+            remove_current_binary()
+        }
+    };
+
+    if let Err(e) = result {
+        eprintln!("\x1b[31mUninstall failed: {}\x1b[0m", e);
         return;
     }
-    println!("\x1b[32mBinary removed.\x1b[0m");
+    println!("\x1b[32mPackage removed.\x1b[0m");
 
     if purge {
         match purge_data() {
-            Ok(()) => println!("\x1b[32mConfig and data purged.\x1b[0m"),
+            Ok(()) => println!("\x1b[32mConfig, data and cache purged.\x1b[0m"),
             Err(e) => eprintln!("\x1b[31mPurge failed: {}\x1b[0m", e),
         }
     }
 
     println!("\x1b[32mAI Shell has been uninstalled. Goodbye!\x1b[0m");
+}
+
+/// Fallback: remove the currently running binary.
+fn remove_current_binary() -> Result<(), AishError> {
+    let exe = std::env::current_exe()
+        .map_err(|e| AishError::Config(format!("Cannot determine binary path: {e}")))?;
+    if exe.exists() {
+        std::fs::remove_file(&exe)
+            .map_err(|e| AishError::Config(format!("Failed to remove binary: {e}")))?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_elf_binary_nonexistent() {
+        assert!(!is_elf_binary(Path::new("/nonexistent/file")));
+    }
+
+    #[test]
+    fn test_is_elf_binary_text_file() {
+        let dir = std::env::temp_dir().join("aish_test_elf");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("script.sh");
+        std::fs::write(&path, "#!/bin/bash\necho hello").unwrap();
+        assert!(!is_elf_binary(&path));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_is_safe_purge_path_valid() {
+        let path = PathBuf::from("/home/user/.config/aish");
+        assert!(is_safe_purge_path(&path));
+    }
+
+    #[test]
+    fn test_safe_purge_path_cache() {
+        let path = PathBuf::from("/home/user/.cache/aish");
+        assert!(is_safe_purge_path(&path));
+    }
+
+    #[test]
+    fn test_is_safe_purge_path_rejects_root() {
+        assert!(!is_safe_purge_path(&PathBuf::from("/")));
+    }
+
+    #[test]
+    fn test_is_safe_purge_path_rejects_system() {
+        assert!(!is_safe_purge_path(&PathBuf::from("/usr/aish")));
+        assert!(!is_safe_purge_path(&PathBuf::from("/etc/aish")));
+    }
+
+    #[test]
+    fn test_is_safe_purge_path_rejects_wrong_name() {
+        assert!(!is_safe_purge_path(&PathBuf::from("/home/user/.config/other")));
+    }
+
+    #[test]
+    fn test_is_safe_purge_path_rejects_short() {
+        assert!(!is_safe_purge_path(&PathBuf::from("/aish")));
+    }
+
+    #[test]
+    fn test_detect_installation_method_runs() {
+        // Just verify it doesn't panic
+        let _method = detect_installation_method();
+    }
+
+    #[test]
+    fn test_get_data_directories() {
+        let dirs = get_data_directories();
+        assert!(!dirs.is_empty());
+        for (name, path) in &dirs {
+            assert!(path.ends_with("aish"), "{} should end with aish", name);
+        }
+    }
 }

--- a/crates/aish-cli/src/update.rs
+++ b/crates/aish-cli/src/update.rs
@@ -1,35 +1,112 @@
 //! Self-update via GitHub releases.
+//!
+//! Supports platform-aware download, progress display, mirror fallback,
+//! archive extraction with install.sh execution, and automatic cleanup.
 
-use std::io::{self, Write};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
 
 use aish_core::AishError;
 
-const GITHUB_REPO: &str = "xzx-idc/aish";
+const GITHUB_API_LATEST: &str =
+    "https://api.github.com/repos/AI-Shell-Team/aish/releases/latest";
+const GITHUB_API_LIST: &str =
+    "https://api.github.com/repos/AI-Shell-Team/aish/releases";
+const GITHUB_RELEASES_BASE: &str =
+    "https://github.com/AI-Shell-Team/aish/releases/download";
+const FALLBACK_MIRROR: &str = "https://www.aishell.ai/repo";
+const CONNECTION_TIMEOUT_SECS: u64 = 10;
+const DOWNLOAD_TIMEOUT_SECS: u64 = 300;
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct UpdateInfo {
-    #[allow(dead_code)]
     pub tag_name: String,
     pub current_version: String,
     pub latest_version: String,
     pub html_url: String,
+    #[allow(dead_code)]
+    pub release_notes: String,
+}
+
+// ---------------------------------------------------------------------------
+// Version comparison
+// ---------------------------------------------------------------------------
+
+/// Compare two version strings by numeric parts.
+fn compare_versions(a: &str, b: &str) -> std::cmp::Ordering {
+    let parse_parts = |v: &str| -> Vec<u64> {
+        v.strip_prefix('v')
+            .unwrap_or(v)
+            .split('.')
+            .filter_map(|s| s.parse().ok())
+            .collect()
+    };
+    let a_parts = parse_parts(a);
+    let b_parts = parse_parts(b);
+    for i in 0..a_parts.len().max(b_parts.len()) {
+        let a_val = a_parts.get(i).unwrap_or(&0);
+        let b_val = b_parts.get(i).unwrap_or(&0);
+        match a_val.cmp(b_val) {
+            std::cmp::Ordering::Equal => continue,
+            other => return other,
+        }
+    }
+    std::cmp::Ordering::Equal
+}
+
+// ---------------------------------------------------------------------------
+// Platform detection
+// ---------------------------------------------------------------------------
+
+fn detect_platform() -> Result<(&'static str, &'static str), AishError> {
+    let plat = match std::env::consts::OS {
+        "linux" => "linux",
+        "macos" => "darwin",
+        other => {
+            return Err(AishError::Config(format!(
+                "Unsupported platform: {}",
+                other
+            )))
+        }
+    };
+    let arch = match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        other => {
+            return Err(AishError::Config(format!(
+                "Unsupported architecture: {}",
+                other
+            )))
+        }
+    };
+    Ok((plat, arch))
+}
+
+// ---------------------------------------------------------------------------
+// Update check
+// ---------------------------------------------------------------------------
+
+fn build_http_client(timeout_secs: u64) -> Result<reqwest::blocking::Client, AishError> {
+    reqwest::blocking::Client::builder()
+        .user_agent("aish-update-checker")
+        .timeout(std::time::Duration::from_secs(timeout_secs))
+        .build()
+        .map_err(|e| AishError::Config(format!("HTTP client error: {e}")))
 }
 
 pub fn check_for_updates(
     current_version: &str,
     include_pre_release: bool,
 ) -> Result<Option<UpdateInfo>, AishError> {
-    let url = format!("https://api.github.com/repos/{}/releases", GITHUB_REPO);
-
-    let client = reqwest::blocking::Client::builder()
-        .user_agent("aish-update-checker")
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .map_err(|e| AishError::Config(format!("HTTP client error: {e}")))?;
+    let client = build_http_client(CONNECTION_TIMEOUT_SECS)?;
+    let url = if include_pre_release {
+        GITHUB_API_LIST
+    } else {
+        GITHUB_API_LATEST
+    };
 
     let resp = client
-        .get(&url)
+        .get(url)
         .send()
         .map_err(|e| AishError::Config(format!("Failed to check for updates: {e}")))?;
 
@@ -40,50 +117,270 @@ pub fn check_for_updates(
         )));
     }
 
-    let releases: Vec<serde_json::Value> = resp
-        .json()
-        .map_err(|e| AishError::Config(format!("Failed to parse releases: {e}")))?;
-
-    let current = normalize_version(current_version);
-
-    for release in releases {
-        let is_prerelease = release
-            .get("prerelease")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-        if is_prerelease && !include_pre_release {
-            continue;
+    let release = if include_pre_release {
+        let releases: Vec<serde_json::Value> = resp
+            .json()
+            .map_err(|e| AishError::Config(format!("Failed to parse releases: {e}")))?;
+        match releases.into_iter().next() {
+            Some(r) => r,
+            None => return Ok(None),
         }
+    } else {
+        resp.json()
+            .map_err(|e| AishError::Config(format!("Failed to parse release: {e}")))?
+    };
 
-        let tag = release
-            .get("tag_name")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        let latest = normalize_version(tag);
-        let html_url = release
-            .get("html_url")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
+    extract_update_info(&release, current_version)
+}
 
-        if latest != current {
-            return Ok(Some(UpdateInfo {
-                tag_name: tag.to_string(),
-                current_version: current.to_string(),
-                latest_version: tag.to_string(),
-                html_url,
-            }));
-        }
+fn extract_update_info(
+    release: &serde_json::Value,
+    current_version: &str,
+) -> Result<Option<UpdateInfo>, AishError> {
+    let tag = release
+        .get("tag_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let latest = tag.strip_prefix('v').unwrap_or(tag);
+    let current = current_version
+        .strip_prefix('v')
+        .unwrap_or(current_version);
 
-        break;
+    if compare_versions(latest, current) == std::cmp::Ordering::Greater {
+        return Ok(Some(UpdateInfo {
+            tag_name: tag.to_string(),
+            current_version: current.to_string(),
+            latest_version: latest.to_string(),
+            html_url: release
+                .get("html_url")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            release_notes: release
+                .get("body")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        }));
     }
 
     Ok(None)
 }
 
-fn normalize_version(v: &str) -> String {
-    v.strip_prefix('v').unwrap_or(v).to_string()
+// ---------------------------------------------------------------------------
+// Download with progress
+// ---------------------------------------------------------------------------
+
+fn download_with_progress(
+    url: &str,
+    dest: &Path,
+    label: &str,
+) -> Result<(), AishError> {
+    let client = build_http_client(DOWNLOAD_TIMEOUT_SECS)?;
+
+    let resp = client
+        .get(url)
+        .send()
+        .map_err(|e| AishError::Config(format!("Download failed: {e}")))?;
+
+    if !resp.status().is_success() {
+        return Err(AishError::Config(format!(
+            "Download returned status {}",
+            resp.status()
+        )));
+    }
+
+    let total: u64 = resp
+        .headers()
+        .get("content-length")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    let mut file = std::fs::File::create(dest)
+        .map_err(|e| AishError::Config(format!("Failed to create file: {e}")))?;
+
+    let mut downloaded: u64 = 0;
+    let mut buf = [0u8; 8192];
+    let mut resp = resp;
+
+    loop {
+        let n = resp
+            .read(&mut buf)
+            .map_err(|e| AishError::Config(format!("Download read error: {e}")))?;
+        if n == 0 {
+            break;
+        }
+        file.write_all(&buf[..n])
+            .map_err(|e| AishError::Config(format!("Write error: {e}")))?;
+        downloaded += n as u64;
+
+        if total > 0 {
+            let pct = (downloaded as f64 / total as f64 * 100.0) as u32;
+            print!(
+                "\r\x1b[2K\x1b[1;36m{}: {:.1}/{:.1} MB ({}%)\x1b[0m",
+                label,
+                downloaded as f64 / 1_048_576.0,
+                total as f64 / 1_048_576.0,
+                pct
+            );
+        } else {
+            print!(
+                "\r\x1b[2K\x1b[1;36m{}: {:.1} MB\x1b[0m",
+                label,
+                downloaded as f64 / 1_048_576.0
+            );
+        }
+        std::io::stdout().flush().ok();
+    }
+    println!();
+    Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// SHA256
+// ---------------------------------------------------------------------------
+
+fn sha256_file(path: &Path) -> Result<String, AishError> {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    let mut file =
+        std::fs::File::open(path).map_err(|e| AishError::Config(format!("Open error: {e}")))?;
+    let mut buf = [0u8; 8192];
+    loop {
+        let n = file
+            .read(&mut buf)
+            .map_err(|e| AishError::Config(format!("Read error: {e}")))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+// ---------------------------------------------------------------------------
+// Download release (GitHub → mirror fallback)
+// ---------------------------------------------------------------------------
+
+fn download_release(tag_name: &str) -> Result<PathBuf, AishError> {
+    let (plat, arch) = detect_platform()?;
+    let version_str = tag_name.strip_prefix('v').unwrap_or(tag_name);
+    let filename = format!("aish-{}-{}-{}.tar.gz", version_str, plat, arch);
+
+    let temp_dir = std::env::temp_dir().join("aish_update");
+    std::fs::create_dir_all(&temp_dir)
+        .map_err(|e| AishError::Config(format!("Failed to create temp dir: {e}")))?;
+
+    let dest_path = temp_dir.join(&filename);
+
+    // Try GitHub first
+    let github_url = format!("{}/{}/{}", GITHUB_RELEASES_BASE, tag_name, filename);
+    println!("\x1b[1;36mDownloading from GitHub...\x1b[0m");
+    if download_with_progress(&github_url, &dest_path, &filename).is_ok() {
+        println!("\x1b[32mDownloaded: {}\x1b[0m", dest_path.display());
+        return Ok(dest_path);
+    }
+
+    // Fallback to mirror
+    println!("\x1b[33mGitHub download failed, trying mirror...\x1b[0m");
+    let mirror_url = format!("{}/{}/{}", FALLBACK_MIRROR, tag_name, filename);
+    download_with_progress(
+        &mirror_url,
+        &dest_path,
+        &format!("{} (mirror)", filename),
+    )?;
+    println!("\x1b[32mDownloaded: {}\x1b[0m", dest_path.display());
+    Ok(dest_path)
+}
+
+// ---------------------------------------------------------------------------
+// Archive extraction & install
+// ---------------------------------------------------------------------------
+
+fn find_install_sh(dir: &Path) -> Result<PathBuf, AishError> {
+    fn search(dir: &Path) -> Option<PathBuf> {
+        for entry in std::fs::read_dir(dir).ok()? {
+            let entry = entry.ok()?;
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(found) = search(&path) {
+                    return Some(found);
+                }
+            } else if path
+                .file_name()
+                .is_some_and(|n| n == "install.sh")
+            {
+                return Some(path);
+            }
+        }
+        None
+    }
+    search(dir).ok_or_else(|| AishError::Config("install.sh not found in archive".into()))
+}
+
+fn install_release(archive_path: &Path) -> Result<(), AishError> {
+    let extract_dir = std::env::temp_dir()
+        .join("aish_update")
+        .join("extract");
+
+    // Clean previous extraction
+    let _ = std::fs::remove_dir_all(&extract_dir);
+    std::fs::create_dir_all(&extract_dir)
+        .map_err(|e| AishError::Config(format!("Failed to create extract dir: {e}")))?;
+
+    // Extract via system tar
+    println!("\x1b[1;36mExtracting archive...\x1b[0m");
+    let output = std::process::Command::new("tar")
+        .arg("-xzf")
+        .arg(archive_path)
+        .arg("-C")
+        .arg(&extract_dir)
+        .output()
+        .map_err(|e| AishError::Config(format!("Failed to run tar: {e}")))?;
+
+    if !output.status.success() {
+        return Err(AishError::Config(format!(
+            "Extraction failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+
+    // Locate install.sh
+    let install_script = find_install_sh(&extract_dir)?;
+
+    // Show SHA256 for verification
+    let hash = sha256_file(&install_script)?;
+    println!("\x1b[2minstall.sh SHA256: {}\x1b[0m", hash);
+
+    // Run with sudo
+    println!("\x1b[1;36mRunning install script...\x1b[0m");
+    let result = std::process::Command::new("sudo")
+        .arg(&install_script)
+        .output()
+        .map_err(|e| AishError::Config(format!("Failed to run install script: {e}")))?;
+
+    if !result.status.success() {
+        return Err(AishError::Config(format!(
+            "Installation failed: {}",
+            String::from_utf8_lossy(&result.stderr)
+        )));
+    }
+
+    println!("\x1b[32mInstallation successful!\x1b[0m");
+    Ok(())
+}
+
+/// Remove temporary download and extraction files.
+fn cleanup() {
+    let temp_dir = std::env::temp_dir().join("aish_update");
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
 
 pub fn run_update(check_only: bool, pre_release: bool) {
     let current = env!("CARGO_PKG_VERSION").to_string();
@@ -96,8 +393,6 @@ pub fn run_update(check_only: bool, pre_release: bool) {
                 "\x1b[1;33mUpdate available: {} → {}\x1b[0m",
                 info.current_version, info.latest_version
             );
-            println!("\x1b[2mCurrent: {}\x1b[0m", info.current_version);
-            println!("\x1b[2mLatest:  {}\x1b[0m", info.latest_version);
             println!("\x1b[2m{}\x1b[0m", info.html_url);
 
             if check_only {
@@ -105,16 +400,26 @@ pub fn run_update(check_only: bool, pre_release: bool) {
             }
 
             print!("\n\x1b[33mDownload and install? [y/N] \x1b[0m");
-            io::stdout().flush().unwrap();
+            std::io::stdout().flush().unwrap();
             let mut answer = String::new();
-            io::stdin().read_line(&mut answer).unwrap();
+            std::io::stdin().read_line(&mut answer).unwrap();
             if answer.trim().to_lowercase() != "y" {
                 println!("Update cancelled.");
                 return;
             }
 
-            println!("\x1b[33mAutomatic update is not yet implemented in the Rust version.\x1b[0m");
-            println!("Download from: {}", info.html_url);
+            match download_release(&info.tag_name) {
+                Ok(archive_path) => {
+                    if let Err(e) = install_release(&archive_path) {
+                        eprintln!("\x1b[31mInstallation error: {}\x1b[0m", e);
+                    }
+                }
+                Err(e) => {
+                    eprintln!("\x1b[31mDownload failed: {}\x1b[0m", e);
+                }
+            }
+
+            cleanup();
         }
         Ok(None) => {
             println!(
@@ -125,5 +430,95 @@ pub fn run_update(check_only: bool, pre_release: bool) {
         Err(e) => {
             eprintln!("\x1b[31mUpdate check failed: {}\x1b[0m", e);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compare_versions_equal() {
+        assert_eq!(
+            compare_versions("0.2.0", "0.2.0"),
+            std::cmp::Ordering::Equal
+        );
+    }
+
+    #[test]
+    fn test_compare_versions_major() {
+        assert_eq!(
+            compare_versions("1.0.0", "0.9.9"),
+            std::cmp::Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn test_compare_versions_minor() {
+        assert_eq!(
+            compare_versions("0.3.0", "0.2.9"),
+            std::cmp::Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn test_compare_versions_patch() {
+        assert_eq!(
+            compare_versions("0.2.1", "0.2.0"),
+            std::cmp::Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn test_compare_versions_with_v_prefix() {
+        assert_eq!(
+            compare_versions("v0.2.0", "0.2.0"),
+            std::cmp::Ordering::Equal
+        );
+    }
+
+    #[test]
+    fn test_detect_platform() {
+        // Should succeed on any supported platform
+        let result = detect_platform();
+        assert!(result.is_ok());
+        let (plat, arch) = result.unwrap();
+        assert!(plat == "linux" || plat == "darwin");
+        assert!(arch == "amd64" || arch == "arm64");
+    }
+
+    #[test]
+    fn test_sha256_file() {
+        let dir = std::env::temp_dir().join("aish_test_sha256");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("test.txt");
+        std::fs::write(&path, b"hello world").unwrap();
+        let hash = sha256_file(&path).unwrap();
+        assert_eq!(
+            hash,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_find_install_sh() {
+        let dir = std::env::temp_dir().join("aish_test_find");
+        let sub = dir.join("aish-0.3.0");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(sub.join("install.sh"), "#!/bin/bash\necho ok").unwrap();
+        let result = find_install_sh(&dir);
+        assert!(result.is_ok());
+        assert!(result.unwrap().ends_with("install.sh"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_find_install_sh_not_found() {
+        let dir = std::env::temp_dir().join("aish_test_find_empty");
+        std::fs::create_dir_all(&dir).unwrap();
+        let result = find_install_sh(&dir);
+        assert!(result.is_err());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/aish-cli/src/update.rs
+++ b/crates/aish-cli/src/update.rs
@@ -8,12 +8,9 @@ use std::path::{Path, PathBuf};
 
 use aish_core::AishError;
 
-const GITHUB_API_LATEST: &str =
-    "https://api.github.com/repos/AI-Shell-Team/aish/releases/latest";
-const GITHUB_API_LIST: &str =
-    "https://api.github.com/repos/AI-Shell-Team/aish/releases";
-const GITHUB_RELEASES_BASE: &str =
-    "https://github.com/AI-Shell-Team/aish/releases/download";
+const GITHUB_API_LATEST: &str = "https://api.github.com/repos/AI-Shell-Team/aish/releases/latest";
+const GITHUB_API_LIST: &str = "https://api.github.com/repos/AI-Shell-Team/aish/releases";
+const GITHUB_RELEASES_BASE: &str = "https://github.com/AI-Shell-Team/aish/releases/download";
 const FALLBACK_MIRROR: &str = "https://www.aishell.ai/repo";
 const CONNECTION_TIMEOUT_SECS: u64 = 10;
 const DOWNLOAD_TIMEOUT_SECS: u64 = 300;
@@ -142,9 +139,7 @@ fn extract_update_info(
         .and_then(|v| v.as_str())
         .unwrap_or("");
     let latest = tag.strip_prefix('v').unwrap_or(tag);
-    let current = current_version
-        .strip_prefix('v')
-        .unwrap_or(current_version);
+    let current = current_version.strip_prefix('v').unwrap_or(current_version);
 
     if compare_versions(latest, current) == std::cmp::Ordering::Greater {
         return Ok(Some(UpdateInfo {
@@ -171,11 +166,7 @@ fn extract_update_info(
 // Download with progress
 // ---------------------------------------------------------------------------
 
-fn download_with_progress(
-    url: &str,
-    dest: &Path,
-    label: &str,
-) -> Result<(), AishError> {
+fn download_with_progress(url: &str, dest: &Path, label: &str) -> Result<(), AishError> {
     let client = build_http_client(DOWNLOAD_TIMEOUT_SECS)?;
 
     let resp = client
@@ -286,11 +277,7 @@ fn download_release(tag_name: &str) -> Result<PathBuf, AishError> {
     // Fallback to mirror
     println!("\x1b[33mGitHub download failed, trying mirror...\x1b[0m");
     let mirror_url = format!("{}/{}/{}", FALLBACK_MIRROR, tag_name, filename);
-    download_with_progress(
-        &mirror_url,
-        &dest_path,
-        &format!("{} (mirror)", filename),
-    )?;
+    download_with_progress(&mirror_url, &dest_path, &format!("{} (mirror)", filename))?;
     println!("\x1b[32mDownloaded: {}\x1b[0m", dest_path.display());
     Ok(dest_path)
 }
@@ -308,10 +295,7 @@ fn find_install_sh(dir: &Path) -> Result<PathBuf, AishError> {
                 if let Some(found) = search(&path) {
                     return Some(found);
                 }
-            } else if path
-                .file_name()
-                .is_some_and(|n| n == "install.sh")
-            {
+            } else if path.file_name().is_some_and(|n| n == "install.sh") {
                 return Some(path);
             }
         }
@@ -321,9 +305,7 @@ fn find_install_sh(dir: &Path) -> Result<PathBuf, AishError> {
 }
 
 fn install_release(archive_path: &Path) -> Result<(), AishError> {
-    let extract_dir = std::env::temp_dir()
-        .join("aish_update")
-        .join("extract");
+    let extract_dir = std::env::temp_dir().join("aish_update").join("extract");
 
     // Clean previous extraction
     let _ = std::fs::remove_dir_all(&extract_dir);

--- a/crates/aish-llm/src/agent.rs
+++ b/crates/aish-llm/src/agent.rs
@@ -304,22 +304,27 @@ impl<'a> ReActAgent<'a> {
                 messages.push(assistant_msg);
 
                 // Execute each tool and collect observations.
+                // Note: execute_tool_external already emits TOOL_EXECUTION_START/END
+                // via session.execute_tool, so we do NOT call emit_agent_step for
+                // Action/Observation here (that would cause duplicate events).
+                let mut final_answer_result: Option<String> = None;
                 for tc in &tool_calls {
                     if cancel.is_cancelled() {
                         return Err(AishError::Cancelled);
                     }
 
                     let result = self.session.execute_tool_external(tc).await;
-                    let obs_text = result.output.clone();
+                    messages.push(ChatMessage::tool_result(&tc.id, result.output.clone()));
 
-                    self.emit_agent_step(AgentStep::Action {
-                        tool_name: tc.name.clone(),
-                        args: serde_json::from_str(&tc.arguments)
-                            .unwrap_or(serde_json::Value::Null),
-                    });
-                    self.emit_agent_step(AgentStep::Observation(obs_text.clone()));
+                    // Detect final_answer tool — terminate the loop immediately.
+                    if tc.name == "final_answer" && result.ok {
+                        final_answer_result = Some(result.output);
+                    }
+                }
 
-                    messages.push(ChatMessage::tool_result(&tc.id, result.output));
+                if let Some(answer) = final_answer_result {
+                    self.emit_agent_step(AgentStep::FinalAnswer(answer.clone()));
+                    return Ok(answer);
                 }
 
                 // After tool results, add a user prompt nudging the LLM to continue.
@@ -355,6 +360,7 @@ impl<'a> ReActAgent<'a> {
                         let obs = match self
                             .session
                             .execute_tool_by_name(&action.tool_name, action.args.clone())
+                            .await
                         {
                             Ok(result) => result.output,
                             Err(e) => format!("Error executing tool '{}': {}", action.tool_name, e),
@@ -388,7 +394,7 @@ impl<'a> ReActAgent<'a> {
             ),
             AgentStep::Action { tool_name, args } => (
                 LlmEventType::ToolExecutionStart,
-                serde_json::json!({ "tool_name": tool_name, "args": args }),
+                serde_json::json!({ "tool_name": tool_name, "tool_args": args }),
             ),
             AgentStep::Observation(o) => (
                 LlmEventType::ToolExecutionEnd,

--- a/crates/aish-llm/src/provider.rs
+++ b/crates/aish-llm/src/provider.rs
@@ -34,7 +34,7 @@ pub fn detect_provider_from_model(model: &str) -> ProviderInfo {
     } else if model_lower.starts_with("deepseek") {
         ("deepseek", "DeepSeek")
     } else if model_lower.starts_with("qwen") || model_lower.starts_with("qwq") {
-        ("alibaba", "Alibaba Cloud")
+        ("qwen", "Qwen (Alibaba Cloud)")
     } else if model_lower.starts_with("llama")
         || model_lower.starts_with("mistral")
         || model_lower.starts_with("mixtral")
@@ -87,8 +87,8 @@ pub fn refine_provider_from_api_base(provider: &mut ProviderInfo, api_base: &str
         provider.id = "deepseek".into();
         provider.display_name = "DeepSeek".into();
     } else if base_lower.contains("dashscope") || base_lower.contains("aliyuncs") {
-        provider.id = "alibaba".into();
-        provider.display_name = "Alibaba Cloud".into();
+        provider.id = "qwen".into();
+        provider.display_name = "Qwen (Alibaba Cloud)".into();
     } else if base_lower.contains("mistral.ai") {
         provider.id = "mistral".into();
         provider.display_name = "Mistral AI".into();
@@ -167,7 +167,7 @@ fn dashboard_url_for(provider_id: &str) -> Option<String> {
         "minimax" => {
             Some("https://platform.minimaxi.com/user-center/basic-information/interface-key".into())
         }
-        "alibaba" => Some("https://dashscope.console.aliyun.com/overview".into()),
+        "qwen" => Some("https://dashscope.console.aliyun.com/overview".into()),
         "zhipu" | "zai" => Some("https://platform.z.ai/usage".into()),
         "openrouter" => Some("https://openrouter.ai/settings/credits".into()),
         "together" => Some("https://api.together.xyz/settings/api-keys".into()),
@@ -182,7 +182,7 @@ fn dashboard_url_for(provider_id: &str) -> Option<String> {
 fn supports_tools_for(provider_id: &str) -> bool {
     match provider_id {
         "openai" | "anthropic" | "google" | "deepseek" | "mistral" | "ollama" | "xai"
-        | "moonshot" | "minimax" | "openrouter" | "together" | "zhipu" | "zai" | "alibaba"
+        | "moonshot" | "minimax" | "openrouter" | "together" | "zhipu" | "zai" | "qwen"
         | "qianfan" | "vllm" => true,
         _ => false,
     }
@@ -326,17 +326,17 @@ mod tests {
     #[test]
     fn test_qwen_detection() {
         let p = detect_provider_from_model("qwen-max");
-        assert_eq!(p.id, "alibaba");
-        assert_eq!(p.display_name, "Alibaba Cloud");
+        assert_eq!(p.id, "qwen");
+        assert_eq!(p.display_name, "Qwen (Alibaba Cloud)");
 
         let p2 = detect_provider_from_model("qwq-32b");
-        assert_eq!(p2.id, "alibaba");
+        assert_eq!(p2.id, "qwen");
 
         let p3 = detect_provider(
             "qwen-turbo",
             "https://dashscope.aliyuncs.com/compatible-mode/v1",
         );
-        assert_eq!(p3.id, "alibaba");
+        assert_eq!(p3.id, "qwen");
     }
 
     #[test]

--- a/crates/aish-llm/src/providers/registry.rs
+++ b/crates/aish-llm/src/providers/registry.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use super::codex::CodexProviderAdapter;
 use super::openai_compat::OpenAiCompatProvider;
 use super::types::ProviderAdapter;
 
@@ -15,11 +16,13 @@ pub struct ProviderRegistry {
 }
 
 impl ProviderRegistry {
-    /// Create a new registry pre-loaded with the default `OpenAiCompatProvider`
-    /// as the universal fallback.
+    /// Create a new registry pre-loaded with Codex and OpenAI-compat adapters.
     pub fn new() -> Self {
         Self {
-            providers: vec![Arc::new(OpenAiCompatProvider)],
+            providers: vec![
+                Arc::new(CodexProviderAdapter),
+                Arc::new(OpenAiCompatProvider),
+            ],
         }
     }
 
@@ -173,7 +176,7 @@ mod tests {
     fn test_registry_default() {
         let registry = ProviderRegistry::new();
         let ids = registry.list_provider_ids();
-        assert_eq!(ids, vec!["openai-compat"]);
+        assert_eq!(ids, vec!["openai-codex", "openai-compat"]);
     }
 
     #[test]
@@ -233,7 +236,7 @@ mod tests {
         let mut registry = ProviderRegistry::new();
         registry.register(Arc::new(TestProvider));
         let ids = registry.list_provider_ids();
-        // TestProvider should appear before the fallback.
-        assert_eq!(ids, vec!["test-provider", "openai-compat"]);
+        // TestProvider should appear before the fallbacks.
+        assert_eq!(ids, vec!["openai-codex", "test-provider", "openai-compat"]);
     }
 }

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -149,14 +149,14 @@ impl LlmSession {
         self.execute_tool(tool_call).await
     }
 
-    /// Execute a tool by name with given arguments.
-    pub fn execute_tool_by_name(
+    /// Execute a tool by name with given arguments (async path).
+    pub async fn execute_tool_by_name(
         &self,
         name: &str,
         args: serde_json::Value,
     ) -> Result<ToolResult, String> {
         match self.tools.get(name) {
-            Some(tool) => Ok(tool.execute(args)),
+            Some(tool) => Ok(tool.as_ref().execute_async(args).await),
             None => Err(format!("Unknown tool: {}", name)),
         }
     }
@@ -703,7 +703,7 @@ impl LlmSession {
             // Execute with retry: try once, retry once on failure.
             // Mirrors Python's normalize_tool_result + error recovery pattern.
             let result = {
-                let first = self.execute_tool_inner(tool, &args);
+                let first = tool.as_ref().execute_async(args.clone()).await;
                 if first.ok {
                     first
                 } else {
@@ -713,7 +713,7 @@ impl LlmSession {
                         tool_call.name,
                         first.output
                     );
-                    let second = self.execute_tool_inner(tool, &args);
+                    let second = tool.as_ref().execute_async(args.clone()).await;
                     if second.ok {
                         second
                     } else {
@@ -765,35 +765,6 @@ impl LlmSession {
             result
         } else {
             ToolResult::error(format!("Unknown tool: {}", tool_call.name))
-        }
-    }
-
-    /// Inner tool execution that catches panics and normalizes results,
-    /// mirroring Python's `normalize_tool_result`.
-    fn execute_tool_inner(&self, tool: &Box<dyn Tool>, args: &serde_json::Value) -> ToolResult {
-        // Use catch_unwind to gracefully handle panics in tool execution.
-        // This mirrors Python's try/except wrapping in normalize_tool_result.
-        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| tool.execute(args.clone())))
-        {
-            Ok(result) => result,
-            Err(payload) => {
-                // Normalize panic into a ToolResult error
-                let message = if let Some(s) = payload.downcast_ref::<&str>() {
-                    s.to_string()
-                } else if let Some(s) = payload.downcast_ref::<String>() {
-                    s.clone()
-                } else {
-                    "Tool execution panicked".to_string()
-                };
-                ToolResult {
-                    ok: false,
-                    output: format!("Error: {}", message),
-                    meta: Some(serde_json::json!({
-                        "kind": "panic",
-                        "exception_type": "panic"
-                    })),
-                }
-            }
         }
     }
 

--- a/crates/aish-llm/src/types.rs
+++ b/crates/aish-llm/src/types.rs
@@ -225,9 +225,7 @@ pub trait Tool: Send + Sync {
         args: serde_json::Value,
     ) -> Pin<Box<dyn Future<Output = ToolResult> + Send + 'a>> {
         Box::pin(async move {
-            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                self.execute(args)
-            })) {
+            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| self.execute(args))) {
                 Ok(result) => result,
                 Err(payload) => {
                     let message = if let Some(s) = payload.downcast_ref::<&str>() {

--- a/crates/aish-llm/src/types.rs
+++ b/crates/aish-llm/src/types.rs
@@ -1,3 +1,6 @@
+use std::future::Future;
+use std::pin::Pin;
+
 use serde::{Deserialize, Serialize};
 
 /// Result of a callback invoked during LLM processing.
@@ -212,6 +215,33 @@ pub trait Tool: Send + Sync {
     }
 
     fn execute(&self, args: serde_json::Value) -> ToolResult;
+
+    /// Async variant of `execute`. The default implementation delegates to the
+    /// synchronous `execute` wrapped in `catch_unwind` so panics are gracefully
+    /// converted to `ToolResult::error`. Tools that need async I/O (e.g.
+    /// spawning sub-sessions) should override this method.
+    fn execute_async<'a>(
+        &'a self,
+        args: serde_json::Value,
+    ) -> Pin<Box<dyn Future<Output = ToolResult> + Send + 'a>> {
+        Box::pin(async move {
+            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                self.execute(args)
+            })) {
+                Ok(result) => result,
+                Err(payload) => {
+                    let message = if let Some(s) = payload.downcast_ref::<&str>() {
+                        s.to_string()
+                    } else if let Some(s) = payload.downcast_ref::<String>() {
+                        s.clone()
+                    } else {
+                        "Tool execution panicked".to_string()
+                    };
+                    ToolResult::error(format!("Error: {}", message))
+                }
+            }
+        })
+    }
 }
 
 /// Token used to cancel an in-progress LLM request.

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -182,6 +182,27 @@ impl AishShell {
         tool_registry.register(Box::new(aish_tools::EnterPlanModeTool::new()));
         tool_registry.register(Box::new(aish_tools::ExitPlanModeTool::new()));
 
+        // System diagnose tool — needs session credentials to spawn sub-sessions.
+        // The shared event callback holder allows setting the callback after
+        // tool registration (the event callback is created later).
+        let diagnose_security_check = {
+            let mgr = SecurityManager::new(security_manager.policy().clone());
+            std::sync::Arc::new(move |cmd: &str| -> aish_security::SecurityDecision {
+                mgr.check_command(cmd)
+            }) as std::sync::Arc<dyn Fn(&str) -> aish_security::SecurityDecision + Send + Sync>
+        };
+        let diagnose_event_callback: aish_tools::SharedEventCallback =
+            std::sync::Arc::new(std::sync::Mutex::new(None));
+        tool_registry.register(Box::new(aish_tools::SystemDiagnoseTool::new(
+            &config.api_base,
+            &config.api_key,
+            &config.model,
+            Some(config.temperature),
+            config.max_tokens,
+            Some(diagnose_security_check),
+            diagnose_event_callback.clone(),
+        )));
+
         // Initialize shared memory manager (best-effort)
         let memory_manager: SharedMemoryManager = Arc::new(Mutex::new(
             MemoryManager::new(MemoryManager::default_path()).ok(),
@@ -603,7 +624,11 @@ impl AishShell {
                 None // Always continue
             });
 
-        llm_session.set_event_callback(event_callback);
+        llm_session.set_event_callback(event_callback.clone());
+
+        // Share the event callback with the diagnose tool so it can forward
+        // sub-session events (bash_exec, read_file, etc.) to the UI.
+        *diagnose_event_callback.lock().unwrap() = Some(event_callback);
 
         // Set up confirmation callback for tool approval flow
         let confirmation_callback: Arc<dyn Fn(&str, &str) -> bool + Send + Sync> =

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -189,7 +189,8 @@ impl AishShell {
             let mgr = SecurityManager::new(security_manager.policy().clone());
             std::sync::Arc::new(move |cmd: &str| -> aish_security::SecurityDecision {
                 mgr.check_command(cmd)
-            }) as std::sync::Arc<dyn Fn(&str) -> aish_security::SecurityDecision + Send + Sync>
+            })
+                as std::sync::Arc<dyn Fn(&str) -> aish_security::SecurityDecision + Send + Sync>
         };
         let diagnose_event_callback: aish_tools::SharedEventCallback =
             std::sync::Arc::new(std::sync::Mutex::new(None));

--- a/crates/aish-tools/src/lib.rs
+++ b/crates/aish-tools/src/lib.rs
@@ -25,6 +25,7 @@ pub mod python;
 pub mod registry;
 pub mod secure_bash;
 pub mod skill_tool;
+pub mod system_diagnose;
 
 pub use ask_user::AskUserTool;
 pub use final_answer::FinalAnswerTool;
@@ -37,3 +38,5 @@ pub use python::PythonTool;
 pub use registry::ToolRegistry;
 pub use secure_bash::SecureBashTool;
 pub use skill_tool::{SkillInfo, SkillTool};
+pub use system_diagnose::SystemDiagnoseTool;
+pub use system_diagnose::SharedEventCallback;

--- a/crates/aish-tools/src/lib.rs
+++ b/crates/aish-tools/src/lib.rs
@@ -38,5 +38,5 @@ pub use python::PythonTool;
 pub use registry::ToolRegistry;
 pub use secure_bash::SecureBashTool;
 pub use skill_tool::{SkillInfo, SkillTool};
-pub use system_diagnose::SystemDiagnoseTool;
 pub use system_diagnose::SharedEventCallback;
+pub use system_diagnose::SystemDiagnoseTool;

--- a/crates/aish-tools/src/system_diagnose.rs
+++ b/crates/aish-tools/src/system_diagnose.rs
@@ -1,0 +1,185 @@
+//! System diagnose tool that the LLM can invoke to investigate system issues.
+//!
+//! When called, creates an isolated sub-session with diagnostic tools
+//! (bash, read_file, etc.) and runs a ReAct loop to produce a diagnosis.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+
+use aish_core::LlmEvent;
+use aish_llm::diagnose_agent::build_diagnose_prompt;
+use aish_llm::types::LlmCallbackResult;
+use aish_llm::{DiagnoseAgent, LlmSession, SubSessionConfig, Tool, ToolResult};
+use aish_security::SecurityDecision;
+
+/// Shared event callback holder that can be set after tool construction.
+///
+/// Uses `Mutex<Option<Arc<...>>>` because the event callback is created
+/// after the tool is registered in the session.
+pub type SharedEventCallback =
+    Arc<Mutex<Option<Arc<dyn Fn(LlmEvent) -> Option<LlmCallbackResult> + Send + Sync>>>>;
+
+/// Tool that allows the LLM to trigger an isolated system diagnosis session.
+///
+/// Registered under the name `system_diagnose_agent`, matching the Python version.
+/// When the main LLM decides a user query requires deep system investigation,
+/// it calls this tool with a `query` describing the problem. The tool spawns
+/// an isolated ReAct agent with its own context, tools, and system prompt.
+pub struct SystemDiagnoseTool {
+    api_base: String,
+    api_key: String,
+    model: String,
+    temperature: Option<f32>,
+    max_tokens: Option<u32>,
+    security_check: Option<Arc<dyn Fn(&str) -> SecurityDecision + Send + Sync>>,
+    event_callback: SharedEventCallback,
+}
+
+impl SystemDiagnoseTool {
+    pub fn new(
+        api_base: &str,
+        api_key: &str,
+        model: &str,
+        temperature: Option<f32>,
+        max_tokens: Option<u32>,
+        security_check: Option<Arc<dyn Fn(&str) -> SecurityDecision + Send + Sync>>,
+        event_callback: SharedEventCallback,
+    ) -> Self {
+        Self {
+            api_base: api_base.to_string(),
+            api_key: api_key.to_string(),
+            model: model.to_string(),
+            temperature,
+            max_tokens,
+            security_check,
+            event_callback,
+        }
+    }
+}
+
+impl Tool for SystemDiagnoseTool {
+    fn name(&self) -> &str {
+        "system_diagnose_agent"
+    }
+
+    fn description(&self) -> &str {
+        "Advanced log analysis and system diagnosis agent that can read files, \
+         analyze patterns, and provide detailed diagnostic reports"
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "The diagnostic query or system issue to analyze. \
+                                    Describe the problem, symptoms, or specific logs to investigate."
+                }
+            },
+            "required": ["query"]
+        })
+    }
+
+    fn execute(&self, _args: serde_json::Value) -> ToolResult {
+        ToolResult::error(
+            "system_diagnose_agent requires async execution; use execute_async",
+        )
+    }
+
+    fn execute_async<'a>(
+        &'a self,
+        args: serde_json::Value,
+    ) -> Pin<Box<dyn Future<Output = ToolResult> + Send + 'a>> {
+        Box::pin(async move {
+            let query = args
+                .get("query")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+
+            if query.is_empty() {
+                return ToolResult::error("Missing required parameter: query");
+            }
+
+            // Create a temporary parent session to derive client credentials.
+            let mut parent = LlmSession::new(
+                &self.api_base,
+                &self.api_key,
+                &self.model,
+                self.temperature,
+                self.max_tokens,
+            );
+
+            // Set up event callback proxy that forwards sub-session events
+            // to the main session's callback with "source" tagging (matching
+            // the Python event_proxy_callback pattern).
+            let maybe_cb = self.event_callback.lock().unwrap().clone();
+            if let Some(cb) = maybe_cb {
+                let proxy_cb: Arc<dyn Fn(LlmEvent) -> Option<LlmCallbackResult> + Send + Sync> =
+                    Arc::new(move |event: LlmEvent| {
+                        let mut modified_data = match event.data.as_object() {
+                            Some(obj) => {
+                                let mut new_obj = obj.clone();
+                                new_obj.insert(
+                                    "source".to_string(),
+                                    serde_json::json!("system_diagnose_agent"),
+                                );
+                                serde_json::Value::Object(new_obj)
+                            }
+                            None => serde_json::json!({
+                                "source": "system_diagnose_agent"
+                            }),
+                        };
+                        // Preserve non-object data by merging
+                        if !event.data.is_object() {
+                            modified_data = serde_json::json!({
+                                "source": "system_diagnose_agent",
+                                "original_data": event.data
+                            });
+                        }
+                        let forwarded = LlmEvent {
+                            event_type: event.event_type,
+                            data: modified_data,
+                            timestamp: event.timestamp,
+                            metadata: event.metadata,
+                        };
+                        cb(forwarded)
+                    });
+                parent.set_event_callback(proxy_cb);
+            }
+
+            let config = SubSessionConfig {
+                max_context_messages: 30,
+                max_iterations: 4,
+                system_prompt: Some(build_diagnose_prompt()),
+            };
+
+            let agent = DiagnoseAgent::with_config(config);
+
+            // Build bash tool with the same security policy as the main session.
+            let bash_tool = match &self.security_check {
+                Some(check) => {
+                    let check = Arc::clone(check);
+                    crate::SecureBashTool::with_security_check(move |cmd| check(cmd))
+                }
+                None => crate::SecureBashTool::new(),
+            };
+
+            // Tools available for diagnosis
+            let tools: Vec<Box<dyn Tool>> = vec![
+                Box::new(bash_tool),
+                Box::new(crate::fs::ReadFileTool::new()),
+                Box::new(crate::fs::WriteFileTool::new()),
+                Box::new(crate::fs::EditFileTool::new()),
+                Box::new(crate::FinalAnswerTool::new()),
+            ];
+
+            match agent.diagnose(&parent, &query, tools).await {
+                Ok(result) => ToolResult::success(result),
+                Err(e) => ToolResult::error(format!("Diagnosis failed: {}", e)),
+            }
+        })
+    }
+}

--- a/crates/aish-tools/src/system_diagnose.rs
+++ b/crates/aish-tools/src/system_diagnose.rs
@@ -83,9 +83,7 @@ impl Tool for SystemDiagnoseTool {
     }
 
     fn execute(&self, _args: serde_json::Value) -> ToolResult {
-        ToolResult::error(
-            "system_diagnose_agent requires async execution; use execute_async",
-        )
+        ToolResult::error("system_diagnose_agent requires async execution; use execute_async")
     }
 
     fn execute_async<'a>(


### PR DESCRIPTION
## Summary
- **事件回调传播**：`SystemDiagnoseTool` 创建子会话时未传递事件回调，导致诊断过程中的工具调用（bash_exec、read_file 等）不可见。添加了 `SharedEventCallback` 机制，通过代理回调转发子会话事件并标记 `"source": "system_diagnose_agent"`
- **final_answer 工具检测**：`ReActAgent` 未识别 `final_answer` 工具调用的终止信号，导致即使诊断完成也会继续循环直到达到迭代上限。现在检测到 `final_answer` 后立即返回结果
- **消除重复事件**：原生工具调用路径中 `execute_tool_external` 和 `emit_agent_step` 都发出 `ToolExecutionStart/End` 事件，导致双倍显示。移除了重复的事件发射

## Test plan
- [ ] 触发系统诊断（如 `;我的系统为什么卡顿`），确认诊断过程中的 bash_exec、read_file 等工具调用正确显示
- [ ] 确认诊断完成后不再出现 "ReAct agent hit max iterations" 警告
- [ ] 确认不再重复执行相同的命令
- [ ] 运行 `cargo test --package aish-llm --package aish-tools` 全部通过