### PR TITLE
fix(ci): recreate live smoke install dirs after bundle build

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -98,9 +98,10 @@ jobs:
           BUNDLE="aish-${VERSION}-linux-amd64"
 
           rm -rf "$OUTPUT_DIR" "$EXTRACT_DIR" "$INSTALL_ROOT"
-          mkdir -p "$OUTPUT_DIR" "$EXTRACT_DIR" "$INSTALL_ROOT"
+          mkdir -p "$OUTPUT_DIR"
 
           VERSION="$VERSION" PLATFORM="linux" ARCH="amd64" OUTPUT_DIR="$OUTPUT_DIR" ./packaging/build_bundle.sh
+          mkdir -p "$EXTRACT_DIR" "$INSTALL_ROOT"
           tar -xzf "$OUTPUT_DIR/${BUNDLE}.tar.gz" -C "$EXTRACT_DIR"
           AISH_INSTALL_ROOT="$INSTALL_ROOT" AISH_SKIP_SYSTEMD=1 "$EXTRACT_DIR/${BUNDLE}/install.sh"
           bash ./packaging/scripts/smoke-installed-aish.sh "$INSTALL_ROOT/usr/local/bin/aish"


### PR DESCRIPTION
## Summary
- fix the live smoke workflow so extract and install directories are created after `packaging/build_bundle.sh` runs
- avoid losing `build/live-smoke-extract` and `build/live-smoke-install-root` when the bundle build cleans `build/`
- unblock Release Preparation for fork-based release PRs that reach the live smoke validation stage

## Root Cause
`packaging/build_bundle.sh` may clean the `build/` tree as part of the binary build path. The live smoke workflow created `build/live-smoke-extract` and `build/live-smoke-install-root` before invoking that script, so those directories were removed before `tar -xzf ... -C "$EXTRACT_DIR"` ran.

## Validation
- Reproduced the failure from the workflow log: `tar: .../build/live-smoke-extract: Cannot open: No such file or directory`
- Re-ran the workflow step locally after this change with the same directory layout and bundle install sequence
- Command used: `set -euo pipefail && VERSION=0.0.0+localtest ... ./packaging/build_bundle.sh ... tar -xzf ... && AISH_INSTALL_ROOT=... install.sh && bash ./packaging/scripts/smoke-installed-aish.sh ...`

## Release Impact
- Blocks #124 until this PR is merged and `Release Preparation` is rerun on the release PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build workflow process for improved efficiency in the live smoke testing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->