### PR TITLE
Fix cancelling in-flight LLM operations

### DIFF
--- a/src/aish/llm/session.py
+++ b/src/aish/llm/session.py
@@ -1774,14 +1774,14 @@ class LLMSession:
                         else:
                             msg = response["choices"][0]["message"]  # type: ignore
                             finish_reason = response["choices"][0]["finish_reason"]  # type: ignore
-                except TimeoutError:
+                except TimeoutError as err:
                     if (
                         self.cancellation_token
                         and self.cancellation_token.is_cancelled()
                     ):
                         events.emit_cancelled("llm_cancelled")
                         events.emit_generation_end(status="cancelled")
-                        raise anyio.get_cancelled_exc_class()
+                        raise anyio.get_cancelled_exc_class() from err
                     events.emit_generation_end(status="timeout")
                     output = "LLM request timed out"
                     break
@@ -2016,11 +2016,11 @@ class LLMSession:
             events.emit_cancelled("llm_cancelled")
             events.emit_generation_end(status="cancelled")
             raise
-        except TimeoutError:
+        except TimeoutError as err:
             if self.cancellation_token and self.cancellation_token.is_cancelled():
                 events.emit_cancelled("llm_cancelled")
                 events.emit_generation_end(status="cancelled")
-                raise anyio.get_cancelled_exc_class()
+                raise anyio.get_cancelled_exc_class() from err
             result = "LLM request timed out"
             events.emit_generation_end(status="timeout")
         except Exception as e:

--- a/src/aish/llm/session.py
+++ b/src/aish/llm/session.py
@@ -1775,6 +1775,13 @@ class LLMSession:
                             msg = response["choices"][0]["message"]  # type: ignore
                             finish_reason = response["choices"][0]["finish_reason"]  # type: ignore
                 except TimeoutError:
+                    if (
+                        self.cancellation_token
+                        and self.cancellation_token.is_cancelled()
+                    ):
+                        events.emit_cancelled("llm_cancelled")
+                        events.emit_generation_end(status="cancelled")
+                        raise anyio.get_cancelled_exc_class()
                     events.emit_cancelled("llm_timeout")
                     events.emit_generation_end(status="timeout")
                     output = "LLM request timed out"
@@ -2011,6 +2018,10 @@ class LLMSession:
             events.emit_generation_end(status="cancelled")
             raise
         except TimeoutError:
+            if self.cancellation_token and self.cancellation_token.is_cancelled():
+                events.emit_cancelled("llm_cancelled")
+                events.emit_generation_end(status="cancelled")
+                raise anyio.get_cancelled_exc_class()
             result = "LLM request timed out"
             events.emit_cancelled("llm_timeout")
             events.emit_generation_end(status="timeout")

--- a/src/aish/llm/session.py
+++ b/src/aish/llm/session.py
@@ -1782,7 +1782,6 @@ class LLMSession:
                         events.emit_cancelled("llm_cancelled")
                         events.emit_generation_end(status="cancelled")
                         raise anyio.get_cancelled_exc_class()
-                    events.emit_cancelled("llm_timeout")
                     events.emit_generation_end(status="timeout")
                     output = "LLM request timed out"
                     break
@@ -2023,7 +2022,6 @@ class LLMSession:
                 events.emit_generation_end(status="cancelled")
                 raise anyio.get_cancelled_exc_class()
             result = "LLM request timed out"
-            events.emit_cancelled("llm_timeout")
             events.emit_generation_end(status="timeout")
         except Exception as e:
             if isinstance(e, Exception) and is_litellm_exception(e):

