### PR TITLE
fix: prevent stdin race between AI monitor and PTY executor for sudo

### DIFF
--- a/src/aish/shell/runtime/ai.py
+++ b/src/aish/shell/runtime/ai.py
@@ -32,9 +32,13 @@ class AIHandler:
 
     _SKILL_REF_EXTRACT_RE = re.compile(r"@(\w+)")
     _AUTO_RETAIN_PATTERNS = [
-        re.compile(r"^(?:please\s+)?remember(?:\s+that)?\s+(?P<fact>.+)$", re.IGNORECASE),
+        re.compile(
+            r"^(?:please\s+)?remember(?:\s+that)?\s+(?P<fact>.+)$", re.IGNORECASE
+        ),
         re.compile(r"^(?:please\s+)?note(?:\s+that)?\s+(?P<fact>.+)$", re.IGNORECASE),
-        re.compile(r"^(?:for\s+future\s+reference[:,]?\s*)(?P<fact>.+)$", re.IGNORECASE),
+        re.compile(
+            r"^(?:for\s+future\s+reference[:,]?\s*)(?P<fact>.+)$", re.IGNORECASE
+        ),
         re.compile(r"^(?P<fact>i\s+prefer.+)$", re.IGNORECASE),
         re.compile(r"^(?P<fact>my\s+preferred.+)$", re.IGNORECASE),
         re.compile(r"^(?P<fact>we\s+use.+)$", re.IGNORECASE),
@@ -95,7 +99,7 @@ class AIHandler:
         """Try to parse response as JSON command."""
         import json
 
-        json_match = re.search(r'```(?:json)?\s*(\{.*?\})\s*```', response, re.DOTALL)
+        json_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", response, re.DOTALL)
         if json_match:
             try:
                 return json.loads(json_match.group(1))
@@ -128,7 +132,10 @@ class AIHandler:
 
         Uses polling-based cancellation to allow Ctrl+C interruption.
         """
-        from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
+        from concurrent.futures import (
+            ThreadPoolExecutor,
+            TimeoutError as FutureTimeoutError,
+        )
 
         result_box: list[Optional[str]] = [None]
         exc_box: list[BaseException | None] = [None]
@@ -275,11 +282,16 @@ class AIHandler:
 
     def _categorize_retained_fact(self, fact: str, memory_category):
         lowered = fact.casefold()
-        if any(token in lowered for token in ["prefer", "preferred", "default", "always use"]):
+        if any(
+            token in lowered
+            for token in ["prefer", "preferred", "default", "always use"]
+        ):
             return memory_category.PREFERENCE
         if any(token in lowered for token in ["pattern", "convention", "style"]):
             return memory_category.PATTERN
-        if any(token in lowered for token in ["fix", "solution", "workaround", "resolved"]):
+        if any(
+            token in lowered for token in ["fix", "solution", "workaround", "resolved"]
+        ):
             return memory_category.SOLUTION
         if any(
             token in lowered
@@ -300,7 +312,6 @@ class AIHandler:
         ):
             return memory_category.ENVIRONMENT
         return memory_category.OTHER
-
 
     @staticmethod
     def _get_cancel_exceptions() -> tuple[type[BaseException], ...]:
@@ -364,12 +375,22 @@ class AIHandler:
         # at a prompt and forwarding them would pollute its readline buffer.
         cancel_requested = threading.Event()
 
+        # When PTY-based tools (e.g. bash_exec with sudo) need to take over
+        # stdin, they set this event so _stdin_loop pauses and stops
+        # competing for sys.stdin reads.
+        stdin_yield_event = threading.Event()
+        bash_tool = getattr(self.llm_session, "bash_tool", None)
+        if bash_tool is not None:
+            bash_tool.stdin_yield_event = stdin_yield_event
+
         def _stdin_loop():
             while not cancel_requested.is_set():
+                # Yield stdin to PTY-based tools when requested.
+                if stdin_yield_event.is_set():
+                    cancel_requested.wait(0.05)
+                    continue
                 try:
-                    ready, _, _ = select.select(
-                        [sys.stdin.fileno()], [], [], 0.5
-                    )
+                    ready, _, _ = select.select([sys.stdin.fileno()], [], [], 0.5)
                     if not ready:
                         continue
                     data = os.read(sys.stdin.fileno(), 1)
@@ -404,9 +425,14 @@ class AIHandler:
             shell.handle_processing_cancelled()
         finally:
             cancel_requested.set()
+            # Clear yield event so _stdin_loop doesn't block forever.
+            stdin_yield_event.clear()
+            if bash_tool is not None:
+                bash_tool.stdin_yield_event = None
             monitor_thread.join(timeout=1.0)
             if monitor_thread.is_alive():
                 import logging
+
                 logging.getLogger(__name__).warning(
                     "stdin monitor thread did not exit in time"
                 )
@@ -420,11 +446,13 @@ class AIHandler:
             if pre_monitor_settings is not None:
                 try:
                     termios.tcsetattr(
-                        sys.stdin.fileno(), termios.TCSADRAIN,
+                        sys.stdin.fileno(),
+                        termios.TCSADRAIN,
                         pre_monitor_settings,
                     )
                 except Exception:
                     import logging
+
                     logging.getLogger(__name__).warning(
                         "failed to restore terminal settings"
                     )
@@ -588,7 +616,9 @@ Please analyze the error and suggest a fix. Check the shell history context abov
                         f"[yellow]⚠ {t('shell.error_correction.no_valid_command')}[/yellow]"
                     )
                     if description:
-                        clean_desc = description.split("Insufficient context")[0].strip()
+                        clean_desc = description.split("Insufficient context")[
+                            0
+                        ].strip()
                         if clean_desc:
                             console.print(f"   {clean_desc}")
                     console.print(
@@ -607,7 +637,9 @@ Please analyze the error and suggest a fix. Check the shell history context abov
                 sys.stderr.flush()
                 return command
 
-            console.print(Panel(Markdown(response), border_style="green", box=HORIZONTALS))
+            console.print(
+                Panel(Markdown(response), border_style="green", box=HORIZONTALS)
+            )
             sys.stdout.flush()
             sys.stderr.flush()
             console.show_cursor()

--- a/src/aish/tools/bash_executor.py
+++ b/src/aish/tools/bash_executor.py
@@ -17,10 +17,15 @@ import fcntl
 from typing import Any, Dict, Optional, Tuple
 
 from ..shell.environment import sanitize_subprocess_loader_env
-from .shell_state_capture import (apply_changes, cleanup_state_file,
-                                  create_state_file, detect_changes,
-                                  get_current_state, parse_state_file,
-                                  wrap_command_with_state_capture)
+from .shell_state_capture import (
+    apply_changes,
+    cleanup_state_file,
+    create_state_file,
+    detect_changes,
+    get_current_state,
+    parse_state_file,
+    wrap_command_with_state_capture,
+)
 
 
 class UnifiedBashExecutor:
@@ -63,6 +68,7 @@ class UnifiedBashExecutor:
         timeout: Optional[int] = None,
         use_pty: bool = False,
         cancel_event: Optional[Any] = None,
+        stdin_yield_event: Optional[Any] = None,
     ) -> Tuple[bool, str, str, int, Dict]:
         """
         Execute command and detect state changes.
@@ -73,6 +79,8 @@ class UnifiedBashExecutor:
             timeout: Optional timeout in seconds; None disables timeout
             use_pty: Whether to use PTY (for interactive commands)
             cancel_event: Cancellation event (PTY mode only)
+            stdin_yield_event: When set, signals _stdin_loop to stop reading
+                stdin so the PTY executor can take over.
 
         Returns:
             (success, stdout, stderr, returncode, changes)
@@ -95,7 +103,12 @@ class UnifiedBashExecutor:
             if use_pty:
                 # PTY execution (interactive commands)
                 success, stdout, stderr, returncode = self._execute_with_pty(
-                    command, state_file, old_state["pwd"], env_vars, cancel_event
+                    command,
+                    state_file,
+                    old_state["pwd"],
+                    env_vars,
+                    cancel_event,
+                    stdin_yield_event,
                 )
             else:
                 # Normal execution (AI tool calls)
@@ -166,6 +179,7 @@ class UnifiedBashExecutor:
         cwd: str,
         env_vars: Dict[str, str],
         cancel_event: Optional[Any],
+        stdin_yield_event: Optional[Any] = None,
     ) -> Tuple[bool, str, str, int]:
         """PTY execution for interactive commands."""
         import pty
