### PR TITLE
Add R2 release publishing for stable downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,17 +120,64 @@ jobs:
           test -f "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.socket"
           grep -q '^ExecStart=/usr/local/bin/aish-sandbox$' "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.service"
 
-      - name: Upload assets to release
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-bundle-linux-${{ matrix.arch }}
+          path: artifacts/${{ matrix.arch }}/*
+          if-no-files-found: error
+
+      - name: Upload assets to GitHub release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.release-meta.outputs.tag }}
           files: artifacts/${{ matrix.arch }}/*
 
+  publish-release-bundles:
+    name: Publish release bundles
+    needs:
+      - release-meta
+      - release-gate
+      - build-release-packages
+    runs-on: ubuntu-latest
+    environment: release
+    env:
+      VERSION: ${{ needs.release-meta.outputs.version }}
+      ARTIFACT_ROOT: artifacts/release
+      R2_BUCKET: ${{ secrets.R2_BUCKET }}
+      R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: auto
+      CDN_BASE_URL: ${{ vars.CDN_BASE_URL }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v6
+        with:
+          pattern: release-bundle-linux-*
+          path: ${{ env.ARTIFACT_ROOT }}
+
+      - name: Ensure aws CLI is available
+        run: |
+          if ! command -v aws >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y awscli
+          fi
+          aws --version
+
+      - name: Publish release bundles
+        run: bash ./packaging/scripts/publish_release.sh
+
   release-summary:
     name: Summarize published release
     needs:
       - release-meta
+      - create-release
       - build-release-packages
+      - publish-release-bundles
     runs-on: ubuntu-latest
     steps:
       - name: Write job summary
@@ -141,5 +188,5 @@ jobs:
           - Version: ${{ needs.release-meta.outputs.version }}
           - Tag: ${{ needs.release-meta.outputs.tag }}
 
-          GitHub Release metadata was generated from the tag push, and bundle assets were uploaded successfully.
+          GitHub Release metadata was generated from the tag push, bundle assets were uploaded to both GitHub Release and the release bucket, and download/latest was updated successfully.
           EOF

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -10,7 +10,7 @@ curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 
 ### Method 2: Manual Bundle Install
 
-Download the matching `aish-<version>-linux-<arch>.tar.gz` bundle from the official release directory, then run:
+Download the matching `aish-<version>-linux-<arch>.tar.gz` bundle from the GitHub Release assets for your target version: `https://github.com/AI-Shell-Team/aish/releases`, then run:
 
 ```bash
 tar -xzf aish-<version>-linux-<arch>.tar.gz

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ aish> ;explain this command: tar -czf a.tgz ./dir
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-The installer resolves the latest release directory under `https://www.aishell.ai/repo`, downloads the matching bundle for your architecture, and installs `aish`, `aish-sandbox`, and `aish-uninstall` into `/usr/local/bin`.
+The installer resolves the latest stable version, downloads the matching bundle for your architecture, and installs `aish`, `aish-sandbox`, and `aish-uninstall` into `/usr/local/bin`.
 
 ### Run from Source (Development/Trial)
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -121,7 +121,7 @@ aish> ;解释一下这个命令：tar -czf a.tgz ./dir
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-该安装器会在 `https://www.aishell.ai/repo` 下解析最新发布目录，下载与你当前架构匹配的 bundle，并把 `aish`、`aish-sandbox` 和 `aish-uninstall` 安装到 `/usr/local/bin`。
+该安装器会解析最新稳定版本，下载与你当前架构匹配的 bundle，并把 `aish`、`aish-sandbox` 和 `aish-uninstall` 安装到 `/usr/local/bin`。
 
 ### 从源码运行（开发/试用）
 

--- a/README_DE.md
+++ b/README_DE.md
@@ -126,7 +126,7 @@ aish> ;erkläre diesen Befehl: tar -czf a.tgz ./dir
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-Der Installer ermittelt das neueste Release-Verzeichnis unter `https://www.aishell.ai/repo`, lädt das passende Bundle für deine Architektur herunter und installiert `aish`, `aish-sandbox` und `aish-uninstall` in `/usr/local/bin`.
+Der Installer ermittelt die neueste stabile Version, lädt das passende Bundle für deine Architektur herunter und installiert `aish`, `aish-sandbox` und `aish-uninstall` in `/usr/local/bin`.
 
 ### Aus dem Quellcode ausführen (Entwicklung/Test)
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -126,7 +126,7 @@ aish> ;explica este comando: tar -czf a.tgz ./dir
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-El instalador resuelve el último directorio de release en `https://www.aishell.ai/repo`, descarga el bundle correspondiente a tu arquitectura e instala `aish`, `aish-sandbox` y `aish-uninstall` en `/usr/local/bin`.
+El instalador resuelve la versión estable más reciente, descarga el bundle correspondiente para tu arquitectura e instala `aish`, `aish-sandbox` y `aish-uninstall` en `/usr/local/bin`.
 
 ### Ejecutar desde el código fuente (desarrollo/prueba)
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -126,7 +126,7 @@ aish> ;explique cette commande : tar -czf a.tgz ./dir
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-L’installeur résout le répertoire de la dernière release sous `https://www.aishell.ai/repo`, télécharge le bundle correspondant à votre architecture et installe `aish`, `aish-sandbox` et `aish-uninstall` dans `/usr/local/bin`.
+L’installeur détermine la dernière version stable, télécharge le bundle correspondant à votre architecture et installe `aish`, `aish-sandbox` et `aish-uninstall` dans `/usr/local/bin`.
 
 ### Exécuter depuis les sources (développement/essai)
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -126,7 +126,7 @@ aish> ;このコマンドを説明して: tar -czf a.tgz ./dir
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-インストーラは `https://www.aishell.ai/repo` 配下の最新リリースディレクトリを解決し、アーキテクチャに合ったバンドルをダウンロードして `aish`、`aish-sandbox`、`aish-uninstall` を `/usr/local/bin` にインストールします。
+インストーラは最新の安定版を解決し、アーキテクチャに対応するバンドルをダウンロードして `aish`、`aish-sandbox`、`aish-uninstall` を `/usr/local/bin` にインストールします。
 
 ### ソースから実行（開発/試用）
 

--- a/packaging/scripts/publish_release.sh
+++ b/packaging/scripts/publish_release.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_env() {
+	local name="$1"
+	if [[ -z "${!name:-}" ]]; then
+		echo "Missing required environment variable: ${name}" >&2
+		exit 1
+	fi
+}
+
+require_env VERSION
+require_env ARTIFACT_ROOT
+require_env R2_BUCKET
+require_env R2_ENDPOINT
+require_env AWS_ACCESS_KEY_ID
+require_env AWS_SECRET_ACCESS_KEY
+
+DOWNLOAD_PREFIX="${DOWNLOAD_PREFIX:-download}"
+CDN_BASE_URL="${CDN_BASE_URL:-https://cdn.aishell.ai}"
+VERSION="${VERSION#v}"
+ARTIFACT_ROOT="${ARTIFACT_ROOT%/}"
+
+mapfile -t ARTIFACT_FILES < <(
+	find "$ARTIFACT_ROOT" -type f \( \
+		-name "aish-${VERSION}-linux-*.tar.gz" -o \
+		-name "aish-${VERSION}-linux-*.tar.gz.sha256" \
+	\) | sort
+)
+
+if [[ "${#ARTIFACT_FILES[@]}" -eq 0 ]]; then
+	echo "No release artifacts found under ${ARTIFACT_ROOT}" >&2
+	exit 1
+fi
+
+upload_object() {
+	local source_path="$1"
+	local destination_key="$2"
+	local cache_control="$3"
+	shift 3
+
+	aws s3 cp "$source_path" "s3://${R2_BUCKET}/${destination_key}" \
+		--endpoint-url "$R2_ENDPOINT" \
+		--cache-control "$cache_control" \
+		"$@"
+}
+
+for artifact_path in "${ARTIFACT_FILES[@]}"; do
+	artifact_name="$(basename "$artifact_path")"
+	release_key="${DOWNLOAD_PREFIX}/releases/${VERSION}/${artifact_name}"
+	cache_control="public, max-age=31536000, immutable"
+	content_type_args=()
+
+	if [[ "$artifact_name" == *.sha256 ]]; then
+		content_type_args=(--content-type text/plain)
+	fi
+
+	echo "Uploading ${artifact_name} to ${release_key}"
+	upload_object "$artifact_path" "$release_key" "$cache_control" "${content_type_args[@]}"
+done
+
+latest_file="$(mktemp)"
+trap 'rm -f "$latest_file"' EXIT
+printf '%s' "$VERSION" > "$latest_file"
+
+echo "Updating ${DOWNLOAD_PREFIX}/latest"
+	upload_object "$latest_file" "${DOWNLOAD_PREFIX}/latest" "no-store" --content-type text/plain
+
+validated_urls=(
+	"${CDN_BASE_URL%/}/${DOWNLOAD_PREFIX}/latest"
+)
+
+for artifact_path in "${ARTIFACT_FILES[@]}"; do
+	artifact_name="$(basename "$artifact_path")"
+	validated_urls+=("${CDN_BASE_URL%/}/${DOWNLOAD_PREFIX}/releases/${VERSION}/${artifact_name}")
+done
+
+for url in "${validated_urls[@]}"; do
+	echo "Validating ${url}"
+	curl -fsSI --connect-timeout 10 --max-time 30 "$url" >/dev/null
+done
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+	{
+		echo "## CDN Publish"
+		echo
+		echo "- Version: ${VERSION}"
+		echo "- Bucket: ${R2_BUCKET}"
+		echo "- Latest URL: ${CDN_BASE_URL%/}/${DOWNLOAD_PREFIX}/latest"
+		echo
+		echo "### Published artifacts"
+		for artifact_path in "${ARTIFACT_FILES[@]}"; do
+			artifact_name="$(basename "$artifact_path")"
+			echo "- ${DOWNLOAD_PREFIX}/releases/${VERSION}/${artifact_name}"
+		done
+	} >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/src/aish/cli/update_manager.py
+++ b/src/aish/cli/update_manager.py
@@ -82,6 +82,11 @@ class UpdateManager:
             f"{self.get_download_base_url()}/latest",
         )
 
+    def get_release_download_url(self, tag_name: str, filename: str) -> str:
+        """Resolve the CDN URL for a versioned release artifact."""
+        version_str = tag_name.lstrip("v")
+        return f"{self.get_download_base_url()}/releases/{version_str}/{filename}"
+
     @staticmethod
     def normalize_tag(version_value: str) -> str:
         """Normalize a version string into a release tag."""
@@ -259,7 +264,7 @@ class UpdateManager:
         version_str = tag_name.lstrip("v")
         filename = f"aish-{version_str}-{plat}-{arch}.tar.gz"
         dest_path = dest_dir / filename
-        download_url = f"{self.get_download_base_url()}/{filename}"
+        download_url = self.get_release_download_url(tag_name, filename)
 
         try:
             self._download_with_progress(download_url, dest_path, filename)

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -122,8 +122,10 @@ def test_download_release_success(mock_client_class, update_manager, tmp_path):
     assert result is not None
     assert result.name == "aish-0.3.0-linux-amd64.tar.gz"
     stream_url = mock_client_instance.stream.call_args[0][1]
-    assert stream_url.endswith("/aish-0.3.0-linux-amd64.tar.gz")
-    assert "/v0.3.0/" not in stream_url
+    assert (
+        stream_url
+        == "https://cdn.aishell.ai/download/releases/0.3.0/aish-0.3.0-linux-amd64.tar.gz"
+    )
 
 
 @pytest.mark.timeout(5)
@@ -149,7 +151,10 @@ def test_download_release_respects_download_base_override(
 
     assert result is not None
     stream_url = mock_client_instance.stream.call_args[0][1]
-    assert stream_url == "https://cdn.example.com/releases/aish-0.3.0-linux-amd64.tar.gz"
+    assert (
+        stream_url
+        == "https://cdn.example.com/releases/releases/0.3.0/aish-0.3.0-linux-amd64.tar.gz"
+    )
 
 
 @pytest.mark.timeout(5)


### PR DESCRIPTION
## Summary

This PR keeps GitHub Release assets as part of the release flow while also publishing stable release bundles to the R2-backed download bucket.

It moves stable self-update downloads to versioned release paths, adds a dedicated publish step that refreshes `download/latest`, and updates public install documentation so stable installs are described in generic product terms while manual bundle downloads point to GitHub Releases.

## What Changed

- Updated `.github/workflows/release.yml` to:
  - keep uploading built bundles to GitHub Release
  - upload release artifacts for cross-job reuse
  - add a `publish-release-bundles` job gated by the `release` environment
  - publish versioned artifacts to the release bucket and refresh `download/latest`
  - include the bucket publish result in the release summary
- Added `packaging/scripts/publish_release.sh` to:
  - discover built release artifacts
  - upload bundles and `.sha256` files to `download/releases/<version>/`
  - write the stable version to `download/latest`
  - validate the published CDN URLs after upload
- Updated `src/aish/cli/update_manager.py` so stable downloads resolve through `download/releases/<version>/...` instead of the old flat path
- Updated `tests/test_update_manager.py` to cover the versioned stable download URLs and the download-base override behavior
- Updated `README*.md` and `QUICKSTART.md` copy in this repo so:
  - stable install text no longer exposes CDN implementation details
  - manual bundle download guidance points readers to GitHub Release assets

## Why

The stable install and self-update flows now depend on a `download/latest` metadata file plus versioned release artifact directories. The release pipeline has to publish those objects automatically, otherwise stable installs and updates would keep depending on the old flat release layout.

## Validation

- `/home/lixin/workspace/aishell/aish/.venv/bin/python -m pytest tests/test_update_manager.py -k download_release -q`
- `bash -n /home/lixin/workspace/aishell/aish/packaging/scripts/publish_release.sh`

## Notes

- GitHub Release assets remain part of the release process; this change adds synchronized bucket publishing rather than replacing Release assets.
- The PR only contains changes from the `aish` repository itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated installation guides across all languages to reflect downloads from GitHub Releases instead of legacy distribution sources.

* **New Features**
  * Introduced CDN-based release distribution system for faster and more reliable downloads.
  * Updated version resolution to explicitly target the latest stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->