### PR TITLE
fix: route sudo bash_exec through PTY

### DIFF
--- a/src/aish/tools/bash_executor.py
+++ b/src/aish/tools/bash_executor.py
@@ -13,6 +13,7 @@ import os
 import subprocess
 import sys
 import termios
+import fcntl
 from typing import Any, Dict, Optional, Tuple
 
 from ..shell.environment import sanitize_subprocess_loader_env
@@ -188,22 +189,14 @@ class UnifiedBashExecutor:
             # Create PTY
             master_fd, slave_fd = pty.openpty()
 
-            # Set non-blocking mode
-            import fcntl
-
             flags = fcntl.fcntl(master_fd, fcntl.F_GETFL)
             fcntl.fcntl(master_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
 
             def preexec_setup():
                 os.setsid()
-                # Set up controlling terminal
-                os.close(slave_fd)
-                os.close(0)
-                os.close(1)
-                os.close(2)
-                os.open(os.ttyname(0), os.O_RDWR)
-                os.open(os.ttyname(0), os.O_RDWR)
-                os.open(os.ttyname(0), os.O_RDWR)
+                # subprocess has already duplicated slave_fd onto 0/1/2 in the child.
+                # Claim fd 0 as the controlling terminal for interactive programs.
+                fcntl.ioctl(0, termios.TIOCSCTTY, 0)
 
             # Start process
             process = subprocess.Popen(
@@ -222,10 +215,14 @@ class UnifiedBashExecutor:
 
             # Set raw mode
             if old_settings:
-                new_settings = self._build_passthrough_stdin_termios(
-                    termios.tcgetattr(sys.stdin.fileno())
-                )
-                termios.tcsetattr(sys.stdin.fileno(), termios.TCSANOW, new_settings)
+                try:
+                    stdin_fd = sys.stdin.fileno()
+                    new_settings = self._build_passthrough_stdin_termios(
+                        termios.tcgetattr(stdin_fd)
+                    )
+                    termios.tcsetattr(stdin_fd, termios.TCSANOW, new_settings)
+                except (OSError, ValueError, termios.error):
+                    old_settings = None
 
             # I/O multiplexing
             stdout_buffer = b""
@@ -308,7 +305,10 @@ class UnifiedBashExecutor:
         finally:
             # Restore terminal settings
             if old_settings:
-                termios.tcsetattr(sys.stdin.fileno(), termios.TCSANOW, old_settings)
+                try:
+                    termios.tcsetattr(sys.stdin.fileno(), termios.TCSANOW, old_settings)
+                except (OSError, ValueError, termios.error):
+                    pass
 
             # Clean up file descriptors
             if master_fd is not None:

--- a/src/aish/tools/code_exec.py
+++ b/src/aish/tools/code_exec.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import sys
+import threading
 from pathlib import Path
 from typing import ClassVar, Optional
 
@@ -21,6 +22,11 @@ from aish.tools.result import ToolResult
 DISPLAY_MAX_LINES = 2
 DISPLAY_ELLIPSIS = " ..."
 logger = logging.getLogger("aish.tools.code_exec")
+
+
+def _needs_interactive_bash(command: str) -> bool:
+    lower = command.lower()
+    return "sudo" in lower or " su " in lower or lower.startswith("su ")
 
 
 def _collapse_output_lines(text: str, max_lines: int = DISPLAY_MAX_LINES) -> str:
@@ -282,6 +288,23 @@ class BashTool(ToolBase):
         )
         self.context_manager.add_memory(MemoryType.SHELL, history_entry)
 
+    def _get_cancel_event(self):
+        token = self._get_cancellation_token()
+        if token is None:
+            return None
+        if hasattr(token, "is_set"):
+            return token
+        if not hasattr(token, "is_cancelled"):
+            return None
+
+        cancel_event = threading.Event()
+        if token.is_cancelled():
+            cancel_event.set()
+            return cancel_event
+        if hasattr(token, "add_cancellation_callback"):
+            token.add_cancellation_callback(cancel_event.set)
+        return cancel_event
+
     def need_confirm_before_exec(self, code: Optional[str] = None) -> bool:
         """Override ToolBase method to integrate security check"""
         command = code
@@ -500,7 +523,19 @@ class BashTool(ToolBase):
             self.interruption_manager.set_state(ShellState.COMMAND_EXEC)
 
         # Choose execution backend
-        if self.pty_manager and self.pty_manager.is_running:
+        used_interactive_executor = False
+        if _needs_interactive_bash(code):
+            # Shared PTY execution cannot accept stdin mid-tool-call, so route a
+            # small set of known interactive commands to the legacy PTY executor.
+            _success, stdout, stderr, returncode, _changes = self.executor.execute(
+                code,
+                source="ai",
+                use_pty=True,
+                cancel_event=self._get_cancel_event(),
+            )
+            pty_rc = returncode
+            used_interactive_executor = True
+        elif self.pty_manager and self.pty_manager.is_running:
             # PTY execution: share user's bash session
             pty_stdout, pty_rc = self.pty_manager.execute_command(code)
             stdout = pty_stdout
@@ -540,10 +575,10 @@ class BashTool(ToolBase):
                 pass
 
         # 展示执行结果到终端
-        if stdout:
+        if stdout and not used_interactive_executor:
             display_output = _collapse_output_lines(stdout)
             print(display_output)
-        if stderr:
+        if stderr and not used_interactive_executor:
             display_stderr = _collapse_output_lines(stderr)
             print(f"\033[91m{display_stderr}\033[0m")  # 红色输出
 

--- a/tests/tools/test_bash_executor.py
+++ b/tests/tools/test_bash_executor.py
@@ -3,6 +3,7 @@
 import os
 import subprocess
 import sys
+import termios
 from types import SimpleNamespace
 
 import pytest
@@ -278,6 +279,69 @@ class TestUnifiedBashExecutor:
         assert stdout == "ok\n"
         assert captured["LD_LIBRARY_PATH"] == "/usr/lib/system"
         assert captured["TEST_USER_VAR"] == "kept"
+
+    def test_execute_with_pty_claims_controlling_terminal(self, executor, monkeypatch):
+        """测试 PTY 模式会将子进程 stdin 设为 controlling terminal"""
+        self._patch_state_capture(monkeypatch)
+
+        captured = {}
+
+        class DummyProcess:
+            pid = 123
+
+            def poll(self):
+                return 0
+
+            def wait(self, timeout=None):
+                return 0
+
+        def fake_openpty():
+            return (10, 11)
+
+        def fake_tcgetattr(_fd):
+            return [0, 0, 0, 0, 0, 0, [0] * 32]
+
+        def fake_tcsetattr(_fd, _when, _settings):
+            return None
+
+        def fake_fcntl(_fd, _cmd, arg=None):
+            if arg is None:
+                return 0
+            return 0
+
+        def fake_popen(*args, **kwargs):
+            captured["stdin"] = kwargs["stdin"]
+            captured["stdout"] = kwargs["stdout"]
+            captured["stderr"] = kwargs["stderr"]
+            kwargs["preexec_fn"]()
+            return DummyProcess()
+
+        def fake_ioctl(fd, request, arg=0):
+            captured["ioctl"] = (fd, request, arg)
+            return 0
+
+        monkeypatch.setattr("pty.openpty", fake_openpty)
+        monkeypatch.setattr("termios.tcgetattr", fake_tcgetattr)
+        monkeypatch.setattr("termios.tcsetattr", fake_tcsetattr)
+        monkeypatch.setattr("fcntl.fcntl", fake_fcntl)
+        monkeypatch.setattr("fcntl.ioctl", fake_ioctl)
+        monkeypatch.setattr(os, "setsid", lambda: None)
+        monkeypatch.setattr(subprocess, "Popen", fake_popen)
+        reads = iter([b"ok\n", b""])
+
+        monkeypatch.setattr(
+            "select.select", lambda *args, **kwargs: ([10], [], [])
+        )
+        monkeypatch.setattr(os, "read", lambda fd, size: next(reads))
+        monkeypatch.setattr(os, "write", lambda fd, data: len(data))
+        monkeypatch.setattr(os, "close", lambda fd: None)
+
+        executor.execute("echo ok", use_pty=True)
+
+        assert captured["stdin"] == 11
+        assert captured["stdout"] == 11
+        assert captured["stderr"] == 11
+        assert captured["ioctl"] == (0, termios.TIOCSCTTY, 0)
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_bash_output_offload.py
+++ b/tests/tools/test_bash_output_offload.py
@@ -9,7 +9,7 @@ from aish.config import BashOutputOffloadSettings
 from aish.security.security_manager import SecurityDecision
 from aish.security.security_policy import RiskLevel
 from aish.terminal.pty.manager import PTYManager
-from aish.tools.code_exec import BashTool
+from aish.tools.code_exec import BashTool, _needs_interactive_bash
 
 
 def _allow_decision() -> SecurityDecision:
@@ -25,6 +25,14 @@ def _extract_tag(xml_text: str, tag_name: str) -> str:
     match = re.search(rf"<{tag_name}>(.*?)</{tag_name}>", xml_text, flags=re.S)
     assert match is not None
     return match.group(1).strip("\n")
+
+
+def test_needs_interactive_bash_matches_rust_heuristic():
+    assert _needs_interactive_bash("sudo apt update") is True
+    assert _needs_interactive_bash("echo 3 | sudo tee /tmp/x") is True
+    assert _needs_interactive_bash("su -") is True
+    assert _needs_interactive_bash("cmd && su -") is True
+    assert _needs_interactive_bash("ls -la") is False
 
 
 @pytest.mark.asyncio
@@ -125,6 +133,40 @@ async def test_bash_exec_uses_shared_pty_without_metadata_leak(tmp_path: Path):
         assert "__AISH_ACTIVE_COMMAND_TEXT" not in result.output
     finally:
         manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_bash_exec_bypasses_shared_pty_for_interactive_commands():
+    class _FakePTYManager:
+        is_running = True
+
+        def execute_command(self, _code: str):
+            raise AssertionError("interactive commands should not use shared PTY")
+
+    tool = BashTool(
+        pty_manager=_FakePTYManager(),
+        offload_settings=BashOutputOffloadSettings(
+            enabled=True,
+            threshold_bytes=1024,
+            preview_bytes=1024,
+        ),
+    )
+
+    with (
+        patch.object(tool.security_manager, "decide", return_value=_allow_decision()),
+        patch.object(
+            tool.executor,
+            "execute",
+            return_value=(True, "Password:\n", "", 0, {}),
+        ) as execute_mock,
+        patch("builtins.print") as print_mock,
+    ):
+        result = await tool("sudo whoami")
+
+    assert result.ok is True
+    execute_mock.assert_called_once()
+    assert execute_mock.call_args.kwargs["use_pty"] is True
+    print_mock.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 概述

- 问题: `bash_exec` 在共享 PTY 路径下执行 `sudo`/`su` 一类命令时，会停在密码提示处但无法接收用户输入，导致工具调用卡住。
- 改动: 对 `sudo`/`su` 增加最小启发式分流，命中时绕过共享 `PTYManager`，改走 `UnifiedBashExecutor.execute(use_pty=True)`；同时修复旧 PTY 执行器的 controlling terminal 建立逻辑，并补充针对分流与 PTY 启动的测试。
- 关联 Issue: #

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档
- [ ] 其他

## 涉及范围

- [x] 核心 Shell / PTY
- [ ] AI 代理 / LLM
- [x] 技能 / 工具
- [ ] 安全模块
- [ ] 配置系统
- [ ] CLI / 界面
- [ ] 打包 / 安装
- [ ] CI/CD
- [ ] 文档

## 用户可见变更

- `bash_exec` 遇到 `sudo`/`su` 时不再卡死在密码提示处，用户输入会被转发到命令。
- 密码失败或命令结束后，aish 提示符能够正常恢复，后续 shell 命令和普通 `bash_exec` 调用仍可继续使用。

## 兼容性

- 向后兼容? 是
- 配置变更? 否

## 测试验证

- `pytest tests/tools/test_bash_executor.py tests/tools/test_bash_output_offload.py -q`
- 真实场景验证 1: 在交互式 aish 会话中让 AI 使用 `bash_exec` 执行 `sudo -k whoami`，确认出现密码提示并可消费错误密码输入，命令结束后提示符恢复。
- 真实场景验证 2: 在同一会话中完成上述 `sudo` 失败流程后，再执行 `echo shell-alive` 与 `bash_exec("echo tool-ok")`，确认 shell 和工具链均恢复正常。
- AI-assisted: 本 PR 由 Copilot 协助完成；已人工阅读改动并完成上述验证。

## 检查清单

- [x] 代码风格符合项目规范
- [x] 已添加必要的测试
- [ ] 文档已更新（如需要)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent detection and special routing for interactive bash commands (sudo/su-prefixed) for improved execution handling.
  * Enhanced cancellation support for interactive command scenarios.

* **Bug Fixes**
  * Improved terminal configuration robustness with exception-safe error handling and recovery.

* **Tests**
  * Added comprehensive test coverage for PTY execution mode and interactive command detection heuristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->