### PR TITLE
chore: release v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.7] - 2026-05-13
+
+### Changed
+
+- Changed prerelease self-update handling so beta installs stay on the beta channel instead of drifting to a broader prerelease track.
+
+### Fixed
+
+- Fixed AI-triggered Bash actions that require terminal input so they now ask for explicit confirmation before taking over the shell.
+- Fixed `ask_user` prompts during AI-driven shell runs so background stdin monitoring pauses while the assistant is waiting for your reply.
+- Fixed `grep_search` and `glob_search` workspace scoping so search results stay limited to the active workspace even after commands change directories.
+
+### Security
+
+- Hardened self-update by verifying downloaded release archives before installing them.
+- Hardened live-smoke diagnostics handling so secrets are redacted from CI artifacts.
+
 ## [0.2.6] - 2026-05-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aish"
-version = "0.2.6"
+version = "0.2.7"
 description = "AI Shell - A shell with built-in LLM capabilities"
 readme = "README.md"
 authors = [{ name = "Sian Cao", email = "yinshuiboy@gmail.com" }]

--- a/src/aish/__init__.py
+++ b/src/aish/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 
 # Avoid importing heavy modules (and any side-effects) at package import time.
 # This matters for system services like aish-sandbox, which only need aish.sandboxd.

--- a/uv.lock
+++ b/uv.lock
@@ -146,7 +146,7 @@ wheels = [
 
 [[package]]
 name = "aish"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Background
Prepare the v0.2.7 stable release candidate from main.

## Changes
- bump package and lockfile versions to 0.2.7
- add finalized v0.2.7 release notes to CHANGELOG.md

## Validation
- /home/lixin/workspace/aishell/aish/.venv/bin/python -m pytest tests/scripts/packaging/test_update_release_files.py tests/scripts/packaging/test_release_metadata.py -q
- make test
- make build-bundle
- bash packaging/scripts/smoke-installed-aish.sh ./dist/aish

## Risk
Release notes wording and version metadata only; no product code changes in this PR.