### PR TITLE
fix: parse interactive bash commands safely

### DIFF
--- a/src/aish/tools/code_exec.py
+++ b/src/aish/tools/code_exec.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import shlex
 import sys
 import threading
 from pathlib import Path
@@ -28,9 +29,48 @@ DISPLAY_ELLIPSIS = " ..."
 logger = logging.getLogger("aish.tools.code_exec")
 
 
+_INTERACTIVE_COMMANDS = {"sudo", "su"}
+_COMMAND_SEPARATORS = {";", "&", "&&", "||", "|", "(", ")"}
+
+
+def _is_shell_assignment(token: str) -> bool:
+    if "=" not in token:
+        return False
+
+    name, _value = token.split("=", 1)
+    return bool(name) and (name[0].isalpha() or name[0] == "_") and all(
+        char.isalnum() or char == "_" for char in name
+    )
+
+
 def _needs_interactive_bash(command: str) -> bool:
-    lower = command.lower()
-    return "sudo" in lower or " su " in lower or lower.startswith("su ")
+    lexer = shlex.shlex(
+        command.replace("\n", ";"),
+        posix=True,
+        punctuation_chars=";&|()",
+    )
+    lexer.whitespace_split = True
+    lexer.commenters = "#"
+
+    try:
+        tokens = list(lexer)
+    except ValueError:
+        return False
+
+    command_position = True
+    for token in tokens:
+        if token in _COMMAND_SEPARATORS:
+            command_position = True
+            continue
+        if command_position and token == "!":
+            continue
+        if command_position and _is_shell_assignment(token):
+            continue
+        if command_position and token in _INTERACTIVE_COMMANDS:
+            return True
+        command_position = False
+
+    return False
 
 
 def _collapse_output_lines(text: str, max_lines: int = DISPLAY_MAX_LINES) -> str:

--- a/tests/tools/test_bash_output_offload.py
+++ b/tests/tools/test_bash_output_offload.py
@@ -27,12 +27,17 @@ def _extract_tag(xml_text: str, tag_name: str) -> str:
     return match.group(1).strip("\n")
 
 
-def test_needs_interactive_bash_matches_rust_heuristic():
+def test_needs_interactive_bash_matches_shell_commands_only():
     assert _needs_interactive_bash("sudo apt update") is True
     assert _needs_interactive_bash("echo 3 | sudo tee /tmp/x") is True
     assert _needs_interactive_bash("su -") is True
     assert _needs_interactive_bash("cmd && su -") is True
+    assert _needs_interactive_bash("FOO=bar sudo apt update") is True
     assert _needs_interactive_bash("ls -la") is False
+    assert _needs_interactive_bash("printf 'sudo prompt'") is False
+    assert _needs_interactive_bash("echo ok # sudo") is False
+    assert _needs_interactive_bash("printf '[sudo] password: '; read pw # sudo") is False
+    assert _needs_interactive_bash("echo nosudo") is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- The prior substring-based heuristic treated any occurrence of `sudo`/`su` inside comments, strings, or unrelated tokens as an interactive invocation and routed the command to the PTY executor, allowing an AI-controlled command to solicit and leak live terminal input.
- The intent is to only treat true shell invocations of `sudo`/`su` (command words at shell command positions) as interactive so PTY routing is only used when stdin could legitimately be read by a child process.

### Description
- Replace the substring heuristic in `_needs_interactive_bash` with a `shlex`-based tokenizer that respects quoting and `#` comments and recognizes shell command separators, so only command-position tokens trigger interactive routing.
- Add `_INTERACTIVE_COMMANDS`, `_COMMAND_SEPARATORS`, and helper `_is_shell_assignment` to allow leading environment assignments (e.g. `FOO=bar sudo ...`), shell negation (`!`), and separators/pipelines to be handled correctly.
- Update regression test coverage in `tests/tools/test_bash_output_offload.py` to assert that real `sudo`/`su` invocations still match while quoted/comment-only or substring occurrences (e.g. `printf 'sudo prompt'`, `echo ok # sudo`) no longer trigger PTY execution.

### Testing
- Ran `uv run pytest tests/tools/test_bash_output_offload.py -q` and the file-level tests passed (`10 passed`).
- Ran `uv run pytest tests/tools -q` and the tools test suite passed (`61 passed`).
- Ran `uv run ruff check src/aish/tools/code_exec.py tests/tools/test_bash_output_offload.py` and lint checks passed, and `git diff --check` reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a028346e0208320b820481965dc94ab)