### PR TITLE
feat: add beta CDN release channel flow

### DIFF
--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -7,6 +7,11 @@ on:
         description: "Target release version, for example 0.2.0 or 0.3.0-beta.1"
         required: true
         type: string
+      ref:
+        description: "Git ref to validate, for example release/v0.3.0-beta.1-prep or a commit SHA"
+        required: false
+        default: rust
+        type: string
 
 permissions:
   contents: read
@@ -29,6 +34,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.ref }}
 
       - name: Compute release metadata
         id: metadata
@@ -53,6 +59,7 @@ jobs:
 
           - Version: ${{ needs.release-meta.outputs.version }}
           - Tag: ${{ needs.release-meta.outputs.tag }}
+          - Ref: ${{ github.event.inputs.ref }}
           - Previous stable tag: ${{ needs.release-meta.outputs.previous_stable_tag || 'none' }}
 
           ## Release Notes
@@ -61,50 +68,50 @@ jobs:
           EOF
 
   dry-run-package-validation:
-    name: Dry-run package validation
+    name: Dry-run package validation (${{ matrix.arch }})
     needs: release-meta
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            target: x86_64-unknown-linux-musl
+            runs_on: ubuntu-latest
+          - arch: arm64
+            target: aarch64-unknown-linux-musl
+            runs_on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runs_on }}
+    container:
+      image: rockylinux:8
+    defaults:
+      run:
+        shell: bash
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
         with:
-          targets: x86_64-unknown-linux-musl
+          ref: ${{ github.event.inputs.ref }}
 
-      - name: Install musl tools
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
-
-      - name: Cache Cargo artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: linux-musl-cargo-v1-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            linux-musl-cargo-v1-
-
-      - name: Build release binary
-        run: cargo build --release --target x86_64-unknown-linux-musl
+      - name: Set up build environment
+        env:
+          AISH_BUILD_TARGET: ${{ matrix.target }}
+        run: ./packaging/scripts/setup-ci-env.sh
 
       - name: Build bundle
         run: |
           VERSION="${{ needs.release-meta.outputs.version }}"
-          OUTPUT_DIR="artifacts/amd64"
-          VERSION="$VERSION" PLATFORM="linux" ARCH="amd64" OUTPUT_DIR="$OUTPUT_DIR" ./packaging/build_bundle.sh
+          OUTPUT_DIR="artifacts/${{ matrix.arch }}"
+          VERSION="$VERSION" PLATFORM="linux" ARCH="${{ matrix.arch }}" AISH_BUILD_TARGET="${{ matrix.target }}" OUTPUT_DIR="$OUTPUT_DIR" ./packaging/build_bundle.sh
           ls -lah "$OUTPUT_DIR"
 
       - name: Smoke test bundle install
         run: |
           VERSION="${{ needs.release-meta.outputs.version }}"
-          OUTPUT_DIR="artifacts/amd64"
-          BUNDLE="aish-${VERSION}-linux-amd64"
-          EXTRACT_DIR="$PWD/build/install-smoke"
-          INSTALL_ROOT="$PWD/build/install-root"
+          OUTPUT_DIR="artifacts/${{ matrix.arch }}"
+          BUNDLE="aish-${VERSION}-linux-${{ matrix.arch }}"
+          EXTRACT_DIR="$PWD/build/install-smoke/${{ matrix.arch }}"
+          INSTALL_ROOT="$PWD/build/install-root/${{ matrix.arch }}"
 
           rm -rf "$EXTRACT_DIR" "$INSTALL_ROOT"
           mkdir -p "$EXTRACT_DIR" "$INSTALL_ROOT"
@@ -120,8 +127,8 @@ jobs:
       - name: Upload dry-run artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: release-preparation-aish-linux-amd64
