### PR TITLE
chore: prepare 0.3.0-beta.1 release

### DIFF
--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -113,7 +113,6 @@ jobs:
           AISH_INSTALL_ROOT="$INSTALL_ROOT" AISH_SKIP_SYSTEMD=1 "$EXTRACT_DIR/${BUNDLE}/install.sh"
 
           test -x "$INSTALL_ROOT/usr/local/bin/aish"
-          test -x "$INSTALL_ROOT/usr/local/bin/aish-uninstall"
           test -f "$INSTALL_ROOT/etc/aish/security_policy.yaml"
           test -f "$INSTALL_ROOT/lib/systemd/system/aish-sandbox.service"
           test -f "$INSTALL_ROOT/lib/systemd/system/aish-sandbox.socket"

--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -113,8 +113,10 @@ jobs:
           AISH_INSTALL_ROOT="$INSTALL_ROOT" AISH_SKIP_SYSTEMD=1 "$EXTRACT_DIR/${BUNDLE}/install.sh"
 
           test -x "$INSTALL_ROOT/usr/local/bin/aish"
-          test -x "$INSTALL_ROOT/usr/local/bin/aish-sandbox"
+          test -x "$INSTALL_ROOT/usr/local/bin/aish-uninstall"
           test -f "$INSTALL_ROOT/etc/aish/security_policy.yaml"
+          test -f "$INSTALL_ROOT/lib/systemd/system/aish-sandbox.service"
+          test -f "$INSTALL_ROOT/lib/systemd/system/aish-sandbox.socket"
 
       - name: Upload dry-run artifacts
         uses: actions/upload-artifact@v6

--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Target release version, for example 0.2.0 or 1.0.0-beta.1"
+        description: "Target release version, for example 0.2.0 or 0.3.0-beta.1"
         required: true
         type: string
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,8 +125,9 @@ jobs:
           AISH_INSTALL_ROOT="$INSTALL_ROOT" AISH_SKIP_SYSTEMD=1 "$EXTRACT_DIR/${BUNDLE}/install.sh"
 
           test -x "$INSTALL_ROOT/usr/local/bin/aish"
-          test -x "$INSTALL_ROOT/usr/local/bin/aish-sandbox"
           test -f "$INSTALL_ROOT/etc/aish/security_policy.yaml"
+          test -f "$INSTALL_ROOT/lib/systemd/system/aish-sandbox.service"
+          test -f "$INSTALL_ROOT/lib/systemd/system/aish-sandbox.socket"
 
       - name: Upload assets to release
         uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,110 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `aish update` command for self-updating to latest version from GitHub releases
