### PR TITLE
fix: restore release preparation on rocky ci

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -75,6 +75,13 @@ if [[ "$TARGET" == *musl* ]]; then
         if command -v apt-get &>/dev/null; then
             echo -e "${YELLOW}Installing musl-tools...${NC}"
             sudo apt-get update && sudo apt-get install -y musl-tools
+        elif command -v dnf &>/dev/null || command -v yum &>/dev/null; then
+            if command -v gcc &>/dev/null; then
+                echo -e "${YELLOW}musl-gcc not found; using the Rust musl target with system gcc in this CI environment.${NC}"
+            else
+                echo -e "${RED}Error: gcc is required to link the musl target in this environment.${NC}"
+                exit 1
+            fi
         elif command -v brew &>/dev/null; then
             echo -e "${RED}Error: musl cross-compilation on macOS requires a cross toolchain.${NC}"
             echo -e "${YELLOW}Install with: brew install filosottile/musl-cross/musl-cross${NC}"

--- a/packaging/scripts/setup-ci-env.sh
+++ b/packaging/scripts/setup-ci-env.sh
@@ -41,12 +41,12 @@ ensure_rust_target() {
 
 if command -v apt-get >/dev/null 2>&1; then
     apt-get update
-    apt-get install -y curl build-essential musl-tools pkg-config libssl-dev
+    apt-get install -y curl build-essential musl-tools pkg-config libssl-dev tar gzip findutils
 elif command -v dnf >/dev/null 2>&1; then
-    dnf install -y curl gcc openssl-devel
+    dnf install -y curl gcc make tar gzip findutils openssl-devel
     dnf install -y pkgconf-pkg-config || dnf install -y pkgconf || true
 elif command -v yum >/dev/null 2>&1; then
-    yum install -y curl gcc openssl-devel
+    yum install -y curl gcc make tar gzip findutils openssl-devel
     yum install -y pkgconfig || yum install -y pkgconf || true
 else
     echo "No supported package manager found" >&2


### PR DESCRIPTION
## Background

`Release Preparation` failed while building the beta.2 bundle inside the Rocky Linux CI container. The job stopped in `build.sh` after treating the lack of `musl-gcc` as fatal, even though the CI environment already had a usable Rust musl target path with system `gcc`.

## Changes

- relax the musl toolchain precheck in `build.sh` for `dnf`/`yum` CI environments so the build can continue when `gcc` is available
- install the remaining bundle prerequisites in `packaging/scripts/setup-ci-env.sh`, including `make`, `tar`, `gzip`, and `findutils`

## Validation

- `bash -n build.sh packaging/scripts/setup-ci-env.sh`
- `git diff --check`
- simulated the Rocky CI path with `dnf + gcc` and no `musl-gcc`; `build.sh` completed instead of failing at the old guard

## Risk

Low. The change is limited to CI/build-environment detection and package installation for release preparation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI build environment compatibility across multiple Linux distributions (apt, dnf, yum).
  * Enhanced musl target toolchain detection with better error reporting for missing dependencies.
  * Added installation of essential build utilities to ensure more complete CI environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/164)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->