### PR TITLE
fix: improve interactive command handling and tool cancellation

### DIFF
--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -12,7 +12,7 @@ use crate::types::*;
 pub struct LlmSession {
     client: LlmClient,
     tools: HashMap<String, Box<dyn Tool>>,
-    cancellation_token: CancellationToken,
+    cancellation_token: Arc<CancellationToken>,
     event_callback: Option<Arc<dyn Fn(LlmEvent) -> Option<LlmCallbackResult> + Send + Sync>>,
     confirmation_callback: Option<Arc<dyn Fn(&str, &str) -> bool + Send + Sync>>,
     temperature: Option<f32>,
@@ -37,7 +37,7 @@ impl LlmSession {
         Self {
             client: LlmClient::new(api_base, api_key, model),
             tools: HashMap::new(),
-            cancellation_token: CancellationToken::new(),
+            cancellation_token: Arc::new(CancellationToken::new()),
             event_callback: None,
             confirmation_callback: None,
             temperature,
@@ -68,6 +68,12 @@ impl LlmSession {
 
     pub fn cancellation_token(&self) -> &CancellationToken {
         &self.cancellation_token
+    }
+
+    /// Return a shared reference to the cancellation token, allowing tools
+    /// and other components to monitor cancellation without borrowing self.
+    pub fn cancellation_token_arc(&self) -> Arc<CancellationToken> {
+        Arc::clone(&self.cancellation_token)
     }
 
     /// Set the maximum context token budget for message trimming.
@@ -809,7 +815,7 @@ impl LlmSession {
                 self.client.model_name(),
             ),
             tools: HashMap::new(),
-            cancellation_token: CancellationToken::new(),
+            cancellation_token: Arc::new(CancellationToken::new()),
             event_callback: self.event_callback.clone(),
             confirmation_callback: self.confirmation_callback.clone(),
             temperature: self.temperature,

--- a/crates/aish-pty/src/bash_rc_wrapper.sh
+++ b/crates/aish-pty/src/bash_rc_wrapper.sh
@@ -168,6 +168,19 @@ __aish_on_debug() {
             ;;
     esac
 
+    # Re-enable echo for interactive session commands (ssh, telnet, etc.)
+    # so that the remote PTY inherits normal terminal settings.  The
+    # local PTY has -echo set by this wrapper, and SSH propagates these
+    # settings to the remote server, which can confuse the remote shell's
+    # readline.
+    local __aish_cmd_name="${BASH_COMMAND%% *}"
+    __aish_cmd_name="${__aish_cmd_name##*/}"
+    case "$__aish_cmd_name" in
+        ssh|telnet|mosh|nc|netcat|ftp|sftp)
+            stty echo 2>/dev/null || true
+            ;;
+    esac
+
     __AISH_AT_PROMPT=0
     __aish_emit_command_started "$BASH_COMMAND"
     return 0
@@ -183,6 +196,9 @@ __aish_prompt_command() {
     fi
     # Keep PS1 empty — prompt rendering is handled by the Python frontend.
     PS1=''
+    # Re-disable echo in case a session command (ssh, telnet) re-enabled
+    # it via the DEBUG trap.  The frontend handles all display itself.
+    stty -echo -echonl 2>/dev/null || true
     __AISH_AT_PROMPT=1
     __aish_emit_prompt_ready "$exit_code"
 }

--- a/crates/aish-pty/src/persistent.rs
+++ b/crates/aish-pty/src/persistent.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use nix::fcntl::{fcntl, FcntlArg, OFlag};
 use nix::pty::openpty;
 use nix::sys::signal::{kill, Signal};
-use nix::sys::termios::{cfmakeraw, tcgetattr, tcsetattr, SetArg};
+use nix::sys::termios::{cfmakeraw, tcgetattr, tcsetattr, OutputFlags, SetArg};
 use nix::unistd::{close, dup2, execvp, fork, pipe, ForkResult, Pid};
 
 use aish_core::AishError;
@@ -117,16 +117,18 @@ impl PersistentPty {
             exec_mode: Arc::new(AtomicBool::new(false)),
         };
 
-        // Wait for session_ready event.
-        pty.wait_for_session_ready(Duration::from_secs(5))?;
+        // Wait for session_ready event.  Also returns whether the
+        // initial PromptReady was seen in the same control-pipe read
+        // (common case: both arrive together).
+        let saw_prompt = pty.wait_for_session_ready(Duration::from_secs(5))?;
 
-        // Drain any stale events (e.g., prompt_ready from bash's initial
-        // prompt rendering) left in the control pipe after session_ready.
-        // Without this, the first user command would match the stale
-        // prompt_ready and exit the forwarding loop immediately, producing
-        // no output.
+        // Consume the initial PromptReady if it wasn't already seen
+        // during session_ready.  Use a short timeout — bash emits it
+        // very quickly after SessionReady.
+        if !saw_prompt {
+            pty.wait_for_initial_prompt_ready(Duration::from_millis(500));
+        }
         pty.drain_master_to_stdout();
-        pty.drain_control_pipe();
 
         // Now safe to clean up rcfile -- bash has loaded it.
         let _ = std::fs::remove_file(&rcfile_path);
@@ -216,12 +218,18 @@ impl PersistentPty {
         command: &str,
     ) -> aish_core::Result<(i32, String, String)> {
         let is_session = is_session_command(command);
+
+        // Drain stale data from both the PTY master fd and the control
+        // pipe BEFORE registering the new command.  A stale PromptReady
+        // left in the control pipe (e.g. from bash's initial prompt or
+        // from a previous command whose event arrived late) would be
+        // matched with the new command's submission, producing a wrong
+        // exit code (the classic off-by-one shift).
+        self.drain_master_silent();
+        self.drain_control_pipe_raw();
+
         self.command_state
             .register_command(command, CommandSource::User, None);
-
-        // Drain any stale PTY output left from the previous command's
-        // prompt rendering (PS1 / readline init sequences, etc.).
-        self.drain_master_silent();
 
         // Write command to bash.  Prepend Ctrl-U (NAK) to clear any
         // stale input in the PTY line discipline canonical buffer so
@@ -239,6 +247,13 @@ impl PersistentPty {
         if let Some(ref saved) = saved_termios {
             let mut raw = saved.clone();
             cfmakeraw(&mut raw);
+            // Re-enable output processing so that \n in PTY output is
+            // converted to \r\n by the terminal driver.  Without this,
+            // interactive sessions (ssh, telnet) display prompts
+            // concatenated on the same line because the terminal emulator
+            // only moves the cursor down for bare \n without returning to
+            // column 0.
+            raw.output_flags |= OutputFlags::OPOST | OutputFlags::ONLCR;
             let _ = tcsetattr(stdin_borrowed, SetArg::TCSANOW, &raw);
         }
 
@@ -541,6 +556,28 @@ impl PersistentPty {
         }
     }
 
+    /// Drain stale data from the control pipe and discard it without
+    /// processing events through the command state machine.  Called
+    /// before registering a new command to prevent a stale PromptReady
+    /// (e.g. from bash's initial prompt or a late-arriving event) from
+    /// being matched with the wrong command submission.
+    fn drain_control_pipe_raw(&mut self) {
+        self.control_buffer.clear();
+        let mut tmp = [0u8; 4096];
+        loop {
+            match unsafe {
+                libc::read(
+                    self.control_fd,
+                    tmp.as_mut_ptr() as *mut libc::c_void,
+                    tmp.len(),
+                )
+            } {
+                n if n > 0 => { /* discard */ }
+                _ => break,
+            }
+        }
+    }
+
     /// Drain any remaining data from master_fd to stdout.
     /// Called after the forwarding loop exits to prevent stale output
     /// from appearing at the start of the next command.
@@ -593,13 +630,13 @@ impl PersistentPty {
         }
     }
 
-    /// Drain all remaining events from the control pipe.
-    /// Called after session_ready to consume any stale prompt_ready events
-    /// emitted during bash initialization, preventing them from being
-    /// misinterpreted as completion of the first user command.
-    fn drain_control_pipe(&mut self) {
-        let mut tmp = [0u8; 4096];
-        loop {
+    /// Wait for the first PromptReady event from bash (the initial prompt
+    /// displayed after startup).  Best-effort — a timeout is not fatal
+    /// because `send_command_interactive` also drains stale events.
+    fn wait_for_initial_prompt_ready(&mut self, timeout: Duration) {
+        let deadline = std::time::Instant::now() + timeout;
+        while std::time::Instant::now() < deadline {
+            let mut tmp = [0u8; 4096];
             match unsafe {
                 libc::read(
                     self.control_fd,
@@ -609,15 +646,39 @@ impl PersistentPty {
             } {
                 n if n > 0 => {
                     let events = decode_control_chunk(&mut self.control_buffer, &tmp[..n as usize]);
-                    // Process events (e.g., update command_state) but
-                    // don't act on them -- they're stale.
                     for event in &events {
-                        let _ = self.command_state.handle_event(event);
+                        if matches!(event, BackendControlEvent::PromptReady { .. }) {
+                            debug!("consumed initial prompt_ready from bash");
+                            return;
+                        }
                     }
                 }
-                _ => break, // EAGAIN / nothing more to read
+                0 => {
+                    // Control pipe closed.
+                    return;
+                }
+                _ => {}
             }
+            // Drain master_fd to the output callback so initial bash output
+            // (MOTD, etc.) is not lost.
+            let mut mtmp = [0u8; 8192];
+            match unsafe {
+                libc::read(
+                    self.master_fd,
+                    mtmp.as_mut_ptr() as *mut libc::c_void,
+                    mtmp.len(),
+                )
+            } {
+                n if n > 0 => {
+                    if let Some(ref cb) = self.output_callback {
+                        cb(&mtmp[..n as usize]);
+                    }
+                }
+                _ => {}
+            }
+            std::thread::sleep(Duration::from_millis(10));
         }
+        debug!("timed out waiting for initial prompt_ready (non-fatal)");
     }
 
     fn write_master(&self, data: &[u8]) -> aish_core::Result<()> {
@@ -639,7 +700,8 @@ impl PersistentPty {
         Ok(())
     }
 
-    fn wait_for_session_ready(&mut self, timeout: Duration) -> aish_core::Result<()> {
+    /// Returns Ok(true) if PromptReady was also seen in the same batch.
+    fn wait_for_session_ready(&mut self, timeout: Duration) -> aish_core::Result<bool> {
         let deadline = std::time::Instant::now() + timeout;
         while std::time::Instant::now() < deadline {
             // Drain any initial bash output from master_fd.
@@ -676,11 +738,18 @@ impl PersistentPty {
                 n if n > 0 => {
                     let events =
                         decode_control_chunk(&mut self.control_buffer, &ctrl_tmp[..n as usize]);
+                    let mut found_session = false;
+                    let mut found_prompt = false;
                     for event in &events {
-                        if matches!(event, BackendControlEvent::SessionReady { .. }) {
-                            debug!("received session_ready from bash");
-                            return Ok(());
+                        match event {
+                            BackendControlEvent::SessionReady { .. } => found_session = true,
+                            BackendControlEvent::PromptReady { .. } => found_prompt = true,
+                            _ => {}
                         }
+                    }
+                    if found_session {
+                        debug!("received session_ready from bash");
+                        return Ok(found_prompt);
                     }
                 }
                 0 => {

--- a/crates/aish-shell/src/ai_handler.rs
+++ b/crates/aish-shell/src/ai_handler.rs
@@ -218,6 +218,11 @@ impl AiHandler {
         self.llm_session.cancellation_token()
     }
 
+    /// Get a shared reference to the cancellation token for use in tools.
+    pub fn cancellation_token_arc(&self) -> std::sync::Arc<aish_llm::CancellationToken> {
+        self.llm_session.cancellation_token_arc()
+    }
+
     /// Add a shell command result to the LLM context so the AI can reference
     /// previous command output in follow-up questions.
     pub fn add_shell_context(&mut self, entry: &str) {

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -184,9 +184,9 @@ impl AishShell {
             move |cmd: &str| mgr.check_command(cmd)
         };
         let mut tool_registry = ToolRegistry::new();
-        tool_registry.register(Box::new(aish_tools::SecureBashTool::with_security_check(
-            security_check,
-        )));
+        let mut bash_tool = aish_tools::SecureBashTool::with_security_check(security_check);
+        bash_tool.set_cancellation_token(llm_session.cancellation_token_arc());
+        tool_registry.register(Box::new(bash_tool));
         tool_registry.register(Box::new(aish_tools::fs::ReadFileTool::new()));
         tool_registry.register(Box::new(aish_tools::fs::WriteFileTool::new()));
         tool_registry.register(Box::new(aish_tools::fs::EditFileTool::new()));

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -100,7 +101,11 @@ impl ShellHelper {
 
 impl Helper for ShellHelper {}
 
-impl Highlighter for ShellHelper {}
+impl Highlighter for ShellHelper {
+    fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
+        Cow::Owned(format!("\x1b[38;5;242m{}\x1b[0m", hint))
+    }
+}
 
 impl Hinter for ShellHelper {
     type Hint = String;
@@ -252,7 +257,7 @@ pub struct ShellReadline {
 
 impl ShellReadline {
     pub fn new(pty: Arc<Mutex<aish_pty::PersistentPty>>) -> rustyline::Result<Self> {
-        let autosuggest = Arc::new(Mutex::new(AutoSuggest::new(1000)));
+        let autosuggest = Arc::new(Mutex::new(AutoSuggest::new(5000)));
 
         let builder = Config::builder()
             .completion_type(CompletionType::List)
@@ -349,8 +354,15 @@ impl ShellReadline {
     }
 
     /// Load history from a file (best-effort).
+    /// Also populates the autosuggest engine so hints appear immediately.
     pub fn load_history(&mut self, path: &std::path::Path) {
-        let _ = self.editor.load_history(path);
+        if self.editor.load_history(path).is_ok() {
+            let history = self.editor.history();
+            let mut guard = self.autosuggest.lock().unwrap();
+            for entry in history.iter() {
+                guard.add(entry);
+            }
+        }
     }
 
     /// Save history to a file (best-effort).

--- a/crates/aish-tools/src/bash.rs
+++ b/crates/aish-tools/src/bash.rs
@@ -1,8 +1,9 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use aish_i18n;
-use aish_llm::{Tool, ToolResult};
+use aish_llm::{CancellationToken, Tool, ToolResult};
 use aish_pty::{BashOffloadSettings, BashOutputOffload, CancelToken, PtyExecutor};
 
 /// Large keep_bytes for the silent PTY executor to capture full command output.
@@ -12,16 +13,45 @@ const CAPTURE_KEEP_BYTES: usize = 10 * 1024 * 1024; // 10MB
 /// Default timeout for command execution in seconds.
 const DEFAULT_TIMEOUT_SECS: u64 = 120;
 
-/// Check if a command likely needs interactive stdin (e.g. sudo password prompt).
-/// False positives (e.g. `grep sudo file`) are harmless — interactive mode just
-/// means output also goes to the terminal, it's still captured for the LLM.
+/// Commands that need a real terminal for interactive use.
+const INTERACTIVE_COMMANDS: &[&str] = &[
+    "vim", "vi", "nano", "emacs", "ssh", "telnet", "mosh", "htop", "top", "btop", "iotop", "less",
+    "more", "most", "man", "screen", "tmux", "mc", "ranger",
+];
+
+/// Commands that establish a remote session where Ctrl-C should be forwarded
+/// as a character rather than converted to SIGINT.
+const SESSION_COMMANDS: &[&str] = &["ssh", "telnet", "mosh", "nc", "netcat", "ftp", "sftp"];
+
+/// Check if a command likely needs interactive stdin (e.g. sudo password prompt,
+/// ssh password, or a full-screen TUI program).
+/// False positives are acceptable because output is still captured for the LLM.
 fn needs_interactive(command: &str) -> bool {
     let lower = command.to_lowercase();
-    lower.contains("sudo") || lower.contains(" su ") || lower.starts_with("su ")
+
+    // sudo / su always need interactive stdin for password prompts.
+    if lower.contains("sudo") || lower.contains(" su ") || lower.starts_with("su ") {
+        return true;
+    }
+
+    // Check first word against known interactive commands.
+    let first = command.split_whitespace().next().unwrap_or("");
+    let basename = first.rsplit('/').next().unwrap_or(first);
+
+    if INTERACTIVE_COMMANDS.contains(&basename) || SESSION_COMMANDS.contains(&basename) {
+        return true;
+    }
+
+    false
 }
 
 /// Tool for executing bash commands via PTY.
-pub struct BashTool {}
+pub struct BashTool {
+    /// Shared cancellation token from the AI handler.
+    /// When the user presses Ctrl+C during AI processing, this token is set,
+    /// and a bridge thread propagates the cancellation to the tool's CancelToken.
+    cancellation_token: Option<Arc<CancellationToken>>,
+}
 
 /// Cached translated description.
 static DESCRIPTION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
@@ -38,7 +68,15 @@ impl Default for BashTool {
 
 impl BashTool {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            cancellation_token: None,
+        }
+    }
+
+    /// Set the shared cancellation token from the AI handler.
+    /// This allows Ctrl+C during AI processing to cancel in-progress tool execution.
+    pub fn set_cancellation_token(&mut self, token: Arc<CancellationToken>) {
+        self.cancellation_token = Some(token);
     }
 }
 
@@ -96,9 +134,33 @@ impl Tool for BashTool {
             timeout_token.cancel();
         });
 
+        // Bridge: watch the AI handler's CancellationToken and propagate to our
+        // local CancelToken.  This ensures Ctrl+C during tool execution actually
+        // kills the PTY child process.
+        let done = Arc::new(AtomicBool::new(false));
+        if let Some(ref ct) = self.cancellation_token {
+            let ct = Arc::clone(ct);
+            let tool_cancel = Arc::clone(&cancel_token);
+            let done = Arc::clone(&done);
+            std::thread::spawn(move || {
+                while !done.load(Ordering::SeqCst) {
+                    if ct.is_cancelled() {
+                        tool_cancel.cancel();
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+            });
+        }
+
         let env_vars: std::collections::HashMap<String, String> = std::env::vars().collect();
 
-        match executor.execute_blocking(command, env_vars, &cancel_token) {
+        let result = executor.execute_blocking(command, env_vars, &cancel_token);
+
+        // Signal the bridge thread to stop polling.
+        done.store(true, Ordering::SeqCst);
+
+        match result {
             Ok(result) => {
                 // Use BashOutputOffload for threshold-based offload, matching Python's
                 // render_bash_output(). This handles:
@@ -172,6 +234,25 @@ mod tests {
     fn test_needs_interactive_no() {
         assert!(!needs_interactive("ls -la"));
         assert!(!needs_interactive("echo hello"));
+        assert!(!needs_interactive("cat /etc/hosts"));
+        assert!(!needs_interactive("grep pattern file.txt"));
+    }
+
+    #[test]
+    fn test_needs_interactive_ssh() {
+        assert!(needs_interactive("ssh user@host"));
+        assert!(needs_interactive("ssh -l root 10.10.17.112"));
+        assert!(needs_interactive("/usr/bin/ssh user@host"));
+        assert!(needs_interactive("telnet example.com 23"));
+        assert!(needs_interactive("mosh user@host"));
+    }
+
+    #[test]
+    fn test_needs_interactive_tui() {
+        assert!(needs_interactive("vim file.txt"));
+        assert!(needs_interactive("htop"));
+        assert!(needs_interactive("top"));
+        assert!(needs_interactive("less /var/log/syslog"));
     }
 
     #[test]

--- a/crates/aish-tools/src/secure_bash.rs
+++ b/crates/aish-tools/src/secure_bash.rs
@@ -1,4 +1,6 @@
-use aish_llm::{Tool, ToolResult};
+use std::sync::Arc;
+
+use aish_llm::{CancellationToken, Tool, ToolResult};
 use aish_security::SecurityDecision;
 
 /// Type of the security check callback.
@@ -74,6 +76,11 @@ impl SecureBashTool {
             inner: crate::bash::BashTool::new(),
             security_check: Some(Box::new(security_check)),
         }
+    }
+
+    /// Set the shared cancellation token from the AI handler.
+    pub fn set_cancellation_token(&mut self, token: Arc<CancellationToken>) {
+        self.inner.set_cancellation_token(token);
     }
 }
 


### PR DESCRIPTION
## Summary
- Add cancellation token bridging from AI handler to BashTool so Ctrl+C during AI tool execution terminates the PTY child process
- Expand interactive command detection with explicit lists for TUI programs (vim, htop, less) and session commands (ssh, telnet, mosh)
- Re-enable echo and output processing (OPOST/ONLCR) for session commands so remote PTY displays correctly
- Improve PTY initialization to prevent stale PromptReady events from shifting exit codes
- Enhance readline with gray hint highlighting and autosuggest pre-population from saved history

## Test plan
- [x] `cargo build` — 0 warnings
- [x] `cargo clippy` — clean
- [x] `cargo test` — 524 passed, 0 failed, 3 ignored
- [ ] Manual: run `ssh user@host` from aish and verify remote prompt displays correctly
- [ ] Manual: run AI tool with long command, press Ctrl+C, verify child process is terminated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shell readline now shows colored hint highlighting.
  * Tools can receive shared cancellation tokens so long-running shell tools respect LLM-driven cancellation.

* **Bug Fixes**
  * Restored terminal echo for remote-session commands to prevent broken remote shells.
  * Prevented prompt concatenation by improving interactive prompt handling and output translation.

* **Improvements**
  * Better propagation of cancellation tokens across LLM and tooling paths.
  * Autosuggest seeded from loaded history for immediate hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->