### PR TITLE
fix(pty): clear stale line-discipline input before each command

### DIFF
--- a/crates/aish-pty/src/persistent.rs
+++ b/crates/aish-pty/src/persistent.rs
@@ -143,17 +143,22 @@ impl PersistentPty {
         };
         self.command_state.register_command(command, source, seq);
 
-        let mut payload = String::new();
+        // Prepend Ctrl-U (NAK) to clear stale input in the PTY line
+        // discipline canonical buffer.  Keystrokes forwarded from the
+        // interactive forwarding loop may linger there and corrupt the
+        // next command.
+        let mut payload = b"\x15".to_vec();
         if let Some(s) = seq {
             let quoted = shell_quote_escape(command);
-            payload.push_str(&format!(
-                " __AISH_ACTIVE_COMMAND_SEQ={s}; __AISH_ACTIVE_COMMAND_TEXT={quoted}; "
-            ));
+            payload.extend_from_slice(
+                format!(" __AISH_ACTIVE_COMMAND_SEQ={s}; __AISH_ACTIVE_COMMAND_TEXT={quoted}; ")
+                    .as_bytes(),
+            );
         }
-        payload.push_str(command);
-        payload.push('\n');
+        payload.extend_from_slice(command.as_bytes());
+        payload.push(b'\n');
 
-        self.write_master(payload.as_bytes())
+        self.write_master(&payload)
     }
 
     /// Execute a command and wait for completion with timeout.
