### PR TITLE
Update self-update flow to use CDN release metadata

### DIFF
--- a/src/aish/cli/update_manager.py
+++ b/src/aish/cli/update_manager.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import platform
+import re
 import shutil
 import subprocess
 import tarfile
@@ -31,11 +33,12 @@ class UpdateCheckError(Exception):
 
 
 # Constants
+DEFAULT_DOWNLOAD_BASE_URL = "https://cdn.aishell.ai/download"
+GITHUB_RELEASES_PAGE_BASE = "https://github.com/AI-Shell-Team/aish/releases"
 GITHUB_API_LATEST = "https://api.github.com/repos/AI-Shell-Team/aish/releases/latest"
 GITHUB_API_LIST = "https://api.github.com/repos/AI-Shell-Team/aish/releases"
-GITHUB_RELEASES_BASE = "https://github.com/AI-Shell-Team/aish/releases/download"
-FALLBACK_MIRROR = "https://www.aishell.ai/repo"
 CONNECTION_TIMEOUT = 10  # seconds
+VERSION_PATTERN = re.compile(r"^v?[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9]+)*$")
 
 # Version from package
 CURRENT_VERSION = __version__
@@ -61,6 +64,33 @@ class UpdateManager:
             Current version string.
         """
         return CURRENT_VERSION
+
+    def get_download_base_url(self) -> str:
+        """Resolve bundle download base URL.
+
+        Mirrors the standalone installer environment variables.
+        """
+        return os.getenv(
+            "AISH_DOWNLOAD_BASE_URL",
+            os.getenv("AISH_REPO_URL", DEFAULT_DOWNLOAD_BASE_URL),
+        ).rstrip("/")
+
+    def get_latest_version_url(self) -> str:
+        """Resolve the stable latest-version metadata URL."""
+        return os.getenv(
+            "AISH_LATEST_URL",
+            f"{self.get_download_base_url()}/latest",
+        )
+
+    @staticmethod
+    def normalize_tag(version_value: str) -> str:
+        """Normalize a version string into a release tag."""
+        cleaned_value = version_value.strip()
+        if not cleaned_value or not VERSION_PATTERN.fullmatch(cleaned_value):
+            raise UpdateCheckError(
+                f"Invalid latest version metadata: {cleaned_value or '<empty>'}"
+            )
+        return f"v{cleaned_value.lstrip('v')}"
 
     def detect_platform(self) -> tuple[str, str]:
         """Detect operating system and architecture.
@@ -88,7 +118,7 @@ class UpdateManager:
         return plat, arch
 
     def get_latest_release(self, include_pre_release: bool = False) -> Optional[dict]:
-        """Get latest release information from GitHub API.
+        """Get latest release information.
 
         Args:
             include_pre_release: Whether to include pre-releases.
@@ -110,21 +140,28 @@ class UpdateManager:
                 if not releases:
                     return None
                 data = releases[0]
-            else:
-                response = self.client.get(GITHUB_API_LATEST)
-                response.raise_for_status()
-                data = response.json()
+                tag_name = data.get("tag_name")
+                if not tag_name:
+                    return None
 
-            tag_name = data.get("tag_name")
-            if not tag_name:
-                return None
+                return {
+                    "tag_name": tag_name,
+                    "name": data.get("name"),
+                    "body": data.get("body"),
+                    "html_url": data.get("html_url"),
+                    "assets": data.get("assets", []),
+                }
+            else:
+                response = self.client.get(self.get_latest_version_url())
+                response.raise_for_status()
+                tag_name = self.normalize_tag(response.text)
 
             return {
                 "tag_name": tag_name,
-                "name": data.get("name"),
-                "body": data.get("body"),
-                "html_url": data.get("html_url"),
-                "assets": data.get("assets", []),
+                "name": tag_name,
+                "body": "",
+                "html_url": f"{GITHUB_RELEASES_PAGE_BASE}/tag/{tag_name}",
+                "assets": [],
             }
         except httpx.HTTPError as e:
             raise UpdateCheckError(f"Network error while checking for updates: {e}") from e
