### PR TITLE
fix: pause ai stdin monitor during ask_user

### DIFF
--- a/src/aish/shell/runtime/ai.py
+++ b/src/aish/shell/runtime/ai.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import anyio
 import asyncio
+import io
 import os
 import re
 import select
@@ -379,21 +380,87 @@ class AIHandler:
         # stdin, they set this event so _stdin_loop pauses and stops
         # competing for sys.stdin reads.
         stdin_yield_event = threading.Event()
+        stdin_yield_ack_event = threading.Event()
+        stdin_wakeup_read: int | None = None
+        stdin_wakeup_write: int | None = None
+
+        try:
+            stdin_wakeup_read, stdin_wakeup_write = os.pipe()
+            os.set_blocking(stdin_wakeup_read, False)
+            os.set_blocking(stdin_wakeup_write, False)
+        except (AttributeError, OSError):
+            if stdin_wakeup_read is not None:
+                try:
+                    os.close(stdin_wakeup_read)
+                except OSError:
+                    pass
+            if stdin_wakeup_write is not None:
+                try:
+                    os.close(stdin_wakeup_write)
+                except OSError:
+                    pass
+            stdin_wakeup_read = None
+            stdin_wakeup_write = None
+
+        def _wake_stdin_monitor() -> None:
+            if stdin_wakeup_write is None:
+                return
+            try:
+                os.write(stdin_wakeup_write, b"\0")
+            except BlockingIOError:
+                pass
+            except OSError:
+                pass
+
+        shell._stdin_yield_event = stdin_yield_event
+        shell._stdin_yield_ack_event = stdin_yield_ack_event
+        shell._wake_stdin_monitor = _wake_stdin_monitor
+
         bash_tool = getattr(self.llm_session, "bash_tool", None)
         if bash_tool is not None:
             bash_tool.stdin_yield_event = stdin_yield_event
 
+        try:
+            stdin_fd = sys.stdin.fileno()
+        except (AttributeError, io.UnsupportedOperation, OSError, ValueError):
+            stdin_fd = None
+
         def _stdin_loop():
+            if stdin_fd is None:
+                return
+
+            def _drain_wakeup_pipe() -> None:
+                if stdin_wakeup_read is None:
+                    return
+                while True:
+                    try:
+                        if not os.read(stdin_wakeup_read, 1024):
+                            break
+                    except BlockingIOError:
+                        break
+                    except OSError:
+                        break
+
             while not cancel_requested.is_set():
                 # Yield stdin to PTY-based tools when requested.
                 if stdin_yield_event.is_set():
+                    stdin_yield_ack_event.set()
                     cancel_requested.wait(0.05)
                     continue
+                stdin_yield_ack_event.clear()
                 try:
-                    ready, _, _ = select.select([sys.stdin.fileno()], [], [], 0.5)
+                    read_fds = [stdin_fd]
+                    if stdin_wakeup_read is not None:
+                        read_fds.append(stdin_wakeup_read)
+                    ready, _, _ = select.select(read_fds, [], [], 0.5)
                     if not ready:
                         continue
-                    data = os.read(sys.stdin.fileno(), 1)
+                    if stdin_wakeup_read is not None and stdin_wakeup_read in ready:
+                        _drain_wakeup_pipe()
+                        continue
+                    if stdin_yield_event.is_set():
+                        continue
+                    data = os.read(stdin_fd, 1)
                     if not data:  # EOF — stdin closed
                         break
                     if data == b"\x03":  # Ctrl+C — cancel AI operation
@@ -425,8 +492,10 @@ class AIHandler:
             shell.handle_processing_cancelled()
         finally:
             cancel_requested.set()
+            _wake_stdin_monitor()
             # Clear yield event so _stdin_loop doesn't block forever.
             stdin_yield_event.clear()
+            stdin_yield_ack_event.clear()
             if bash_tool is not None:
                 bash_tool.stdin_yield_event = None
             monitor_thread.join(timeout=1.0)
