### PR TITLE
Require confirmation for AI-driven interactive bash stdin and harden detection

### DIFF
--- a/src/aish/tools/code_exec.py
+++ b/src/aish/tools/code_exec.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import shlex
 import sys
 import threading
 from pathlib import Path
@@ -28,9 +29,76 @@ DISPLAY_ELLIPSIS = " ..."
 logger = logging.getLogger("aish.tools.code_exec")
 
 
+_SHELL_COMMAND_SEPARATORS = {";", "&&", "||", "|", "("}
+_SHELL_COMMAND_KEYWORDS = {
+    "if",
+    "then",
+    "while",
+    "until",
+    "do",
+    "else",
+    "elif",
+    "time",
+    "!",
+}
+_INTERACTIVE_STDIN_COMMANDS = {"sudo", "su"}
+_COMMAND_WRAPPERS = {"command", "builtin", "exec", "env", "nohup"}
+
+
+def _tokenize_bash_command(command: str) -> list[str]:
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    try:
+        return list(lexer)
+    except ValueError:
+        # If the command is syntactically incomplete, fall back to the normal
+        # non-interactive executor instead of granting stdin to a substring hit.
+        return []
+
+
+def _is_assignment(token: str) -> bool:
+    name, sep, _value = token.partition("=")
+    return bool(
+        sep and name and name.replace("_", "").isalnum() and not name[0].isdigit()
+    )
+
+
+def _command_basename(token: str) -> str:
+    return os.path.basename(token).lower()
+
+
 def _needs_interactive_bash(command: str) -> bool:
-    lower = command.lower()
-    return "sudo" in lower or " su " in lower or lower.startswith("su ")
+    tokens = _tokenize_bash_command(command)
+    expect_command = True
+    wrapper_pending = False
+
+    for token in tokens:
+        normalized = token.lower()
+        if normalized in _SHELL_COMMAND_SEPARATORS:
+            expect_command = True
+            wrapper_pending = False
+            continue
+        if normalized in _SHELL_COMMAND_KEYWORDS:
+            expect_command = True
+            wrapper_pending = False
+            continue
+        if not expect_command:
+            continue
+        if _is_assignment(token):
+            continue
+
+        basename = _command_basename(token)
+        if wrapper_pending or basename not in _COMMAND_WRAPPERS:
+            if basename in _INTERACTIVE_STDIN_COMMANDS:
+                return True
+            expect_command = False
+            wrapper_pending = False
+            continue
+
+        wrapper_pending = True
+
+    return False
 
 
 def _collapse_output_lines(text: str, max_lines: int = DISPLAY_MAX_LINES) -> str:
@@ -335,6 +403,8 @@ class BashTool(ToolBase):
 
         if not self._last_decision.allow:
             return False
+        if _needs_interactive_bash(command):
+            return True
         return bool(self._last_decision.require_confirmation)
 
     def prepare_invocation(
@@ -370,12 +440,6 @@ class BashTool(ToolBase):
             remember_key=command,
         )
 
-        if isinstance(analysis_data, dict) and analysis_data.get("fail_open") is True:
-            return ToolPreflightResult(action=ToolPreflightAction.EXECUTE)
-
-        if callable(context.is_approved) and context.is_approved(command):
-            return ToolPreflightResult(action=ToolPreflightAction.EXECUTE)
-
         if not decision.allow:
             reasons = (
                 analysis_data.get("reasons", [])
@@ -405,6 +469,29 @@ class BashTool(ToolBase):
                     stop_tool_chain=True,
                 ),
             )