@@ -222,31 +259,16 @@ class UpdateManager:
         version_str = tag_name.lstrip("v")
         filename = f"aish-{version_str}-{plat}-{arch}.tar.gz"
         dest_path = dest_dir / filename
-
-        # Try GitHub first
-        github_url = f"{GITHUB_RELEASES_BASE}/{tag_name}/{filename}"
+        download_url = f"{self.get_download_base_url()}/{filename}"
 
         try:
-            self._download_with_progress(github_url, dest_path, filename)
+            self._download_with_progress(download_url, dest_path, filename)
             self.console.print(f"[green]Downloaded: {dest_path}[/green]")
             return dest_path
 
-        except httpx.HTTPError:
-            self.console.print(
-                "[yellow]GitHub download failed, trying mirror...[/yellow]"
-            )
-            mirror_url = f"{FALLBACK_MIRROR}/{tag_name}/{filename}"
-
-            try:
-                self._download_with_progress(
-                    mirror_url, dest_path, f"{filename} (mirror)"
-                )
-                self.console.print(f"[green]Downloaded: {dest_path}[/green]")
-                return dest_path
-
-            except httpx.HTTPError as e:
-                self.console.print(f"[red]Download failed from mirror: {e}[/red]")
-                return None
+        except httpx.HTTPError as e:
+            self.console.print(f"[red]Download failed from CDN: {e}[/red]")
+            return None
 
         except Exception as e:
             self.console.print(f"[red]Unexpected error during download: {e}[/red]")

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -14,21 +14,9 @@ def update_manager():
 
 
 @pytest.fixture
-def mock_github_response():
-    """Mock GitHub API response."""
-    return {
-        "tag_name": "v0.3.0",
-        "name": "v0.3.0",
-        "body": "Release notes for v0.3.0",
-        "html_url": "https://github.com/AI-Shell-Team/aish/releases/tag/v0.3.0",
-        "assets": [
-            {
-                "name": "aish-0.3.0-linux-amd64.tar.gz",
-                "browser_download_url": "https://example.com/aish-0.3.0-linux-amd64.tar.gz",
-            }
-        ],
-        "prerelease": False,
-    }
+def mock_latest_version_text():
+    """Mock stable latest-version response body."""
+    return "0.3.0\n"
 
 
 @pytest.mark.timeout(5)
@@ -48,12 +36,12 @@ def test_detect_platform(update_manager):
 @pytest.mark.timeout(5)
 @patch("aish.cli.update_manager.httpx.Client")
 def test_get_latest_release_success(
-    mock_client_class, update_manager, mock_github_response
+    mock_client_class, update_manager, mock_latest_version_text
 ):
-    """Test successful fetching of latest release."""
+    """Test successful fetching of latest release from CDN metadata."""
     mock_response = Mock()
     mock_response.raise_for_status = Mock()
-    mock_response.json = Mock(return_value=mock_github_response)
+    mock_response.text = mock_latest_version_text
     mock_client_instance = mock_client_class.return_value
     mock_client_instance.get = Mock(return_value=mock_response)
 
