### PR TITLE
fix: preserve musl wrapper runtime args

### DIFF
--- a/packaging/scripts/setup-ci-env.sh
+++ b/packaging/scripts/setup-ci-env.sh
@@ -83,10 +83,7 @@ configure_musl_cc() {
             exit 1
         fi
 
-        cat > "$wrapper_path" <<EOF
-#!/usr/bin/env bash
-exec "$compiler_bin" "$@"
-EOF
+        printf '%s\n' '#!/usr/bin/env bash' "exec \"$compiler_bin\" \"\$@\"" > "$wrapper_path"
         chmod +x "$wrapper_path"
     fi
 


### PR DESCRIPTION
## Background

`Release Preparation` still failed in `Build bundle` after the previous musl target compiler env fix landed. The remaining issue was in the generated target wrapper script itself: the wrapper was created from an unquoted heredoc inside a shell function, so the function argument expanded into the file and replaced the runtime `"$@"` forwarding.

On arm64 this produced a wrapper that effectively called `gcc aarch64-unknown-linux-musl`, which matches the current failure log:

- `gcc: error: aarch64-unknown-linux-musl: No such file or directory`
- `cc-rs: command did not execute successfully ... /github/home/.cargo/bin/aarch64-linux-musl-gcc`

## Changes

- generate the musl target wrapper with `printf` instead of an expanding heredoc
- preserve the runtime `"$@"` forwarding so the wrapper actually behaves like `aarch64-linux-musl-gcc` / `x86_64-linux-musl-gcc`

## Validation

- `bash -n packaging/scripts/setup-ci-env.sh`
- `git diff --check`
- simulated wrapper generation for `aarch64-unknown-linux-musl`
- verified the generated wrapper body is now:
  - `exec "/bin/musl-gcc" "$@"`

## Risk

Very low. This is a one-line wrapper-generation fix limited to the CI musl compiler shim used by release preparation and release packaging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the CI environment setup script by refactoring how compiler wrapper scripts are generated, improving code maintainability without affecting functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/166)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->