-          path: artifacts/amd64/*
+          name: release-preparation-aish-linux-${{ matrix.arch }}
+          path: artifacts/${{ matrix.arch }}/*
           if-no-files-found: error
 
   release-preparation-summary:
@@ -139,7 +146,8 @@ jobs:
 
           - Version: ${{ needs.release-meta.outputs.version }}
           - Tag: ${{ needs.release-meta.outputs.tag }}
+          - Ref: ${{ github.event.inputs.ref }}
           - Previous stable tag: ${{ needs.release-meta.outputs.previous_stable_tag || 'none' }}
 
-          Release metadata artifacts and dry-run bundle validation have completed successfully.
+          Release metadata artifacts and dry-run bundle validation have completed successfully for all configured architectures.
           EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,54 +69,52 @@ jobs:
           body: ${{ needs.release-meta.outputs.release_notes }}
           prerelease: ${{ contains(needs.release-meta.outputs.version, '-') }}
 
-  build-release-bundle:
-    name: Build release bundle
+  build-release-packages:
+    name: Build release bundle (${{ matrix.arch }})
     needs:
       - release-meta
       - release-gate
       - create-release
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            target: x86_64-unknown-linux-musl
+            runs_on: ubuntu-latest
+          - arch: arm64
+            target: aarch64-unknown-linux-musl
+            runs_on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runs_on }}
+    container:
+      image: rockylinux:8
+    defaults:
+      run:
+        shell: bash
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-unknown-linux-musl
-
-      - name: Install musl tools
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
-
-      - name: Cache Cargo artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: linux-musl-cargo-v1-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            linux-musl-cargo-v1-
-
-      - name: Build release binary
-        run: cargo build --release --target x86_64-unknown-linux-musl
+      - name: Set up build environment
+        env:
+          AISH_BUILD_TARGET: ${{ matrix.target }}
+        run: ./packaging/scripts/setup-ci-env.sh
 
       - name: Build release bundle
         run: |
           VERSION="${{ needs.release-meta.outputs.version }}"
-          OUTPUT_DIR="artifacts/amd64"
-          VERSION="$VERSION" PLATFORM="linux" ARCH="amd64" OUTPUT_DIR="$OUTPUT_DIR" ./packaging/build_bundle.sh
+          OUTPUT_DIR="artifacts/${{ matrix.arch }}"
+          VERSION="$VERSION" PLATFORM="linux" ARCH="${{ matrix.arch }}" AISH_BUILD_TARGET="${{ matrix.target }}" OUTPUT_DIR="$OUTPUT_DIR" ./packaging/build_bundle.sh
           ls -lah "$OUTPUT_DIR"
 
       - name: Smoke test bundle install
         run: |
           VERSION="${{ needs.release-meta.outputs.version }}"
-          OUTPUT_DIR="artifacts/amd64"
-          BUNDLE="aish-${VERSION}-linux-amd64"
-          EXTRACT_DIR="$PWD/build/install-smoke"
-          INSTALL_ROOT="$PWD/build/install-root"
+          OUTPUT_DIR="artifacts/${{ matrix.arch }}"
+          BUNDLE="aish-${VERSION}-linux-${{ matrix.arch }}"
+          EXTRACT_DIR="$PWD/build/install-smoke/${{ matrix.arch }}"
+          INSTALL_ROOT="$PWD/build/install-root/${{ matrix.arch }}"
 
           rm -rf "$EXTRACT_DIR" "$INSTALL_ROOT"
           mkdir -p "$EXTRACT_DIR" "$INSTALL_ROOT"
@@ -134,13 +132,60 @@ jobs:
         with:
           tag_name: ${{ needs.release-meta.outputs.tag }}
           prerelease: ${{ contains(needs.release-meta.outputs.version, '-') }}
-          files: artifacts/amd64/*
+          files: artifacts/${{ matrix.arch }}/*
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-bundle-linux-${{ matrix.arch }}
+          path: artifacts/${{ matrix.arch }}/*
+          if-no-files-found: error
+
+  publish-release-bundles:
+    name: Publish release bundles
+    needs:
+      - release-meta
+      - release-gate
+      - build-release-packages
+    runs-on: ubuntu-latest
+    environment: release
+    env:
+      VERSION: ${{ needs.release-meta.outputs.version }}
+      ARTIFACT_ROOT: artifacts/release
+      R2_BUCKET: ${{ secrets.R2_BUCKET }}
+      R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: auto
+      CDN_BASE_URL: ${{ vars.CDN_BASE_URL }}
+      DOWNLOAD_PREFIX: ${{ contains(needs.release-meta.outputs.version, '-') && 'download/beta' || 'download' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v6
+        with:
+          pattern: release-bundle-linux-*
+          path: ${{ env.ARTIFACT_ROOT }}
+
+      - name: Ensure aws CLI is available
+        run: |
+          if ! command -v aws >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y awscli
+          fi
+          aws --version
+
+      - name: Publish release bundles
+        run: bash ./packaging/scripts/publish_release.sh
 
   release-summary:
     name: Summarize published release
     needs:
       - release-meta
-      - build-release-bundle
+      - build-release-packages
+      - publish-release-bundles
     runs-on: ubuntu-latest
     steps:
       - name: Write job summary
@@ -151,5 +196,5 @@ jobs:
           - Version: ${{ needs.release-meta.outputs.version }}
           - Tag: ${{ needs.release-meta.outputs.tag }}
 
-          GitHub Release metadata was generated from the tag push, and bundle assets were uploaded successfully.
+          GitHub Release metadata was generated from the tag push, bundle assets were uploaded successfully, and the CDN channel was updated for this release.
           EOF

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,21 @@ BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-TARGET="${AISH_BUILD_TARGET:-x86_64-unknown-linux-musl}"
+default_build_target() {
+    case "$(uname -m)" in
+        x86_64|amd64)
+            printf 'x86_64-unknown-linux-musl\n'
+            ;;
+        aarch64|arm64)
+            printf 'aarch64-unknown-linux-musl\n'
+            ;;
+        *)
+            printf 'x86_64-unknown-linux-musl\n'
+            ;;
+    esac
+}
+
+TARGET="${AISH_BUILD_TARGET:-$(default_build_target)}"
 
 restore_rust_path() {
     if [[ -f "$HOME/.cargo/env" ]]; then

--- a/packaging/build_bundle.sh
+++ b/packaging/build_bundle.sh
@@ -17,7 +17,21 @@ if [[ -z "$VERSION" ]]; then
 fi
 ARCH="${ARCH:-${2:-amd64}}"
 PLATFORM="${PLATFORM:-${4:-linux}}"
-TARGET="${AISH_BUILD_TARGET:-x86_64-unknown-linux-musl}"
+default_bundle_target() {
+  case "$ARCH" in
+    amd64)
+      printf 'x86_64-unknown-linux-musl\n'
+      ;;
+    arm64)
+      printf 'aarch64-unknown-linux-musl\n'
+      ;;
+    *)
+      printf 'x86_64-unknown-linux-musl\n'
+      ;;
+  esac
+}
+
+TARGET="${AISH_BUILD_TARGET:-$(default_bundle_target)}"
 OUTPUT_DIR="${OUTPUT_DIR:-${3:-dist/release}}"
 BUNDLE_NAME="aish-${VERSION}-${PLATFORM}-${ARCH}"
 STAGE_DIR="build/bundle/${BUNDLE_NAME}"

--- a/packaging/scripts/publish_release.sh
+++ b/packaging/scripts/publish_release.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_env() {
+        local name="$1"
+        if [[ -z "${!name:-}" ]]; then
+                echo "Missing required environment variable: ${name}" >&2
+                exit 1
+        fi
+}
+
+require_env VERSION
+require_env ARTIFACT_ROOT
+require_env R2_BUCKET
+require_env R2_ENDPOINT
+require_env AWS_ACCESS_KEY_ID
+require_env AWS_SECRET_ACCESS_KEY
+
+DOWNLOAD_PREFIX="${DOWNLOAD_PREFIX:-download}"
+CDN_BASE_URL="${CDN_BASE_URL:-https://cdn.aishell.ai}"
+VERSION="${VERSION#v}"
+ARTIFACT_ROOT="${ARTIFACT_ROOT%/}"
+
+mapfile -t ARTIFACT_FILES < <(
+        find "$ARTIFACT_ROOT" -type f \( \
+                -name "aish-${VERSION}-linux-*.tar.gz" -o \
+                -name "aish-${VERSION}-linux-*.tar.gz.sha256" \
+        \) | sort
+)
+
+if [[ "${#ARTIFACT_FILES[@]}" -eq 0 ]]; then
+        echo "No release artifacts found under ${ARTIFACT_ROOT}" >&2
+        exit 1
+fi
+
+upload_object() {
+        local source_path="$1"
+        local destination_key="$2"
+        local cache_control="$3"
+        shift 3
+
+        aws s3 cp "$source_path" "s3://${R2_BUCKET}/${destination_key}" \
+                --endpoint-url "$R2_ENDPOINT" \
+                --cache-control "$cache_control" \
+                "$@"
+}
+
+for artifact_path in "${ARTIFACT_FILES[@]}"; do
+        artifact_name="$(basename "$artifact_path")"
+        release_key="${DOWNLOAD_PREFIX}/releases/${VERSION}/${artifact_name}"
+        cache_control="public, max-age=31536000, immutable"
+        content_type_args=()
+
+        if [[ "$artifact_name" == *.sha256 ]]; then
+                content_type_args=(--content-type text/plain)
+        fi
+
+        echo "Uploading ${artifact_name} to ${release_key}"
+        upload_object "$artifact_path" "$release_key" "$cache_control" "${content_type_args[@]}"
+done
+
+latest_file="$(mktemp)"
+trap 'rm -f "$latest_file"' EXIT
+printf '%s' "$VERSION" > "$latest_file"
+
+echo "Updating ${DOWNLOAD_PREFIX}/latest"
+upload_object "$latest_file" "${DOWNLOAD_PREFIX}/latest" "no-store" --content-type text/plain
+
+validated_urls=(
+        "${CDN_BASE_URL%/}/${DOWNLOAD_PREFIX}/latest"
+)
+
+for artifact_path in "${ARTIFACT_FILES[@]}"; do
+        artifact_name="$(basename "$artifact_path")"
+        validated_urls+=("${CDN_BASE_URL%/}/${DOWNLOAD_PREFIX}/releases/${VERSION}/${artifact_name}")
+done
+
+for url in "${validated_urls[@]}"; do
+        echo "Validating ${url}"
+        curl -fsSI --connect-timeout 10 --max-time 30 "$url" >/dev/null
+done
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        {
+                echo "## CDN Publish"
+                echo
+                echo "- Version: ${VERSION}"
+                echo "- Bucket: ${R2_BUCKET}"
+                echo "- Latest URL: ${CDN_BASE_URL%/}/${DOWNLOAD_PREFIX}/latest"
+                echo
+                echo "### Published artifacts"
+                for artifact_path in "${ARTIFACT_FILES[@]}"; do
+                        artifact_name="$(basename "$artifact_path")"
+                        echo "- ${DOWNLOAD_PREFIX}/releases/${VERSION}/${artifact_name}"
+                done
+        } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/packaging/scripts/setup-ci-env.sh
+++ b/packaging/scripts/setup-ci-env.sh
@@ -7,6 +7,22 @@ set -euo pipefail
 # script. This file is kept for self-hosted runners or container environments
 # where the action is not available.
 
+default_build_target() {
+    case "${RUNNER_ARCH:-$(uname -m)}" in
+        X64|x86_64|amd64)
+            printf 'x86_64-unknown-linux-musl\n'
+            ;;
+        ARM64|aarch64|arm64)
+            printf 'aarch64-unknown-linux-musl\n'
+            ;;
+        *)
+            printf 'x86_64-unknown-linux-musl\n'
+            ;;
+    esac
+}
+
+TARGET="${AISH_BUILD_TARGET:-$(default_build_target)}"
+
 ensure_rust_target() {
     local target="$1"
 
@@ -47,7 +63,7 @@ if [[ -n "${GITHUB_PATH:-}" && -d "$HOME/.cargo/bin" ]]; then
     echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 fi
 
-ensure_rust_target x86_64-unknown-linux-musl
+ensure_rust_target "$TARGET"
 
 cargo --version
 rustc --version


### PR DESCRIPTION
## Background

Prepare the Rust release flow for a dedicated beta CDN channel so prereleases can publish separately from stable artifacts. This also fills the current arm64 release gap for beta bundles.

## Changes

- port the existing CDN publish script from `main` into the Rust release line
- publish prerelease tags to `download/beta/...` and stable tags to `download/...`
- expand `Release` and `Release Preparation` to build and validate both `amd64` and `arm64`
- make build/setup scripts choose the correct musl target for each architecture
- add `ref` support back to `Release Preparation` so release-prep branches can be validated explicitly

## Validation

- local shell syntax checks for `build.sh`, `packaging/build_bundle.sh`, `packaging/scripts/setup-ci-env.sh`, and `packaging/scripts/publish_release.sh`
- local YAML parse for `.github/workflows/release.yml` and `.github/workflows/release-preparation.yml`
- mocked `publish_release.sh` run verifying both `amd64` and `arm64` upload to `download/beta/releases/<version>/...` and update `download/beta/latest`

## Risk

- this PR changes release automation and should be merged before adding installer-side `--beta` support
- GitHub workflow editor may still show local environment/secrets warnings until evaluated in the repository context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Release bundles now built for both AMD64 and ARM64 Linux architectures
  * Automated CDN publication of release artifacts with smoke testing and validation

* **Chores**
  * Enhanced CI/CD pipeline with containerized multi-architecture builds
  * Improved build environment setup with dynamic host architecture detection
  * Release preparation workflow now supports custom repository references

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/161)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->