@@ -227,6 +241,10 @@ class UnifiedBashExecutor:
             # I/O multiplexing
             stdout_buffer = b""
             KEEP_LEN = 1024 * 16
+
+            # Signal the AI stdin monitor to stop reading so we can take over.
+            if stdin_yield_event is not None:
+                stdin_yield_event.set()
 
             while True:
                 process_alive = process.poll() is None
@@ -303,6 +321,10 @@ class UnifiedBashExecutor:
             return False, "", f"Error: {str(e)}", -1
 
         finally:
+            # Release stdin back to the AI monitor thread.
+            if stdin_yield_event is not None:
+                stdin_yield_event.clear()
+
             # Restore terminal settings
             if old_settings:
                 try:

--- a/src/aish/tools/code_exec.py
+++ b/src/aish/tools/code_exec.py
@@ -11,11 +11,15 @@ from aish.config import BashOutputOffloadSettings
 from aish.i18n import t
 from aish.shell.interruption import ShellState
 from aish.offload import render_bash_output
-from aish.security.security_manager import (SecurityDecision,
-                                            SimpleSecurityManager)
+from aish.security.security_manager import SecurityDecision, SimpleSecurityManager
 from aish.state import MemoryType
-from aish.tools.base import (ToolBase, ToolExecutionContext, ToolPanelSpec,
-                             ToolPreflightAction, ToolPreflightResult)
+from aish.tools.base import (
+    ToolBase,
+    ToolExecutionContext,
+    ToolPanelSpec,
+    ToolPreflightAction,
+    ToolPreflightResult,
+)
 from aish.tools.bash_executor import UnifiedBashExecutor
 from aish.tools.result import ToolResult
 
