### PR TITLE
fix(ci): prevent live smoke secret artifacts

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -129,7 +129,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: live-smoke-diagnostics-${{ github.run_id }}
-          path: build/pytest-live-smoke
+          path: build/pytest-live-smoke/**/live-smoke/diagnostics/**
           if-no-files-found: ignore
 
       - name: Write workflow summary

--- a/tests/flows/live_smoke/conftest.py
+++ b/tests/flows/live_smoke/conftest.py
@@ -109,7 +109,9 @@ def _write_config_file(
     if api_base:
         config_data["api_base"] = api_base
 
-    config_file.write_text(yaml.safe_dump(config_data, sort_keys=True), encoding="utf-8")
+    config_file.write_text(
+        yaml.safe_dump(config_data, sort_keys=True), encoding="utf-8"
+    )
     return config_file
 
 
@@ -120,6 +122,77 @@ def _close_shell(child: Any, timeout: float = 5.0) -> None:
         child.expect(pexpect.EOF, timeout=timeout)
     except pexpect.TIMEOUT:
         child.close(force=True)
+
+
+def _live_smoke_secret_values() -> tuple[str, ...]:
+    return tuple(
+        value
+        for value in (os.environ.get("AISH_LIVE_SMOKE_API_KEY", "").strip(),)
+        if value
+    )
+
+
+def _redact_live_smoke_text(text: str) -> str:
+    redacted = text
+    for secret in _live_smoke_secret_values():
+        redacted = redacted.replace(secret, "<redacted>")
+    return redacted
+
+
+def _redact_live_smoke_argv(argv: list[str]) -> list[str]:
+    redacted: list[str] = []
+    redact_next = False
+    for arg in argv:
+        if redact_next:
+            redacted.append("<redacted>")
+            redact_next = False
+            continue
+        if arg == "--api-key":
+            redacted.append(arg)
+            redact_next = True
+            continue
+        if arg.startswith("--api-key="):
+            redacted.append("--api-key=<redacted>")
+            continue
+        redacted.append(_redact_live_smoke_text(arg))
+    return redacted
+
+
+def _redact_live_smoke_artifact(value: Any) -> Any:
+    if isinstance(value, LiveSmokeCommandResult):
+        return asdict(
+            LiveSmokeCommandResult(
+                argv=_redact_live_smoke_argv(value.argv),
+                cwd=value.cwd,
+                returncode=value.returncode,
+                stdout=_redact_live_smoke_text(value.stdout),
+                stderr=_redact_live_smoke_text(value.stderr),
+                duration_seconds=value.duration_seconds,
+            )
+        )
+    if isinstance(value, LiveSmokeChatResult):
+        return asdict(
+            LiveSmokeChatResult(
+                argv=_redact_live_smoke_argv(value.argv),
+                cwd=value.cwd,
+                transcript=_redact_live_smoke_text(value.transcript),
+                exitstatus=value.exitstatus,
+                signalstatus=value.signalstatus,
+                duration_seconds=value.duration_seconds,
+                expected_token_seen=value.expected_token_seen,
+            )
+        )
+    if isinstance(value, dict):
+        return {key: _redact_live_smoke_artifact(item) for key, item in value.items()}
+    if isinstance(value, list):
+        if all(isinstance(item, str) for item in value):
+            return _redact_live_smoke_argv(value)
+        return [_redact_live_smoke_artifact(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_live_smoke_artifact(item) for item in value)
+    if isinstance(value, str):
+        return _redact_live_smoke_text(value)
+    return value
 
 
 def _env_summary(env: dict[str, str]) -> dict[str, str]:
@@ -263,7 +336,11 @@ def live_smoke_artifacts(
     for index, artifact in enumerate(artifacts, start=1):
         artifact_path = artifact_dir / f"artifact-{index}.yaml"
         artifact_path.write_text(
-            yaml.safe_dump(artifact, allow_unicode=False, sort_keys=False),
+            yaml.safe_dump(
+                _redact_live_smoke_artifact(artifact),
+                allow_unicode=False,
+                sort_keys=False,
+            ),
             encoding="utf-8",
         )
 
@@ -297,11 +374,11 @@ def live_smoke_runner(
         live_smoke_artifacts.append(
             {
                 "type": "command",
-                "argv": argv,
+                "argv": _redact_live_smoke_argv(argv),
                 "cwd": str(live_smoke_paths.workspace),
                 "duration_seconds": duration_seconds,
                 "env_summary": _env_summary(live_smoke_env),
-                "result": asdict(result),
+                "result": _redact_live_smoke_artifact(result),
             }
         )
         return result
@@ -420,12 +497,12 @@ def live_smoke_chat_runner(
             live_smoke_artifacts.append(
                 {
                     "type": "chat",
-                    "argv": argv,
+                    "argv": _redact_live_smoke_argv(argv),
                     "cwd": str(live_smoke_paths.workspace),
                     "duration_seconds": duration_seconds,
                     "env_summary": _env_summary(live_smoke_env),
                     "config_file": str(live_smoke_config_file),
-                    "transcript": result.transcript,
+                    "transcript": _redact_live_smoke_text(result.transcript),
                     "exitstatus": result.exitstatus,
                     "signalstatus": result.signalstatus,
                     "expected_token_seen": result.expected_token_seen,

--- a/tests/security/test_live_smoke_diagnostics_redaction.py
+++ b/tests/security/test_live_smoke_diagnostics_redaction.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_live_smoke_conftest():
+    conftest_path = Path(__file__).parents[1] / "flows" / "live_smoke" / "conftest.py"
+    spec = importlib.util.spec_from_file_location("live_smoke_conftest", conftest_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_live_smoke_artifact_redacts_api_key_from_argv_and_text(monkeypatch):
+    live_smoke_conftest = _load_live_smoke_conftest()
+    monkeypatch.setenv("AISH_LIVE_SMOKE_API_KEY", "LIVE_SECRET_VALUE")
+
+    artifact = {
+        "argv": [
+            "aish",
+            "check-tool-support",
+            "--api-key",
+            "LIVE_SECRET_VALUE",
+            "--api-key=LIVE_SECRET_VALUE",
+        ],
+        "result": live_smoke_conftest.LiveSmokeCommandResult(
+            argv=["aish", "--api-key", "LIVE_SECRET_VALUE"],
+            cwd="/workspace",
+            returncode=1,
+            stdout="stdout LIVE_SECRET_VALUE",
+            stderr="stderr LIVE_SECRET_VALUE",
+            duration_seconds=0.1,
+        ),
+    }
+
+    redacted = live_smoke_conftest._redact_live_smoke_artifact(artifact)
+
+    assert "LIVE_SECRET_VALUE" not in repr(redacted)
+    assert redacted["argv"] == [
+        "aish",
+        "check-tool-support",
+        "--api-key",
+        "<redacted>",
+        "--api-key=<redacted>",
+    ]
+    assert redacted["result"]["argv"] == ["aish", "--api-key", "<redacted>"]
+    assert redacted["result"]["stdout"] == "stdout <redacted>"
+    assert redacted["result"]["stderr"] == "stderr <redacted>"


### PR DESCRIPTION
### Motivation
- Prevent accidental upload of live provider API keys and other secrets produced by the live smoke pytest suite into CI artifacts.

### Description
- Limit the workflow artifact upload to only diagnostics files by changing the upload `path` from `build/pytest-live-smoke` to `build/pytest-live-smoke/**/live-smoke/diagnostics/**` in `.github/workflows/live-smoke.yml`.
- Add redaction helpers (`_live_smoke_secret_values`, `_redact_live_smoke_text`, `_redact_live_smoke_argv`, `_redact_live_smoke_artifact`) to `tests/flows/live_smoke/conftest.py` that remove the configured `AISH_LIVE_SMOKE_API_KEY` from recorded text and argv (handles both `--api-key value` and `--api-key=value`).
- Apply redaction when recording command/chat artifacts and before writing failure diagnostic YAML so stored artifacts do not contain raw secrets.
- Add a regression test `tests/security/test_live_smoke_diagnostics_redaction.py` that loads the live-smoke conftest and asserts the API key is redacted from argv, stdout, and stderr.

### Testing
- Ran the regression test with `python -m pytest tests/security/test_live_smoke_diagnostics_redaction.py` and it passed (`1 passed`).
- Ran lint/format checks with `ruff` and `black` on the modified files and resolved formatting; checks passed afterwards.
- Verified the workflow YAML is parseable with `yaml.safe_load` to ensure no syntax regressions.
- Verified the redaction logic via the added unit test which demonstrates that `LIVE_SECRET_VALUE` is not present in serialized artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0283b30ee0832097eab86d1bb44030)