-- `aish uninstall` command for uninstalling aish with optional `--purge` flag
-- UpdateManager class for handling update logic with GitHub API integration
-- UninstallManager class for handling uninstall logic and data cleanup
-- i18n support for update and uninstall commands in Chinese and English
-- DejaGnu integration tests for update and uninstall commands
+- No unreleased changes yet.
+
+## [1.0.0-beta.1] - 2026-05-09
+
+### Added
+
+- Added the first Rust-based 1.0 preview of AISH while keeping the existing product release history intact.
+- Added a crate-based runtime split across the CLI, shell, PTY, security, tools, memory, prompts, skills, and configuration layers, replacing the older Python runtime that centered more behavior inside a single long-lived shell application process.
+- Added the Rust sandbox runtime with packaged daemon assets, systemd units, and release-bundle install validation as part of the default 1.0 execution path.
+- Added channel-based follow-up tools for SSH-, telnet-, and other session-style commands so AISH can continue asking questions and chaining tool work inside remote interactive sessions.
+
+### Changed
+
+- Changed the interactive shell from the Python `prompt_toolkit`-driven runtime into a Rust shell built around explicit modules for input classification, rendering, PTY-backed completion, autosuggest, prompt rendering, and shell state management.
+- Changed command execution and tool handling so interactive Bash sessions, remote session commands, cancellation, and job-control flows are managed through the Rust PTY and tool layers instead of Python-specific runtime glue.
+- Changed the security model from the older Python manager centered on dictionary-shaped analysis and IPC wrappers into a typed Rust security pipeline with structured requests, explicit sandbox decisions, fallback rule handling, and degraded-mode analysis.
+- Changed self-update and release publishing so the Rust release line uses semver-aware prerelease comparison, prerelease-capable metadata validation, and consistent `linux-amd64` bundle naming for installer and update paths.
+
+### Removed
+
+- Removed the Python application package, test suite, and development metadata from the active release workspace; the remaining Python code is now limited to narrow release automation helpers under `packaging/scripts`.
+
+### Fixed
+
+- Fixed several interaction gaps that were especially visible in the Python line under heavy PTY use, including completion/query isolation, cancellation handoff, interactive stdin ownership, and Ctrl+Z job control for shell-driven commands.
+- Fixed error presentation around model and tool execution so duplicate failures are suppressed and long-running operations unwind more predictably in the terminal UI.
+- Fixed sandbox cleanup, no-change probe handling, and worker lifecycle behavior so sandboxed execution degrades more predictably when the runtime or host environment cannot complete the ideal path.
+
+## [0.2.6] - 2026-05-07
+
+### Added
+
+- Added PTY-backed Bash tab completion so interactive completion can use shell-aware suggestions, installed Bash completion scripts, and PATH command discovery.
+- Added Ctrl+Z job-control forwarding for Bash commands and AI-triggered PTY tool runs, making it possible to suspend and resume interactive jobs more reliably.
+
+### Fixed
+
+- Fixed assistant tool-call rendering so tool responses stay attached to the invoking assistant turn instead of appearing out of order.
+- Fixed PTY completion and command-state isolation so background completion queries and repeated completion filtering no longer interfere with the active shell command.
+- Fixed AI-triggered `sudo` command handling so PTY stdin ownership is restored correctly and password prompts no longer race with background AI output monitoring.
+
+## [0.2.5] - 2026-04-24
+
+### Fixed
+
+- Fixed AI-initiated `bash_exec` commands that invoke `sudo` so they now run through a PTY-backed path instead of hanging when the system prompts for a password.
+
+## [0.2.4] - 2026-04-23
+
+### Changed
+
+- Changed stable release publishing so tagged releases now keep GitHub Release assets while also publishing versioned Linux bundles and latest-version metadata to the CDN download paths used by the installer and stable self-update.
+- Changed shell startup to reuse the PTY startup handshake, reducing duplicate initialization work and keeping startup state tracking more consistent.
+
+### Fixed
+
+- Fixed final AI answer rendering so completed responses are shown once and no longer leak startup or timing state into the visible shell session.
+
+## [0.2.3] - 2026-04-22
+
+### Changed
+
+- Changed `aish update` stable release detection to read CDN-hosted latest release metadata, and switched archive downloads to the CDN bundle path while preserving `AISH_DOWNLOAD_BASE_URL`, `AISH_LATEST_URL`, and legacy `AISH_REPO_URL` overrides.
+
+### Fixed
+
+- Fixed shared PTY commands so they no longer time out after 30 seconds unless a caller explicitly requests a timeout.
+- Fixed PTY command lifecycle tracking by moving command metadata off the shell input path onto a dedicated metadata pipe, preventing metadata leaks and incorrect backend event binding.
+- Fixed PyInstaller subprocess launches by sanitizing loader environment variables before spawning child processes.
+
+## [0.2.2] - 2026-04-16
+
+### Added
+
+- Added a dedicated `Release Final Check` workflow so maintainers can confirm merged `main` release metadata before pushing a stable tag.
+
+### Changed
+
+- Changed release candidate validation so release PRs now run installed-binary runtime smoke checks and artifact-based live smoke against the built bundle before merge.
+- Changed the plan mode keyboard toggle from `F2` to `Shift+Tab` and `Ctrl+X P`, reducing conflicts with terminal key handling.
+
+### Fixed
+
+- Fixed normal streamed conversations so the live reasoning display is no longer interrupted by partial content rendering while the model is still responding.
+
+## [0.2.1] - 2026-04-15
+
+### Added
+
+- Added an interactive plan mode for non-trivial tasks, including persisted plan artifacts, review and approval flow, and an explicit transition back into execution. Enter plan mode with `/plan` or `F2`, then leave it with `/plan exit` or `F2` when you want to return to normal shell execution.
+- Added persistent long-term memory backed by Markdown storage, with memory recall and store tooling that can carry forward user preferences and project context across sessions.
+- Added `aish update` and `aish uninstall` commands so archive, pip, and system-package installs have a built-in path for upgrade and removal.
+
+### Changed
+
+- Changed the terminal UI to show a visible thinking timer while the model is working, making longer requests easier to track.
+- Changed startup and session wiring so plan mode, memory, and the new CLI management flows are initialized more consistently from the current package layout.
+
+### Fixed
+
+- Fixed the interactive shell so `quit` works again as an exit alias.
+- Fixed compact prompt theme spacing and related prompt rendering regressions in the shell UI.
+- Fixed standalone bundle startup so PyInstaller builds include the lazy-loaded shell entry modules needed to launch `aish` after installation.
+- Fixed release automation paths so preparation and publishing workflows target the current repository layout.
 
 ## [0.2.0] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - No unreleased changes yet.
 