@@ -218,10 +223,14 @@ impl PersistentPty {
         // prompt rendering (PS1 / readline init sequences, etc.).
         self.drain_master_silent();
 
-        // Write command to bash.
-        let mut payload = command.to_string();
-        payload.push('\n');
-        self.write_master(payload.as_bytes())?;
+        // Write command to bash.  Prepend Ctrl-U (NAK) to clear any
+        // stale input in the PTY line discipline canonical buffer so
+        // that leftover keystrokes from a previous interactive session
+        // are not prepended to the actual command.
+        let mut payload = vec![0x15];
+        payload.extend_from_slice(command.as_bytes());
+        payload.push(b'\n');
+        self.write_master(&payload)?;
 
         // Save and set terminal to raw mode.
         let stdin_fd = libc::STDIN_FILENO;
@@ -408,6 +417,11 @@ impl PersistentPty {
                             }
                             if let Some(r) = self.command_state.handle_event(event) {
                                 result_exit_code = r.exit_code;
+                                // Discard any stdin bytes captured in the same
+                                // poll cycle.  Without this, a buffered newline
+                                // could execute a stale line before the next
+                                // command's Ctrl-U gets a chance to clear it.
+                                write_buf.clear();
                                 // Enter drain phase instead of exiting immediately.
                                 // The control pipe may deliver PromptReady before
                                 // all PTY output has been flushed to master_fd.

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -110,8 +110,16 @@ impl Hinter for ShellHelper {
         if pos == 0 || pos < line.len() {
             return None;
         }
+        let trimmed = line.trim_start();
         let guard = self.autosuggest.lock().unwrap();
-        guard.suggest(line).map(|s| s[line.len()..].to_string())
+        guard.suggest(trimmed).and_then(|s| {
+            let start = line.len();
+            if start < s.len() && s.is_char_boundary(start) {
+                Some(s[start..].to_string())
+            } else {
+                None
+            }
+        })
     }
 }
 
@@ -126,6 +134,15 @@ impl Completer for ShellHelper {
         pos: usize,
         ctx: &Context<'_>,
     ) -> rustyline::Result<(usize, Vec<Pair>)> {
+        // Clamp pos to nearest valid char boundary (guards against CJK misalignment)
+        let pos = if line.is_char_boundary(pos) {
+            pos
+        } else {
+            (0..=pos)
+                .rev()
+                .find(|&p| line.is_char_boundary(p))
+                .unwrap_or(0)
+        };
         let before = &line[..pos];
         let word_start = before.rfind(' ').map(|i| i + 1).unwrap_or(0);
         let word = &before[word_start..];

--- a/crates/aish-tools/src/python.rs
+++ b/crates/aish-tools/src/python.rs
@@ -3,6 +3,9 @@ use std::process::Command;
 use aish_i18n;
 use aish_llm::{Tool, ToolResult};
 
+/// Maximum output length (matches main branch's 1000 chars).
+const MAX_OUTPUT_CHARS: usize = 1000;
+
 /// Cached translated description.
 static DESCRIPTION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
 
@@ -53,25 +56,21 @@ impl Tool for PythonTool {
             None => return ToolResult::error(aish_i18n::t("tools.python.missing_code")),
         };
 
-        // Build a wrapper script that captures stdout and handles errors
+        let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/"));
+
+        // Spawn python3 with cwd set via Command::current_dir so non-UTF-8
+        // paths are handled correctly (no lossy string conversion needed).
+        let indented_code = indent_each_line(code, " ");
         let wrapper = format!(
-            "import sys, os\n\
-             os.chdir({:?})\n\
-             try:\n\
-             {}\
-             except Exception as e:\n\
-             print(f'Error: {{e}}', file=sys.stderr)\n\
-             sys.exit(1)",
-            std::env::current_dir()
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or_else(|_| "/".to_string()),
-            indent_each_line(code, "    ")
+            "import sys\ntry:\n{indented_code}\nexcept Exception as e:\n print(f'Error: {{e}}',file=sys.stderr)\n sys.exit(1)",
         );
 
         let result = Command::new("python3")
+            .current_dir(&cwd)
             .arg("-c")
             .arg(&wrapper)
             .env("PYTHONIOENCODING", "utf-8")
+            .env("PYTHONUTF8", "1")
             .output();
 
         match result {
@@ -80,22 +79,29 @@ impl Tool for PythonTool {
                 let stderr = String::from_utf8_lossy(&output.stderr);
                 let exit_code = output.status.code().unwrap_or(-1);
 
-                let mut result_text = String::new();
-                if !stdout.is_empty() {
-                    result_text.push_str(&stdout);
-                }
-                if !stderr.is_empty() {
-                    if !result_text.is_empty() {
-                        result_text.push('\n');
-                    }
-                    result_text.push_str(&format!("[stderr]\n{}", stderr));
-                }
+                // Truncate stdout like the main branch (1000 chars).
+                let stdout_owned = stdout.into_owned();
+                let stdout =
+                    if let Some((end, _)) = stdout_owned.char_indices().nth(MAX_OUTPUT_CHARS) {
+                        let mut s = stdout_owned[..end].to_string();
+                        s.push_str("\n[Output truncated due to length]");
+                        s
+                    } else {
+                        stdout_owned
+                    };
 
-                if exit_code == 0 && result_text.is_empty() {
+                if exit_code == 0 && stdout.is_empty() {
                     ToolResult::success(aish_i18n::t("tools.python.no_output"))
                 } else if exit_code == 0 {
-                    ToolResult::success(result_text)
+                    ToolResult::success(stdout)
                 } else {
+                    let mut result_text = stdout;
+                    if !stderr.is_empty() {
+                        if !result_text.is_empty() {
+                            result_text.push('\n');
+                        }
+                        result_text.push_str(&stderr);
+                    }
                     ToolResult {
                         ok: false,
                         output: result_text,
@@ -119,7 +125,8 @@ impl Tool for PythonTool {
     }
 }
 
-/// Indent each line of code for embedding inside a try block.
+/// Indent each line for embedding inside a try block (1 space, matching the
+/// single-space indentation used in the wrapper format string).
 fn indent_each_line(code: &str, indent: &str) -> String {
     code.lines()
         .map(|line| {


### PR DESCRIPTION
## Summary

- Fix command corruption caused by stale keystrokes lingering in the PTY line-discipline canonical buffer after the interactive forwarding loop exits
- Prepend Ctrl-U (NAK, 0x15) before each command to clear residual input; in canonical mode this is processed immediately as a line-kill, preventing stale bytes from being prepended to the actual command
- Fix readline hinter CJK character boundary misalignment and completer position clamping
- Align python tool output truncation with main branch (1000 chars)

## Root Cause

In `send_command_interactive`'s forwarding loop, when `select()` returns with both stdin data and PromptReady in the same iteration:

1. stdin keystrokes are read into `write_buf` (processed first)
2. PromptReady is received, `draining = true`
3. In the next iteration (draining phase), `write_buf` is still written to master_fd

This causes user keystrokes to be forwarded to the PTY's line-discipline buffer even after the command has finished. On the next `send_command_interactive` call, these stale bytes get prepended to the new command, corrupting it (e.g., `ip a` → `sip a`).

## Test plan

- [x] `cargo test` — 502 passed, 0 failed
- [x] `cargo clippy` — 0 warnings
- [x] `cargo build --release` — success
- [ ] Manual: run a failing command, then run `ip a` — should execute correctly
- [ ] Manual: run `vim` / `ssh` — interactive commands still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shell command submission now clears stale buffered keystrokes before sending, preventing accidental or duplicate input.
  * Autosuggestions and completions handle UTF-8 character boundaries and trimmed leading whitespace to avoid invalid or partial-character suggestions.

* **Improvements**
  * Python tool output is capped and composed more predictably (truncated stdout, stderr included on errors), respects working directory handling, and runs subprocesses in UTF-8 mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->