### PR TITLE
Release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2026-05-07
+
+### Added
+
+- Added PTY-backed Bash tab completion so interactive completion can use shell-aware suggestions, installed Bash completion scripts, and PATH command discovery.
+- Added Ctrl+Z job-control forwarding for Bash commands and AI-triggered PTY tool runs, making it possible to suspend and resume interactive jobs more reliably.
+
+### Fixed
+
+- Fixed assistant tool-call rendering so tool responses stay attached to the invoking assistant turn instead of appearing out of order.
+- Fixed PTY completion and command-state isolation so background completion queries and repeated completion filtering no longer interfere with the active shell command.
+- Fixed AI-triggered `sudo` command handling so PTY stdin ownership is restored correctly and password prompts no longer race with background AI output monitoring.
+
 ## [0.2.5] - 2026-04-24
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aish"
-version = "0.2.5"
+version = "0.2.6"
 description = "AI Shell - A shell with built-in LLM capabilities"
 readme = "README.md"
 authors = [{ name = "Sian Cao", email = "yinshuiboy@gmail.com" }]

--- a/src/aish/__init__.py
+++ b/src/aish/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
 # Avoid importing heavy modules (and any side-effects) at package import time.
 # This matters for system services like aish-sandbox, which only need aish.sandboxd.

--- a/uv.lock
+++ b/uv.lock
@@ -146,7 +146,7 @@ wheels = [
 
 [[package]]
 name = "aish"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Background
Prepare the 0.2.6 release candidate from the current main baseline.

## Changes
- bump package/runtime metadata from 0.2.5 to 0.2.6
- update uv.lock for the 0.2.6 release version
- add the 0.2.6 changelog section covering Bash PTY completion, Ctrl+Z job control, assistant tool-call ordering, PTY completion isolation, and PTY sudo stdin recovery fixes

## Validation
- `/home/lixin/workspace/aishell/aish/.venv/bin/python -m pytest tests/scripts/packaging/test_update_release_files.py tests/scripts/packaging/test_release_metadata.py -q`
- `make test`
- `make build-bundle`

## Risk
Low. This PR only updates release metadata and changelog for an already-validated codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: v0.2.6

* **New Features**
  * PTY-backed Bash tab completion with shell-aware suggestions
  * Bash completion script installation
  * PATH command discovery
  * Ctrl+Z job-control forwarding for Bash commands
  * AI-triggered PTY tool runs

* **Bug Fixes**
  * Fixed assistant tool-call rendering ordering
  * Improved PTY completion isolation
  * Fixed AI-triggered sudo password prompt handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->