-## [1.0.0-beta.1] - 2026-05-09
+## [0.3.0-beta.1] - 2026-05-09
 
 ### Added
 
-- Added the first Rust-based 1.0 preview of AISH while keeping the existing product release history intact.
+- Added the first Rust-based 0.3 preview of AISH while keeping the existing product release history intact.
 - Added a crate-based runtime split across the CLI, shell, PTY, security, tools, memory, prompts, skills, and configuration layers, replacing the older Python runtime that centered more behavior inside a single long-lived shell application process.
-- Added the Rust sandbox runtime with packaged daemon assets, systemd units, and release-bundle install validation as part of the default 1.0 execution path.
+- Added the Rust sandbox runtime with packaged daemon assets, systemd units, and release-bundle install validation as part of the default 0.3 beta execution path.
 - Added channel-based follow-up tools for SSH-, telnet-, and other session-style commands so AISH can continue asking questions and chaining tool work inside remote interactive sessions.
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "aish-cli"
-version = "1.0.0-beta.1"
+version = "0.3.0-beta.1"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "aish-config"
-version = "1.0.0-beta.1"
+version = "0.3.0-beta.1"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "aish-context"
-version = "1.0.0-beta.1"
+version = "0.3.0-beta.1"
 dependencies = [
  "aish-core",
  "serde",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "aish-core"
-version = "1.0.0-beta.1"
+version = "0.3.0-beta.1"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "aish-i18n"
-version = "1.0.0-beta.1"
+version = "0.3.0-beta.1"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "aish-llm"
-version = "1.0.0-beta.1"
+version = "0.3.0-beta.1"
 dependencies = [
  "aish-context",
  "aish-core",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "aish-memory"
-version = "1.0.0-beta.1"
+version = "0.3.0-beta.1"
 dependencies = [
  "aish-core",
  "chrono",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "aish-prompts"
-version = "1.0.0-beta.1"
+version = "0.3.0-beta.1"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "aish-pty"
-version = "1.0.0-beta.1"
+version = "0.3.0-beta.1"
 dependencies = [
  "aish-core",
  "aish-i18n",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "aish-scripts"
-version = "1.0.0-beta.1"
+version = "0.3.0-beta.1"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aish-security"
-version = "1.0.0-beta.1"
+version = "0.3.0-beta.1"
 dependencies = [
  "libc",
  "serde",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "aish-session"
-version = "1.0.0-beta.1"
+version = "0.3.0-beta.1"
 dependencies = [
  "aish-core",
  "chrono",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "aish-shell"
-version = "1.0.0-beta.1"
+version = "0.3.0-beta.1"
 dependencies = [
  "aish-config",
  "aish-context",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "aish-skills"
-version = "1.0.0-beta.1"
+version = "0.3.0-beta.1"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "aish-tools"
-version = "1.0.0-beta.1"
+version = "0.3.0-beta.1"
 dependencies = [
  "aish-core",
  "aish-i18n",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "aish-cli"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "aish-config"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "aish-context"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "aish-core",
  "serde",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "aish-core"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "aish-i18n"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "aish-llm"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "aish-context",
  "aish-core",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "aish-memory"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "aish-core",
  "chrono",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "aish-prompts"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "aish-pty"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "aish-core",
  "aish-i18n",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "aish-scripts"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aish-security"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "libc",
  "serde",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "aish-session"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "aish-core",
  "chrono",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "aish-shell"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "aish-config",
  "aish-context",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "aish-skills"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "aish-tools"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "aish-core",
  "aish-i18n",
@@ -550,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -586,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -608,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1069,13 +1069,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1341,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1613,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1639,7 +1638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1716,16 +1715,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,9 +1737,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1796,11 +1785,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "libc",
 ]
 
@@ -1860,9 +1849,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
@@ -1870,10 +1859,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.1",
  "libc",
- "plain",
- "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2281,7 +2267,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2378,7 +2364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2416,16 +2402,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
@@ -2504,9 +2484,9 @@ checksum = "bd348ff538bc9caeda7ee8cad2d1d48236a1f443c1fa3913c6a02fe0043b1dd3"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -2599,9 +2579,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
 ]
@@ -2751,15 +2731,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -3007,9 +2978,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
  "ring",
@@ -3021,9 +2992,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3031,9 +3002,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3198,9 +3169,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3217,9 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3347,9 +3318,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3709,9 +3680,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3786,20 +3757,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3896,9 +3867,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -3985,9 +3956,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",
@@ -4051,11 +4022,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -4064,14 +4035,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4082,9 +4053,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4092,9 +4063,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4102,9 +4073,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4115,9 +4086,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -4171,9 +4142,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4191,9 +4162,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4661,6 +4632,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0-beta.1"
+version = "0.3.0-beta.1"
 edition = "2021"
 license = "MIT"
 rust-version = "1.80"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.0-beta.1"
 edition = "2021"
 license = "MIT"
 rust-version = "1.80"

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ packaging-test:
 	PYTHON="$(PYTHON)" ./packaging/tests/release_scripts_smoke.sh
 
 prepare-release-files:
-	@test -n "$(VERSION)" || { echo "VERSION is required, for example: make prepare-release-files VERSION=1.0.0-beta.1" >&2; exit 2; }
+	@test -n "$(VERSION)" || { echo "VERSION is required, for example: make prepare-release-files VERSION=0.3.0-beta.1" >&2; exit 2; }
 	$(PYTHON) packaging/scripts/update_release_files.py --version "$(VERSION)" $(if $(DATE),--date "$(DATE)",)
 
 lint:

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ aish> ;explain this command: tar -czf a.tgz ./dir
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-The installer resolves the latest release directory under `https://www.aishell.ai/repo`, downloads the matching bundle for your architecture, and installs `aish`, `aish-sandbox`, and `aish-uninstall` into `/usr/local/bin`.
+The installer resolves the latest release directory under `https://www.aishell.ai/repo`, downloads the matching bundle for your architecture, and installs `aish` and `aish-uninstall` into `/usr/local/bin`, along with the bundled sandbox systemd units.
 
 ### Run from Source (Development/Trial)
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ aish> ;explain this command: tar -czf a.tgz ./dir
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-The installer resolves the latest release directory under `https://www.aishell.ai/repo`, downloads the matching bundle for your architecture, and installs `aish` and `aish-uninstall` into `/usr/local/bin`, along with the bundled sandbox systemd units.
+The installer resolves the latest release directory under `https://www.aishell.ai/repo`, downloads the matching bundle for your architecture, and installs `aish` into `/usr/local/bin`, along with the bundled sandbox systemd units.
 
 ### Run from Source (Development/Trial)
 
@@ -141,13 +141,13 @@ cargo run --bin aish
 Uninstall (keep configuration files):
 
 ```bash
-sudo aish-uninstall
+sudo aish uninstall --yes
 ```
 
 Complete uninstallation (also removes system-level security policies):
 
 ```bash
-sudo aish-uninstall --purge-config
+sudo aish uninstall --yes --purge
 ```
 
 Optional: Clean user-level configuration (will clear model/API keys etc.):

--- a/README_CN.md
+++ b/README_CN.md
@@ -121,7 +121,7 @@ aish> ;解释一下这个命令：tar -czf a.tgz ./dir
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-该安装器会在 `https://www.aishell.ai/repo` 下解析最新发布目录，下载与你当前架构匹配的 bundle，并把 `aish`、`aish-sandbox` 和 `aish-uninstall` 安装到 `/usr/local/bin`。
+该安装器会在 `https://www.aishell.ai/repo` 下解析最新发布目录，下载与你当前架构匹配的 bundle，并把 `aish` 和 `aish-uninstall` 安装到 `/usr/local/bin`，同时部署随包附带的 sandbox systemd 单元。
 
 ### 从源码运行（开发/试用）
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -121,7 +121,7 @@ aish> ;解释一下这个命令：tar -czf a.tgz ./dir
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-该安装器会在 `https://www.aishell.ai/repo` 下解析最新发布目录，下载与你当前架构匹配的 bundle，并把 `aish` 和 `aish-uninstall` 安装到 `/usr/local/bin`，同时部署随包附带的 sandbox systemd 单元。
+该安装器会在 `https://www.aishell.ai/repo` 下解析最新发布目录，下载与你当前架构匹配的 bundle，并把 `aish` 安装到 `/usr/local/bin`，同时部署随包附带的 sandbox systemd 单元。
 
 ### 从源码运行（开发/试用）
 
@@ -136,13 +136,13 @@ cargo run --bin aish
 卸载（保留配置文件）：
 
 ```bash
-sudo aish-uninstall
+sudo aish uninstall --yes
 ```
 
 彻底卸载（同时删除系统级安全策略）：
 
 ```bash
-sudo aish-uninstall --purge-config
+sudo aish uninstall --yes --purge
 ```
 
 可选：清理用户级配置（会清空模型/API Key 等）：

--- a/README_DE.md
+++ b/README_DE.md
@@ -126,7 +126,7 @@ aish> ;erkläre diesen Befehl: tar -czf a.tgz ./dir
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-Der Installer ermittelt das neueste Release-Verzeichnis unter `https://www.aishell.ai/repo`, lädt das passende Bundle für deine Architektur herunter und installiert `aish`, `aish-sandbox` und `aish-uninstall` in `/usr/local/bin`.
+Der Installer ermittelt das neueste Release-Verzeichnis unter `https://www.aishell.ai/repo`, lädt das passende Bundle für deine Architektur herunter und installiert `aish` und `aish-uninstall` in `/usr/local/bin` sowie die mitgelieferten Sandbox-systemd-Units.
 
 ### Aus dem Quellcode ausführen (Entwicklung/Test)
 

--- a/README_DE.md
+++ b/README_DE.md
@@ -126,7 +126,7 @@ aish> ;erkläre diesen Befehl: tar -czf a.tgz ./dir
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-Der Installer ermittelt das neueste Release-Verzeichnis unter `https://www.aishell.ai/repo`, lädt das passende Bundle für deine Architektur herunter und installiert `aish` und `aish-uninstall` in `/usr/local/bin` sowie die mitgelieferten Sandbox-systemd-Units.
+Der Installer ermittelt das neueste Release-Verzeichnis unter `https://www.aishell.ai/repo`, lädt das passende Bundle für deine Architektur herunter und installiert `aish` in `/usr/local/bin` sowie die mitgelieferten Sandbox-systemd-Units.
 
 ### Aus dem Quellcode ausführen (Entwicklung/Test)
 
@@ -141,13 +141,13 @@ cargo run --bin aish
 Deinstallieren (Konfigurationsdateien behalten):
 
 ```bash
-sudo aish-uninstall
+sudo aish uninstall --yes
 ```
 
 Vollständige Deinstallation (entfernt auch systemweite Sicherheitsrichtlinien):
 
 ```bash
-sudo aish-uninstall --purge-config
+sudo aish uninstall --yes --purge
 ```
 
 Optional: Benutzerkonfiguration bereinigen (löscht Modell/API-Keys usw.):

--- a/README_ES.md
+++ b/README_ES.md
@@ -126,7 +126,7 @@ aish> ;explica este comando: tar -czf a.tgz ./dir
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-El instalador resuelve el último directorio de release en `https://www.aishell.ai/repo`, descarga el bundle correspondiente a tu arquitectura e instala `aish` y `aish-uninstall` en `/usr/local/bin`, junto con las unidades systemd del sandbox incluidas en el bundle.
+El instalador resuelve el último directorio de release en `https://www.aishell.ai/repo`, descarga el bundle correspondiente a tu arquitectura e instala `aish` en `/usr/local/bin`, junto con las unidades systemd del sandbox incluidas en el bundle.
 
 ### Ejecutar desde el código fuente (desarrollo/prueba)
 
@@ -141,13 +141,13 @@ cargo run --bin aish
 Desinstalar (conservar archivos de configuración):
 
 ```bash
-sudo aish-uninstall
+sudo aish uninstall --yes
 ```
 
 Desinstalación completa (también elimina políticas de seguridad a nivel sistema):
 
 ```bash
-sudo aish-uninstall --purge-config
+sudo aish uninstall --yes --purge
 ```
 
 Opcional: limpiar configuración del usuario (borra claves de modelo/API, etc.):

--- a/README_ES.md
+++ b/README_ES.md
@@ -126,7 +126,7 @@ aish> ;explica este comando: tar -czf a.tgz ./dir
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-El instalador resuelve el último directorio de release en `https://www.aishell.ai/repo`, descarga el bundle correspondiente a tu arquitectura e instala `aish`, `aish-sandbox` y `aish-uninstall` en `/usr/local/bin`.
+El instalador resuelve el último directorio de release en `https://www.aishell.ai/repo`, descarga el bundle correspondiente a tu arquitectura e instala `aish` y `aish-uninstall` en `/usr/local/bin`, junto con las unidades systemd del sandbox incluidas en el bundle.
 
 ### Ejecutar desde el código fuente (desarrollo/prueba)
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -126,7 +126,7 @@ aish> ;explique cette commande : tar -czf a.tgz ./dir
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-L’installeur résout le répertoire de la dernière release sous `https://www.aishell.ai/repo`, télécharge le bundle correspondant à votre architecture et installe `aish`, `aish-sandbox` et `aish-uninstall` dans `/usr/local/bin`.
+L’installeur résout le répertoire de la dernière release sous `https://www.aishell.ai/repo`, télécharge le bundle correspondant à votre architecture et installe `aish` et `aish-uninstall` dans `/usr/local/bin`, ainsi que les unités systemd sandbox incluses dans le bundle.
 
 ### Exécuter depuis les sources (développement/essai)
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -126,7 +126,7 @@ aish> ;explique cette commande : tar -czf a.tgz ./dir
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-L’installeur résout le répertoire de la dernière release sous `https://www.aishell.ai/repo`, télécharge le bundle correspondant à votre architecture et installe `aish` et `aish-uninstall` dans `/usr/local/bin`, ainsi que les unités systemd sandbox incluses dans le bundle.
+L’installeur résout le répertoire de la dernière release sous `https://www.aishell.ai/repo`, télécharge le bundle correspondant à votre architecture et installe `aish` dans `/usr/local/bin`, ainsi que les unités systemd sandbox incluses dans le bundle.
 
 ### Exécuter depuis les sources (développement/essai)
 
@@ -141,13 +141,13 @@ cargo run --bin aish
 Désinstaller (conserver les fichiers de configuration) :
 
 ```bash
-sudo aish-uninstall
+sudo aish uninstall --yes
 ```
 
 Désinstallation complète (supprime aussi les politiques de sécurité système) :
 
 ```bash
-sudo aish-uninstall --purge-config
+sudo aish uninstall --yes --purge
 ```
 
 Optionnel : nettoyer la configuration utilisateur (efface les clés modèle/API, etc.) :

--- a/README_JA.md
+++ b/README_JA.md
@@ -126,7 +126,7 @@ aish> ;このコマンドを説明して: tar -czf a.tgz ./dir
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-インストーラは `https://www.aishell.ai/repo` 配下の最新リリースディレクトリを解決し、アーキテクチャに合ったバンドルをダウンロードして `aish` と `aish-uninstall` を `/usr/local/bin` にインストールし、同梱された sandbox systemd ユニットも配置します。
+インストーラは `https://www.aishell.ai/repo` 配下の最新リリースディレクトリを解決し、アーキテクチャに合ったバンドルをダウンロードして `aish` を `/usr/local/bin` にインストールし、同梱された sandbox systemd ユニットも配置します。
 
 ### ソースから実行（開発/試用）
 
@@ -141,13 +141,13 @@ cargo run --bin aish
 アンインストール（設定ファイルは保持）：
 
 ```bash
-sudo aish-uninstall
+sudo aish uninstall --yes
 ```
 
 完全アンインストール（システムレベルのセキュリティポリシーも削除）：
 
 ```bash
-sudo aish-uninstall --purge-config
+sudo aish uninstall --yes --purge
 ```
 
 任意：ユーザー設定のクリーンアップ（モデル/APIキーなどを削除）：

--- a/README_JA.md
+++ b/README_JA.md
@@ -126,7 +126,7 @@ aish> ;このコマンドを説明して: tar -czf a.tgz ./dir
 curl -fsSL https://www.aishell.ai/repo/install.sh | bash
 ```
 
-インストーラは `https://www.aishell.ai/repo` 配下の最新リリースディレクトリを解決し、アーキテクチャに合ったバンドルをダウンロードして `aish`、`aish-sandbox`、`aish-uninstall` を `/usr/local/bin` にインストールします。
+インストーラは `https://www.aishell.ai/repo` 配下の最新リリースディレクトリを解決し、アーキテクチャに合ったバンドルをダウンロードして `aish` と `aish-uninstall` を `/usr/local/bin` にインストールし、同梱された sandbox systemd ユニットも配置します。
 
 ### ソースから実行（開発/試用）
 

--- a/crates/aish-cli/src/uninstall.rs
+++ b/crates/aish-cli/src/uninstall.rs
@@ -12,7 +12,6 @@ use aish_i18n::{t, t_with_args};
 
 // Paths used by the archive/script installer (install.sh)
 const ARCHIVE_BIN_DIR: &str = "/usr/local/bin";
-const ARCHIVE_BINARY_NAMES: &[&str] = &["aish", "aish-uninstall"];
 const ARCHIVE_SHARE_DIR: &str = "/usr/local/share/aish";
 const SYSTEM_CONFIG_DIR: &str = "/etc/aish";
 const SYSTEMD_UNIT_DIR: &str = "/lib/systemd/system";
@@ -136,36 +135,9 @@ fn run_sudo(args: &[&str]) -> Result<(), AishError> {
 }
 
 fn uninstall_archive(purge: bool) -> Result<(), AishError> {
-    // Prefer bundled uninstall script
-    let uninstall_script = PathBuf::from(ARCHIVE_BIN_DIR).join("aish-uninstall");
-    if uninstall_script.exists() {
-        let mut args = vec![uninstall_script.to_str().unwrap_or("")];
-        if purge {
-            args.push("--purge-config");
-        }
-        return run_sudo(&args);
-    }
-
-    // Fallback: remove files manually
     let mut success = true;
 
     stop_and_remove_sandbox_units();
-
-    for name in ARCHIVE_BINARY_NAMES {
-        let binary = PathBuf::from(ARCHIVE_BIN_DIR).join(name);
-        if binary.exists() {
-            if let Err(e) = run_sudo(&["rm", "-f", binary.to_str().unwrap_or("")]) {
-                let path_str = binary.display().to_string();
-                eprintln!("\x1b[31m{}\x1b[0m", {
-                    let mut args = std::collections::HashMap::new();
-                    args.insert("path".to_string(), path_str);
-                    args.insert("error".to_string(), e.to_string());
-                    t_with_args("cli.uninstall.file_remove_failed", &args)
-                });
-                success = false;
-            }
-        }
-    }
 
     let share_dir = PathBuf::from(ARCHIVE_SHARE_DIR);
     if share_dir.exists() {
@@ -183,6 +155,20 @@ fn uninstall_archive(purge: bool) -> Result<(), AishError> {
 
     if purge {
         purge_system_config();
+    }
+
+    let archive_bin = PathBuf::from(ARCHIVE_BIN_DIR).join("aish");
+    if archive_bin.exists() {
+        if let Err(e) = run_sudo(&["rm", "-f", archive_bin.to_str().unwrap_or("")]) {
+            let path_str = archive_bin.display().to_string();
+            eprintln!("\x1b[31m{}\x1b[0m", {
+                let mut args = std::collections::HashMap::new();
+                args.insert("path".to_string(), path_str);
+                args.insert("error".to_string(), e.to_string());
+                t_with_args("cli.uninstall.file_remove_failed", &args)
+            });
+            success = false;
+        }
     }
 
     if success {

--- a/crates/aish-cli/src/update.rs
+++ b/crates/aish-cli/src/update.rs
@@ -591,7 +591,7 @@ mod tests {
     #[test]
     fn test_compare_versions_prerelease_newer_than_previous_stable() {
         assert_eq!(
-            compare_versions("1.0.0-beta.1", "0.2.0"),
+            compare_versions("0.3.0-beta.1", "0.2.0"),
             std::cmp::Ordering::Greater
         );
     }
@@ -599,7 +599,7 @@ mod tests {
     #[test]
     fn test_compare_versions_stable_newer_than_prerelease() {
         assert_eq!(
-            compare_versions("1.0.0", "1.0.0-beta.1"),
+            compare_versions("0.3.0", "0.3.0-beta.1"),
             std::cmp::Ordering::Greater
         );
     }
@@ -607,7 +607,7 @@ mod tests {
     #[test]
     fn test_compare_versions_prerelease_identifiers() {
         assert_eq!(
-            compare_versions("1.0.0-beta.2", "1.0.0-beta.1"),
+            compare_versions("0.3.0-beta.2", "0.3.0-beta.1"),
             std::cmp::Ordering::Greater
         );
     }

--- a/packaging/scripts/install-bundle.sh
+++ b/packaging/scripts/install-bundle.sh
@@ -188,7 +188,6 @@ check_runtime_dependencies
 BIN_DIR="$(binary_target_dir)"
 
 install_file "$ROOTFS_DIR/usr/bin/aish" "${BIN_DIR}/aish" 0755
-install_file "$SCRIPT_DIR/uninstall.sh" "${BIN_DIR}/aish-uninstall" 0755
 install_config "$ROOTFS_DIR/etc/aish/security_policy.yaml" "/etc/aish/security_policy.yaml"
 install_file "$ROOTFS_DIR/usr/share/doc/aish/skills-guide.md" "/usr/local/share/aish/skills-guide.md" 0644
 

--- a/packaging/scripts/uninstall-bundle.sh
+++ b/packaging/scripts/uninstall-bundle.sh
@@ -86,7 +86,7 @@ BIN_DIR="$(binary_target_dir)"
 
 remove_systemd_units
 
-rm -f "$(target_path "${BIN_DIR}/aish")" "$(target_path "${BIN_DIR}/aish-uninstall")"
+rm -f "$(target_path "${BIN_DIR}/aish")"
 
 rm -rf "$(target_path "/usr/local/share/aish/skills")"
 rm -f "$(target_path "/usr/local/share/aish/skills-guide.md")"

--- a/packaging/scripts/update_release_files.py
+++ b/packaging/scripts/update_release_files.py
@@ -93,7 +93,7 @@ def main() -> int:
     parser.add_argument(
         "--version",
         required=True,
-        help="Release version, for example 0.2.0 or 1.0.0-beta.1",
+        help="Release version, for example 0.2.0 or 0.3.0-beta.1",
     )
     parser.add_argument(
         "--date",

--- a/packaging/tests/release_scripts_smoke.sh
+++ b/packaging/tests/release_scripts_smoke.sh
@@ -29,24 +29,24 @@ cat > "$SANDBOX/CHANGELOG.md" <<'EOF'
 EOF
 
 "$PYTHON_BIN" "$SANDBOX/packaging/scripts/update_release_files.py" \
-  --version 1.0.0-beta.1 \
+  --version 0.3.0-beta.1 \
   --date 2026-05-09
 
-grep -Fq 'version = "1.0.0-beta.1"' "$SANDBOX/Cargo.toml"
-grep -Fq '## [1.0.0-beta.1] - 2026-05-09' "$SANDBOX/CHANGELOG.md"
+grep -Fq 'version = "0.3.0-beta.1"' "$SANDBOX/Cargo.toml"
+grep -Fq '## [0.3.0-beta.1] - 2026-05-09' "$SANDBOX/CHANGELOG.md"
 
 if "$PYTHON_BIN" "$SANDBOX/packaging/scripts/update_release_files.py" \
-  --version 1.0.0-beta.1 \
+  --version 0.3.0-beta.1 \
   --date 2026-05-09 > "$TMP_DIR/duplicate.out" 2>&1; then
   echo "Expected duplicate changelog version to be rejected" >&2
   exit 1
 fi
-grep -Fq 'already contains a section for version 1.0.0-beta.1' "$TMP_DIR/duplicate.out"
+grep -Fq 'already contains a section for version 0.3.0-beta.1' "$TMP_DIR/duplicate.out"
 
 cat > "$SANDBOX/CHANGELOG.md" <<'EOF'
 # Changelog
 
-## [1.0.0-beta.1] - 2026-05-09
+## [0.3.0-beta.1] - 2026-05-09
 
 ### Changed
 
@@ -60,17 +60,17 @@ cat > "$SANDBOX/CHANGELOG.md" <<'EOF'
 EOF
 
 "$PYTHON_BIN" "$SANDBOX/packaging/scripts/release_metadata.py" \
-  --expected-version v1.0.0-beta.1 \
+  --expected-version v0.3.0-beta.1 \
   --json-file "$TMP_DIR/metadata.json" \
   --summary-file "$TMP_DIR/summary.md"
 
-grep -Fq '"version": "1.0.0-beta.1"' "$TMP_DIR/metadata.json"
-grep -Fq '"tag": "v1.0.0-beta.1"' "$TMP_DIR/metadata.json"
+grep -Fq '"version": "0.3.0-beta.1"' "$TMP_DIR/metadata.json"
+grep -Fq '"tag": "v0.3.0-beta.1"' "$TMP_DIR/metadata.json"
 grep -Fq 'Beta release note' "$TMP_DIR/summary.md"
 
 "$PYTHON_BIN" "$SANDBOX/packaging/scripts/release_metadata.py" \
   --print-json > "$TMP_DIR/metadata-default.json"
-grep -Fq '"version": "1.0.0-beta.1"' "$TMP_DIR/metadata-default.json"
+grep -Fq '"version": "0.3.0-beta.1"' "$TMP_DIR/metadata-default.json"
 grep -Fq 'Beta release note' "$TMP_DIR/metadata-default.json"
 
 if "$PYTHON_BIN" "$SANDBOX/packaging/scripts/release_metadata.py" \


### PR DESCRIPTION
## Background

Prepare the Rust release branch for `0.3.0-beta.1` validation before promoting the Rust release line further.

## Changes

- switch the Rust workspace version and lockfile to `0.3.0-beta.1`
- rewrite the Rust changelog entry to describe the Rust rewrite as the `0.3.0-beta.1` preview release
- update release-preparation examples, smoke tests, and semver fixtures to use the `0.3.0-beta.1` beta line consistently
- keep beta validation scoped to the `rust` line for now

## Validation

- make packaging-test PYTHON=/home/lixin/workspace/aishell/aish/.venv/bin/python
- python packaging/scripts/release_metadata.py --expected-version 0.3.0-beta.1 --print-json
- cargo test -p aish-cli test_compare_versions
- cargo build --release --target x86_64-unknown-linux-musl
- VERSION=0.3.0-beta.1 PLATFORM=linux ARCH=amd64 OUTPUT_DIR=artifacts/amd64 ./packaging/build_bundle.sh
- bundle install smoke test for aish-0.3.0-beta.1-linux-amd64

## Risk

This PR changes version metadata and release notes on the Rust release line. The main risk remains release automation correctness for the beta tag, so this stays on the Rust validation path first.