### PR TITLE
Reuse PTY startup handshake during shell startup

### DIFF
--- a/src/aish/shell/runtime/app.py
+++ b/src/aish/shell/runtime/app.py
@@ -1123,7 +1123,13 @@ class PTYAIShell:
             rows=rows, cols=cols, cwd=self._current_cwd, use_output_thread=False,
         )
         self._pty_manager.start()
-        time.sleep(0.2)
+        if self._pty_manager.startup_cwd:
+            self._sync_backend_cwd(self._pty_manager.startup_cwd)
+        if self._pty_manager.startup_ready:
+            self._backend_session_ready = True
+            self._shell_phase = "editing"
+        else:
+            time.sleep(0.2)
 
     def _setup_components(self) -> None:
         self.user_interaction._original_termios = self._original_termios

--- a/src/aish/terminal/pty/manager.py
+++ b/src/aish/terminal/pty/manager.py
@@ -74,6 +74,9 @@ class PTYManager:
         self._completed_results: list[CommandResult] = []
         self._completion_condition = threading.Condition()
         self._next_backend_command_seq = -1
+        self._startup_session_ready = False
+        self._startup_prompt_ready = False
+        self._startup_cwd: Optional[str] = None
 
         # Lock for thread-safe operations
         self._lock = threading.RLock()
@@ -111,6 +114,26 @@ class PTYManager:
     def control_fd(self) -> Optional[int]:
         """Get the read end of the backend control channel."""
         return self._control_fd
+
+    @property
+    def startup_session_ready(self) -> bool:
+        """Whether the startup handshake emitted session_ready."""
+        return self._startup_session_ready
+
+    @property
+    def startup_prompt_ready(self) -> bool:
+        """Whether the startup handshake emitted an initial prompt_ready."""
+        return self._startup_prompt_ready
+
+    @property
+    def startup_ready(self) -> bool:
+        """Whether startup reached an interactive prompt before start() returned."""
+        return self._startup_session_ready and self._startup_prompt_ready
+
+    @property
+    def startup_cwd(self) -> Optional[str]:
+        """Initial cwd reported by the backend startup handshake."""
+        return self._startup_cwd
 
     def set_output_callback(self, callback: Callable[[bytes], None]) -> None:
         """Set callback for PTY output."""
@@ -212,8 +235,8 @@ class PTYManager:
             return
 
         start = time.monotonic()
-        saw_session_ready = False
-        saw_startup_prompt_ready = False
+        saw_session_ready = self._startup_session_ready
+        saw_startup_prompt_ready = self._startup_prompt_ready
         quiet_since: float | None = None
 
         while time.monotonic() - start < timeout:
@@ -234,12 +257,24 @@ class PTYManager:
                     break
                 if not data:
                     continue
-                events = self._dispatch_control_chunk(data)
+                events, errors = self.decode_control_events(data)
+                if errors:
+                    self._protocol_issues.extend(errors)
+                    self._protocol_issues = self._protocol_issues[-50:]
                 for event in events:
                     if event.type == "session_ready":
+                        ps2 = event.payload.get("ps2")
+                        if isinstance(ps2, str) and ps2:
+                            self._continuation_prompt = ps2
+                        cwd = event.payload.get("cwd")
+                        if isinstance(cwd, str) and cwd:
+                            self._startup_cwd = cwd
                         saw_session_ready = True
                     elif event.type == "prompt_ready" and event.payload.get("command_seq") in {None, "", "null"}:
                         saw_startup_prompt_ready = True
+
+        self._startup_session_ready = saw_session_ready
+        self._startup_prompt_ready = saw_startup_prompt_ready
 
     def _output_loop(self) -> None:
         """Background thread to read and forward PTY output."""

--- a/src/aish/terminal/pty/manager.py
+++ b/src/aish/terminal/pty/manager.py
@@ -149,6 +149,10 @@ class PTYManager:
         if self._running:
             return
 
+        self._startup_session_ready = False
+        self._startup_prompt_ready = False
+        self._startup_cwd = None
+
         self._control_fd, self._control_write_fd = os.pipe()
         os.set_inheritable(self._control_write_fd, True)
         self._metadata_read_fd, self._metadata_write_fd = os.pipe()