@@ -62,7 +50,8 @@ def test_get_latest_release_success(
 
     assert result is not None
     assert result["tag_name"] == "v0.3.0"
-    assert result["body"] == "Release notes for v0.3.0"
+    assert result["body"] == ""
+    assert mock_client_instance.get.call_args[0][0].endswith("/latest")
 
 
 @pytest.mark.timeout(5)
@@ -80,12 +69,12 @@ def test_get_latest_release_http_error(mock_client_class, update_manager):
 @pytest.mark.timeout(5)
 @patch("aish.cli.update_manager.httpx.Client")
 def test_check_for_updates_available(
-    mock_client_class, update_manager, mock_github_response
+    mock_client_class, update_manager, mock_latest_version_text
 ):
     """Test checking when update is available."""
     mock_response = Mock()
     mock_response.raise_for_status = Mock()
-    mock_response.json = Mock(return_value=mock_github_response)
+    mock_response.text = mock_latest_version_text
     mock_client_instance = mock_client_class.return_value
     mock_client_instance.get = Mock(return_value=mock_response)
 
@@ -101,17 +90,9 @@ def test_check_for_updates_available(
 @patch("aish.cli.update_manager.httpx.Client")
 def test_check_for_updates_none_available(mock_client_class, update_manager):
     """Test checking when no update available."""
-    old_response = {
-        "tag_name": "v0.1.0",
-        "name": "v0.1.0",
-        "body": "Old release",
-        "html_url": "https://example.com",
-        "assets": [],
-        "prerelease": False,
-    }
     mock_response = Mock()
     mock_response.raise_for_status = Mock()
-    mock_response.json = Mock(return_value=old_response)
+    mock_response.text = "0.1.0\n"
     mock_client_instance = mock_client_class.return_value
     mock_client_instance.get = Mock(return_value=mock_response)
 
@@ -124,7 +105,7 @@ def test_check_for_updates_none_available(mock_client_class, update_manager):
 @pytest.mark.timeout(5)
 @patch("aish.cli.update_manager.httpx.Client")
 def test_download_release_success(mock_client_class, update_manager, tmp_path):
-    """Test successful download."""
+    """Test successful download from CDN."""
     mock_response = Mock()
     mock_response.raise_for_status = Mock()
     mock_response.iter_bytes = Mock(return_value=[b"test data"])
@@ -140,6 +121,35 @@ def test_download_release_success(mock_client_class, update_manager, tmp_path):
 
     assert result is not None
     assert result.name == "aish-0.3.0-linux-amd64.tar.gz"
+    stream_url = mock_client_instance.stream.call_args[0][1]
+    assert stream_url.endswith("/aish-0.3.0-linux-amd64.tar.gz")
+    assert "/v0.3.0/" not in stream_url
+
+
+@pytest.mark.timeout(5)
+@patch("aish.cli.update_manager.httpx.Client")
+def test_download_release_respects_download_base_override(
+    mock_client_class, update_manager, tmp_path, monkeypatch
+):
+    """Test download uses the configured CDN base URL override."""
+    monkeypatch.setenv("AISH_DOWNLOAD_BASE_URL", "https://cdn.example.com/releases")
+
+    mock_response = Mock()
+    mock_response.raise_for_status = Mock()
+    mock_response.iter_bytes = Mock(return_value=[b"test data"])
+    mock_response.headers = {"content-length": "9"}
+    mock_cm = Mock()
+    mock_cm.__enter__ = Mock(return_value=mock_response)
+    mock_cm.__exit__ = Mock(return_value=False)
+    mock_client_instance = mock_client_class.return_value
+    mock_client_instance.stream = Mock(return_value=mock_cm)
+
+    with patch.object(update_manager, "client", mock_client_instance):
+        result = update_manager.download_release("v0.3.0", dest_dir=tmp_path)
+
+    assert result is not None
+    stream_url = mock_client_instance.stream.call_args[0][1]
+    assert stream_url == "https://cdn.example.com/releases/aish-0.3.0-linux-amd64.tar.gz"
 
 
 @pytest.mark.timeout(5)


### PR DESCRIPTION
## Summary
Switch the stable aish update flow to the CDN release metadata and download path used by the installer.

## What changed
- Read the stable latest version from the CDN latest endpoint instead of the GitHub latest release API.
- Build update bundle download URLs from the CDN base URL instead of GitHub release tag paths.
- Honor AISH_DOWNLOAD_BASE_URL and AISH_LATEST_URL, while keeping AISH_REPO_URL as a compatibility alias.
- Update the update manager tests to cover latest metadata parsing, CDN download URLs, and download base overrides.

## Why
The installer now resolves releases from the CDN, so the update command needs to follow the same distribution path. This keeps install and update behavior aligned and avoids depending on the old GitHub release download layout for stable updates.

## Notes
- Stable updates now use CDN metadata and CDN bundle downloads.
- The pre-release lookup path still uses the GitHub releases list because GitHub's latest endpoint excludes prereleases.

## Validation
- /home/lixin/workspace/aishell/aish/.venv/bin/python -m pytest tests/test_update_manager.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Update system now supports configuration via environment variables (`AISH_DOWNLOAD_BASE_URL`, `AISH_REPO_URL`, `AISH_LATEST_URL`) to customize CDN and metadata sources.

* **Chores**
  * Simplified update download process; releases now download directly from configured CDN without fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->