### PR TITLE
chore: release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2026-04-23
+
+### Changed
+
+- Changed stable release publishing so tagged releases now keep GitHub Release assets while also publishing versioned Linux bundles and latest-version metadata to the CDN download paths used by the installer and stable self-update.
+- Changed shell startup to reuse the PTY startup handshake, reducing duplicate initialization work and keeping startup state tracking more consistent.
+
+### Fixed
+
+- Fixed final AI answer rendering so completed responses are shown once and no longer leak startup or timing state into the visible shell session.
+
 ## [0.2.3] - 2026-04-22
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aish"
-version = "0.2.3"
+version = "0.2.4"
 description = "AI Shell - A shell with built-in LLM capabilities"
 readme = "README.md"
 authors = [{ name = "Sian Cao", email = "yinshuiboy@gmail.com" }]

--- a/src/aish/__init__.py
+++ b/src/aish/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 # Avoid importing heavy modules (and any side-effects) at package import time.
 # This matters for system services like aish-sandbox, which only need aish.sandboxd.

--- a/uv.lock
+++ b/uv.lock
@@ -146,7 +146,7 @@ wheels = [
 
 [[package]]
 name = "aish"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary
- bump package version metadata from 0.2.3 to 0.2.4
- add the 0.2.4 changelog section for stable release publishing, PTY startup handshake reuse, and final answer rendering fixes
- refresh uv.lock for the 0.2.4 release candidate

## Validation
- /home/lixin/workspace/aishell/aish/.venv/bin/python -m pytest tests/scripts/packaging/test_update_release_files.py tests/scripts/packaging/test_release_metadata.py -q
- make test
- make build-bundle
- bash packaging/scripts/smoke-installed-aish.sh ./dist/aish

AI-assisted: GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Versioned Linux bundles and "latest-version" metadata now published to CDN paths
  * PTY startup handshake optimization reduces duplicate initialization

* **Bug Fixes**
  * Final AI answer rendering fixed to display completed responses once, without exposing internal state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->