### PR TITLE
chore: prepare 0.2.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5] - 2026-04-24
+
+### Fixed
+
+- Fixed AI-initiated `bash_exec` commands that invoke `sudo` so they now run through a PTY-backed path instead of hanging when the system prompts for a password.
+
 ## [0.2.4] - 2026-04-23
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aish"
-version = "0.2.4"
+version = "0.2.5"
 description = "AI Shell - A shell with built-in LLM capabilities"
 readme = "README.md"
 authors = [{ name = "Sian Cao", email = "yinshuiboy@gmail.com" }]

--- a/src/aish/__init__.py
+++ b/src/aish/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
 # Avoid importing heavy modules (and any side-effects) at package import time.
 # This matters for system services like aish-sandbox, which only need aish.sandboxd.

--- a/uv.lock
+++ b/uv.lock
@@ -146,7 +146,7 @@ wheels = [
 
 [[package]]
 name = "aish"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary
- bump package version files and lockfile from 0.2.4 to 0.2.5
- add the 0.2.5 changelog entry for the sudo bash_exec PTY fix
- prepare the release candidate branch from main for release validation

## Changelog
- Fixed AI-initiated `bash_exec` commands that invoke `sudo` so they now run through a PTY-backed path instead of hanging when the system prompts for a password.

## Validation
- `/home/lixin/workspace/aishell/aish/.venv/bin/python -m pytest tests/scripts/packaging/test_update_release_files.py tests/scripts/packaging/test_release_metadata.py -q`
- `make test` (634 passed, 6 skipped)

AI-assisted: GitHub Copilot (GPT-5.4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 0.2.5

* **Bug Fixes**
  * Resolved an issue where AI-initiated bash commands invoking `sudo` could hang when prompting for passwords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->