@@ -256,9 +260,13 @@ class BashTool(ToolBase):
             stderr_preview = ""
 
         if stdout_truncated:
-            stdout_preview += f"\n... [stdout preview truncated to {preview_bytes} bytes]"
+            stdout_preview += (
+                f"\n... [stdout preview truncated to {preview_bytes} bytes]"
+            )
         if stderr_truncated:
-            stderr_preview += f"\n... [stderr preview truncated to {preview_bytes} bytes]"
+            stderr_preview += (
+                f"\n... [stderr preview truncated to {preview_bytes} bytes]"
+            )
 
         status_symbol = "\u2713" if returncode == 0 else "\u2717"
         summary = f"$ {command} \u2192 {status_symbol} (exit {returncode})"
@@ -362,10 +370,7 @@ class BashTool(ToolBase):
             remember_key=command,
         )
 
-        if (
-            isinstance(analysis_data, dict)
-            and analysis_data.get("fail_open") is True
-        ):
+        if isinstance(analysis_data, dict) and analysis_data.get("fail_open") is True:
             return ToolPreflightResult(action=ToolPreflightAction.EXECUTE)
 
         if callable(context.is_approved) and context.is_approved(command):
@@ -405,17 +410,23 @@ class BashTool(ToolBase):
             analysis_data.get("sandbox", {}) if isinstance(analysis_data, dict) else {}
         )
         sandbox_reason = (
-            str(sandbox_info.get("reason", "")) if isinstance(sandbox_info, dict) else ""
+            str(sandbox_info.get("reason", ""))
+            if isinstance(sandbox_info, dict)
+            else ""
         )
         fallback_rule_matched = bool(
             analysis_data.get("fallback_rule_matched")
             if isinstance(analysis_data, dict)
             else False
         )
-        skip_notice_panel = sandbox_reason in {
-            "sandbox_disabled",
-            "sandbox_disabled_by_policy",
-        } and not fallback_rule_matched
+        skip_notice_panel = (
+            sandbox_reason
+            in {
+                "sandbox_disabled",
+                "sandbox_disabled_by_policy",
+            }
+            and not fallback_rule_matched
+        )
 
         if decision.require_confirmation:
             panel.mode = "confirm"
@@ -532,6 +543,7 @@ class BashTool(ToolBase):
                 source="ai",
                 use_pty=True,
                 cancel_event=self._get_cancel_event(),
+                stdin_yield_event=getattr(self, "stdin_yield_event", None),
             )
             pty_rc = returncode
             used_interactive_executor = True


### PR DESCRIPTION
## Summary
- Fixed sudo commands hanging when executed via `bash_exec` — the AI stdin monitor thread (`_stdin_loop`) was competing for `sys.stdin` reads and silently discarding password input
- Added `stdin_yield_event` (threading.Event) to coordinate between the AI monitor and PTY executor: PTY executor sets the event to pause the monitor, clears it on exit

## Root Cause
`_execute_ai_operation` (ai.py) starts a background thread `_stdin_loop` that reads `sys.stdin` to intercept Ctrl+C, discarding all other keystrokes. When `bash_exec` routes sudo through `_execute_with_pty`, both threads compete for `sys.stdin`, and password input gets dropped by the monitor thread.

## Test plan
- [x] Existing tests pass (61/61 in `tests/tools/`)
- [ ] Manual test: `;exec sudo ls /root` — enter correct password, verify output displayed
- [ ] Manual test: Ctrl+C still cancels AI operations during sudo execution