@@ -436,6 +505,16 @@ class AIHandler:
                 logging.getLogger(__name__).warning(
                     "stdin monitor thread did not exit in time"
                 )
+            for fd in (stdin_wakeup_read, stdin_wakeup_write):
+                if fd is None:
+                    continue
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            shell._stdin_yield_event = None
+            shell._stdin_yield_ack_event = None
+            shell._wake_stdin_monitor = None
             # Flush stale input (escape sequences, cursor reports) so they
             # don't confuse the next prompt_toolkit render.
             try:

--- a/src/aish/shell/ui/prompt_io.py
+++ b/src/aish/shell/ui/prompt_io.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 import sys
 import termios
 import threading
@@ -364,6 +365,39 @@ def _prepare_interaction_prompt(shell: Any) -> None:
         finally:
             self.current_live = None
     self._finalize_content_preview()
+
+
+@contextmanager
+def _pause_ai_stdin_monitor(shell: Any):
+    stdin_yield_event = getattr(shell, "_stdin_yield_event", None)
+    if stdin_yield_event is None:
+        yield
+        return
+
+    stdin_yield_ack_event = getattr(shell, "_stdin_yield_ack_event", None)
+    wake_stdin_monitor = getattr(shell, "_wake_stdin_monitor", None)
+
+    stdin_yield_event.set()
+    if callable(wake_stdin_monitor):
+        try:
+            wake_stdin_monitor()
+        except Exception:
+            pass
+    if stdin_yield_ack_event is not None:
+        try:
+            stdin_yield_ack_event.wait(timeout=1.0)
+        except Exception:
+            pass
+
+    try:
+        yield
+    finally:
+        stdin_yield_event.clear()
+        if callable(wake_stdin_monitor):
+            try:
+                wake_stdin_monitor()
+            except Exception:
+                pass
 
 
 def _build_interaction_response(
@@ -950,7 +984,8 @@ def handle_interaction_required(shell: Any, event: LLMEvent) -> LLMCallbackResul
         return LLMCallbackResult.CONTINUE
     request = InteractionRequest.from_dict(request_payload)
     _prepare_interaction_prompt(shell)
-    response = render_interaction_modal(shell, request)
+    with _pause_ai_stdin_monitor(shell):
+        response = render_interaction_modal(shell, request)
 
     try:
         apply_interaction_response_to_data(data, response)

--- a/tests/shell/runtime/test_shell_pty_core.py
+++ b/tests/shell/runtime/test_shell_pty_core.py
@@ -176,6 +176,29 @@ def test_ai_handler_marks_cancelled_operation_and_notifies_shell():
     shell.handle_processing_cancelled.assert_called_once_with()
 
 
+def test_ai_handler_exposes_and_cleans_stdin_yield_controls():
+    handler, shell = _make_ai_handler()
+    dummy_coro = Mock()
+
+    def _capture_shell_state(coro, cancellation_token=None):
+        _ = cancellation_token
+        assert coro is dummy_coro
+        assert shell._stdin_yield_event is not None
+        assert shell._stdin_yield_ack_event is not None
+        assert callable(shell._wake_stdin_monitor)
+        return "ok"
+
+    handler._run_async_in_thread = Mock(side_effect=_capture_shell_state)
+
+    response, was_cancelled = handler._execute_ai_operation(dummy_coro, shell)
+
+    assert response == "ok"
+    assert was_cancelled is False
+    assert shell._stdin_yield_event is None
+    assert shell._stdin_yield_ack_event is None
+    assert shell._wake_stdin_monitor is None
+
+
 def test_ai_handler_auto_retain_persists_explicit_fact():
     handler, shell = _make_ai_handler()
     shell.memory_manager = Mock()

--- a/tests/shell/ui/test_shell_prompt_io.py
+++ b/tests/shell/ui/test_shell_prompt_io.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import termios
+import threading
 import time
 import pytest
 from unittest.mock import patch
@@ -10,6 +11,10 @@ from rich.console import Console
 
 from aish.plan.approval import PlanApprovalRequestBuilder
 from aish.terminal.interaction import AskUserRequestBuilder
+from aish.terminal.interaction import InteractionAnswer
+from aish.terminal.interaction import InteractionAnswerType
+from aish.terminal.interaction import InteractionResponse
+from aish.terminal.interaction import InteractionStatus
 from aish.llm import LLMCallbackResult, LLMEvent, LLMEventType
 from aish.shell.ui.prompt_io import (
     display_security_panel,
@@ -250,6 +255,60 @@ def test_handle_interaction_required_prefills_text_input_default():
     assert isinstance(response_payload, dict)
     assert response_payload.get("interaction_id") == request.id
     assert response_payload.get("answer", {}).get("value") == "kiwi"
+
+
+def test_handle_interaction_required_yields_stdin_monitor_while_modal_is_open():
+    shell = _DummyShell()
+    shell._stdin_yield_event = threading.Event()
+    shell._stdin_yield_ack_event = threading.Event()
+    wake_calls: list[str] = []
+
+    def _wake_stdin_monitor() -> None:
+        wake_calls.append("wake")
+        shell._stdin_yield_ack_event.set()
+
+    shell._wake_stdin_monitor = _wake_stdin_monitor
+    request = AskUserRequestBuilder.from_tool_args(
+        kind="choice_or_text",
+        prompt="Pick one",
+        options=[
+            {"value": "opt1", "label": "Option 1"},
+            {"value": "opt2", "label": "Option 2"},
+        ],
+        default="opt1",
+    )
+    event = LLMEvent(
+        event_type=LLMEventType.INTERACTION_REQUIRED,
+        data={"interaction_request": request.to_dict()},
+        timestamp=time.time(),
+    )
+
+    def _fake_render_interaction_modal(shell_obj, request_obj):
+        assert shell_obj is shell
+        assert request_obj.id == request.id
+        assert shell._stdin_yield_event.is_set() is True
+        return InteractionResponse(
+            interaction_id=request.id,
+            status=InteractionStatus.SUBMITTED,
+            answer=InteractionAnswer(
+                type=InteractionAnswerType.OPTION,
+                value="opt2",
+                label="Option 2",
+            ),
+        )
+
+    with patch(
+        "aish.shell.ui.prompt_io.render_interaction_modal",
+        side_effect=_fake_render_interaction_modal,
+    ):
+        result = handle_interaction_required(shell, event)
+
+    assert result == LLMCallbackResult.CONTINUE
+    assert shell._stdin_yield_event.is_set() is False
+    assert len(wake_calls) == 2
+    response_payload = event.data.get("interaction_response")
+    assert isinstance(response_payload, dict)
+    assert response_payload.get("answer", {}).get("value") == "opt2"
 
 
 @pytest.mark.timeout(5)


### PR DESCRIPTION
## Background

During an `ask_user` interaction, the AI stdin monitor thread remained active and competed with the prompt_toolkit modal for terminal input. Multi-byte escape sequences such as arrow keys could be partially consumed by the monitor, which led to artifacts like `[B` appearing in the custom input field and caused lost leading characters for normal text input.

## Changes

- add yield, ack, and wakeup controls for the AI stdin monitor in the shell runtime
- pause the monitor before showing the `ask_user` modal and resume it after the interaction completes
- add tests for the stdin-yield lifecycle and the interaction handoff behavior

## Validation

- `uv run pytest tests/shell/runtime/test_shell_pty_core.py tests/shell/ui/test_shell_prompt_io.py -q`

## Risk

This change is scoped to the stdin handoff between AI streaming and interactive UI. It does not redesign the broader monitor architecture, so the behavior change should stay local to AI-driven interaction flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Ctrl+C/Ctrl+Z interrupt signal handling coordination with PTY-based tools for more reliable signal processing.
  * Enhanced interactive modal handling to prevent background monitoring interference during user interactions.

* **Tests**
  * Added test coverage for stdin control lifecycle management during AI operations.
  * Added test coverage for interactive modal coordination with background monitoring.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/174)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->