### PR TITLE
fix: install bundle systemd units under /etc

### DIFF
--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -115,6 +115,8 @@ jobs:
           test -x "$INSTALL_ROOT/usr/local/bin/aish"
           test -x "$INSTALL_ROOT/usr/local/bin/aish-sandbox"
           test -f "$INSTALL_ROOT/etc/aish/security_policy.yaml"
+          test -f "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.service"
+          test -f "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.socket"
 
       - name: Upload dry-run artifacts
         uses: actions/upload-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,8 @@ jobs:
           test -x "$INSTALL_ROOT/usr/local/bin/aish"
           test -x "$INSTALL_ROOT/usr/local/bin/aish-sandbox"
           test -f "$INSTALL_ROOT/etc/aish/security_policy.yaml"
+          test -f "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.service"
+          test -f "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.socket"
 
       - name: Upload assets to release
         uses: softprops/action-gh-release@v2

--- a/packaging/scripts/install-bundle.sh
+++ b/packaging/scripts/install-bundle.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOTFS_DIR="${SCRIPT_DIR}/rootfs"
 SYSTEMD_DIR="${SCRIPT_DIR}/systemd"
 MIN_GLIBC_VERSION="2.28"
+BUNDLE_SYSTEMD_UNITDIR="/etc/systemd/system"
 FORCE_CONFIG_OVERWRITE=0
 INSTALL_ROOT="${AISH_INSTALL_ROOT:-}"
 INSTALL_PREFIX=""
@@ -134,7 +135,7 @@ install_systemd_units() {
 		return
 	fi
 
-	local unit_dir="/lib/systemd/system"
+	local unit_dir="$BUNDLE_SYSTEMD_UNITDIR"
 	local service_target socket_target
 	service_target="$(target_path "${unit_dir}/aish-sandbox.service")"
 	socket_target="$(target_path "${unit_dir}/aish-sandbox.socket")"

--- a/packaging/scripts/uninstall-bundle.sh
+++ b/packaging/scripts/uninstall-bundle.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 PURGE_CONFIG=0
+BUNDLE_SYSTEMD_UNITDIR="/etc/systemd/system"
 INSTALL_ROOT="${AISH_INSTALL_ROOT:-}"
 INSTALL_PREFIX=""
 SKIP_SYSTEMD="${AISH_SKIP_SYSTEMD:-0}"
@@ -50,8 +51,8 @@ remove_systemd_units() {
 	fi
 
 	rm -f \
-		"$(target_path "/lib/systemd/system/aish-sandbox.service")" \
-		"$(target_path "/lib/systemd/system/aish-sandbox.socket")"
+		"$(target_path "${BUNDLE_SYSTEMD_UNITDIR}/aish-sandbox.service")" \
+		"$(target_path "${BUNDLE_SYSTEMD_UNITDIR}/aish-sandbox.socket")"
 
 	if [[ -z "$INSTALL_ROOT" && "$SKIP_SYSTEMD" != "1" && -d /run/systemd/system ]] && command -v systemctl >/dev/null 2>&1; then
 		systemctl daemon-reload >/dev/null 2>&1 || true


### PR DESCRIPTION
## Background

The Rust beta bundle installer wrote systemd units to `/lib/systemd/system`, which fails on systems where that path is read-only during archive installs and beta self-update.

## Changes

- install and remove bundle-managed systemd units under `/etc/systemd/system`
- keep bundle uninstall logic aligned with the installer path
- update release workflow staging assertions to match the bundle install location

## Validation

- staged bundle install/uninstall with `AISH_INSTALL_ROOT` and `AISH_SKIP_SYSTEMD=1`

## Risk

- limited to the Rust bundle installer, bundle uninstall script, and release workflow assertions