--- a/tests/shell/runtime/test_shell_pty_core.py
+++ b/tests/shell/runtime/test_shell_pty_core.py
@@ -267,6 +267,7 @@ def test_output_processor_filters_user_command_echo_before_command_output():
 def test_setup_pty_reuses_manager_startup_handshake(monkeypatch, tmp_path):
     frontend_cwd = str(tmp_path / "frontend")
     backend_cwd = str(tmp_path / "backend")
+    sleep_mock = Mock()
 
     class _StartedPTYManager:
         def __init__(self, *, rows: int, cols: int, cwd: str, use_output_thread: bool):
@@ -285,7 +286,7 @@ def test_setup_pty_reuses_manager_startup_handshake(monkeypatch, tmp_path):
 
     monkeypatch.setattr("aish.shell.runtime.app.PTYManager", _StartedPTYManager)
     monkeypatch.setattr("aish.shell.runtime.app.shutil.get_terminal_size", _terminal_size)
-    monkeypatch.setattr("aish.shell.runtime.app.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("aish.shell.runtime.app.time.sleep", sleep_mock)
     monkeypatch.setattr("aish.shell.runtime.app.get_current_env_info", lambda: "env-info")
     monkeypatch.setattr("aish.shell.runtime.app.os.chdir", lambda _cwd: None)
 
@@ -301,6 +302,7 @@ def test_setup_pty_reuses_manager_startup_handshake(monkeypatch, tmp_path):
     assert shell.current_env_info == "env-info"
     assert shell._backend_session_ready is True
     assert shell._shell_phase == "editing"
+    sleep_mock.assert_not_called()
 
 
 def test_output_processor_filters_split_user_command_echo_across_chunks():

--- a/tests/shell/runtime/test_shell_pty_core.py
+++ b/tests/shell/runtime/test_shell_pty_core.py
@@ -38,6 +38,8 @@ class _FakePTYManager:
         self._completion_condition = threading.Condition()
         self._exit_code_callback = None
         self._error_info = error_info
+        self.startup_ready = False
+        self.startup_cwd = None
         self.last_command = last_command
         self.last_exit_code = last_exit_code
         self.register_user_command = Mock(side_effect=self._remember_user_command)
@@ -260,6 +262,39 @@ def test_output_processor_filters_user_command_echo_before_command_output():
     rendered = processor.process(b"pwd\r\n/tmp/project\r\n")
 
     assert rendered == b"/tmp/project\r\n"
+
+
+def test_setup_pty_reuses_manager_startup_handshake(monkeypatch):
+    class _StartedPTYManager:
+        def __init__(self, *, rows: int, cols: int, cwd: str, use_output_thread: bool):
+            assert rows == 24
+            assert cols == 80
+            assert cwd == "/tmp/frontend"
+            assert use_output_thread is False
+            self.startup_ready = True
+            self.startup_cwd = "/tmp/backend"
+
+        def start(self) -> None:
+            return None
+
+    monkeypatch.setattr("aish.shell.runtime.app.PTYManager", _StartedPTYManager)
+    monkeypatch.setattr("aish.shell.runtime.app.shutil.get_terminal_size", lambda: os.terminal_size((80, 24)))
+    monkeypatch.setattr("aish.shell.runtime.app.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("aish.shell.runtime.app.get_current_env_info", lambda: "env-info")
+    monkeypatch.setattr("aish.shell.runtime.app.os.chdir", lambda _cwd: None)
+
+    shell = object.__new__(PTYAIShell)
+    shell._current_cwd = "/tmp/frontend"
+    shell._backend_session_ready = False
+    shell._shell_phase = "booting"
+
+    PTYAIShell._setup_pty(shell)
+
+    assert shell._pty_manager is not None
+    assert shell._current_cwd == "/tmp/backend"
+    assert shell.current_env_info == "env-info"
+    assert shell._backend_session_ready is True
+    assert shell._shell_phase == "editing"
 
 
 def test_output_processor_filters_split_user_command_echo_across_chunks():

--- a/tests/shell/runtime/test_shell_pty_core.py
+++ b/tests/shell/runtime/test_shell_pty_core.py
@@ -264,34 +264,40 @@ def test_output_processor_filters_user_command_echo_before_command_output():
     assert rendered == b"/tmp/project\r\n"
 
 
-def test_setup_pty_reuses_manager_startup_handshake(monkeypatch):
+def test_setup_pty_reuses_manager_startup_handshake(monkeypatch, tmp_path):
+    frontend_cwd = str(tmp_path / "frontend")
+    backend_cwd = str(tmp_path / "backend")
+
     class _StartedPTYManager:
         def __init__(self, *, rows: int, cols: int, cwd: str, use_output_thread: bool):
             assert rows == 24
             assert cols == 80
-            assert cwd == "/tmp/frontend"
+            assert cwd == frontend_cwd
             assert use_output_thread is False
             self.startup_ready = True
-            self.startup_cwd = "/tmp/backend"
+            self.startup_cwd = backend_cwd
 
         def start(self) -> None:
             return None
 
+    def _terminal_size(*_args, **_kwargs):
+        return os.terminal_size((80, 24))
+
     monkeypatch.setattr("aish.shell.runtime.app.PTYManager", _StartedPTYManager)
-    monkeypatch.setattr("aish.shell.runtime.app.shutil.get_terminal_size", lambda: os.terminal_size((80, 24)))
+    monkeypatch.setattr("aish.shell.runtime.app.shutil.get_terminal_size", _terminal_size)
     monkeypatch.setattr("aish.shell.runtime.app.time.sleep", lambda _seconds: None)
     monkeypatch.setattr("aish.shell.runtime.app.get_current_env_info", lambda: "env-info")
     monkeypatch.setattr("aish.shell.runtime.app.os.chdir", lambda _cwd: None)
 
     shell = object.__new__(PTYAIShell)
-    shell._current_cwd = "/tmp/frontend"
+    shell._current_cwd = frontend_cwd
     shell._backend_session_ready = False
     shell._shell_phase = "booting"
 
     PTYAIShell._setup_pty(shell)
 
     assert shell._pty_manager is not None
-    assert shell._current_cwd == "/tmp/backend"
+    assert shell._current_cwd == backend_cwd
     assert shell.current_env_info == "env-info"
     assert shell._backend_session_ready is True
     assert shell._shell_phase == "editing"

--- a/tests/terminal/pty/test_pty_control_protocol.py
+++ b/tests/terminal/pty/test_pty_control_protocol.py
@@ -183,6 +183,12 @@ def test_start_drains_startup_prompt_ready_in_poll_mode():
     try:
         manager.start()
 
+        assert manager.startup_session_ready is True
+        assert manager.startup_prompt_ready is True
+        assert manager.startup_ready is True
+        assert manager.startup_cwd
+        assert manager.consume_protocol_issues() == ()
+
         ready, _, _ = select.select([manager.control_fd], [], [], 0.1)
         assert ready == []
 


### PR DESCRIPTION
## Summary
- expose PTY startup handshake state and startup cwd from `PTYManager`
- reuse that startup-ready state in `PTYAIShell._setup_pty()` instead of waiting for a second backend-ready timeout
- keep the old sleep only as a fallback when startup handshake is unavailable
- add regression tests for manager startup state exposure and shell-side startup handshake reuse

## Validation
- `pytest tests/terminal/pty/test_pty_control_protocol.py tests/shell/runtime/test_shell_pty_core.py`
- repeated startup timing check dropped first-prompt latency from about `3.1s` to about `0.89s` in local measurement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved shell startup: backend session readiness is detected during initialization, the backend working directory is synchronized when available, and the shell moves to editing mode immediately when ready.

* **Bug Fixes**
  * Removed an unnecessary startup delay so initialization proceeds promptly when readiness is confirmed.

* **Tests**
  * Added tests validating the startup handshake, readiness indicators, and immediate post-start state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->