### PR TITLE
fix(search): scope grep and glob roots to workspace

### DIFF
--- a/src/aish/tools/glob_tool.py
+++ b/src/aish/tools/glob_tool.py
@@ -28,18 +28,23 @@ _DEFAULT_EXCLUDE_DIRS: frozenset[str] = frozenset(
 _DEFAULT_MAX_RESULTS: int = 200
 
 
-def _normalize_root(root: str | None) -> Path:
-    if isinstance(root, str) and root.strip():
-        return Path(root).expanduser().resolve()
-    return Path.cwd().resolve()
-
-
 def _is_relative_to(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
         return True
     except ValueError:
         return False
+
+
+def _normalize_root(root: str | None) -> Path:
+    workspace_root = Path.cwd().resolve()
+    if isinstance(root, str) and root.strip():
+        resolved = Path(root).expanduser().resolve()
+    else:
+        resolved = workspace_root
+    if not _is_relative_to(resolved, workspace_root):
+        raise ValueError(f"root must be within the current workspace: {workspace_root}")
+    return resolved
 
 
 class GlobTool(ToolBase):
@@ -56,9 +61,7 @@ class GlobTool(ToolBase):
                 "properties": {
                     "pattern": {
                         "type": "string",
-                        "description": (
-                            "Glob pattern such as **/*.py or src/**/*.md"
-                        ),
+                        "description": ("Glob pattern such as **/*.py or src/**/*.md"),
                     },
                     "root": {
                         "type": "string",
@@ -76,7 +79,10 @@ class GlobTool(ToolBase):
         if not isinstance(pattern, str) or not pattern.strip():
             return ToolResult(ok=False, output="Error: pattern is required")
 
-        base = _normalize_root(root)
+        try:
+            base = _normalize_root(root)
+        except ValueError as exc:
+            return ToolResult(ok=False, output=f"Error: {exc}")
         if not base.exists() or not base.is_dir():
             return ToolResult(
                 ok=False,

--- a/src/aish/tools/glob_tool.py
+++ b/src/aish/tools/glob_tool.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from pydantic import Field
+
 from aish.tools.base import ToolBase
 from aish.tools.result import ToolResult
 
@@ -36,19 +38,28 @@ def _is_relative_to(path: Path, root: Path) -> bool:
         return False
 
 
-def _normalize_root(root: str | None) -> Path:
-    workspace_root = Path.cwd().resolve()
+def _normalize_root(root: str | None, workspace_root: Path) -> Path:
     if isinstance(root, str) and root.strip():
         resolved = Path(root).expanduser().resolve()
     else:
-        resolved = workspace_root
+        resolved = Path.cwd().resolve()
     if not _is_relative_to(resolved, workspace_root):
         raise ValueError(f"root must be within the current workspace: {workspace_root}")
     return resolved
 
 
 class GlobTool(ToolBase):
-    def __init__(self) -> None:
+    workspace_root: Path = Field(
+        default_factory=lambda: Path.cwd().resolve(),
+        exclude=True,
+    )
+
+    def __init__(self, workspace_root: str | Path | None = None) -> None:
+        resolved_workspace_root = (
+            Path(workspace_root).expanduser().resolve()
+            if workspace_root is not None
+            else Path.cwd().resolve()
+        )
         super().__init__(
             name="glob",
             description=(
@@ -74,13 +85,14 @@ class GlobTool(ToolBase):
                 "required": ["pattern"],
             },
         )
+        self.workspace_root = resolved_workspace_root
 
     def __call__(self, pattern: str, root: str | None = None) -> ToolResult:
         if not isinstance(pattern, str) or not pattern.strip():
             return ToolResult(ok=False, output="Error: pattern is required")
 
         try:
-            base = _normalize_root(root)
+            base = _normalize_root(root, self.workspace_root)
         except ValueError as exc:
             return ToolResult(ok=False, output=f"Error: {exc}")
         if not base.exists() or not base.is_dir():

--- a/src/aish/tools/grep_tool.py
+++ b/src/aish/tools/grep_tool.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from pydantic import Field
+
 from aish.tools.base import ToolBase
 from aish.tools.result import ToolResult
 
@@ -38,12 +40,11 @@ def _is_relative_to(path: Path, root: Path) -> bool:
         return False
 
 
-def _normalize_root(root: str | None) -> Path:
-    workspace_root = Path.cwd().resolve()
+def _normalize_root(root: str | None, workspace_root: Path) -> Path:
     if isinstance(root, str) and root.strip():
         resolved = Path(root).expanduser().resolve()
     else:
-        resolved = workspace_root
+        resolved = Path.cwd().resolve()
     if not _is_relative_to(resolved, workspace_root):
         raise ValueError(f"root must be within the current workspace: {workspace_root}")
     return resolved
@@ -104,7 +105,17 @@ def _walk_files(
 
 
 class GrepTool(ToolBase):
-    def __init__(self) -> None:
+    workspace_root: Path = Field(
+        default_factory=lambda: Path.cwd().resolve(),
+        exclude=True,
+    )
+
+    def __init__(self, workspace_root: str | Path | None = None) -> None:
+        resolved_workspace_root = (
+            Path(workspace_root).expanduser().resolve()
+            if workspace_root is not None
+            else Path.cwd().resolve()
+        )
         super().__init__(
             name="grep",
             description=(
@@ -137,6 +148,7 @@ class GrepTool(ToolBase):
                 "required": ["pattern"],
             },
         )
+        self.workspace_root = resolved_workspace_root
 
     def __call__(
         self,
@@ -148,7 +160,7 @@ class GrepTool(ToolBase):
             return ToolResult(ok=False, output="Error: pattern is required")
 
         try:
-            base = _normalize_root(root)
+            base = _normalize_root(root, self.workspace_root)
         except ValueError as exc:
             return ToolResult(ok=False, output=f"Error: {exc}")
         if not base.exists() or not base.is_dir():

--- a/src/aish/tools/grep_tool.py
+++ b/src/aish/tools/grep_tool.py
@@ -30,18 +30,23 @@ _DEFAULT_MAX_RESULTS: int = 200
 _MAX_LINE_LENGTH: int = 500
 
 
-def _normalize_root(root: str | None) -> Path:
-    if isinstance(root, str) and root.strip():
-        return Path(root).expanduser().resolve()
-    return Path.cwd().resolve()
-
-
 def _is_relative_to(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
         return True
     except ValueError:
         return False
+
+
+def _normalize_root(root: str | None) -> Path:
+    workspace_root = Path.cwd().resolve()
+    if isinstance(root, str) and root.strip():
+        resolved = Path(root).expanduser().resolve()
+    else:
+        resolved = workspace_root
+    if not _is_relative_to(resolved, workspace_root):
+        raise ValueError(f"root must be within the current workspace: {workspace_root}")
+    return resolved
 
 
 def _walk_files(
@@ -142,7 +147,10 @@ class GrepTool(ToolBase):
         if not isinstance(pattern, str) or not pattern.strip():
             return ToolResult(ok=False, output="Error: pattern is required")
 
-        base = _normalize_root(root)
+        try:
+            base = _normalize_root(root)
+        except ValueError as exc:
+            return ToolResult(ok=False, output=f"Error: {exc}")
         if not base.exists() or not base.is_dir():
             return ToolResult(
                 ok=False,
@@ -169,9 +177,7 @@ class GrepTool(ToolBase):
                             display_line = line.rstrip()
                             if len(display_line) > _MAX_LINE_LENGTH:
                                 display_line = display_line[:_MAX_LINE_LENGTH] + "…"
-                            matches.append(
-                                f"{resolved}:{line_no}: {display_line}"
-                            )
+                            matches.append(f"{resolved}:{line_no}: {display_line}")
                             if len(matches) >= _DEFAULT_MAX_RESULTS:
                                 break
                     if len(matches) >= _DEFAULT_MAX_RESULTS:

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from aish.tools.glob_tool import GlobTool
+from aish.tools.grep_tool import GrepTool
+
+
+def test_glob_rejects_root_outside_current_workspace(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    secret = outside / "token.txt"
+    secret.write_text("AISH_VALIDATION_SECRET=sk-validation\n", encoding="utf-8")
+    monkeypatch.chdir(workspace)
+
+    result = GlobTool()(pattern="**/*.txt", root=str(outside))
+
+    assert result.ok is False
+    assert "root must be within the current workspace" in result.output
+    assert "token.txt" not in result.output
+
+
+def test_grep_rejects_root_outside_current_workspace(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    secret = outside / "token.txt"
+    secret.write_text("AISH_VALIDATION_SECRET=sk-validation\n", encoding="utf-8")
+    monkeypatch.chdir(workspace)
+
+    result = GrepTool()(pattern="AISH_VALIDATION_SECRET", root=str(outside))
+
+    assert result.ok is False
+    assert "root must be within the current workspace" in result.output
+    assert "sk-validation" not in result.output
+
+
+def test_search_tools_allow_roots_inside_current_workspace(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    source = workspace / "src"
+    source.mkdir(parents=True)
+    file_path = source / "example.py"
+    file_path.write_text("needle = True\n", encoding="utf-8")
+    monkeypatch.chdir(workspace)
+
+    glob_result = GlobTool()(pattern="**/*.py", root="src")
+    grep_result = GrepTool()(pattern="needle", root="src")
+
+    assert glob_result.ok is True
+    assert str(file_path) in glob_result.output
+    assert grep_result.ok is True
+    assert f"{file_path}:1: needle = True" in grep_result.output

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -51,3 +51,25 @@ def test_search_tools_allow_roots_inside_current_workspace(tmp_path, monkeypatch
     assert str(file_path) in glob_result.output
     assert grep_result.ok is True
     assert f"{file_path}:1: needle = True" in grep_result.output
+
+
+def test_search_tools_allow_workspace_sibling_roots_after_chdir(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    source = workspace / "src"
+    tests_dir = workspace / "tests"
+    source.mkdir(parents=True)
+    tests_dir.mkdir()
+    file_path = tests_dir / "example.txt"
+    file_path.write_text("needle from sibling\n", encoding="utf-8")
+    monkeypatch.chdir(workspace)
+    glob_tool = GlobTool()
+    grep_tool = GrepTool()
+    monkeypatch.chdir(source)
+
+    glob_result = glob_tool(pattern="**/*.txt", root="../tests")
+    grep_result = grep_tool(pattern="needle", root=str(tests_dir))
+
+    assert glob_result.ok is True
+    assert str(file_path) in glob_result.output
+    assert grep_result.ok is True
+    assert f"{file_path}:1: needle from sibling" in grep_result.output


### PR DESCRIPTION
### Motivation
- Prevent model-controlled `root` arguments to `grep` and `glob` from enumerating or searching arbitrary local paths (e.g., `~/.ssh`, `/etc`) which can leak secrets or cause broad traversal DoS. 
- Ensure search tools are safe to expose to LLM-driven tool calls by restricting filesystem discovery to the current workspace.

### Description
- Change `_normalize_root` in `src/aish/tools/grep_tool.py` and `src/aish/tools/glob_tool.py` to resolve the requested `root` and enforce it is inside the current workspace (`Path.cwd().resolve()`), raising a `ValueError` when it is not. 
- Catch the `ValueError` in both tools and return a `ToolResult(ok=False, ...)` error before any filesystem traversal or regex work begins. 
- Add `tests/test_search_tools.py` with regression tests asserting outside-workspace roots are rejected and inside-workspace roots continue to work. 
- Apply minor formatting tidies in the two tool files to keep linting happy.

### Testing
- Ran the new focused tests with `uv run --group dev python -m pytest tests/test_search_tools.py -v` and they passed (`3 passed`).
- Ran lint with `make lint` and it succeeded (`ruff`/`mypy` checks passed).
- Ran the full test suite with `make test` and it completed successfully (`633 passed, 15 skipped` as reported by the test run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0284306f3083208861779ad1804bf6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search tools now validate provided root paths against the workspace, rejecting out-of-workspace roots with clear error messages instead of failing.
  * Tool outputs avoid leaking secrets and handle sibling workspace paths after directory changes.

* **Tests**
  * Added tests covering rejection of external roots, acceptance of in-workspace and sibling roots, output formatting, and secret exclusion.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/172)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->