### PR TITLE
fix: set musl target compiler env in ci

### DIFF
--- a/packaging/scripts/setup-ci-env.sh
+++ b/packaging/scripts/setup-ci-env.sh
@@ -23,6 +23,20 @@ default_build_target() {
 
 TARGET="${AISH_BUILD_TARGET:-$(default_build_target)}"
 
+target_cc_wrapper_name() {
+    case "$1" in
+        x86_64-unknown-linux-musl)
+            printf 'x86_64-linux-musl-gcc\n'
+            ;;
+        aarch64-unknown-linux-musl)
+            printf 'aarch64-linux-musl-gcc\n'
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
 ensure_rust_target() {
     local target="$1"
 
@@ -37,6 +51,59 @@ ensure_rust_target() {
 
     echo "Rust target $target is not available and rustup is not installed" >&2
     exit 1
+}
+
+configure_musl_cc() {
+    local target="$1"
+    local wrapper_name
+    local wrapper_dir
+    local target_env_name
+    local cargo_target_env_name
+    local wrapper_path
+    local compiler_bin
+
+    if [[ "$target" != *musl* ]]; then
+        return 0
+    fi
+
+    wrapper_name="$(target_cc_wrapper_name "$target")" || return 0
+    wrapper_dir="${HOME}/.cargo/bin"
+    wrapper_path="${wrapper_dir}/${wrapper_name}"
+    mkdir -p "$wrapper_dir"
+
+    if command -v "$wrapper_name" >/dev/null 2>&1; then
+        wrapper_path="$(command -v "$wrapper_name")"
+    else
+        if command -v musl-gcc >/dev/null 2>&1; then
+            compiler_bin="$(command -v musl-gcc)"
+        elif command -v gcc >/dev/null 2>&1; then
+            compiler_bin="$(command -v gcc)"
+        else
+            echo "No usable C compiler found for musl target ${target}" >&2
+            exit 1
+        fi
+
+        cat > "$wrapper_path" <<EOF
+#!/usr/bin/env bash
+exec "$compiler_bin" "$@"
+EOF
+        chmod +x "$wrapper_path"
+    fi
+
+    if [[ -n "${GITHUB_PATH:-}" ]]; then
+        echo "$wrapper_dir" >> "$GITHUB_PATH"
+    fi
+
+    if [[ -n "${GITHUB_ENV:-}" ]]; then
+        target_env_name="${target//-/_}"
+        cargo_target_env_name="${target_env_name^^}"
+        {
+            echo "CC_${target_env_name}=$wrapper_path"
+            echo "CC_${target}=$wrapper_path"
+            echo "TARGET_CC=$wrapper_path"
+            echo "CARGO_TARGET_${cargo_target_env_name}_LINKER=$wrapper_path"
+        } >> "$GITHUB_ENV"
+    fi
 }
 
 if command -v apt-get >/dev/null 2>&1; then
@@ -64,6 +131,7 @@ if [[ -n "${GITHUB_PATH:-}" && -d "$HOME/.cargo/bin" ]]; then
 fi
 
 ensure_rust_target "$TARGET"
+configure_musl_cc "$TARGET"
 
 cargo --version
 rustc --version


### PR DESCRIPTION
## Background

The previous Rocky CI fix was merged, but `Release Preparation` still fails when `ring` builds for `x86_64-unknown-linux-musl`. The remaining issue is that `cc-rs` falls back to looking for the target-specific compiler name `x86_64-linux-musl-gcc`, and the CI setup script did not provide a target-specific wrapper or persist the target compiler variables for later steps.

## Changes

- generate or resolve the target-specific musl compiler wrapper name in `packaging/scripts/setup-ci-env.sh`
- export the musl target compiler through the target-specific `CC_...` variables and `CARGO_TARGET_..._LINKER`
- keep the compiler path available to later workflow steps via `GITHUB_ENV` and `GITHUB_PATH`

## Validation

- `bash -n packaging/scripts/setup-ci-env.sh`
- verified the script has no diagnostics in the workspace
- simulated the CI setup path and confirmed it now writes target-specific musl compiler environment variables instead of leaving them unset

## Risk

Low. The change only affects musl-target CI environment setup used by release preparation and release packaging.