### PR TITLE
fix: restore musl release jobs on host runners

### DIFF
--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -81,11 +81,6 @@ jobs:
             target: aarch64-unknown-linux-musl
             runs_on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs_on }}
-    container:
-      image: rockylinux:8
-    defaults:
-      run:
-        shell: bash
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,11 +86,6 @@ jobs:
             target: aarch64-unknown-linux-musl
             runs_on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs_on }}
-    container:
-      image: rockylinux:8
-    defaults:
-      run:
-        shell: bash
 
     steps:
       - name: Checkout repository

--- a/packaging/scripts/setup-ci-env.sh
+++ b/packaging/scripts/setup-ci-env.sh
@@ -23,6 +23,21 @@ default_build_target() {
 
 TARGET="${AISH_BUILD_TARGET:-$(default_build_target)}"
 
+run_as_root() {
+    if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+        "$@"
+        return
+    fi
+
+    if command -v sudo >/dev/null 2>&1; then
+        sudo "$@"
+        return
+    fi
+
+    echo "Root privileges are required to install CI build dependencies" >&2
+    exit 1
+}
+
 target_cc_wrapper_name() {
     case "$1" in
         x86_64-unknown-linux-musl)
@@ -104,14 +119,14 @@ configure_musl_cc() {
 }
 
 if command -v apt-get >/dev/null 2>&1; then
-    apt-get update
-    apt-get install -y curl build-essential musl-tools pkg-config libssl-dev tar gzip findutils
+    run_as_root apt-get update
+    run_as_root apt-get install -y curl build-essential musl-tools pkg-config libssl-dev tar gzip findutils
 elif command -v dnf >/dev/null 2>&1; then
-    dnf install -y curl gcc make tar gzip findutils openssl-devel
-    dnf install -y pkgconf-pkg-config || dnf install -y pkgconf || true
+    run_as_root dnf install -y curl gcc make tar gzip findutils openssl-devel
+    run_as_root dnf install -y pkgconf-pkg-config || run_as_root dnf install -y pkgconf || true
 elif command -v yum >/dev/null 2>&1; then
-    yum install -y curl gcc make tar gzip findutils openssl-devel
-    yum install -y pkgconfig || yum install -y pkgconf || true
+    run_as_root yum install -y curl gcc make tar gzip findutils openssl-devel
+    run_as_root yum install -y pkgconfig || run_as_root yum install -y pkgconf || true
 else
     echo "No supported package manager found" >&2
     exit 1

--- a/packaging/scripts/setup-ci-env.sh
+++ b/packaging/scripts/setup-ci-env.sh
@@ -83,10 +83,7 @@ configure_musl_cc() {
             exit 1
         fi
 
-        cat > "$wrapper_path" <<EOF
-#!/usr/bin/env bash
-exec "$compiler_bin" "$@"
-EOF
+        printf '%s\n' '#!/usr/bin/env bash' "exec \"$compiler_bin\" \"\$@\"" > "$wrapper_path"
         chmod +x "$wrapper_path"
     fi
 


### PR DESCRIPTION
## Background
The latest Rust Release Preparation run still failed after the wrapper fix because the jobs were running inside `rockylinux:8`, which does not provide a usable native musl toolchain for these builds. That forced the CI path into compiler fallbacks and produced linker failures in `libsqlite3-sys` on amd64.

## Changes
- keep the musl wrapper runtime-args fix in `setup-ci-env.sh`
- run Rust release-preparation and release bundle jobs on the native GitHub runners instead of the Rocky container
- make `setup-ci-env.sh` use `sudo` when package installation runs on non-root runners

## Validation
- `bash -n packaging/scripts/setup-ci-env.sh`
- simulated non-root runner invocation to confirm `sudo apt-get update/install` is used
- `git diff --check`
- confirmed latest failing workflow log now points at missing musl-native toolchain behavior rather than the previous wrapper bug

## Risk
This changes the Rust release build environment from the Rocky container to the hosted Ubuntu runners. That matches the environment where local musl bundle validation already succeeded, but the workflow should be rerun for both amd64 and arm64 before tagging beta.2.