### PR TITLE
feat: Ctrl+Z job control + spinner fix

### DIFF
--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -274,7 +274,7 @@ impl LlmSession {
                 metadata: None,
             });
 
-            let response = self
+            let response = match self
                 .client
                 .chat_completion(
                     &messages,
@@ -283,7 +283,25 @@ impl LlmSession {
                     self.temperature,
                     self.max_tokens,
                 )
-                .await?;
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    self.emit_event(LlmEvent {
+                        event_type: LlmEventType::Error,
+                        data: serde_json::json!({"error": e.to_string()}),
+                        timestamp: now_timestamp(),
+                        metadata: None,
+                    });
+                    self.emit_event(LlmEvent {
+                        event_type: LlmEventType::OpEnd,
+                        data: serde_json::json!({"reason": "api_error"}),
+                        timestamp: now_timestamp(),
+                        metadata: None,
+                    });
+                    return Err(e);
+                }
+            };
 
             match response {
                 LlmResponse::Json(json) => {

--- a/crates/aish-pty/src/bash_rc_wrapper.sh
+++ b/crates/aish-pty/src/bash_rc_wrapper.sh
@@ -7,6 +7,9 @@
 set +o emacs
 set +o vi
 
+# Enable job control so Ctrl+Z suspends foreground jobs
+set -m
+
 # Source user's bashrc if exists
 if [ -f ~/.bashrc ]; then
     source ~/.bashrc

--- a/crates/aish-pty/src/executor.rs
+++ b/crates/aish-pty/src/executor.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::fs::File;
 use std::os::fd::{AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use nix::fcntl::{fcntl, FcntlArg, OFlag};
 use nix::pty::openpty;
@@ -15,38 +14,7 @@ use aish_core::{AishError, CommandResult, CommandStatus};
 use tracing::{debug, warn};
 
 use crate::offload::PtyOutputOffload;
-use crate::types::StreamName;
-
-// ---------------------------------------------------------------------------
-// CancelToken
-// ---------------------------------------------------------------------------
-
-/// Simple cancellation token backed by an atomic bool.
-pub struct CancelToken {
-    cancelled: AtomicBool,
-}
-
-impl Default for CancelToken {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl CancelToken {
-    pub fn new() -> Self {
-        Self {
-            cancelled: AtomicBool::new(false),
-        }
-    }
-
-    pub fn cancel(&self) {
-        self.cancelled.store(true, Ordering::SeqCst);
-    }
-
-    pub fn is_cancelled(&self) -> bool {
-        self.cancelled.load(Ordering::SeqCst)
-    }
-}
+use crate::types::{CancelToken, StreamName};
 
 /// Send a signal to the process *group* led by `pid`.
 fn kill_pg(pid: Pid, sig: Signal) -> nix::Result<()> {

--- a/crates/aish-pty/src/lib.rs
+++ b/crates/aish-pty/src/lib.rs
@@ -23,7 +23,8 @@ pub mod types;
 
 pub use command_state::CommandState;
 pub use control::{decode_control_chunk, encode_control_event, BackendControlEvent};
-pub use executor::{CancelToken, PtyExecutor};
+pub use executor::PtyExecutor;
+pub use types::CancelToken;
 pub use offload::{
     BashOffloadResult, BashOffloadSettings, BashOutputOffload, OffloadResult, OffloadState,
     PtyOutputOffload,

--- a/crates/aish-pty/src/persistent.rs
+++ b/crates/aish-pty/src/persistent.rs
@@ -15,7 +15,7 @@ use tracing::debug;
 
 use crate::command_state::CommandState;
 use crate::control::{decode_control_chunk, BackendControlEvent};
-use crate::types::CommandSource;
+use crate::types::{CancelToken, CommandSource};
 
 /// Bash rc wrapper script embedded at compile time.
 const BASH_RC_WRAPPER: &str = include_str!("bash_rc_wrapper.sh");
@@ -165,10 +165,14 @@ impl PersistentPty {
 
     /// Execute a command and wait for completion with timeout.
     /// Returns cleaned output and exit code.
+    /// When `cancel_token` is provided, the caller can request
+    /// cancellation; on cancel the method sends SIGINT and returns
+    /// exit code -1.
     pub fn execute_command(
         &mut self,
         command: &str,
         timeout: Duration,
+        cancel_token: Option<&CancelToken>,
     ) -> aish_core::Result<(String, i32)> {
         let seq = self.allocate_backend_seq();
 
@@ -178,17 +182,175 @@ impl PersistentPty {
 
         self.send_command(command, Some(seq))?;
 
-        // Poll for prompt_ready event.
-        let result = self.wait_for_prompt_ready(seq, timeout);
+        // Save and set terminal to non-canonical mode so we can read
+        // individual bytes (Ctrl+Z = 0x1a, Ctrl+C = 0x03) without the
+        // terminal driver intercepting them.
+        let stdin_fd = libc::STDIN_FILENO;
+        let stdin_borrowed = unsafe { std::os::fd::BorrowedFd::borrow_raw(stdin_fd) };
+        let saved_termios = tcgetattr(stdin_borrowed).ok();
+        if let Some(ref saved) = saved_termios {
+            let mut raw = saved.clone();
+            use nix::sys::termios::{ControlFlags, InputFlags, LocalFlags};
+            raw.local_flags &= !(LocalFlags::ICANON | LocalFlags::ECHO | LocalFlags::ISIG);
+            raw.input_flags &= !InputFlags::ISTRIP;
+            raw.control_flags &= !ControlFlags::CSIZE;
+            raw.control_flags |= ControlFlags::CS8;
+            raw.control_chars[libc::VMIN] = 1;
+            raw.control_chars[libc::VTIME] = 0;
+            let _ = tcsetattr(stdin_borrowed, SetArg::TCSANOW, &raw);
+        }
 
-        // Drain any remaining master_fd output into exec buffer before
-        // exiting exec mode, so stale data doesn't leak to the next command.
+        let deadline = std::time::Instant::now() + timeout;
+        let mut result_exit_code: i32 = -1;
+        let mut cancelled = false;
+
+        // Select-based I/O loop.
+        'select_loop: while std::time::Instant::now() < deadline {
+            // Check external cancellation.
+            if let Some(ref ct) = cancel_token {
+                if ct.is_cancelled() {
+                    let _ = self.write_master(b"\x03");
+                    cancelled = true;
+                    break;
+                }
+            }
+
+            let mut read_fds: libc::fd_set = unsafe { std::mem::zeroed() };
+            unsafe {
+                libc::FD_ZERO(&mut read_fds);
+                libc::FD_SET(stdin_fd, &mut read_fds);
+                libc::FD_SET(self.master_fd, &mut read_fds);
+                libc::FD_SET(self.control_fd, &mut read_fds);
+            }
+            let max_fd = self.master_fd.max(self.control_fd).max(stdin_fd) + 1;
+
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            let mut tv = libc::timeval {
+                tv_sec: remaining.as_secs().min(1) as libc::c_long,
+                tv_usec: (remaining.subsec_micros() % 1_000_000) as libc::c_long,
+            };
+
+            let sel = unsafe {
+                libc::select(
+                    max_fd,
+                    &mut read_fds,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    &mut tv,
+                )
+            };
+
+            if sel < 0 {
+                let errno = unsafe { *libc::__errno_location() };
+                if errno == libc::EINTR {
+                    continue;
+                }
+                break;
+            }
+
+            if sel == 0 {
+                continue;
+            }
+
+            // Read stdin -> forward to master.
+            if unsafe { libc::FD_ISSET(stdin_fd, &read_fds) } {
+                let mut tmp = [0u8; 64];
+                match unsafe {
+                    libc::read(stdin_fd, tmp.as_mut_ptr() as *mut libc::c_void, tmp.len())
+                } {
+                    n if n > 0 => {
+                        let data = &tmp[..n as usize];
+                        if data.contains(&0x03) {
+                            // Ctrl+C: cancel and send SIGINT to bash.
+                            let _ = kill_pg(self.child_pid, Signal::SIGINT);
+                            if let Some(ref ct) = cancel_token {
+                                ct.cancel();
+                            }
+                            cancelled = true;
+                        } else {
+                            // Forward everything else (including Ctrl+Z = 0x1a)
+                            // to the PTY so bash handles it natively.
+                            let _ = self.write_master(data);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            // Read master -> exec buffer.
+            if unsafe { libc::FD_ISSET(self.master_fd, &read_fds) } {
+                let mut tmp = [0u8; 8192];
+                match unsafe {
+                    libc::read(
+                        self.master_fd,
+                        tmp.as_mut_ptr() as *mut libc::c_void,
+                        tmp.len(),
+                    )
+                } {
+                    n if n > 0 => {
+                        if self.exec_mode.load(Ordering::SeqCst) {
+                            self.exec_buffer
+                                .lock()
+                                .unwrap()
+                                .extend_from_slice(&tmp[..n as usize]);
+                        }
+                    }
+                    0 => {
+                        self.running.store(false, Ordering::SeqCst);
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+
+            // Read control pipe for events.
+            if unsafe { libc::FD_ISSET(self.control_fd, &read_fds) } {
+                let mut tmp = [0u8; 4096];
+                match unsafe {
+                    libc::read(
+                        self.control_fd,
+                        tmp.as_mut_ptr() as *mut libc::c_void,
+                        tmp.len(),
+                    )
+                } {
+                    n if n > 0 => {
+                        let events =
+                            decode_control_chunk(&mut self.control_buffer, &tmp[..n as usize]);
+                        for event in &events {
+                            if let BackendControlEvent::ShellExiting { .. } = event {
+                                self.running.store(false, Ordering::SeqCst);
+                            }
+                            if let Some(r) = self.command_state.handle_event(event) {
+                                if r.command_seq == Some(seq) {
+                                    result_exit_code = r.exit_code;
+                                    break 'select_loop;
+                                }
+                            }
+                        }
+                    }
+                    0 => {
+                        self.running.store(false, Ordering::SeqCst);
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // Drain remaining output.
         self.drain_master_to_exec_buffer();
-
-        // Exit exec mode.
         self.exec_mode.store(false, Ordering::SeqCst);
 
-        // Grab buffered output.
+        // Flush stale input so escape sequences don't confuse the next prompt.
+        unsafe {
+            libc::tcflush(stdin_fd, libc::TCIFLUSH);
+        }
+
+        // Restore terminal settings.
+        if let Some(ref saved) = saved_termios {
+            let _ = tcsetattr(stdin_borrowed, SetArg::TCSADRAIN, saved);
+        }
+
         let raw_output = self
             .exec_buffer
             .lock()
@@ -197,17 +359,12 @@ impl PersistentPty {
             .collect::<Vec<u8>>();
         let raw_str = String::from_utf8_lossy(&raw_output).to_string();
 
-        match result {
-            Some(pty_result) => {
-                let cleaned = clean_pty_output(&raw_str, command);
-                Ok((cleaned, pty_result.exit_code))
-            }
-            None => {
-                // Timeout -- send Ctrl-C.
-                let _ = self.write_master(b"\x03");
-                let cleaned = clean_pty_output(&raw_str, command);
-                Ok((cleaned, -1))
-            }
+        if cancelled {
+            let cleaned = clean_pty_output(&raw_str, command);
+            Ok((cleaned, -1))
+        } else {
+            let cleaned = clean_pty_output(&raw_str, command);
+            Ok((cleaned, result_exit_code))
         }
     }
 
@@ -769,73 +926,6 @@ impl PersistentPty {
         ))
     }
 
-    fn wait_for_prompt_ready(
-        &mut self,
-        expected_seq: i32,
-        timeout: Duration,
-    ) -> Option<crate::types::PtyCommandResult> {
-        let deadline = std::time::Instant::now() + timeout;
-        while std::time::Instant::now() < deadline {
-            // Drain master output into exec buffer.
-            let mut tmp = [0u8; 8192];
-            match unsafe {
-                libc::read(
-                    self.master_fd,
-                    tmp.as_mut_ptr() as *mut libc::c_void,
-                    tmp.len(),
-                )
-            } {
-                n if n > 0 => {
-                    let data: Vec<u8> = tmp[..n as usize].to_vec();
-                    if self.exec_mode.load(Ordering::SeqCst) {
-                        self.exec_buffer.lock().unwrap().extend_from_slice(&data);
-                    } else if let Some(ref cb) = self.output_callback {
-                        cb(&data);
-                    }
-                }
-                0 => {
-                    // EOF on master_fd -- bash exited.
-                    self.running.store(false, Ordering::SeqCst);
-                    return None;
-                }
-                _ => {}
-            }
-
-            // Read control pipe.
-            let mut ctrl_tmp = [0u8; 4096];
-            match unsafe {
-                libc::read(
-                    self.control_fd,
-                    ctrl_tmp.as_mut_ptr() as *mut libc::c_void,
-                    ctrl_tmp.len(),
-                )
-            } {
-                n if n > 0 => {
-                    let events =
-                        decode_control_chunk(&mut self.control_buffer, &ctrl_tmp[..n as usize]);
-                    for event in &events {
-                        if let BackendControlEvent::ShellExiting { .. } = event {
-                            self.running.store(false, Ordering::SeqCst);
-                        }
-                        if let Some(result) = self.command_state.handle_event(event) {
-                            if result.command_seq == Some(expected_seq) {
-                                return Some(result);
-                            }
-                        }
-                    }
-                }
-                0 => {
-                    // Control pipe closed -- bash exited.
-                    self.running.store(false, Ordering::SeqCst);
-                    return None;
-                }
-                _ => {}
-            }
-
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        None
-    }
 }
 
 impl Drop for PersistentPty {
@@ -1086,7 +1176,7 @@ mod tests {
         let mut pty = PersistentPty::start(&cwd, 24, 80).expect("start should succeed");
 
         let (output, exit_code) = pty
-            .execute_command("echo hello_world_123", Duration::from_secs(5))
+            .execute_command("echo hello_world_123", Duration::from_secs(5), None)
             .expect("execute should succeed");
         assert_eq!(exit_code, 0);
         assert!(output.contains("hello_world_123"), "output was: {}", output);
@@ -1102,13 +1192,13 @@ mod tests {
         let mut pty = PersistentPty::start(&cwd, 24, 80).expect("start should succeed");
 
         let (out1, code1) = pty
-            .execute_command("echo first", Duration::from_secs(5))
+            .execute_command("echo first", Duration::from_secs(5), None)
             .expect("cmd1");
         assert_eq!(code1, 0);
         assert!(out1.contains("first"));
 
         let (out2, code2) = pty
-            .execute_command("echo second", Duration::from_secs(5))
+            .execute_command("echo second", Duration::from_secs(5), None)
             .expect("cmd2");
         assert_eq!(code2, 0);
         assert!(out2.contains("second"));

--- a/crates/aish-pty/src/types.rs
+++ b/crates/aish-pty/src/types.rs
@@ -1,3 +1,32 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Simple cancellation token backed by an atomic bool.
+pub struct CancelToken {
+    cancelled: AtomicBool,
+}
+
+impl Default for CancelToken {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CancelToken {
+    pub fn new() -> Self {
+        Self {
+            cancelled: AtomicBool::new(false),
+        }
+    }
+
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::SeqCst);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::SeqCst)
+    }
+}
+
 /// Identifies which output stream we are dealing with.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StreamName {

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -1059,9 +1059,14 @@ impl AishShell {
                                 }
                                 Err(e) => {
                                     self.animation.stop();
-                                    let msg = t("shell.error.llm_error_message")
-                                        .replace("{error}", &e.to_string());
-                                    eprintln!("\x1b[31m{}\x1b[0m", msg);
+                                    // Errors are already displayed via the LlmEventType::Error
+                                    // event callback — avoid printing twice. Only handle
+                                    // non-LLM errors that bypass the event system.
+                                    if !matches!(e, aish_core::AishError::Llm(_)) {
+                                        let msg = t("shell.error.llm_error_message")
+                                            .replace("{error}", &e.to_string());
+                                        eprintln!("\x1b[31m{}\x1b[0m", msg);
+                                    }
                                 }
                             }
                             continue;

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -184,8 +184,12 @@ impl AishShell {
             move |cmd: &str| mgr.check_command(cmd)
         };
         let mut tool_registry = ToolRegistry::new();
+        // Shared PTY slot — will be populated after PersistentPty starts.
+        let pty_slot: aish_tools::bash::PtySlot =
+            std::sync::Arc::new(std::sync::Mutex::new(None));
         let mut bash_tool = aish_tools::SecureBashTool::with_security_check(security_check);
         bash_tool.set_cancellation_token(llm_session.cancellation_token_arc());
+        bash_tool.set_pty_slot(pty_slot.clone());
         tool_registry.register(Box::new(bash_tool));
         tool_registry.register(Box::new(aish_tools::fs::ReadFileTool::new()));
         tool_registry.register(Box::new(aish_tools::fs::WriteFileTool::new()));
@@ -776,6 +780,12 @@ impl AishShell {
             aish_core::AishError::Pty(t_with_args("shell.general_error", &args))
         })?;
         let pty = Arc::new(Mutex::new(pty));
+
+        // Inject PersistentPty into the bash tool slot.
+        {
+            let mut slot = pty_slot.lock().unwrap();
+            *slot = Some(pty.clone());
+        }
 
         // Placeholder instances for struct fields.  The real subsystems live
         // inside AiHandler which needs mutable access during each turn.
@@ -1577,7 +1587,7 @@ impl AishShell {
             .pty
             .lock()
             .unwrap()
-            .execute_command(command, std::time::Duration::from_secs(5));
+            .execute_command(command, std::time::Duration::from_secs(5), None);
     }
 
     /// Restart the PTY session (e.g., after bash exits or crashes).

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -1058,6 +1058,7 @@ impl AishShell {
                                     println!("\x1b[33mInterrupted\x1b[0m");
                                 }
                                 Err(e) => {
+                                    self.animation.stop();
                                     let msg = t("shell.error.llm_error_message")
                                         .replace("{error}", &e.to_string());
                                     eprintln!("\x1b[31m{}\x1b[0m", msg);

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -1213,9 +1213,13 @@ impl AishShell {
                             println!("\x1b[33m{}\x1b[0m", t("shell.interrupted"));
                         }
                         Err(e) => {
-                            let msg = t("shell.error.llm_error_message")
-                                .replace("{error}", &e.to_string());
-                            eprintln!("\x1b[31m{}\x1b[0m", msg);
+                            // Errors are already displayed via the LlmEventType::Error
+                            // event callback — avoid printing twice.
+                            if !matches!(e, aish_core::AishError::Llm(_)) {
+                                let msg = t("shell.error.llm_error_message")
+                                    .replace("{error}", &e.to_string());
+                                eprintln!("\x1b[31m{}\x1b[0m", msg);
+                            }
                             self.record_history(input, 1);
                         }
                     }

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -88,7 +88,7 @@ impl ShellHelper {
         let escaped_line = aish_pty::shell_quote_escape(line);
         let cmd = format!("__aish_query_completions {} {}", escaped_line, pos);
 
-        match pty.execute_command(&cmd, COMPLETION_TIMEOUT) {
+        match pty.execute_command(&cmd, COMPLETION_TIMEOUT, None) {
             Ok((output, _exit_code)) => output
                 .lines()
                 .filter(|l| !l.is_empty())

--- a/crates/aish-tools/src/bash.rs
+++ b/crates/aish-tools/src/bash.rs
@@ -1,5 +1,5 @@
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use aish_i18n;
@@ -45,12 +45,18 @@ fn needs_interactive(command: &str) -> bool {
     false
 }
 
+/// Shared slot for injecting a PersistentPty reference after tool creation.
+/// None = fall back to PtyExecutor (one-shot PTY).
+pub type PtySlot = Arc<Mutex<Option<Arc<Mutex<aish_pty::PersistentPty>>>>>;
+
 /// Tool for executing bash commands via PTY.
 pub struct BashTool {
     /// Shared cancellation token from the AI handler.
     /// When the user presses Ctrl+C during AI processing, this token is set,
     /// and a bridge thread propagates the cancellation to the tool's CancelToken.
     cancellation_token: Option<Arc<CancellationToken>>,
+    /// Shared slot for PersistentPty — set after PTY creation.
+    pty_slot: PtySlot,
 }
 
 /// Cached translated description.
@@ -70,6 +76,7 @@ impl BashTool {
     pub fn new() -> Self {
         Self {
             cancellation_token: None,
+            pty_slot: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -77,6 +84,165 @@ impl BashTool {
     /// This allows Ctrl+C during AI processing to cancel in-progress tool execution.
     pub fn set_cancellation_token(&mut self, token: Arc<CancellationToken>) {
         self.cancellation_token = Some(token);
+    }
+
+    /// Set the shared PersistentPty slot for Ctrl+Z/bg/fg support.
+    pub fn set_pty_slot(&mut self, slot: PtySlot) {
+        self.pty_slot = slot;
+    }
+
+    /// Execute via PersistentPty — supports Ctrl+Z/bg/fg job control.
+    fn execute_via_persistent_pty(
+        &self,
+        command: &str,
+        timeout_secs: u64,
+        pty_arc: Arc<Mutex<aish_pty::PersistentPty>>,
+    ) -> ToolResult {
+        let cancel_token = Arc::new(CancelToken::new());
+
+        // Timeout thread.
+        let timeout_token = Arc::clone(&cancel_token);
+        let timeout_duration = Duration::from_secs(timeout_secs);
+        std::thread::spawn(move || {
+            std::thread::sleep(timeout_duration);
+            timeout_token.cancel();
+        });
+
+        // Bridge: AI handler cancellation -> tool cancel token.
+        let done = Arc::new(AtomicBool::new(false));
+        if let Some(ref ct) = self.cancellation_token {
+            let ct = Arc::clone(ct);
+            let tool_cancel = Arc::clone(&cancel_token);
+            let done = Arc::clone(&done);
+            std::thread::spawn(move || {
+                while !done.load(Ordering::SeqCst) {
+                    if ct.is_cancelled() {
+                        tool_cancel.cancel();
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+            });
+        }
+
+        let mut pty = pty_arc.lock().unwrap();
+        let result = pty.execute_command(
+            command,
+            Duration::from_secs(timeout_secs),
+            Some(&cancel_token),
+        );
+        done.store(true, Ordering::SeqCst);
+
+        match result {
+            Ok((output, exit_code)) => {
+                let session_uuid = uuid::Uuid::new_v4().to_string();
+                let cwd = std::env::current_dir()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_default();
+
+                let settings = BashOffloadSettings::default();
+                let offloader = BashOutputOffload::new(&session_uuid, &cwd, settings);
+                let offload_result =
+                    offloader.render(&output, &"", command, exit_code);
+
+                let output_text = crate::registry::format_tagged_result(
+                    &offload_result.stdout_text,
+                    &offload_result.stderr_text,
+                    exit_code,
+                    offload_result.offload_payload.as_ref(),
+                );
+
+                ToolResult {
+                    ok: true,
+                    output: output_text,
+                    meta: offload_result
+                        .offload_payload
+                        .map(|p| serde_json::to_value(p).unwrap_or(serde_json::Value::Null)),
+                }
+            }
+            Err(e) => {
+                let mut args_map = std::collections::HashMap::new();
+                args_map.insert("error".to_string(), e.to_string());
+                ToolResult::error(aish_i18n::t_with_args(
+                    "tools.bash.execute_failed",
+                    &args_map,
+                ))
+            }
+        }
+    }
+
+    /// Execute via one-shot PtyExecutor — original behavior.
+    fn execute_via_pty_executor(&self, command: &str, timeout_secs: u64) -> ToolResult {
+        let executor = if needs_interactive(command) {
+            PtyExecutor::new(CAPTURE_KEEP_BYTES)
+        } else {
+            PtyExecutor::new_silent(CAPTURE_KEEP_BYTES)
+        };
+        let cancel_token = Arc::new(CancelToken::new());
+
+        let timeout_token = Arc::clone(&cancel_token);
+        let timeout_duration = Duration::from_secs(timeout_secs);
+        std::thread::spawn(move || {
+            std::thread::sleep(timeout_duration);
+            timeout_token.cancel();
+        });
+
+        let done = Arc::new(AtomicBool::new(false));
+        if let Some(ref ct) = self.cancellation_token {
+            let ct = Arc::clone(ct);
+            let tool_cancel = Arc::clone(&cancel_token);
+            let done = Arc::clone(&done);
+            std::thread::spawn(move || {
+                while !done.load(Ordering::SeqCst) {
+                    if ct.is_cancelled() {
+                        tool_cancel.cancel();
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+            });
+        }
+
+        let env_vars: std::collections::HashMap<String, String> = std::env::vars().collect();
+        let result = executor.execute_blocking(command, env_vars, &cancel_token);
+        done.store(true, Ordering::SeqCst);
+
+        match result {
+            Ok(result) => {
+                let session_uuid = uuid::Uuid::new_v4().to_string();
+                let cwd = std::env::current_dir()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_default();
+
+                let settings = BashOffloadSettings::default();
+                let offloader = BashOutputOffload::new(&session_uuid, &cwd, settings);
+                let offload_result =
+                    offloader.render(&result.stdout, &result.stderr, command, result.exit_code);
+
+                let output = crate::registry::format_tagged_result(
+                    &offload_result.stdout_text,
+                    &offload_result.stderr_text,
+                    result.exit_code,
+                    offload_result.offload_payload.as_ref(),
+                );
+
+                ToolResult {
+                    ok: true,
+                    output,
+                    meta: offload_result
+                        .offload_payload
+                        .map(|p| serde_json::to_value(p).unwrap_or(serde_json::Value::Null)),
+                }
+            }
+            Err(e) => {
+                let mut args_map = std::collections::HashMap::new();
+                args_map.insert("error".to_string(), e.to_string());
+                ToolResult::error(aish_i18n::t_with_args(
+                    "tools.bash.execute_failed",
+                    &args_map,
+                ))
+            }
+        }
     }
 }
 
@@ -117,94 +283,17 @@ impl Tool for BashTool {
             .and_then(|t| t.as_u64())
             .unwrap_or(DEFAULT_TIMEOUT_SECS);
 
-        // Use interactive executor (stdin forwarding + terminal display) for
-        // commands that may prompt for a password. Otherwise capture silently.
-        let executor = if needs_interactive(command) {
-            PtyExecutor::new(CAPTURE_KEEP_BYTES)
-        } else {
-            PtyExecutor::new_silent(CAPTURE_KEEP_BYTES)
+        // Try PersistentPty path first (supports Ctrl+Z/bg/fg).
+        let pty_arc = {
+            let guard = self.pty_slot.lock().unwrap();
+            guard.clone()
         };
-        let cancel_token = Arc::new(CancelToken::new());
-
-        // Spawn a thread that cancels after timeout.
-        let timeout_token = Arc::clone(&cancel_token);
-        let timeout_duration = Duration::from_secs(timeout_secs);
-        std::thread::spawn(move || {
-            std::thread::sleep(timeout_duration);
-            timeout_token.cancel();
-        });
-
-        // Bridge: watch the AI handler's CancellationToken and propagate to our
-        // local CancelToken.  This ensures Ctrl+C during tool execution actually
-        // kills the PTY child process.
-        let done = Arc::new(AtomicBool::new(false));
-        if let Some(ref ct) = self.cancellation_token {
-            let ct = Arc::clone(ct);
-            let tool_cancel = Arc::clone(&cancel_token);
-            let done = Arc::clone(&done);
-            std::thread::spawn(move || {
-                while !done.load(Ordering::SeqCst) {
-                    if ct.is_cancelled() {
-                        tool_cancel.cancel();
-                        break;
-                    }
-                    std::thread::sleep(Duration::from_millis(50));
-                }
-            });
+        if let Some(pty_arc) = pty_arc {
+            return self.execute_via_persistent_pty(command, timeout_secs, pty_arc);
         }
 
-        let env_vars: std::collections::HashMap<String, String> = std::env::vars().collect();
-
-        let result = executor.execute_blocking(command, env_vars, &cancel_token);
-
-        // Signal the bridge thread to stop polling.
-        done.store(true, Ordering::SeqCst);
-
-        match result {
-            Ok(result) => {
-                // Use BashOutputOffload for threshold-based offload, matching Python's
-                // render_bash_output(). This handles:
-                // - Checking if output > threshold_bytes (1KB)
-                // - Writing full output to disk (stdout.txt, stderr.txt, result.json)
-                // - Returning HEAD preview (1KB) + offload payload with paths and hint
-                let session_uuid = uuid::Uuid::new_v4().to_string();
-                let cwd = std::env::current_dir()
-                    .map(|p| p.to_string_lossy().to_string())
-                    .unwrap_or_default();
-
-                let settings = BashOffloadSettings::default();
-                let offloader = BashOutputOffload::new(&session_uuid, &cwd, settings);
-                let offload_result =
-                    offloader.render(&result.stdout, &result.stderr, command, result.exit_code);
-
-                let output = crate::registry::format_tagged_result(
-                    &offload_result.stdout_text,
-                    &offload_result.stderr_text,
-                    result.exit_code,
-                    offload_result.offload_payload.as_ref(),
-                );
-
-                // Always report ok=true when PTY execution succeeds.
-                // Non-zero exit codes are normal command outcomes, not tool
-                // failures — the LLM sees <return_code> and decides what to do.
-                // Returning ok=false triggers a pointless retry of the same command.
-                ToolResult {
-                    ok: true,
-                    output,
-                    meta: offload_result
-                        .offload_payload
-                        .map(|p| serde_json::to_value(p).unwrap_or(serde_json::Value::Null)),
-                }
-            }
-            Err(e) => {
-                let mut args_map = std::collections::HashMap::new();
-                args_map.insert("error".to_string(), e.to_string());
-                ToolResult::error(aish_i18n::t_with_args(
-                    "tools.bash.execute_failed",
-                    &args_map,
-                ))
-            }
-        }
+        // Fallback: one-shot PtyExecutor.
+        self.execute_via_pty_executor(command, timeout_secs)
     }
 }
 

--- a/crates/aish-tools/src/secure_bash.rs
+++ b/crates/aish-tools/src/secure_bash.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use aish_llm::{CancellationToken, Tool, ToolResult};
 use aish_security::SecurityDecision;
 
+use super::bash::PtySlot;
+
 /// Type of the security check callback.
 type SecurityCheckFn = Box<dyn Fn(&str) -> SecurityDecision + Send + Sync>;
 
@@ -81,6 +83,11 @@ impl SecureBashTool {
     /// Set the shared cancellation token from the AI handler.
     pub fn set_cancellation_token(&mut self, token: Arc<CancellationToken>) {
         self.inner.set_cancellation_token(token);
+    }
+
+    /// Set the shared PersistentPty slot for Ctrl+Z/bg/fg support.
+    pub fn set_pty_slot(&mut self, slot: PtySlot) {
+        self.inner.set_pty_slot(slot);
     }
 }
 


### PR DESCRIPTION
## Summary
- Enable Ctrl+Z/bg/fg job control for bash commands (port of d193a72)
- Route AI tool commands through PersistentPty for native job control support
- Fix thinking spinner not stopping on API errors (503, 404, etc.)
- Fix duplicate error message printing on API failures

## Changes

### Ctrl+Z Job Control (eeec06b)
- Add `set -m` to bash_rc_wrapper.sh for native job control
- Rewrite `PersistentPty::execute_command()` with select-based I/O loop and stdin forwarding
- Ctrl+Z (0x1a) forwarded to bash, which suspends foreground job and returns to prompt
- Ctrl+C (0x03) cancels AI operation
- Add `PtySlot` to `BashTool` for routing tool commands through PersistentPty
- Move `CancelToken` to `types.rs` for shared use

### Spinner Fix (41d03ff, 77a2e6a, 932389c)
- Emit `Error` + `OpEnd` events before returning API errors from session.rs
- Guard duplicate error printing in both `Err(e)` handlers in app.rs

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` all pass (462 tests)
- [x] `cargo build --release` succeeds
- [ ] Manual: `; sleep 30` → Ctrl+Z → `jobs` shows stopped → `bg`/`fg` works
- [ ] Manual: API error (wrong model) shows single error message, spinner stops immediately