### PR TITLE
fix: ensure tool responses directly follow assistant tool_calls

### DIFF
--- a/src/aish/state/context.py
+++ b/src/aish/state/context.py
@@ -2,6 +2,56 @@ from enum import Enum
 from typing import Any, Optional
 
 
+def _fix_tool_response_ordering(messages: list[dict]) -> list[dict]:
+    """Ensure tool response messages directly follow their assistant tool_calls.
+
+    Non-LLM memories (e.g. SHELL history rendered as user-role messages) can
+    end up between an assistant message with ``tool_calls`` and the matching
+    ``role: "tool"`` response.  The OpenAI / DeepSeek API rejects such
+    sequences, so we re-order: tool responses are pulled forward, and any
+    intervening messages are deferred.
+    """
+    result: list[dict] = []
+    i = 0
+    while i < len(messages):
+        msg = messages[i]
+        result.append(msg)
+
+        tool_calls = msg.get("tool_calls")
+        if (
+            msg.get("role") == "assistant"
+            and isinstance(tool_calls, list)
+            and tool_calls
+        ):
+            needed_ids = {
+                tc["id"]
+                for tc in tool_calls
+                if isinstance(tc, dict) and tc.get("id")
+            }
+            tool_responses: list[dict] = []
+            deferred: list[dict] = []
+
+            for m in messages[i + 1 :]:
+                if (
+                    needed_ids
+                    and m.get("role") == "tool"
+                    and m.get("tool_call_id") in needed_ids
+                ):
+                    tool_responses.append(m)
+                    needed_ids.discard(m["tool_call_id"])
+                else:
+                    deferred.append(m)
+
+            result.extend(tool_responses)
+            messages = deferred
+            i = 0
+            continue
+
+        i += 1
+
+    return result
+
+
 class MemoryType(Enum):
     LLM = "llm"
     SHELL = "shell"
@@ -282,4 +332,8 @@ class ContextManager:
                 # Compact shell history format
                 messages.append({"role": "user", "content": memory["content"]})
 
-        return messages
+        # Non-LLM memories (e.g. SHELL) can be interleaved between an
+        # assistant message with tool_calls and its tool response, which
+        # violates the OpenAI/deepseek message ordering requirement.
+        # Post-process to keep tool responses directly after their caller.
+        return _fix_tool_response_ordering(messages)

--- a/tests/state/test_context_manager.py
+++ b/tests/state/test_context_manager.py
@@ -410,5 +410,121 @@ def test_recall_clears_old_results_on_no_match():
     assert "memory_recall" not in cm.knowledge_cache
 
 
+class TestToolResponseOrdering:
+    """Verify that as_messages() keeps tool responses directly after their
+    assistant tool_calls, even when SHELL memories are interleaved."""
+
+    def test_shell_between_tool_calls_and_response(self):
+        """SHELL memory inserted between assistant tool_calls and tool
+        response must be moved after the tool response."""
+        cm = ContextManager()
+        cm.add_memory(MemoryType.LLM, {"role": "user", "content": "run ip a"})
+        cm.add_memory(
+            MemoryType.LLM,
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_001",
+                        "type": "function",
+                        "function": {"name": "bash_exec", "arguments": "{}"},
+                    }
+                ],
+            },
+        )
+        # SHELL memory added during tool execution
+        cm.add_memory(
+            MemoryType.SHELL, "$ ip a → ✓ (exit 0)\n<stdout>1: lo</stdout>"
+        )
+        cm.add_memory(
+            MemoryType.LLM,
+            {
+                "role": "tool",
+                "tool_call_id": "call_001",
+                "content": "<stdout>1: lo</stdout>",
+            },
+        )
+
+        msgs = cm.as_messages()
+
+        assert msgs[0]["role"] == "user"
+        assert msgs[1]["role"] == "assistant"
+        assert msgs[1].get("tool_calls") is not None
+        # tool response must directly follow assistant tool_calls
+        assert msgs[2]["role"] == "tool"
+        assert msgs[2]["tool_call_id"] == "call_001"
+        # SHELL-originated user message comes after tool response
+        assert msgs[3]["role"] == "user"
+        assert "$ ip a" in msgs[3]["content"]
+
+    def test_multiple_tool_calls(self):
+        """Multiple tool calls from one assistant message."""
+        cm = ContextManager()
+        cm.add_memory(MemoryType.LLM, {"role": "user", "content": "go"})
+        cm.add_memory(
+            MemoryType.LLM,
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {"name": "f1", "arguments": "{}"},
+                    },
+                    {
+                        "id": "call_b",
+                        "type": "function",
+                        "function": {"name": "f2", "arguments": "{}"},
+                    },
+                ],
+            },
+        )
+        cm.add_memory(MemoryType.SHELL, "$ cmd1 → ✓ (exit 0)")
+        cm.add_memory(
+            MemoryType.LLM,
+            {"role": "tool", "tool_call_id": "call_a", "content": "result-a"},
+        )
+        cm.add_memory(MemoryType.SHELL, "$ cmd2 → ✗ (exit 1)")
+        cm.add_memory(
+            MemoryType.LLM,
+            {"role": "tool", "tool_call_id": "call_b", "content": "result-b"},
+        )
+
+        msgs = cm.as_messages()
+
+        assert msgs[0]["role"] == "user"
+        assert msgs[1]["role"] == "assistant"
+        # Both tool responses directly follow
+        assert msgs[2]["role"] == "tool"
+        assert msgs[2]["tool_call_id"] == "call_a"
+        assert msgs[3]["role"] == "tool"
+        assert msgs[3]["tool_call_id"] == "call_b"
+        # Deferred user messages come after
+        assert msgs[4]["role"] == "user"
+        assert msgs[5]["role"] == "user"
+
+    def test_no_tool_calls_unchanged(self):
+        """Messages without tool calls should not be reordered."""
+        cm = ContextManager()
+        cm.add_memory(MemoryType.LLM, {"role": "user", "content": "hello"})
+        cm.add_memory(
+            MemoryType.LLM, {"role": "assistant", "content": "hi there"}
+        )
+        cm.add_memory(MemoryType.SHELL, "$ ls → ✓ (exit 0)")
+        cm.add_memory(
+            MemoryType.LLM, {"role": "user", "content": "thanks"}
+        )
+
+        msgs = cm.as_messages()
+
+        assert len(msgs) == 4
+        assert msgs[0]["content"] == "hello"
+        assert msgs[1]["content"] == "hi there"
+        assert msgs[2]["content"] == "$ ls → ✓ (exit 0)"
+        assert msgs[3]["content"] == "thanks"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Fix API 400 error when using deepseek (and other strict providers) with tool calls
- SHELL memories added during tool execution were interleaved between `assistant` messages with `tool_calls` and their `tool` response messages, violating the OpenAI/DeepSeek API message ordering requirement
- Add `_fix_tool_response_ordering()` post-processing in `as_messages()` to pull tool responses forward and defer intervening messages

## Test plan
- [x] Added 3 unit tests in `TestToolResponseOrdering` covering: single tool_call, multiple tool_calls, and no-op case
- [x] All 634 existing tests pass
- [ ] Manual test: `exec ip a` with deepseek-v4-flash no longer errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message ordering when tool call responses are interleaved with other memory types, ensuring the conversation context maintains valid message sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->