### PR TITLE
Release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2026-04-22
+
+### Changed
+
+- Changed `aish update` stable release detection to read CDN-hosted latest release metadata, and switched archive downloads to the CDN bundle path while preserving `AISH_DOWNLOAD_BASE_URL`, `AISH_LATEST_URL`, and legacy `AISH_REPO_URL` overrides.
+
+### Fixed
+
+- Fixed shared PTY commands so they no longer time out after 30 seconds unless a caller explicitly requests a timeout.
+- Fixed PTY command lifecycle tracking by moving command metadata off the shell input path onto a dedicated metadata pipe, preventing metadata leaks and incorrect backend event binding.
+- Fixed PyInstaller subprocess launches by sanitizing loader environment variables before spawning child processes.
+
 ## [0.2.2] - 2026-04-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aish"
-version = "0.2.2"
+version = "0.2.3"
 description = "AI Shell - A shell with built-in LLM capabilities"
 readme = "README.md"
 authors = [{ name = "Sian Cao", email = "yinshuiboy@gmail.com" }]

--- a/src/aish/__init__.py
+++ b/src/aish/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 # Avoid importing heavy modules (and any side-effects) at package import time.
 # This matters for system services like aish-sandbox, which only need aish.sandboxd.

--- a/uv.lock
+++ b/uv.lock
@@ -146,7 +146,7 @@ wheels = [
 
 [[package]]
 name = "aish"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary
- release version 0.2.3
- switch stable update checks and bundle downloads to CDN-hosted latest metadata and bundle URLs
- include PTY timeout, PTY metadata tracking, and PyInstaller subprocess environment fixes since v0.2.2

## Changelog Highlights
- Changed `aish update` stable release detection to use CDN latest metadata and CDN bundle download paths, while preserving `AISH_DOWNLOAD_BASE_URL`, `AISH_LATEST_URL`, and legacy `AISH_REPO_URL` overrides
- Fixed shared PTY commands so they no longer time out after 30 seconds unless a timeout is explicitly requested
- Fixed PTY command lifecycle tracking by moving metadata onto a dedicated pipe to prevent metadata leaks and incorrect backend event binding
- Fixed PyInstaller subprocess launches by sanitizing loader environment variables before spawning child processes

## Validation
- /home/lixin/workspace/aishell/aish/.venv/bin/python -m pytest tests/scripts/packaging/test_update_release_files.py tests/scripts/packaging/test_release_metadata.py -q
- make test
- make build-bundle
- bash packaging/scripts/smoke-installed-aish.sh ./dist/aish

## Next Step
- After review, manually run `Release Preparation` with `version=0.2.3` and `ref=release/v0.2.3-prep` before merging this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Release detection now uses CDN-hosted metadata and downloads archives from the CDN bundle path for more reliable updates.

* **Bug Fixes**
  * Shared PTY commands no longer timeout unexpectedly unless an explicit timeout is set.
  * PTY metadata handling improved to prevent leaks and incorrect event binding.
  * Subprocess launches in bundled/PyInstaller installs are sanitized to avoid environment-related issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->