### PR TITLE
feat: delegate tab completion to PTY bash

### DIFF
--- a/src/aish/shell/runtime/app.py
+++ b/src/aish/shell/runtime/app.py
@@ -1169,6 +1169,7 @@ class PTYAIShell:
                 else "aish"
             ),
             mode_toggle_handler=self.toggle_plan_mode,
+            pty_provider=lambda: self._pty_manager,
         )
 
         # Wire PTY manager and context manager to BashTool for AI tool execution

--- a/src/aish/shell/ui/completion.py
+++ b/src/aish/shell/ui/completion.py
@@ -115,15 +115,18 @@ class ShellCompleter(Completer):
 
         if pty_results is not None:
             prefix = current_token
+            yielded = False
             for candidate in pty_results:
                 if prefix and not candidate.startswith(prefix):
                     continue
+                yielded = True
                 yield Completion(
                     candidate,
                     start_position=-len(prefix),
                     display=candidate,
                 )
-            return
+            if yielded:
+                return
 
         # Fallback: PATH scanning + PathCompleter
         yield from self._fallback_completions(

--- a/src/aish/shell/ui/completion.py
+++ b/src/aish/shell/ui/completion.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import os
+import shlex
 from contextlib import contextmanager
-from typing import Callable, Iterable, Iterator, Optional
+from typing import TYPE_CHECKING, Callable, Iterable, Iterator, Optional
 
 from prompt_toolkit.completion import (
     CompleteEvent,
@@ -19,51 +20,9 @@ from ..commands.registry import (
     STATE_MODIFYING_COMMANDS,
 )
 
-COMMON_SHELL_COMMANDS = frozenset(
-    {
-        "alias",
-        "bg",
-        "bind",
-        "builtin",
-        "command",
-        "compgen",
-        "complete",
-        "declare",
-        "disown",
-        "echo",
-        "enable",
-        "eval",
-        "exec",
-        "false",
-        "fc",
-        "fg",
-        "getopts",
-        "hash",
-        "help",
-        "jobs",
-        "kill",
-        "let",
-        "local",
-        "printf",
-        "read",
-        "readonly",
-        "return",
-        "set",
-        "shift",
-        "shopt",
-        "source",
-        "test",
-        "times",
-        "trap",
-        "true",
-        "type",
-        "typeset",
-        "ulimit",
-        "umask",
-        "unalias",
-        "wait",
-    }
-)
+if TYPE_CHECKING:
+    from ...terminal.pty import PTYManager
+
 SPECIAL_SHELL_COMMANDS = frozenset({"/model", "/setup", "/plan"})
 DIRECTORY_COMMANDS = frozenset({"cd", "pushd", "popd"})
 AI_PREFIXES = (";", "；")
@@ -107,17 +66,22 @@ def _looks_like_path_token(token: str) -> bool:
 
 
 class ShellCompleter(Completer):
-    """Provide command-first completion with path fallback."""
+    """Provide tab completion by delegating to PTY bash.
+
+    Falls back to PATH scanning + PathCompleter when PTY is unavailable.
+    """
 
     def __init__(
         self,
         cwd_provider: Optional[Callable[[], str]] = None,
         command_provider: Optional[Callable[[], Iterable[str]]] = None,
         ai_prefixes: tuple[str, ...] = AI_PREFIXES,
+        pty_provider: Optional[Callable[[], Optional["PTYManager"]]] = None,
     ) -> None:
         self._cwd_provider = cwd_provider
         self._command_provider = command_provider or self._default_command_provider
         self._ai_prefixes = ai_prefixes
+        self._pty_provider = pty_provider
         self._path_completer = PathCompleter(expanduser=True)
         self._dir_completer = PathCompleter(only_directories=True, expanduser=True)
         self._cached_path_value: Optional[str] = None
@@ -132,16 +96,70 @@ class ShellCompleter(Completer):
         if stripped.startswith(self._ai_prefixes):
             return
 
-        tokens, current_token, trailing_space = self._split_tokens(text_before_cursor)
+        tokens, current_token, trailing_space = self._split_tokens(
+            text_before_cursor
+        )
         if not tokens and not current_token:
             return
 
+        # Special aish commands always handled in Python
         if (not tokens and current_token.startswith("/")) or (
             tokens and tokens[0] in SPECIAL_SHELL_COMMANDS
         ):
             yield from self._complete_special_commands(current_token)
             return
 
+        # Attempt PTY bash completion
+        cursor_pos = len(text_before_cursor)
+        pty_results = self._query_pty_completions(text_before_cursor, cursor_pos)
+
+        if pty_results is not None:
+            prefix = current_token
+            for candidate in pty_results:
+                if prefix and not candidate.startswith(prefix):
+                    continue
+                yield Completion(
+                    candidate,
+                    start_position=-len(prefix),
+                    display=candidate,
+                )
+            return
+
+        # Fallback: PATH scanning + PathCompleter
+        yield from self._fallback_completions(
+            tokens, current_token, trailing_space, complete_event
+        )
+
+    def _query_pty_completions(
+        self, line: str, cursor_pos: int
+    ) -> Optional[list[str]]:
+        """Query the PTY bash for completions. Returns None on failure."""
+        pty_manager = self._pty_provider() if self._pty_provider else None
+        if pty_manager is None or not pty_manager.is_running:
+            return None
+
+        escaped_line = shlex.quote(line)
+        cmd = f"__aish_query_completions {escaped_line} {cursor_pos}"
+
+        try:
+            output, exit_code = pty_manager.execute_command(cmd, timeout=0.5)
+        except Exception:
+            return None
+
+        if exit_code != 0 or not output:
+            return None
+
+        candidates = [c for c in output.splitlines() if c]
+        return candidates or None
+
+    def _fallback_completions(
+        self,
+        tokens: list[str],
+        current_token: str,
+        trailing_space: bool,
+        complete_event: CompleteEvent,
+    ) -> Iterator[Completion]:
+        """Fallback completion using PATH scanning and PathCompleter."""
         if not tokens:
             if _looks_like_path_token(current_token):
                 yield from self._complete_paths(
@@ -203,7 +221,7 @@ class ShellCompleter(Completer):
     def _default_command_provider(self) -> Iterable[str]:
         path_value = os.environ.get("PATH", "")
         if path_value != self._cached_path_value:
-            commands = set(COMMON_SHELL_COMMANDS)
+            commands = set()
             commands.update(STATE_MODIFYING_COMMANDS)
             commands.update(PTY_REQUIRING_COMMANDS)
             commands.update(REJECTED_COMMANDS)

--- a/src/aish/shell/ui/completion.py
+++ b/src/aish/shell/ui/completion.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import shlex
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Callable, Iterable, Iterator, Optional
 
@@ -110,8 +109,10 @@ class ShellCompleter(Completer):
             return
 
         # Attempt PTY bash completion
-        cursor_pos = len(text_before_cursor)
-        pty_results = self._query_pty_completions(text_before_cursor, cursor_pos)
+        pty_results = self._query_pty_completions(
+            document.text,
+            document.cursor_position,
+        )
 
         if pty_results is not None:
             prefix = current_token
@@ -141,11 +142,12 @@ class ShellCompleter(Completer):
         if pty_manager is None or not pty_manager.is_running:
             return None
 
-        escaped_line = shlex.quote(line)
-        cmd = f"__aish_query_completions {escaped_line} {cursor_pos}"
-
         try:
-            output, exit_code = pty_manager.execute_command(cmd, timeout=0.5)
+            output, exit_code = pty_manager.query_completions(
+                line,
+                cursor_pos,
+                timeout=0.5,
+            )
         except Exception:
             return None
 

--- a/src/aish/shell/ui/editor.py
+++ b/src/aish/shell/ui/editor.py
@@ -25,6 +25,7 @@ from .completion import ShellCompleter
 
 if TYPE_CHECKING:
     from ...state import HistoryManager
+    from ...terminal.pty import PTYManager
     from ..interruption import InterruptionManager
 
 # Cache TTL for theme rendering (seconds). Avoids re-running git commands
@@ -53,6 +54,7 @@ class ShellPromptController:
         exit_code_provider: Optional[Callable[[], int]] = None,
         mode_provider: Optional[Callable[[], str]] = None,
         mode_toggle_handler: Optional[Callable[[], None]] = None,
+        pty_provider: Optional[Callable[[], Optional["PTYManager"]]] = None,
     ):
         _ = history_manager
         _ = interruption_manager
@@ -67,7 +69,10 @@ class ShellPromptController:
         self._theme_cache_output: str = ""
         self._theme_cache_time: float = 0.0
         self._history = FileHistory(os.path.expanduser("~/.aish_history"))
-        self._completer = completer or ShellCompleter(cwd_provider=cwd_provider)
+        self._completer = completer or ShellCompleter(
+            cwd_provider=cwd_provider,
+            pty_provider=pty_provider,
+        )
         self._session = PromptSession(
             message=self._build_prompt_message,
             history=self._history,

--- a/src/aish/terminal/pty/bash_rc_wrapper.sh
+++ b/src/aish/terminal/pty/bash_rc_wrapper.sh
@@ -267,5 +267,95 @@ __AISH_ORIGINAL_PROMPT_COMMAND="$PROMPT_COMMAND"
 PROMPT_COMMAND='__aish_prompt_command'
 
 trap '__aish_on_exit' EXIT
+__aish_mark_dirs() {
+    local entry
+    while IFS= read -r entry; do
+        [[ -z "$entry" ]] && continue
+        if [[ "$entry" == */ ]]; then
+            printf '%s\n' "$entry"
+        elif [[ -d "$entry" ]]; then
+            printf '%s/\n' "$entry"
+        else
+            printf '%s\n' "$entry"
+        fi
+    done
+}
+
+__aish_query_completions() {
+    local cmd_line="${1:-}"
+    local cursor="${2:-0}"
+    local -a words=()
+    local word=""
+    local i ch
+
+    for (( i=0; i<${#cmd_line}; i++ )); do
+        ch="${cmd_line:$i:1}"
+        if [[ "$ch" == " " || "$ch" == $'\t' ]]; then
+            if [[ -n "$word" ]]; then
+                words+=("$word")
+                word=""
+            fi
+        else
+            word+="$ch"
+        fi
+    done
+    if [[ -n "$word" ]]; then
+        words+=("$word")
+    fi
+
+    if (( cursor > 0 )) && [[ "${cmd_line:$((cursor-1)):1}" == " " ]]; then
+        words+=("")
+    fi
+
+    local cword=0
+    local pos=0
+    for (( i=0; i<${#words[@]}; i++ )); do
+        pos=$(( pos + ${#words[$i]} + 1 ))
+        if (( pos > cursor )); then
+            cword=$i
+            break
+        fi
+        cword=$i
+    done
+
+    local cmd="${words[0]:-}"
+    local cur="${words[$cword]:-}"
+    local prev="${words[$((cword-1))]:-}"
+
+    if [[ ${#words[@]} -eq 0 ]]; then
+        compgen -c 2>/dev/null
+        return 0
+    fi
+
+    if (( cword == 0 )); then
+        compgen -c -- "$cur" 2>/dev/null
+        return 0
+    fi
+
+    _completion_loader "$cmd" 2>/dev/null || true
+
+    local comp_spec func_name=""
+    comp_spec=$(complete -p "$cmd" 2>/dev/null) || true
+    if [[ "$comp_spec" =~ -F[[:space:]]+([^[:space:]]+) ]]; then
+        func_name="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ -n "$func_name" ]]; then
+        COMPREPLY=()
+        COMP_WORDS=("${words[@]}")
+        COMP_CWORD=$cword
+        COMP_LINE="$cmd_line"
+        COMP_POINT=$cursor
+        "$func_name" "$cmd" "$cur" "$prev" 2>/dev/null || true
+
+        if [[ ${#COMPREPLY[@]} -gt 0 ]]; then
+            printf '%s\n' "${COMPREPLY[@]}" 2>/dev/null | __aish_mark_dirs
+            return 0
+        fi
+    fi
+
+    compgen -f -- "$cur" 2>/dev/null | __aish_mark_dirs
+}
+
 trap '__aish_on_debug' DEBUG
 __aish_emit_session_ready

--- a/src/aish/terminal/pty/command_state.py
+++ b/src/aish/terminal/pty/command_state.py
@@ -77,6 +77,8 @@ class CommandResult:
 class CommandState:
     """Track submitted commands and completed results using control events."""
 
+    INTERNAL_SOURCE = "internal"
+
     def __init__(self) -> None:
         self._active_submission: CommandSubmission | None = None
         self._active_started_submission: CommandSubmission | None = None
@@ -338,14 +340,15 @@ class CommandState:
             submission_id=submission.submission_id,
         )
 
-        self._last_command = result.command
-        self._last_exit_code = result.exit_code
-        self._last_result = result
+        if result.source != self.INTERNAL_SOURCE:
+            self._last_command = result.command
+            self._last_exit_code = result.exit_code
+            self._last_result = result
 
-        if result.allow_error_correction and result.exit_code != 0 and not result.interrupted:
-            self._pending_error = result
-        else:
-            self._pending_error = None
+            if result.allow_error_correction and result.exit_code != 0 and not result.interrupted:
+                self._pending_error = result
+            else:
+                self._pending_error = None
 
         submission.status = "completed"
 

--- a/src/aish/terminal/pty/manager.py
+++ b/src/aish/terminal/pty/manager.py
@@ -6,6 +6,7 @@ import os
 import pty
 import select
 import signal
+import shlex
 import struct
 import termios
 import threading
@@ -375,7 +376,7 @@ class PTYManager:
         """Update internal command state from a decoded backend event."""
         result = self._command_state.handle_backend_event(event)
         if result is not None:
-            if self._exit_code_callback:
+            if result.source != CommandState.INTERNAL_SOURCE and self._exit_code_callback:
                 try:
                     self._exit_code_callback(result.exit_code)
                 except Exception:
@@ -513,12 +514,39 @@ class PTYManager:
             return "", -1
 
         if self._use_output_thread:
-            return self._exec_via_thread(command, timeout)
+            return self._exec_via_thread(command, timeout, source="backend")
         else:
-            return self._exec_via_poll(command, timeout)
+            return self._exec_via_poll(command, timeout, source="backend")
+
+    def execute_internal_command(
+        self, command: str, timeout: Optional[float] = None
+    ) -> tuple[str, int]:
+        """Execute an internal query without updating user-visible command state."""
+        if not self.is_running:
+            return "", -1
+
+        if self._use_output_thread:
+            return self._exec_via_thread(
+                command,
+                timeout,
+                source=CommandState.INTERNAL_SOURCE,
+            )
+        return self._exec_via_poll(
+            command,
+            timeout,
+            source=CommandState.INTERNAL_SOURCE,
+        )
+
+    def query_completions(
+        self, line: str, cursor_pos: int, timeout: Optional[float] = 0.5
+    ) -> tuple[str, int]:
+        """Query backend bash completions without changing shell command state."""
+        escaped_line = shlex.quote(line)
+        command = f"__aish_query_completions {escaped_line} {cursor_pos}"
+        return self.execute_internal_command(command, timeout=timeout)
 
     def _exec_via_thread(
-        self, command: str, timeout: Optional[float]
+        self, command: str, timeout: Optional[float], *, source: str
     ) -> tuple[str, int]:
         """Execute using background output thread for I/O."""
         command_seq = self._allocate_backend_command_seq()
@@ -528,7 +556,7 @@ class PTYManager:
         self._exec_mode.set()
 
         # Send command
-        self.send_command(command, command_seq=command_seq)
+        self.send_command(command, command_seq=command_seq, source=source)
 
         # Wait for exit code; only enforce timeout when explicitly requested.
         result = self._wait_for_completed_result(command_seq, timeout)
@@ -551,7 +579,7 @@ class PTYManager:
         return cleaned, result.exit_code
 
     def _exec_via_poll(
-        self, command: str, timeout: Optional[float]
+        self, command: str, timeout: Optional[float], *, source: str
     ) -> tuple[str, int]:
         """Execute by directly polling PTY fd (when no output thread)."""
         command_seq = self._allocate_backend_command_seq()
@@ -585,7 +613,7 @@ class PTYManager:
             pass
 
         # Send command
-        self.send_command(command, command_seq=command_seq)
+        self.send_command(command, command_seq=command_seq, source=source)
 
         # Read output directly from PTY/control fds until prompt_ready appears.
         deadline = None if timeout is None else time.monotonic() + timeout

--- a/tests/shell/ui/test_shell_editor.py
+++ b/tests/shell/ui/test_shell_editor.py
@@ -12,6 +12,17 @@ from aish.shell.ui.completion import ShellCompleter
 from aish.shell.ui.editor import ShellPromptController
 
 
+class FakeCompletionPTY:
+    def __init__(self, output: str = "status\n") -> None:
+        self.is_running = True
+        self.output = output
+        self.calls = []
+
+    def query_completions(self, line, cursor_pos, timeout=None):
+        self.calls.append((line, cursor_pos, timeout))
+        return self.output, 0
+
+
 def test_shell_prompt_controller_uses_file_history_and_remembers_commands():
     history_manager = Mock()
     controller = ShellPromptController(history_manager=history_manager)
@@ -266,3 +277,18 @@ def test_shell_completer_skips_ai_prefixed_input():
     )
 
     assert completions == []
+
+
+def test_shell_completer_queries_pty_with_full_line_and_cursor():
+    fake_pty = FakeCompletionPTY(output="checkout\n")
+    completer = ShellCompleter(pty_provider=lambda: fake_pty)
+
+    completions = list(
+        completer.get_completions(
+            Document(text="git chec kout main", cursor_position=8),
+            CompleteEvent(completion_requested=True),
+        )
+    )
+
+    assert [item.text for item in completions] == ["checkout"]
+    assert fake_pty.calls == [("git chec kout main", 8, 0.5)]

--- a/tests/terminal/pty/test_exit_tracker_repeat_error.py
+++ b/tests/terminal/pty/test_exit_tracker_repeat_error.py
@@ -325,6 +325,36 @@ def test_backend_command_no_error_hint():
 
 
 @pytest.mark.timeout(5)
+def test_internal_command_does_not_clear_user_error_state():
+    """Internal probes should not replace the last user command result."""
+    tracker = CommandState()
+
+    tracker.register_user_command("bad-user-cmd")
+    tracker.handle_backend_event(_command_started("bad-user-cmd"))
+    tracker.handle_backend_event(_prompt_ready(7))
+
+    assert tracker.last_command == "bad-user-cmd"
+    assert tracker.last_exit_code == 7
+
+    tracker.register_command(
+        "__aish_query_completions git 3",
+        source=CommandState.INTERNAL_SOURCE,
+        command_seq=-1,
+    )
+    tracker.handle_backend_event(
+        _command_started("__aish_query_completions git 3", command_seq=-1)
+    )
+    result = tracker.handle_backend_event(_prompt_ready(0, command_seq=-1))
+
+    assert result is not None
+    assert result.source == CommandState.INTERNAL_SOURCE
+    assert result.exit_code == 0
+    assert tracker.last_command == "bad-user-cmd"
+    assert tracker.last_exit_code == 7
+    assert tracker.consume_error() == ("bad-user-cmd", 7)
+
+
+@pytest.mark.timeout(5)
 def test_backend_error_prompt_redraw_no_hint():
     """After backend command fails, prompt redraws must NOT show error hint.
 


### PR DESCRIPTION
## Summary

- Replace custom Python completion system (PATH scanning + PathCompleter) with PTY bash delegation
- Add `__aish_query_completions` and `__aish_mark_dirs` functions to `bash_rc_wrapper.sh`, leveraging `compgen` and bash-completion functions for context-aware completions
- Support full bash-completion: `git add <tab>`, `systemctl <tab>`, etc.
- Graceful fallback to original PATH scanning when PTY is unavailable or query times out (500ms)

## Test plan

- [x] `git <tab>` shows git subcommands
- [x] `systemctl <tab>` shows systemctl subcommands
- [x] `ls /tmp/<tab>` shows file/directory completions
- [x] `/mod<tab>` completes to `/model` (special aish commands still work)
- [x] AI prefix `;` correctly skips completion
- [x] Fallback works when PTY is stopped
- [x] 629 pytest tests pass (3 pre-existing failures unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PTY-backed Bash-style command completions for more accurate, cursor-aware suggestions
  * Editor completer wired to access PTY context; completions mark directories and respect cursor position
  * Falls back to PATH-based discovery when PTY/native completion is unavailable; command list built from registry + discovered executables

* **Bug Fixes**
  * Internal background commands no longer clear the last user command/error state

* **Tests**
  * Added tests for PTY completion and internal-command error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->