### PR TITLE
fix: switch update prerelease flow to beta channel

### DIFF
--- a/src/aish/cli/__init__.py
+++ b/src/aish/cli/__init__.py
@@ -427,11 +427,10 @@ def update(
         "-c",
         help=t("cli.update.check_only"),
     ),
-    pre_release: bool = typer.Option(
+    beta: bool = typer.Option(
         False,
-        "--pre-release",
-        "-p",
-        help=t("cli.update.pre_release"),
+        "--beta",
+        help=t("cli.update.beta"),
     ),
 ):
     """Update aish to the latest version."""
@@ -439,7 +438,7 @@ def update(
         # Check for updates
         console.print(f"[bold cyan]{t('cli.update.checking')}[/bold cyan]")
         try:
-            update_info = manager.check_for_updates(include_pre_release=pre_release)
+            update_info = manager.check_for_updates(beta=beta)
         except UpdateCheckError as e:
             console.print(f"[red]Update check failed: {e}[/red]")
             raise typer.Exit(1)
@@ -464,7 +463,7 @@ def update(
             return
 
         # Download
-        archive_path = manager.download_release(update_info["tag_name"])
+        archive_path = manager.download_release(update_info["tag_name"], beta=beta)
         if not archive_path:
             console.print(f"[red]{t('cli.update.download_failed')}[/red]")
             raise typer.Exit(1)

--- a/src/aish/cli/update_manager.py
+++ b/src/aish/cli/update_manager.py
@@ -37,7 +37,6 @@ class UpdateCheckError(Exception):
 DEFAULT_DOWNLOAD_BASE_URL = "https://cdn.aishell.ai/download"
 GITHUB_RELEASES_PAGE_BASE = "https://github.com/AI-Shell-Team/aish/releases"
 GITHUB_API_LATEST = "https://api.github.com/repos/AI-Shell-Team/aish/releases/latest"
-GITHUB_API_LIST = "https://api.github.com/repos/AI-Shell-Team/aish/releases"
 GITHUB_API_RELEASE_TAG = (
     "https://api.github.com/repos/AI-Shell-Team/aish/releases/tags/{tag}"
 )
@@ -70,27 +69,44 @@ class UpdateManager:
         """
         return CURRENT_VERSION
 
-    def get_download_base_url(self) -> str:
-        """Resolve bundle download base URL.
+    def get_download_base_url(self, beta: bool = False) -> str:
+        """Resolve bundle download base URL for the selected channel.
 
         Mirrors the standalone installer environment variables.
         """
-        return os.getenv(
+        stable_base_url = os.getenv(
             "AISH_DOWNLOAD_BASE_URL",
             os.getenv("AISH_REPO_URL", DEFAULT_DOWNLOAD_BASE_URL),
         ).rstrip("/")
+        if beta:
+            return os.getenv(
+                "AISH_BETA_DOWNLOAD_BASE_URL",
+                f"{stable_base_url}/beta",
+            ).rstrip("/")
+        return stable_base_url
 
-    def get_latest_version_url(self) -> str:
-        """Resolve the stable latest-version metadata URL."""
+    def get_latest_version_url(self, beta: bool = False) -> str:
+        """Resolve the latest-version metadata URL for the selected channel."""
+        if beta:
+            return os.getenv(
+                "AISH_BETA_LATEST_URL",
+                f"{self.get_download_base_url(beta=True)}/latest",
+            ).rstrip("/")
+
         return os.getenv(
             "AISH_LATEST_URL",
             f"{self.get_download_base_url()}/latest",
-        )
+        ).rstrip("/")
 
-    def get_release_download_url(self, tag_name: str, filename: str) -> str:
+    def get_release_download_url(
+        self, tag_name: str, filename: str, beta: bool = False
+    ) -> str:
         """Resolve the CDN URL for a versioned release artifact."""
         version_str = tag_name.lstrip("v")
-        return f"{self.get_download_base_url()}/releases/{version_str}/{filename}"
+        return (
+            f"{self.get_download_base_url(beta=beta)}/releases/"
+            f"{version_str}/{filename}"
+        )
 
     def get_release_by_tag(self, tag_name: str) -> dict:
         """Fetch trusted GitHub release metadata for a tag."""
@@ -136,11 +152,11 @@ class UpdateManager:
 
         return plat, arch
 
-    def get_latest_release(self, include_pre_release: bool = False) -> Optional[dict]:
+    def get_latest_release(self, beta: bool = False) -> Optional[dict]:
         """Get latest release information.
 
         Args:
-            include_pre_release: Whether to include pre-releases.
+            beta: Whether to use the beta update channel.
 
         Returns:
             Dictionary with release info or None if failed. Keys:
@@ -151,40 +167,20 @@ class UpdateManager:
             - assets: List of asset dictionaries
         """
         try:
-            if include_pre_release:
-                # /releases/latest excludes pre-releases, use list endpoint instead
-                response = self.client.get(GITHUB_API_LIST)
-                response.raise_for_status()
-                releases = response.json()
-                if not releases:
-                    return None
-                data = releases[0]
-                tag_name = data.get("tag_name")
-                if not tag_name:
-                    return None
+            response = self.client.get(self.get_latest_version_url(beta=beta))
+            response.raise_for_status()
+            tag_name = self.normalize_tag(response.text)
+            data = self.get_release_by_tag(tag_name)
 
-                return {
-                    "tag_name": tag_name,
-                    "name": data.get("name"),
-                    "body": data.get("body"),
-                    "html_url": data.get("html_url"),
-                    "assets": data.get("assets", []),
-                }
-            else:
-                response = self.client.get(self.get_latest_version_url())
-                response.raise_for_status()
-                tag_name = self.normalize_tag(response.text)
-                data = self.get_release_by_tag(tag_name)
-
-                return {
-                    "tag_name": tag_name,
-                    "name": data.get("name", tag_name),
-                    "body": data.get("body", ""),
-                    "html_url": data.get(
-                        "html_url", f"{GITHUB_RELEASES_PAGE_BASE}/tag/{tag_name}"
-                    ),
-                    "assets": data.get("assets", []),
-                }
+            return {
+                "tag_name": tag_name,
+                "name": data.get("name", tag_name),
+                "body": data.get("body", ""),
+                "html_url": data.get(
+                    "html_url", f"{GITHUB_RELEASES_PAGE_BASE}/tag/{tag_name}"
+                ),
+                "assets": data.get("assets", []),
+            }
         except UpdateCheckError:
             raise
         except httpx.HTTPError as e:
@@ -196,11 +192,11 @@ class UpdateManager:
                 f"Unexpected error while checking for updates: {e}"
             ) from e
 
-    def check_for_updates(self, include_pre_release: bool = False) -> Optional[dict]:
+    def check_for_updates(self, beta: bool = False) -> Optional[dict]:
         """Check if there's a newer version available.
 
         Args:
-            include_pre_release: Whether to include pre-releases.
+            beta: Whether to use the beta update channel.
 
         Returns:
             Dictionary with update info if update available, None otherwise.
@@ -214,7 +210,7 @@ class UpdateManager:
         current = self.get_current_version()
         # get_latest_release() raises UpdateCheckError on network/API failures;
         # None is only returned for legitimate "no data" cases (empty list, missing tag)
-        release_info = self.get_latest_release(include_pre_release)
+        release_info = self.get_latest_release(beta=beta)
 
         if release_info is None:
             return None
@@ -346,13 +342,14 @@ class UpdateManager:
         return True
 
     def download_release(
-        self, tag_name: str, dest_dir: Optional[Path] = None
+        self, tag_name: str, dest_dir: Optional[Path] = None, beta: bool = False
     ) -> Optional[Path]:
         """Download release archive for current platform.
 
         Args:
             tag_name: Version tag (e.g., "v0.3.0")
             dest_dir: Destination directory. Uses temp dir if None.
+            beta: Whether to use the beta update channel.
 
         Returns:
             Path to downloaded archive or None if failed.
@@ -366,7 +363,7 @@ class UpdateManager:
         version_str = tag_name.lstrip("v")
         filename = f"aish-{version_str}-{plat}-{arch}.tar.gz"
         dest_path = dest_dir / filename
-        download_url = self.get_release_download_url(tag_name, filename)
+        download_url = self.get_release_download_url(tag_name, filename, beta=beta)
 
         try:
             self._download_with_progress(download_url, dest_path, filename)

--- a/src/aish/i18n/en-US.yaml
+++ b/src/aish/i18n/en-US.yaml
@@ -11,7 +11,7 @@ cli:
 
   update:
     check_only: "Only check for updates, do not install"
-    pre_release: "Include pre-release versions"
+    beta: "Use the beta update channel"
     checking: "Checking for updates..."
     current_version: "Current version: {version}"
     latest_version: "Latest version: {version}"

--- a/src/aish/i18n/zh-CN.yaml
+++ b/src/aish/i18n/zh-CN.yaml
@@ -11,7 +11,7 @@ cli:
 
   update:
     check_only: "仅检查更新，不执行安装"
-    pre_release: "包括预发布版本"
+    beta: "使用 beta 更新通道"
     checking: "正在检查更新..."
     current_version: "当前版本: {version}"
     latest_version: "最新版本: {version}"

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -270,30 +270,60 @@ def test_install_release_success(mock_tarfile, mock_run, update_manager, tmp_pat
 
 @pytest.mark.timeout(5)
 @patch("aish.cli.update_manager.httpx.Client")
-def test_get_latest_release_with_pre_release(mock_client_class, update_manager):
-    """Test fetching pre-release uses list endpoint."""
-    pre_release_response = [
-        {
-            "tag_name": "v0.4.0-beta",
-            "name": "v0.4.0-beta",
-            "body": "Beta release",
-            "html_url": "https://example.com",
-            "assets": [],
-            "prerelease": True,
-        }
-    ]
-    mock_response = Mock()
-    mock_response.raise_for_status = Mock()
-    mock_response.json = Mock(return_value=pre_release_response)
+def test_get_latest_release_with_beta(mock_client_class, update_manager):
+    """Test fetching beta release uses beta CDN latest metadata."""
+    mock_response = make_response(text="0.4.0-beta.2\n")
+    release_response = make_release_response(
+        tag_name="v0.4.0-beta.2",
+        body="Beta release",
+    )
     mock_client_instance = mock_client_class.return_value
-    mock_client_instance.get = Mock(return_value=mock_response)
+    mock_client_instance.get = Mock(side_effect=[mock_response, release_response])
 
     with patch.object(update_manager, "client", mock_client_instance):
-        result = update_manager.get_latest_release(include_pre_release=True)
+        result = update_manager.get_latest_release(beta=True)
 
     assert result is not None
-    assert result["tag_name"] == "v0.4.0-beta"
-    # Should have called the list endpoint, not the latest endpoint
-    call_args = mock_client_instance.get.call_args[0][0]
-    assert "releases" in call_args
-    assert "latest" not in call_args
+    assert result["tag_name"] == "v0.4.0-beta.2"
+    assert mock_client_instance.get.call_args_list[0][0][0].endswith("/beta/latest")
+    assert mock_client_instance.get.call_args_list[1][0][0].endswith(
+        "/releases/tags/v0.4.0-beta.2"
+    )
+
+
+@pytest.mark.timeout(5)
+@patch("aish.cli.update_manager.httpx.Client")
+def test_download_beta_release_uses_beta_download_path(
+    mock_client_class, update_manager, tmp_path
+):
+    """Test beta channel download uses the beta CDN release path."""
+    data = b"test data"
+    archive_sha256 = hashlib.sha256(data).hexdigest()
+    filename = "aish-0.3.0-beta.2-linux-amd64.tar.gz"
+    mock_response = Mock()
+    mock_response.raise_for_status = Mock()
+    mock_response.iter_bytes = Mock(return_value=[data])
+    mock_response.headers = {"content-length": "9"}
+    mock_cm = Mock()
+    mock_cm.__enter__ = Mock(return_value=mock_response)
+    mock_cm.__exit__ = Mock(return_value=False)
+    release_response = make_release_response(
+        tag_name="v0.3.0-beta.2",
+        assets=[{"name": filename, "digest": f"sha256:{archive_sha256}"}],
+    )
+    mock_client_instance = mock_client_class.return_value
+    mock_client_instance.stream = Mock(return_value=mock_cm)
+    mock_client_instance.get = Mock(return_value=release_response)
+
+    with patch.object(update_manager, "client", mock_client_instance):
+        result = update_manager.download_release(
+            "v0.3.0-beta.2", dest_dir=tmp_path, beta=True
+        )
+
+    assert result is not None
+    assert result.name == filename
+    stream_url = mock_client_instance.stream.call_args[0][1]
+    assert (
+        stream_url
+        == "https://cdn.aishell.ai/download/beta/releases/0.3.0-beta.2/aish-0.3.0-beta.2-linux-amd64.tar.gz"
+    )


### PR DESCRIPTION
## Background

The Python update command still used a pre-release flag and GitHub release listing logic, but beta builds are now published to the dedicated beta CDN channel.

## Changes

- replace the `--pre-release` update flag with `--beta`
- resolve beta latest metadata and release downloads from the beta CDN path
- update localized CLI help text and update-manager tests for the beta channel

## Validation

- `pytest tests/test_update_manager.py`

## Risk

- limited to the Python self-update flow and related copy/tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced dedicated beta release channels for the update command with separate artifact delivery.
  * Replaced `--pre-release` option with `--beta` in the update command for streamlined beta release access.

* **Localization**
  * Added beta channel option translations for English and Chinese.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/176)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->