### PR TITLE
Verify self-update archives against GitHub release digests before install

### DIFF
--- a/src/aish/cli/update_manager.py
+++ b/src/aish/cli/update_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import os
 import platform
 import re
@@ -37,8 +38,12 @@ DEFAULT_DOWNLOAD_BASE_URL = "https://cdn.aishell.ai/download"
 GITHUB_RELEASES_PAGE_BASE = "https://github.com/AI-Shell-Team/aish/releases"
 GITHUB_API_LATEST = "https://api.github.com/repos/AI-Shell-Team/aish/releases/latest"
 GITHUB_API_LIST = "https://api.github.com/repos/AI-Shell-Team/aish/releases"
+GITHUB_API_RELEASE_TAG = (
+    "https://api.github.com/repos/AI-Shell-Team/aish/releases/tags/{tag}"
+)
 CONNECTION_TIMEOUT = 10  # seconds
 VERSION_PATTERN = re.compile(r"^v?[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9]+)*$")
+SHA256_PATTERN = re.compile(r"^[A-Fa-f0-9]{64}$")
 
 # Version from package
 CURRENT_VERSION = __version__
@@ -86,6 +91,15 @@ class UpdateManager:
         """Resolve the CDN URL for a versioned release artifact."""
         version_str = tag_name.lstrip("v")
         return f"{self.get_download_base_url()}/releases/{version_str}/{filename}"
+
+    def get_release_by_tag(self, tag_name: str) -> dict:
+        """Fetch trusted GitHub release metadata for a tag."""
+        response = self.client.get(GITHUB_API_RELEASE_TAG.format(tag=tag_name))
+        response.raise_for_status()
+        data = response.json()
+        if data.get("tag_name") != tag_name:
+            raise UpdateCheckError(f"GitHub release metadata mismatch for {tag_name}")
+        return data
 
     @staticmethod
     def normalize_tag(version_value: str) -> str:
@@ -160,18 +174,27 @@ class UpdateManager:
                 response = self.client.get(self.get_latest_version_url())
                 response.raise_for_status()
                 tag_name = self.normalize_tag(response.text)
+                data = self.get_release_by_tag(tag_name)
 
-            return {
-                "tag_name": tag_name,
-                "name": tag_name,
-                "body": "",
-                "html_url": f"{GITHUB_RELEASES_PAGE_BASE}/tag/{tag_name}",
-                "assets": [],
-            }
+                return {
+                    "tag_name": tag_name,
+                    "name": data.get("name", tag_name),
+                    "body": data.get("body", ""),
+                    "html_url": data.get(
+                        "html_url", f"{GITHUB_RELEASES_PAGE_BASE}/tag/{tag_name}"
+                    ),
+                    "assets": data.get("assets", []),
+                }
+        except UpdateCheckError:
+            raise
         except httpx.HTTPError as e:
-            raise UpdateCheckError(f"Network error while checking for updates: {e}") from e
+            raise UpdateCheckError(
+                f"Network error while checking for updates: {e}"
+            ) from e
         except Exception as e:
-            raise UpdateCheckError(f"Unexpected error while checking for updates: {e}") from e
+            raise UpdateCheckError(
+                f"Unexpected error while checking for updates: {e}"
+            ) from e
 
     def check_for_updates(self, include_pre_release: bool = False) -> Optional[dict]:
         """Check if there's a newer version available.
@@ -243,6 +266,85 @@ class UpdateManager:
 
         return True
 
+    @staticmethod
+    def _sha256_file(path: Path) -> str:
+        """Calculate the SHA256 digest for a file."""
+        sha256 = hashlib.sha256()
+        with open(path, "rb") as file:
+            for chunk in iter(lambda: file.read(1024 * 1024), b""):
+                sha256.update(chunk)
+        return sha256.hexdigest()
+
+    @staticmethod
+    def _parse_checksum_text(checksum_text: str, filename: str) -> Optional[str]:
+        """Extract the expected SHA256 digest for filename from checksum text."""
+        for line in checksum_text.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+
+            parts = stripped.replace("*", " ").split()
+            if len(parts) >= 2 and SHA256_PATTERN.fullmatch(parts[0]):
+                if any(Path(part).name == filename for part in parts[1:]):
+                    return parts[0].lower()
+
+            # Support `SHA256 (filename) = digest` output from shasum/openssl.
+            match = re.fullmatch(
+                r"SHA256 \((?P<name>.+)\) = (?P<digest>[A-Fa-f0-9]{64})", stripped
+            )
+            if match and Path(match.group("name")).name == filename:
+                return match.group("digest").lower()
+
+        return None
+
+    def get_expected_archive_sha256(self, tag_name: str, filename: str) -> str:
+        """Resolve the trusted SHA256 digest for a release archive from GitHub."""
+        release = self.get_release_by_tag(tag_name)
+        checksum_urls = []
+
+        for asset in release.get("assets", []):
+            asset_name = asset.get("name", "")
+            if asset_name == filename:
+                digest = asset.get("digest", "")
+                prefix = "sha256:"
+                if digest.startswith(prefix) and SHA256_PATTERN.fullmatch(
+                    digest[len(prefix) :]
+                ):
+                    return digest[len(prefix) :].lower()
+
+            lower_name = asset_name.lower()
+            if "sha256" in lower_name or "checksum" in lower_name:
+                checksum_url = asset.get("browser_download_url")
+                if checksum_url:
+                    checksum_urls.append(checksum_url)
+
+        for checksum_url in checksum_urls:
+            response = self.client.get(checksum_url)
+            response.raise_for_status()
+            expected = self._parse_checksum_text(response.text, filename)
+            if expected:
+                return expected
+
+        raise UpdateCheckError(
+            f"No trusted SHA256 digest found on GitHub release {tag_name} for {filename}"
+        )
+
+    def verify_archive(self, archive_path: Path, tag_name: str, filename: str) -> bool:
+        """Verify a downloaded archive against trusted GitHub release metadata."""
+        expected_sha256 = self.get_expected_archive_sha256(tag_name, filename)
+        actual_sha256 = self._sha256_file(archive_path)
+        if not hmac.compare_digest(actual_sha256, expected_sha256):
+            self.console.print(
+                "[red]Security: downloaded archive SHA256 does not match "
+                "trusted GitHub release metadata[/red]"
+            )
+            self.console.print(f"[dim]Expected: {expected_sha256}[/dim]")
+            self.console.print(f"[dim]Actual:   {actual_sha256}[/dim]")
+            return False
+
+        self.console.print(f"[dim]Verified archive SHA256: {actual_sha256}[/dim]")
+        return True
+
     def download_release(
         self, tag_name: str, dest_dir: Optional[Path] = None
     ) -> Optional[Path]:
@@ -269,6 +371,9 @@ class UpdateManager:
         try:
             self._download_with_progress(download_url, dest_path, filename)
             self.console.print(f"[green]Downloaded: {dest_path}[/green]")
+            if not self.verify_archive(dest_path, tag_name, filename):
+                dest_path.unlink(missing_ok=True)
+                return None
             return dest_path
 
         except httpx.HTTPError as e:
@@ -277,6 +382,7 @@ class UpdateManager:
 
         except Exception as e:
             self.console.print(f"[red]Unexpected error during download: {e}[/red]")
+            dest_path.unlink(missing_ok=True)
             return None
 
     def install_release(self, archive_path: Path) -> bool:

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -1,5 +1,7 @@
 """Tests for UpdateManager."""
 
+import hashlib
+
 import httpx
 import pytest
 from unittest.mock import Mock, patch
@@ -17,6 +19,30 @@ def update_manager():
 def mock_latest_version_text():
     """Mock stable latest-version response body."""
     return "0.3.0\n"
+
+
+def make_response(**attrs):
+    """Build a mock HTTP response with raise_for_status set."""
+    response = Mock()
+    response.raise_for_status = Mock()
+    for name, value in attrs.items():
+        setattr(response, name, value)
+    return response
+
+
+def make_release_response(tag_name="v0.3.0", assets=None, body="Release notes"):
+    """Build a trusted GitHub release metadata response."""
+    return make_response(
+        json=Mock(
+            return_value={
+                "tag_name": tag_name,
+                "name": tag_name,
+                "body": body,
+                "html_url": f"https://github.com/AI-Shell-Team/aish/releases/tag/{tag_name}",
+                "assets": assets or [],
+            }
+        )
+    )
 
 
 @pytest.mark.timeout(5)
@@ -39,19 +65,21 @@ def test_get_latest_release_success(
     mock_client_class, update_manager, mock_latest_version_text
 ):
     """Test successful fetching of latest release from CDN metadata."""
-    mock_response = Mock()
-    mock_response.raise_for_status = Mock()
-    mock_response.text = mock_latest_version_text
+    mock_response = make_response(text=mock_latest_version_text)
+    release_response = make_release_response()
     mock_client_instance = mock_client_class.return_value
-    mock_client_instance.get = Mock(return_value=mock_response)
+    mock_client_instance.get = Mock(side_effect=[mock_response, release_response])
 
     with patch.object(update_manager, "client", mock_client_instance):
         result = update_manager.get_latest_release()
 
     assert result is not None
     assert result["tag_name"] == "v0.3.0"
-    assert result["body"] == ""
-    assert mock_client_instance.get.call_args[0][0].endswith("/latest")
+    assert result["body"] == "Release notes"
+    assert mock_client_instance.get.call_args_list[0][0][0].endswith("/latest")
+    assert mock_client_instance.get.call_args_list[1][0][0].endswith(
+        "/releases/tags/v0.3.0"
+    )
 
 
 @pytest.mark.timeout(5)
@@ -72,11 +100,10 @@ def test_check_for_updates_available(
     mock_client_class, update_manager, mock_latest_version_text
 ):
     """Test checking when update is available."""
-    mock_response = Mock()
-    mock_response.raise_for_status = Mock()
-    mock_response.text = mock_latest_version_text
+    mock_response = make_response(text=mock_latest_version_text)
+    release_response = make_release_response()
     mock_client_instance = mock_client_class.return_value
-    mock_client_instance.get = Mock(return_value=mock_response)
+    mock_client_instance.get = Mock(side_effect=[mock_response, release_response])
 
     with patch.object(update_manager, "client", mock_client_instance):
         result = update_manager.check_for_updates()
@@ -90,11 +117,10 @@ def test_check_for_updates_available(
 @patch("aish.cli.update_manager.httpx.Client")
 def test_check_for_updates_none_available(mock_client_class, update_manager):
     """Test checking when no update available."""
-    mock_response = Mock()
-    mock_response.raise_for_status = Mock()
-    mock_response.text = "0.1.0\n"
+    mock_response = make_response(text="0.1.0\n")
+    release_response = make_release_response(tag_name="v0.1.0")
     mock_client_instance = mock_client_class.return_value
-    mock_client_instance.get = Mock(return_value=mock_response)
+    mock_client_instance.get = Mock(side_effect=[mock_response, release_response])
 
     with patch.object(update_manager, "client", mock_client_instance):
         result = update_manager.check_for_updates()
@@ -106,15 +132,22 @@ def test_check_for_updates_none_available(mock_client_class, update_manager):
 @patch("aish.cli.update_manager.httpx.Client")
 def test_download_release_success(mock_client_class, update_manager, tmp_path):
     """Test successful download from CDN."""
+    data = b"test data"
+    archive_sha256 = hashlib.sha256(data).hexdigest()
+    filename = "aish-0.3.0-linux-amd64.tar.gz"
     mock_response = Mock()
     mock_response.raise_for_status = Mock()
-    mock_response.iter_bytes = Mock(return_value=[b"test data"])
+    mock_response.iter_bytes = Mock(return_value=[data])
     mock_response.headers = {"content-length": "9"}
     mock_cm = Mock()
     mock_cm.__enter__ = Mock(return_value=mock_response)
     mock_cm.__exit__ = Mock(return_value=False)
+    release_response = make_release_response(
+        assets=[{"name": filename, "digest": f"sha256:{archive_sha256}"}]
+    )
     mock_client_instance = mock_client_class.return_value
     mock_client_instance.stream = Mock(return_value=mock_cm)
+    mock_client_instance.get = Mock(return_value=release_response)
 
     with patch.object(update_manager, "client", mock_client_instance):
         result = update_manager.download_release("v0.3.0", dest_dir=tmp_path)
@@ -136,15 +169,22 @@ def test_download_release_respects_download_base_override(
     """Test download uses the configured CDN base URL override."""
     monkeypatch.setenv("AISH_DOWNLOAD_BASE_URL", "https://cdn.example.com/releases")
 
+    data = b"test data"
+    archive_sha256 = hashlib.sha256(data).hexdigest()
+    filename = "aish-0.3.0-linux-amd64.tar.gz"
     mock_response = Mock()
     mock_response.raise_for_status = Mock()
-    mock_response.iter_bytes = Mock(return_value=[b"test data"])
+    mock_response.iter_bytes = Mock(return_value=[data])
     mock_response.headers = {"content-length": "9"}
     mock_cm = Mock()
     mock_cm.__enter__ = Mock(return_value=mock_response)
     mock_cm.__exit__ = Mock(return_value=False)
+    release_response = make_release_response(
+        assets=[{"name": filename, "digest": f"sha256:{archive_sha256}"}]
+    )
     mock_client_instance = mock_client_class.return_value
     mock_client_instance.stream = Mock(return_value=mock_cm)
+    mock_client_instance.get = Mock(return_value=release_response)
 
     with patch.object(update_manager, "client", mock_client_instance):
         result = update_manager.download_release("v0.3.0", dest_dir=tmp_path)
@@ -155,6 +195,47 @@ def test_download_release_respects_download_base_override(
         stream_url
         == "https://cdn.example.com/releases/releases/0.3.0/aish-0.3.0-linux-amd64.tar.gz"
     )
+
+
+@pytest.mark.timeout(5)
+@patch("aish.cli.update_manager.httpx.Client")
+def test_download_release_rejects_checksum_mismatch(
+    mock_client_class, update_manager, tmp_path
+):
+    """Test download is rejected when the trusted digest does not match."""
+    filename = "aish-0.3.0-linux-amd64.tar.gz"
+    mock_response = Mock()
+    mock_response.raise_for_status = Mock()
+    mock_response.iter_bytes = Mock(return_value=[b"tampered data"])
+    mock_response.headers = {"content-length": "13"}
+    mock_cm = Mock()
+    mock_cm.__enter__ = Mock(return_value=mock_response)
+    mock_cm.__exit__ = Mock(return_value=False)
+    release_response = make_release_response(
+        assets=[{"name": filename, "digest": f"sha256:{'0' * 64}"}]
+    )
+    mock_client_instance = mock_client_class.return_value
+    mock_client_instance.stream = Mock(return_value=mock_cm)
+    mock_client_instance.get = Mock(return_value=release_response)
+
+    with patch.object(update_manager, "client", mock_client_instance):
+        result = update_manager.download_release("v0.3.0", dest_dir=tmp_path)
+
+    assert result is None
+    assert not (tmp_path / filename).exists()
+
+
+@pytest.mark.timeout(5)
+def test_parse_checksum_text_matches_named_archive(update_manager):
+    """Test SHA256SUMS-style checksum text parsing."""
+    filename = "aish-0.3.0-linux-amd64.tar.gz"
+    expected = "a" * 64
+
+    result = update_manager._parse_checksum_text(
+        f"{expected}  releases/0.3.0/{filename}\n", filename
+    )
+
+    assert result == expected
 
 
 @pytest.mark.timeout(5)


### PR DESCRIPTION
### Motivation
- The stable self-update flow previously trusted CDN-provided version metadata and downloaded archives without cryptographic verification, allowing a malicious CDN or configured update endpoint to supply a higher version and a malicious installer that would be executed with `sudo`.
- The change binds the plain `latest` metadata to the authoritative GitHub release for the matching tag and ensures the downloaded archive matches a trusted SHA256 digest before it can be installed.

### Description
- Added `get_release_by_tag`, checksum discovery, and verification helpers (`_sha256_file`, `_parse_checksum_text`, `get_expected_archive_sha256`, `verify_archive`) to `src/aish/cli/update_manager.py` and a `SHA256_PATTERN` constant and `GITHUB_API_RELEASE_TAG` endpoint constant.
- When resolving a stable `latest` version, the code now fetches the corresponding GitHub release metadata and uses its assets/checksum files as the trust root instead of accepting a version-only CDN response alone.
- `download_release` now verifies the downloaded archive against the expected SHA256 digest (using `hmac.compare_digest`) and removes/rejects the archive if verification fails, preventing unverified installers from being returned for installation.
- Updated `tests/test_update_manager.py` to exercise trusted release metadata lookup, checksum-parsed digests, download verification, download-base overrides, and rejection of checksum mismatches.

### Testing
- Ran linters/formatters: `uv run ruff check src/aish/cli/update_manager.py tests/test_update_manager.py` and `uv run black --check src/aish/cli/update_manager.py tests/test_update_manager.py`, both passed after applying formatting.
- Ran unit tests for the change: `uv run python -m pytest tests/test_update_manager.py` which passed (`12 passed`).
- Ran the full test suite: `uv run python -m pytest` which completed but reported one unrelated failing test (`tests/terminal/pty/test_pty_control_protocol.py::test_pty_manager_execute_command_honors_explicit_timeout`), with the rest of the suite passing (`1 failed, 631 passed, 15 skipped`); this failure is not related to the update manager changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02828f323c8320b40ea252b9e9f51d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Self-update downloads now include SHA256 checksum verification for archive validation.
  * Enhanced error handling for version and release information retrieval.

* **Tests**
  * Expanded test coverage for update verification and checksum validation workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/168)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->