### PR TITLE
fix(tools): support interactive stdin for sudo/su and eliminate pointless retries

### DIFF
--- a/crates/aish-tools/src/bash.rs
+++ b/crates/aish-tools/src/bash.rs
@@ -12,6 +12,14 @@ const CAPTURE_KEEP_BYTES: usize = 10 * 1024 * 1024; // 10MB
 /// Default timeout for command execution in seconds.
 const DEFAULT_TIMEOUT_SECS: u64 = 120;
 
+/// Check if a command likely needs interactive stdin (e.g. sudo password prompt).
+/// False positives (e.g. `grep sudo file`) are harmless — interactive mode just
+/// means output also goes to the terminal, it's still captured for the LLM.
+fn needs_interactive(command: &str) -> bool {
+    let lower = command.to_lowercase();
+    lower.contains("sudo") || lower.starts_with("su ")
+}
+
 /// Tool for executing bash commands via PTY.
 pub struct BashTool {}
 
@@ -71,8 +79,13 @@ impl Tool for BashTool {
             .and_then(|t| t.as_u64())
             .unwrap_or(DEFAULT_TIMEOUT_SECS);
 
-        // Use large keep_bytes so the PTY executor captures full output in memory.
-        let executor = PtyExecutor::new_silent(CAPTURE_KEEP_BYTES);
+        // Use interactive executor (stdin forwarding + terminal display) for
+        // commands that may prompt for a password. Otherwise capture silently.
+        let executor = if needs_interactive(command) {
+            PtyExecutor::new(CAPTURE_KEEP_BYTES)
+        } else {
+            PtyExecutor::new_silent(CAPTURE_KEEP_BYTES)
+        };
         let cancel_token = Arc::new(CancelToken::new());
 
         // Spawn a thread that cancels after timeout.
@@ -109,8 +122,12 @@ impl Tool for BashTool {
                     offload_result.offload_payload.as_ref(),
                 );
 
+                // Always report ok=true when PTY execution succeeds.
+                // Non-zero exit codes are normal command outcomes, not tool
+                // failures — the LLM sees <return_code> and decides what to do.
+                // Returning ok=false triggers a pointless retry of the same command.
                 ToolResult {
-                    ok: result.exit_code == 0,
+                    ok: true,
                     output,
                     meta: offload_result
                         .offload_payload
@@ -134,6 +151,27 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_needs_interactive_sudo() {
+        assert!(needs_interactive("sudo apt update"));
+        assert!(needs_interactive("echo 3 | sudo tee /file"));
+        assert!(needs_interactive("sudo -u root ls"));
+        assert!(needs_interactive("w;sudo ip a"));
+        assert!(needs_interactive("sync&&sudo tee /file"));
+    }
+
+    #[test]
+    fn test_needs_interactive_su() {
+        assert!(needs_interactive("su -"));
+        assert!(needs_interactive("su -c 'whoami'"));
+    }
+
+    #[test]
+    fn test_needs_interactive_no() {
+        assert!(!needs_interactive("ls -la"));
+        assert!(!needs_interactive("echo hello"));
+    }
+
+    #[test]
     #[ignore] // PTY output not reliable in CI environments
     fn test_bash_tool_echo() {
         let tool = BashTool::new();
@@ -154,7 +192,8 @@ mod tests {
         let result = tool.execute(serde_json::json!({
             "command": "exit 42"
         }));
-        assert!(!result.ok, "non-zero exit should report failure");
+        // Tool succeeds even with non-zero exit — LLM reads <return_code> to decide.
+        assert!(result.ok, "tool execution should succeed regardless of exit code");
         assert!(
             result.output.contains("<return_code>\n42\n</return_code>"),
             "output should mention return code 42, got: {}",
@@ -169,7 +208,7 @@ mod tests {
             "command": "sleep 60",
             "timeout": 1
         }));
-        // After timeout + cancellation, exit code should be non-zero.
-        assert!(!result.ok, "timed-out command should report failure");
+        // Tool succeeds even when command is killed by timeout.
+        assert!(result.ok, "tool execution should succeed even after timeout kill");
     }
 }

--- a/crates/aish-tools/src/bash.rs
+++ b/crates/aish-tools/src/bash.rs
@@ -17,7 +17,7 @@ const DEFAULT_TIMEOUT_SECS: u64 = 120;
 /// means output also goes to the terminal, it's still captured for the LLM.
 fn needs_interactive(command: &str) -> bool {
     let lower = command.to_lowercase();
-    lower.contains("sudo") || lower.starts_with("su ")
+    lower.contains("sudo") || lower.contains(" su ") || lower.starts_with("su ")
 }
 
 /// Tool for executing bash commands via PTY.
@@ -163,6 +163,9 @@ mod tests {
     fn test_needs_interactive_su() {
         assert!(needs_interactive("su -"));
         assert!(needs_interactive("su -c 'whoami'"));
+        assert!(needs_interactive("cmd && su -"));
+        assert!(needs_interactive("cmd || su -"));
+        assert!(needs_interactive("cmd | su -"));
     }
 
     #[test]
@@ -193,7 +196,10 @@ mod tests {
             "command": "exit 42"
         }));
         // Tool succeeds even with non-zero exit — LLM reads <return_code> to decide.
-        assert!(result.ok, "tool execution should succeed regardless of exit code");
+        assert!(
+            result.ok,
+            "tool execution should succeed regardless of exit code"
+        );
         assert!(
             result.output.contains("<return_code>\n42\n</return_code>"),
             "output should mention return code 42, got: {}",
@@ -209,6 +215,9 @@ mod tests {
             "timeout": 1
         }));
         // Tool succeeds even when command is killed by timeout.
-        assert!(result.ok, "tool execution should succeed even after timeout kill");
+        assert!(
+            result.ok,
+            "tool execution should succeed even after timeout kill"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Use interactive `PtyExecutor::new()` (stdin forwarding + terminal display) for sudo/su commands, allowing users to type passwords when AI tools execute them. Previously the silent executor ignored stdin, causing sudo to hang until timeout (exit code 143).
- Always report `ok=true` when PTY execution succeeds regardless of exit code. Non-zero exits are normal command outcomes — the LLM sees `<return_code>` and decides what to do. Returning `ok=false` triggered a pointless retry of the same failing command.

## User-visible Changes
- AI tool can now execute sudo/su commands with interactive password input from the user
- sudo commands no longer hang and fail with timeout

## Compatibility
- Fully backward compatible — non-sudo commands continue using silent capture mode

## Testing
- `cargo test -p aish-tools` — 54 passed, 0 failed
- `cargo clippy --all-targets` — 0 warnings
- `cargo fmt --all -- --check` — clean

## Change Type
- Bug fix

## Scope
- `crates/aish-tools/src/bash.rs`