--- a/src/aish/shell/runtime/ai.py
+++ b/src/aish/shell/runtime/ai.py
@@ -130,7 +130,9 @@ class AIHandler:
     def _run_async_in_thread(coro, cancellation_token=None) -> Any:
         """Run an async coroutine in a separate thread with its own event loop.
 
-        Uses polling-based cancellation to allow Ctrl+C interruption.
+        Uses polling-based cancellation to allow Ctrl+C interruption, and
+        forwards cancellation into the event loop so in-flight HTTP requests
+        do not keep running in the background until their timeout expires.
         """
         from concurrent.futures import (
             ThreadPoolExecutor,
@@ -139,20 +141,38 @@ class AIHandler:
 
         result_box: list[Optional[str]] = [None]
         exc_box: list[BaseException | None] = [None]
+        loop_ready = threading.Event()
+        loop_box: list[asyncio.AbstractEventLoop | None] = [None]
+        task_box: list[asyncio.Task | None] = [None]
 
         def run_in_thread() -> None:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
+            loop_box[0] = loop
             try:
-                result_box[0] = loop.run_until_complete(coro)
+                task = loop.create_task(coro)
+                task_box[0] = task
+                loop_ready.set()
+                result_box[0] = loop.run_until_complete(task)
             except BaseException as e:
                 exc_box[0] = e
             finally:
+                loop_ready.set()
                 AIHandler._shutdown_loop(loop)
                 loop.close()
+                loop_box[0] = None
+                task_box[0] = None
 
         pool = ThreadPoolExecutor(max_workers=1)
         future = pool.submit(run_in_thread)
+
+        def _cancel_running_task() -> None:
+            loop = loop_box[0]
+            task = task_box[0]
+            if loop is None or task is None or task.done() or loop.is_closed():
+                return
+            loop.call_soon_threadsafe(task.cancel)
+
         try:
             while not future.done():
                 try:
@@ -160,6 +180,12 @@ class AIHandler:
                 except FutureTimeoutError:
                     # Check if cancellation was requested
                     if cancellation_token and cancellation_token.is_cancelled():
+                        if loop_ready.wait(timeout=0.2):
+                            _cancel_running_task()
+                        try:
+                            future.result(timeout=2.0)
+                        except FutureTimeoutError:
+                            pass
                         raise KeyboardInterrupt("AI operation cancelled by user")
         finally:
             pool.shutdown(wait=False)

--- a/tests/llm/test_llm_events.py
+++ b/tests/llm/test_llm_events.py
@@ -242,3 +242,79 @@ async def test_process_input_litellm_error_uses_raw_message():
         text = str(details)
         assert "THIS_SHOULD_NOT_LEAK" not in text
         assert "sk-THIS_SHOULD_NOT_LEAK" not in text
+
+
+@pytest.mark.anyio
+async def test_process_input_timeout_is_not_reported_as_cancellation():
+    config = ConfigModel(model="test-model", api_key="test-key")
+    session = LLMSession(config=config, skill_manager=SkillManager())
+
+    events = []
+
+    def event_callback(event):
+        events.append(event)
+        return LLMCallbackResult.CONTINUE
+
+    session.event_callback = event_callback
+
+    async def fake_acompletion(**kwargs):
+        raise TimeoutError("request timed out")
+
+    context_manager = ContextManager()
+
+    with (
+        patch.object(session, "_get_acompletion", return_value=fake_acompletion),
+        patch.object(session, "_trim_messages", side_effect=lambda msgs: msgs),
+        patch.object(session, "_get_tools_spec", return_value=[]),
+    ):
+        result = await session.process_input(
+            prompt="hi",
+            context_manager=context_manager,
+            system_message="sys",
+        )
+
+    assert result == "LLM request timed out"
+    event_types = [event.event_type for event in events]
+    assert event_types == [
+        LLMEventType.OP_START,
+        LLMEventType.GENERATION_START,
+        LLMEventType.GENERATION_END,
+        LLMEventType.OP_END,
+    ]
+    assert events[2].data.get("status") == "timeout"
+    assert events[-1].data.get("cancelled") is False
+    assert events[-1].data.get("cancelled_reason") is None
+
+
+@pytest.mark.anyio
+async def test_completion_timeout_is_not_reported_as_cancellation():
+    config = ConfigModel(model="test-model", api_key="test-key")
+    session = LLMSession(config=config, skill_manager=SkillManager())
+
+    events = []
+
+    def event_callback(event):
+        events.append(event)
+        return LLMCallbackResult.CONTINUE
+
+    session.event_callback = event_callback
+
+    async def fake_acompletion(**kwargs):
+        raise TimeoutError("request timed out")
+
+    with patch.object(session, "_get_acompletion", return_value=fake_acompletion):
+        result = await session.completion(
+            prompt="hi", system_message="sys", stream=False
+        )
+
+    assert result == "LLM request timed out"
+    event_types = [event.event_type for event in events]
+    assert event_types == [
+        LLMEventType.OP_START,
+        LLMEventType.GENERATION_START,
+        LLMEventType.GENERATION_END,
+        LLMEventType.OP_END,
+    ]
+    assert events[2].data.get("status") == "timeout"
+    assert events[-1].data.get("cancelled") is False
+    assert events[-1].data.get("cancelled_reason") is None

--- a/tests/shell/runtime/test_shell_pty_core.py
+++ b/tests/shell/runtime/test_shell_pty_core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import asyncio
 import threading
 from types import SimpleNamespace
 
@@ -10,6 +11,7 @@ import pytest
 from unittest.mock import Mock
 from unittest.mock import call
 
+from aish.state.cancellation import CancellationToken
 from aish.memory.config import MemoryConfig
 from aish.memory.models import MemoryCategory
 from aish.i18n import t
@@ -174,6 +176,39 @@ def test_ai_handler_marks_cancelled_operation_and_notifies_shell():
     assert response is None
     assert was_cancelled is True
     shell.handle_processing_cancelled.assert_called_once_with()
+
+
+@pytest.mark.timeout(5)
+def test_run_async_in_thread_cancels_running_coroutine():
+    token = CancellationToken()
+    started = threading.Event()
+    cleaned_up = threading.Event()
+    error_box: list[BaseException | None] = [None]
+
+    async def _hang_until_cancelled():
+        started.set()
+        try:
+            while True:
+                await asyncio.sleep(1)
+        finally:
+            cleaned_up.set()
+
+    def _run() -> None:
+        try:
+            AIHandler._run_async_in_thread(_hang_until_cancelled(), token)
+        except BaseException as exc:
+            error_box[0] = exc
+
+    thread = threading.Thread(target=_run)
+    thread.start()
+
+    assert started.wait(timeout=1)
+    token.cancel()
+    thread.join(timeout=3)
+
+    assert not thread.is_alive()
+    assert isinstance(error_box[0], KeyboardInterrupt)
+    assert cleaned_up.wait(timeout=1)
 
 
 def test_ai_handler_auto_retain_persists_explicit_fact():


### PR DESCRIPTION
## Summary

  - Problem: 用户按 `Ctrl+C` 取消 AI 请求后，底层 LLM 请求有时仍会在后台继续运行，之后超时时又打印 `LLM request timed out`，容易让用户误以为是网络问题或取消没有生效。
  - Changes: 将取消信号传入实际执行 LLM 请求的异步任务；如果请求已被用户取消，后续 timeout 按取消处理，不再显示成 LLM 超时；补充取消行为的回归测试。
  - Related Issue: #

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Other

## Scope

- [x] Core shell / PTY
- [x] AI agent / LLM
- [ ] Skills / Tools
- [ ] Security
- [ ] Configuration
- [ ] CLI / Interface
- [ ] Packaging / Installation
- [ ] CI/CD
- [ ] Documentation

## User-visible Changes

  - 用户按 `Ctrl+C` 取消 AI 请求后，已取消的旧请求不会再延迟打印 `LLM request timed out`。
  - 不改变工具执行中断时允许当前任务收尾的行为。
  - 真实的 LLM 请求超时仍会按原有逻辑提示。
-

## Compatibility

- Backward compatible? Yes
- Config changes? No 

## Testing

  - `uv --native-tls run --group dev python -m pytest tests/shell/runtime/test_shell_pty_core.py -q`
    - Result: `69 passed`
  - `uv --native-tls run --group dev ruff check src/aish/shell/runtime/ai.py src/aish/llm/session.py tests/shell/runtime/test_shell_pty_core.py`
  - `python3 -m compileall -q src/aish/shell/runtime/ai.py src/aish/llm/session.py tests/shell/runtime/test_shell_pty_core.py`
  - `git diff --check`

  Additional related test run:

  - `uv --native-tls run --group dev python -m pytest tests/llm tests/tools/test_final_answer.py tests/test_ask_user_tool.py -q`
    - Result: `74 passed, 1 skipped, 1 failed`
    - Failed test: `tests/llm/test_litellm_langfuse.py::testshell_integration`
    - Note: this is a live LLM integration test. The API call completed but returned an empty response, which appears unrelated to this cancellation change.


## Checklist
  - [x] Code follows project style
  - [x] Tests added if needed
  - [  ] Documentation updated if needed
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling for AI operations: cancels running work promptly, emits cancellation events when appropriate, and avoids misreporting timeouts.

* **Tests**
  * Added tests verifying coroutine cancellation behavior and that timeout vs cancellation produce the correct event flow and responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/175)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->