### PR TITLE
feat: update the summary content after bashexec execution

### DIFF
--- a/crates/aish-pty/src/executor.rs
+++ b/crates/aish-pty/src/executor.rs
@@ -61,11 +61,26 @@ fn kill_pg(pid: Pid, sig: Signal) -> nix::Result<()> {
 pub struct PtyExecutor {
     /// How many bytes of tail output to keep in memory.
     pub keep_bytes: usize,
+    /// Whether to write output to the real terminal in real-time.
+    /// When false, output is only captured in buffers (for AI tool use).
+    display_output: bool,
 }
 
 impl PtyExecutor {
     pub fn new(keep_bytes: usize) -> Self {
-        Self { keep_bytes }
+        Self {
+            keep_bytes,
+            display_output: true,
+        }
+    }
+
+    /// Create a silent executor that does not write output to the terminal.
+    /// Suitable for AI tool execution where output should be captured, not displayed.
+    pub fn new_silent(keep_bytes: usize) -> Self {
+        Self {
+            keep_bytes,
+            display_output: false,
+        }
     }
 
     /// Execute a command with full PTY support.
@@ -89,6 +104,18 @@ impl PtyExecutor {
     ) -> aish_core::Result<CommandResult> {
         let session_uuid = uuid::Uuid::new_v4().to_string();
         let base_dir = std::env::temp_dir().to_str().unwrap_or("/tmp").to_string();
+
+        // When display_output is false, skip raw mode and stdin forwarding
+        // since we don't need interactive terminal behavior.
+        if !self.display_output {
+            return self.execute_silent_inner(
+                command,
+                env_vars,
+                cancel_token,
+                &session_uuid,
+                &base_dir,
+            );
+        }
 
         // Create PTY master/slave pair.
         let pty_result =
@@ -188,6 +215,219 @@ impl PtyExecutor {
         let _ = unsafe { File::from_raw_fd(stderr_read_raw) };
 
         result
+    }
+
+    /// Silent execution: no raw mode, no stdin forwarding, no terminal output.
+    /// Only captures stdout/stderr into buffers for structured return.
+    #[allow(clippy::too_many_arguments)]
+    fn execute_silent_inner(
+        &self,
+        command: &str,
+        env_vars: HashMap<String, String>,
+        cancel_token: &CancelToken,
+        session_uuid: &str,
+        base_dir: &str,
+    ) -> aish_core::Result<CommandResult> {
+        // Create PTY master/slave pair.
+        let pty_result =
+            openpty(None, None).map_err(|e| AishError::Pty(format!("failed to openpty: {e}")))?;
+        let master_fd = pty_result.master;
+        let slave_fd = pty_result.slave;
+
+        // Create stderr pipe.
+        let (stderr_pipe_read, stderr_pipe_write) =
+            pipe().map_err(|e| AishError::Pty(format!("failed to create stderr pipe: {e}")))?;
+
+        // Set master fd to non-blocking.
+        set_nonblocking(&master_fd)?;
+
+        // Sync window size from real terminal.
+        let stdin_fd = libc::STDIN_FILENO;
+        let _ = sync_window_size(stdin_fd, master_fd.as_raw_fd());
+
+        let slave_raw = slave_fd.as_raw_fd();
+        let stderr_write_raw = stderr_pipe_write.as_raw_fd();
+
+        let child_pid =
+            match unsafe { fork() }.map_err(|e| AishError::Pty(format!("fork failed: {e}")))? {
+                ForkResult::Parent { child } => {
+                    drop(slave_fd);
+                    drop(stderr_pipe_write);
+                    child
+                }
+                ForkResult::Child => {
+                    child_main(slave_raw, stderr_write_raw, command, env_vars);
+                }
+            };
+
+        debug!(pid = %child_pid, "silent child process started");
+
+        let master_raw = master_fd.into_raw_fd();
+        let stderr_read_raw = stderr_pipe_read.into_raw_fd();
+
+        let result = self.run_silent_io_loop(
+            master_raw,
+            stderr_read_raw,
+            child_pid,
+            cancel_token,
+            session_uuid,
+            base_dir,
+            command,
+        );
+
+        // Close fds.
+        let _ = unsafe { File::from_raw_fd(master_raw) };
+        let _ = unsafe { File::from_raw_fd(stderr_read_raw) };
+
+        result
+    }
+
+    /// Silent I/O loop: only capture output, no terminal display or stdin forwarding.
+    #[allow(clippy::too_many_arguments)]
+    fn run_silent_io_loop(
+        &self,
+        master_fd: RawFd,
+        stderr_read: RawFd,
+        child_pid: Pid,
+        cancel_token: &CancelToken,
+        session_uuid: &str,
+        base_dir: &str,
+        command: &str,
+    ) -> aish_core::Result<CommandResult> {
+        let mut offload =
+            PtyOutputOffload::new(command, session_uuid, "", self.keep_bytes, base_dir);
+
+        let mut stdout_buf: Vec<u8> = Vec::new();
+        let mut stderr_buf: Vec<u8> = Vec::new();
+
+        let mut child_exited = false;
+        let mut exit_code: i32 = -1;
+
+        let tmp_buf_size: usize = 8192;
+
+        while !child_exited {
+            if cancel_token.is_cancelled() {
+                let _ = kill_pg(child_pid, Signal::SIGTERM);
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                let _ = kill_pg(child_pid, Signal::SIGKILL);
+            }
+
+            let mut read_fds: libc::fd_set = unsafe { std::mem::zeroed() };
+            unsafe {
+                libc::FD_ZERO(&mut read_fds);
+                libc::FD_SET(master_fd, &mut read_fds);
+                libc::FD_SET(stderr_read, &mut read_fds);
+            }
+
+            let max_fd = master_fd.max(stderr_read) + 1;
+
+            let mut timeout = libc::timeval {
+                tv_sec: 0,
+                tv_usec: 100_000, // 100ms
+            };
+
+            let select_result = unsafe {
+                libc::select(
+                    max_fd,
+                    &mut read_fds,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    &mut timeout,
+                )
+            };
+
+            if select_result < 0 {
+                let errno = unsafe { *libc::__errno_location() };
+                if errno == libc::EINTR {
+                    child_exited = check_child_exit(child_pid, &mut exit_code);
+                    continue;
+                }
+                return Err(AishError::Pty(format!("select error: errno {errno}")));
+            }
+
+            if select_result == 0 {
+                if !child_exited {
+                    child_exited = check_child_exit_nonblocking(child_pid, &mut exit_code);
+                }
+                continue;
+            }
+
+            // Read from PTY master (stdout) — capture only, no display.
+            if unsafe { libc::FD_ISSET(master_fd, &read_fds) } {
+                let mut tmp = vec![0u8; tmp_buf_size];
+                match unsafe {
+                    libc::read(master_fd, tmp.as_mut_ptr() as *mut libc::c_void, tmp.len())
+                } {
+                    n if n > 0 => {
+                        let data = &tmp[..n as usize];
+                        stdout_buf.extend_from_slice(data);
+                        offload.append_overflow(StreamName::Stdout, data);
+                    }
+                    0 => {
+                        debug!("master fd closed");
+                    }
+                    _ => {}
+                }
+            }
+
+            // Read from stderr pipe — capture only, no display.
+            if unsafe { libc::FD_ISSET(stderr_read, &read_fds) } {
+                let mut tmp = vec![0u8; tmp_buf_size];
+                match unsafe {
+                    libc::read(
+                        stderr_read,
+                        tmp.as_mut_ptr() as *mut libc::c_void,
+                        tmp.len(),
+                    )
+                } {
+                    n if n > 0 => {
+                        let data = &tmp[..n as usize];
+                        stderr_buf.extend_from_slice(data);
+                        offload.append_overflow(StreamName::Stderr, data);
+                    }
+                    _ => {}
+                }
+            }
+
+            if !child_exited {
+                child_exited = check_child_exit_nonblocking(child_pid, &mut exit_code);
+            }
+        }
+
+        // Final wait to reap the child.
+        let (_status, final_exit_code) = reap_child(child_pid, exit_code);
+        exit_code = final_exit_code;
+
+        let stdout_tail = tail_bytes(&stdout_buf, self.keep_bytes);
+        let stderr_tail = tail_bytes(&stderr_buf, self.keep_bytes);
+
+        let offload_result = offload.finalize(&stdout_tail, &stderr_tail, exit_code);
+
+        let stdout_str = String::from_utf8_lossy(&stdout_tail).to_string();
+        let stderr_str = String::from_utf8_lossy(&stderr_tail).to_string();
+
+        let command_status = if cancel_token.is_cancelled() {
+            CommandStatus::Cancelled
+        } else if exit_code == 0 {
+            CommandStatus::Success
+        } else {
+            CommandStatus::Error
+        };
+
+        let offload_value =
+            if offload_result.stdout.path.is_some() || offload_result.stderr.path.is_some() {
+                Some(serde_json::to_value(&offload_result).unwrap_or(serde_json::Value::Null))
+            } else {
+                None
+            };
+
+        Ok(CommandResult {
+            status: command_status,
+            exit_code,
+            stdout: stdout_str,
+            stderr: stderr_str,
+            offload: offload_value,
+        })
     }
 
     /// Main I/O loop: relay bytes between stdin/stdout and the PTY master.

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -411,6 +411,12 @@ impl AishShell {
                     LlmEventType::GenerationStart => {
                         animation_ref.stop();
                         clear_reasoning();
+                        // Reset streamed flag so it only reflects the CURRENT
+                        // generation, not a previous iteration that included
+                        // tool calls with interleaved content.  Without this
+                        // reset, tool-call preview text sets the flag to true,
+                        // and the final text-only response is never printed.
+                        streamed_flag.store(false, Ordering::SeqCst);
                         content_started_flag.store(false, Ordering::SeqCst);
                         reasoning_buf_ref.lock().unwrap().clear();
                         reasoning_frame_ref.store(0, Ordering::SeqCst);

--- a/crates/aish-tools/src/bash.rs
+++ b/crates/aish-tools/src/bash.rs
@@ -74,7 +74,7 @@ impl Tool for BashTool {
             .and_then(|t| t.as_u64())
             .unwrap_or(DEFAULT_TIMEOUT_SECS);
 
-        let executor = PtyExecutor::new(self.keep_bytes);
+        let executor = PtyExecutor::new_silent(self.keep_bytes);
         let cancel_token = Arc::new(CancelToken::new());
 
         // Spawn a thread that cancels after timeout.


### PR DESCRIPTION
## Summary

- Complete Rust implementation of the aish shell, replacing the Python codebase (shell loop, command classification, PTY execution, AI handler, tools, config, memory, skills, completion, plan mode, wizard, i18n, update/uninstall)
- Remove the entire `src/aish/` Python source tree
- Add silent PTY executor mode (`new_silent`) for bash tool calls — skips raw mode and stdin forwarding since AI tool execution doesn't need interactive terminal behavior
- **Fix bash tool calls causing silent response drop**: reset the `streamed_content` flag on each `GenerationStart` event so it only reflects the current generation iteration. Previously, interleaved tool-call preview text set the flag to true, and the final text-only response was never displayed
- Fix Ctrl+C during AI streaming using POSIX sigaction
- Fix diagnose: propagate sub-session events and handle `final_answer` tool
- Delegate tab completion to PTY bash for full bash-completion support

## Test plan

- [x] `cargo build` succeeds
- [x] All existing unit tests pass (`cargo test`)
- [ ] Manual test: AI tool call → verify final response is displayed
- [ ] Manual test: Ctrl+C during AI streaming works correctly
- [ ] Manual test: tab completion works with bash-completion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed CLI application, configuration system, and internationalization support
  * Removed LLM/AI integration, including provider adapters and session management
  * Removed security sandbox infrastructure and permission controls
  * Removed shell runtime, interactive features, and PTY execution
  * Removed memory system, planning mode, and script execution
  * Removed prompt templates and theme system
  * Removed output offloading utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->