### PR TITLE
chore: prepare 0.3.0-beta.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - No unreleased changes yet.
 
+## [0.3.0-beta.2] - 2026-05-11
+
+### Added
+
+- Added beta-channel CDN publishing and installer support so prerelease builds can be installed through the dedicated `download/beta` paths without affecting the stable channel.
+- Added Linux arm64 release bundles and release-preparation validation alongside the existing amd64 artifacts for the Rust beta line.
+
+### Changed
+
+- Changed the Rust release workflows so prerelease tags publish bundle metadata to the beta CDN channel while stable tags continue to update the stable download paths.
+
 ## [0.3.0-beta.1] - 2026-05-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "aish-cli"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "aish-config"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "aish-context"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 dependencies = [
  "aish-core",
  "serde",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "aish-core"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "aish-i18n"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "aish-llm"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 dependencies = [
  "aish-context",
  "aish-core",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "aish-memory"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 dependencies = [
  "aish-core",
  "chrono",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "aish-prompts"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "aish-pty"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 dependencies = [
  "aish-core",
  "aish-i18n",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "aish-scripts"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aish-security"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 dependencies = [
  "libc",
  "serde",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "aish-session"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 dependencies = [
  "aish-core",
  "chrono",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "aish-shell"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 dependencies = [
  "aish-config",
  "aish-context",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "aish-skills"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "aish-tools"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 dependencies = [
  "aish-core",
  "aish-i18n",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 edition = "2021"
 license = "MIT"
 rust-version = "1.80"


### PR DESCRIPTION
## Background

Prepare the next Rust beta release after 0.3.0-beta.1 so the merged beta CDN and arm64 release flow can ship in a tagged prerelease.

## Changes

- bump the workspace version to 0.3.0-beta.2
- add the 0.3.0-beta.2 changelog entry for beta CDN publishing and arm64 release bundles
- refresh Cargo.lock package versions to match the beta.2 workspace version

## Validation

- python3 packaging/scripts/release_metadata.py --expected-version 0.3.0-beta.2 --summary-file build/release-prep-summary-beta2.md --json-file build/release-prep-metadata-beta2.json
- make packaging-test
- cargo metadata --locked --format-version 1 >/tmp/aish-cargo-metadata-beta2.json

## Risk

Low. This PR only advances release metadata and lockfile versions for the next prerelease.