### PR TITLE
fix: prepare 0.3.0-beta.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - No unreleased changes yet.
 
+## [0.3.0-beta.3] - 2026-05-11
+
+### Fixed
+
+- Fixed Rocky Linux release-preparation and release bundle builds so the Rust musl packaging path no longer aborts early when `musl-gcc` is absent but the Rust target toolchain is already available.
+
 ## [0.3.0-beta.2] - 2026-05-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "aish-cli"
-version = "0.3.0-beta.2"
+version = "0.3.0-beta.3"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "aish-config"
-version = "0.3.0-beta.2"
+version = "0.3.0-beta.3"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "aish-context"
-version = "0.3.0-beta.2"
+version = "0.3.0-beta.3"
 dependencies = [
  "aish-core",
  "serde",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "aish-core"
-version = "0.3.0-beta.2"
+version = "0.3.0-beta.3"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "aish-i18n"
-version = "0.3.0-beta.2"
+version = "0.3.0-beta.3"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "aish-llm"
-version = "0.3.0-beta.2"
+version = "0.3.0-beta.3"
 dependencies = [
  "aish-context",
  "aish-core",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "aish-memory"
-version = "0.3.0-beta.2"
+version = "0.3.0-beta.3"
 dependencies = [
  "aish-core",
  "chrono",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "aish-prompts"
-version = "0.3.0-beta.2"
+version = "0.3.0-beta.3"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "aish-pty"
-version = "0.3.0-beta.2"
+version = "0.3.0-beta.3"
 dependencies = [
  "aish-core",
  "aish-i18n",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "aish-scripts"
-version = "0.3.0-beta.2"
+version = "0.3.0-beta.3"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aish-security"
-version = "0.3.0-beta.2"
+version = "0.3.0-beta.3"
 dependencies = [
  "libc",
  "serde",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "aish-session"
-version = "0.3.0-beta.2"
+version = "0.3.0-beta.3"
 dependencies = [
  "aish-core",
  "chrono",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "aish-shell"
-version = "0.3.0-beta.2"
+version = "0.3.0-beta.3"
 dependencies = [
  "aish-config",
  "aish-context",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "aish-skills"
-version = "0.3.0-beta.2"
+version = "0.3.0-beta.3"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "aish-tools"
-version = "0.3.0-beta.2"
+version = "0.3.0-beta.3"
 dependencies = [
  "aish-core",
  "aish-i18n",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0-beta.2"
+version = "0.3.0-beta.3"
 edition = "2021"
 license = "MIT"
 rust-version = "1.80"

--- a/build.sh
+++ b/build.sh
@@ -71,8 +71,10 @@ echo -e "${BLUE}Building AI Shell (Rust)...${NC}"
 if [[ "$TARGET" == *musl* ]]; then
     ensure_rust_target "$TARGET"
 
-    if ! command -v musl-gcc &>/dev/null && ! dpkg -l musl-tools &>/dev/null 2>&1; then
-        if command -v apt-get &>/dev/null; then
+    if ! command -v musl-gcc >/dev/null 2>&1; then
+        if command -v apt-get >/dev/null 2>&1 && dpkg -l musl-tools >/dev/null 2>&1; then
+            :
+        elif command -v apt-get &>/dev/null; then
             echo -e "${YELLOW}Installing musl-tools...${NC}"
             sudo apt-get update && sudo apt-get install -y musl-tools
         elif command -v brew &>/dev/null; then
@@ -80,9 +82,7 @@ if [[ "$TARGET" == *musl* ]]; then
             echo -e "${YELLOW}Install with: brew install filosottile/musl-cross/musl-cross${NC}"
             exit 1
         else
-            echo -e "${RED}Error: musl-tools not found and no supported package manager detected.${NC}"
-            echo -e "${YELLOW}Please install musl-tools or musl-gcc for your platform manually.${NC}"
-            exit 1
+            echo -e "${YELLOW}musl-gcc not found; continuing with the Rust-provided linker toolchain for $TARGET.${NC}"
         fi
     fi
 fi


### PR DESCRIPTION
## Background

0.3.0-beta.2 release preparation failed in both amd64 and arm64 Rocky Linux jobs because build.sh aborted early when `musl-gcc` was absent, even though the Rust musl target toolchain had already been set up.

## Changes

- relax the musl preflight in build.sh so Rocky-based release jobs can continue after Rust target setup
- bump the workspace version to 0.3.0-beta.3
- add the 0.3.0-beta.3 changelog entry for the Rocky/musl release-build fix
- refresh Cargo.lock package versions to match beta.3

## Validation

- cargo metadata --format-version 1 >/tmp/aish-cargo-metadata-beta3.json
- python3 packaging/scripts/release_metadata.py --expected-version 0.3.0-beta.3 --summary-file build/release-prep-summary-beta3.md --json-file build/release-prep-metadata-beta3.json
- mocked build.sh run without musl-gcc in PATH to confirm the musl preflight no longer aborts early
- make packaging-test

## Risk

Low to medium. The release-path change only affects musl preflight behavior, but it changes how Rocky-based release containers reach the actual cargo build step.