+
+        approved = callable(context.is_approved) and context.is_approved(command)
+        if approved:
+            return ToolPreflightResult(action=ToolPreflightAction.EXECUTE)
+
+        if _needs_interactive_bash(command):
+            panel.mode = "confirm"
+            panel.title = "Confirm interactive terminal input"
+            panel.analysis = {
+                **panel.analysis,
+                "interactive_stdin": True,
+                "reason": (
+                    "This AI-generated command may request terminal input; "
+                    "approve only if you trust the exact command shown."
+                ),
+            }
+            return ToolPreflightResult(
+                action=ToolPreflightAction.CONFIRM,
+                panel=panel,
+            )
+
+        if isinstance(analysis_data, dict) and analysis_data.get("fail_open") is True:
+            return ToolPreflightResult(action=ToolPreflightAction.EXECUTE)
 
         sandbox_info = (
             analysis_data.get("sandbox", {}) if isinstance(analysis_data, dict) else {}

--- a/tests/tools/test_bash_output_offload.py
+++ b/tests/tools/test_bash_output_offload.py
@@ -9,6 +9,7 @@ from aish.config import BashOutputOffloadSettings
 from aish.security.security_manager import SecurityDecision
 from aish.security.security_policy import RiskLevel
 from aish.terminal.pty.manager import PTYManager
+from aish.tools.base import ToolExecutionContext, ToolPreflightAction
 from aish.tools.code_exec import BashTool, _needs_interactive_bash
 
 
@@ -32,7 +33,60 @@ def test_needs_interactive_bash_matches_rust_heuristic():
     assert _needs_interactive_bash("echo 3 | sudo tee /tmp/x") is True
     assert _needs_interactive_bash("su -") is True
     assert _needs_interactive_bash("cmd && su -") is True
+    assert _needs_interactive_bash("/usr/bin/sudo whoami") is True
+    assert _needs_interactive_bash("VAR=1 sudo whoami") is True
+    assert _needs_interactive_bash("command sudo whoami") is True
+    assert _needs_interactive_bash("if sudo -v; then echo ok; fi") is True
     assert _needs_interactive_bash("ls -la") is False
+    assert _needs_interactive_bash("echo sudo") is False
+    assert _needs_interactive_bash("printf 'sudo prompt:'") is False
+
+
+def test_bash_exec_interactive_stdin_requires_preflight_confirmation():
+    tool = BashTool()
+
+    with patch.object(tool.security_manager, "decide", return_value=_allow_decision()):
+        preflight = tool.prepare_invocation(
+            {"code": "sudo whoami"},
+            ToolExecutionContext(cwd=Path.cwd(), is_approved=lambda _command: False),
+        )
+
+    assert preflight.action == ToolPreflightAction.CONFIRM
+    assert preflight.panel is not None
+    assert preflight.panel.analysis["interactive_stdin"] is True
+
+
+def test_bash_exec_interactive_stdin_confirmation_overrides_fail_open():
+    tool = BashTool()
+    decision = SecurityDecision(
+        level=RiskLevel.LOW,
+        allow=True,
+        require_confirmation=False,
+        analysis={"risk_level": "LOW", "fail_open": True, "reasons": []},
+    )
+
+    with patch.object(tool.security_manager, "decide", return_value=decision):
+        preflight = tool.prepare_invocation(
+            {"code": "sudo whoami"},
+            ToolExecutionContext(cwd=Path.cwd(), is_approved=lambda _command: False),
+        )
+
+    assert preflight.action == ToolPreflightAction.CONFIRM
+
+
+def test_bash_exec_interactive_stdin_allows_exact_approved_command():
+    tool = BashTool()
+
+    with patch.object(tool.security_manager, "decide", return_value=_allow_decision()):
+        preflight = tool.prepare_invocation(
+            {"code": "sudo whoami"},
+            ToolExecutionContext(
+                cwd=Path.cwd(),
+                is_approved=lambda command: command == "sudo whoami",
+            ),
+        )
+
+    assert preflight.action == ToolPreflightAction.EXECUTE
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Prevent AI-selected commands from silently receiving terminal input by ensuring PTY stdin handoff only occurs for real interactive commands and with explicit user confirmation. 
- Harden the heuristic that previously matched `sudo`/`su` by substring so prompt-injection (e.g., `echo sudo`) cannot force the PTY handoff.

### Description
- Replace the simple substring check with a shell-aware tokenizer and selector: implemented a robust `_needs_interactive_bash` using `shlex` to detect real command positions, wrappers, assignments and separators (file: `src/aish/tools/code_exec.py`).
- Require an explicit preflight confirmation for AI-generated commands that need interactive stdin by returning a `ToolPreflightAction.CONFIRM` from `prepare_invocation` (unless the exact command is already approved), and make `need_confirm_before_exec` return True for interactive commands (file: `src/aish/tools/code_exec.py`).
- Ensure interactive confirmation cannot be bypassed by `fail_open` sandbox decisions by checking interactive detection before honoring `fail_open` (file: `src/aish/tools/code_exec.py`).
- Add regression tests that cover correct detection (including wrapper forms like `/usr/bin/sudo`, `VAR=1 sudo`, `command sudo ...`), avoid false positives for benign substrings, and assert the preflight confirmation behavior and exact-approved command behavior (file: `tests/tools/test_bash_output_offload.py`).

### Testing
- Ran unit tests: `python -m pytest tests/tools/test_bash_output_offload.py -q` and `python -m pytest tests/tools/test_bash_output_offload.py tests/test_ask_user_tool.py -q`, and all tests passed (`13 passed` for the focused suite and `31 passed` for the combined run).
- Ran static checks: `python -m ruff check src/aish/tools/code_exec.py tests/tools/test_bash_output_offload.py`, which returned no issues.
- Ran quick sanity checks (compile/ruff/pytest) used in CI and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0283fa52308320b814bf824bcbbc55)