### PR TITLE
fix: align systemd unitdir paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SYSCONFDIR ?= /etc
 SHAREDIR ?= $(PREFIX)/share
 DATADIR ?= $(SHAREDIR)/aish
 DOCDIR ?= $(SHAREDIR)/doc/aish
-SYSTEMD_UNITDIR ?= /lib/systemd/system
+SYSTEMD_UNITDIR ?= /etc/systemd/system
 DESTDIR ?=
 
 TARGET ?= x86_64-unknown-linux-musl

--- a/crates/aish-cli/src/uninstall.rs
+++ b/crates/aish-cli/src/uninstall.rs
@@ -15,7 +15,7 @@ const ARCHIVE_BIN_DIR: &str = "/usr/local/bin";
 const ARCHIVE_BINARY_NAMES: &[&str] = &["aish", "aish-uninstall"];
 const ARCHIVE_SHARE_DIR: &str = "/usr/local/share/aish";
 const SYSTEM_CONFIG_DIR: &str = "/etc/aish";
-const SYSTEMD_UNIT_DIR: &str = "/lib/systemd/system";
+const SYSTEMD_UNIT_DIR: &str = "/etc/systemd/system";
 
 // ---------------------------------------------------------------------------
 // Installation method detection

--- a/debian/rules
+++ b/debian/rules
@@ -34,7 +34,7 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	rm -rf $(PACKAGE_STAGING)
-	$(MAKE) install NO_BUILD=1 DESTDIR=$(PACKAGE_STAGING) PREFIX=/usr SYSTEMD_UNITDIR=/lib/systemd/system
+	$(MAKE) install NO_BUILD=1 DESTDIR=$(PACKAGE_STAGING) PREFIX=/usr SYSTEMD_UNITDIR=/etc/systemd/system
 
 override_dh_auto_test:
 	# no tests during package build


### PR DESCRIPTION
## Background
The 0.3.0-beta.3 preparation PR has already been merged into `rust`, and the earlier bundle installer fix also landed there. This follow-up PR only carries the remaining path controls that still referenced `/lib/systemd/system`.

## Changes
- change the default `SYSTEMD_UNITDIR` in `Makefile` to `/etc/systemd/system`
- update the archive uninstall fallback in `aish-cli` to remove sandbox units from `/etc/systemd/system`
- update Debian package staging to install sandbox units into `/etc/systemd/system`

## Validation
- `cargo check --workspace --locked`
- `./packaging/tests/release_scripts_smoke.sh`

## Risk
- This changes the install location for package and fallback uninstall flows, so downstream packaging assumptions should continue to be validated in CI.
- The already-merged bundle installer change is intentionally not repeated here; this PR only closes the remaining path mismatch.