### PR TITLE
fix: forward Ctrl+Z to PTY during AI tool execution

### DIFF
--- a/src/aish/shell/runtime/ai.py
+++ b/src/aish/shell/runtime/ai.py
@@ -379,6 +379,9 @@ class AIHandler:
                         cancel_requested.set()
                         self.llm_session.cancellation_token.cancel()
                         break
+                    if data == b"\x1a":  # Ctrl+Z — forward to PTY for job control
+                        if self.pty_manager and self.pty_manager.is_running:
+                            self.pty_manager.send(data)
                     # Discard all other keystrokes during AI streaming.
                 except (OSError, ValueError):
                     break

--- a/src/aish/shell/runtime/ai.py
+++ b/src/aish/shell/runtime/ai.py
@@ -381,7 +381,10 @@ class AIHandler:
                         break
                     if data == b"\x1a":  # Ctrl+Z — forward to PTY for job control
                         if self.pty_manager and self.pty_manager.is_running:
-                            self.pty_manager.send(data)
+                            try:
+                                self.pty_manager.send(data)
+                            except (OSError, ValueError):
+                                pass  # PTY closed between is_running check and write — ignore
                     # Discard all other keystrokes during AI streaming.
                 except (OSError, ValueError):
                     break


### PR DESCRIPTION
## Summary
- Forward Ctrl+Z (0x1a) to the PTY master fd in the stdin monitor thread during AI tool execution
- The monitor thread was discarding all non-Ctrl+C keystrokes, preventing bash from receiving SIGTSTP to suspend foreground jobs

## Test plan
- [ ] Start aish, enter AI mode with `;`
- [ ] Ask AI to run a long-running command (e.g., `sleep 100`)
- [ ] Press Ctrl+Z during execution — command should be suspended
- [ ] Verify `bg`/`fg` work after suspension

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PTY shell to properly forward Ctrl+Z keyboard input to the terminal during AI streaming instead of discarding it. Ctrl+C behavior remains unchanged for cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->