### PR TITLE
fix: restore interactive sudo input and suppress duplicate bash output

### DIFF
--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -1032,6 +1032,7 @@ impl LlmSession {
                 "tool_name": tool_call.name,
                 "tool_call_id": tool_call.id,
                 "ok": result.ok,
+                "tool_args": args,
             });
             if let Some(preview) = output_preview {
                 event_data["output_preview"] = serde_json::Value::String(preview);
@@ -1437,5 +1438,39 @@ mod tests {
         assert!(tool_names.contains(&"read_file"));
         assert!(tool_names.contains(&"grep"));
         assert!(!tool_names.contains(&"bash_exec"));
+    }
+
+    #[tokio::test]
+    async fn tool_execution_end_event_includes_tool_args() {
+        let mut session = LlmSession::new("http://localhost", "key", "model", None, None);
+        session.register_tool(Box::new(MockTool::new("bash")));
+
+        let seen_event = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let seen_event_cb = seen_event.clone();
+        session.set_event_callback(std::sync::Arc::new(move |event| {
+            if matches!(event.event_type, aish_core::LlmEventType::ToolExecutionEnd) {
+                *seen_event_cb.lock().unwrap() = Some(event);
+            }
+            None
+        }));
+
+        let tool_call = ToolCall {
+            id: "call_1".into(),
+            name: "bash".into(),
+            arguments: serde_json::json!({ "command": "sudo ls /root" }).to_string(),
+        };
+
+        let result = session.execute_tool_external(&tool_call).await;
+        assert!(result.ok);
+
+        let event = seen_event
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("missing ToolExecutionEnd event");
+        assert_eq!(
+            event.data["tool_args"]["command"].as_str(),
+            Some("sudo ls /root")
+        );
     }
 }

--- a/crates/aish-pty/src/persistent.rs
+++ b/crates/aish-pty/src/persistent.rs
@@ -173,6 +173,7 @@ impl PersistentPty {
         command: &str,
         timeout: Duration,
         cancel_token: Option<&CancelToken>,
+        display_output: bool,
     ) -> aish_core::Result<(String, i32)> {
         let seq = self.allocate_backend_seq();
 
@@ -288,6 +289,15 @@ impl PersistentPty {
                     )
                 } {
                     n if n > 0 && self.exec_mode.load(Ordering::SeqCst) => {
+                        if display_output {
+                            unsafe {
+                                libc::write(
+                                    libc::STDOUT_FILENO,
+                                    tmp.as_ptr() as *const libc::c_void,
+                                    n as usize,
+                                );
+                            }
+                        }
                         self.exec_buffer
                             .lock()
                             .unwrap()
@@ -3538,11 +3548,52 @@ fn clean_pty_output(raw: &str, command: &str) -> String {
         // Skip to next newline after the echo.
         if let Some(nl) = after.find('\n') {
             let cleaned = after[nl + 1..].to_string();
-            return cleaned.trim().to_string();
+            return strip_auth_interaction_noise(&cleaned, command);
         }
     }
 
-    text.trim().to_string()
+    strip_auth_interaction_noise(&text, command)
+}
+
+fn strip_auth_interaction_noise(text: &str, command: &str) -> String {
+    if !command_may_prompt_for_auth(command) {
+        return text.trim().to_string();
+    }
+
+    text.lines()
+        .filter(|line| !is_auth_interaction_line(line))
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string()
+}
+
+fn command_may_prompt_for_auth(command: &str) -> bool {
+    let lower = command.to_lowercase();
+    lower.contains("sudo")
+        || lower.starts_with("su ")
+        || lower == "su"
+        || lower.contains(" su ")
+        || lower.starts_with("ssh ")
+        || lower.contains(" ssh ")
+}
+
+fn is_auth_interaction_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let lower = trimmed.to_lowercase();
+    lower.contains("password:")
+        || lower.ends_with("password")
+        || lower.contains("password for ")
+        || trimmed.contains("请输入密码")
+        || trimmed.contains("密码：")
+        || trimmed.contains("验证成功")
+        || trimmed.contains("认证成功")
+        || lower.contains("authentication successful")
+        || lower.contains("authentication succeeded")
 }
 
 fn regex_simple() -> regex::Regex {
@@ -3747,6 +3798,13 @@ mod tests {
     }
 
     #[test]
+    fn test_clean_pty_output_strips_sudo_auth_noise() {
+        let raw = "sudo ls /root\r\n请输入密码：\r\n验证成功\r\nconfig.yaml\r\n";
+        let cleaned = clean_pty_output(raw, "sudo ls /root");
+        assert_eq!(cleaned, "config.yaml");
+    }
+
+    #[test]
     fn test_shell_quote_escape() {
         assert_eq!(shell_quote_escape("ls -la"), "'ls -la'");
         assert_eq!(shell_quote_escape("it's"), "'it'\\''s'");
@@ -3771,7 +3829,7 @@ mod tests {
         let mut pty = PersistentPty::start(&cwd, 24, 80).expect("start should succeed");
 
         let (output, exit_code) = pty
-            .execute_command("echo hello_world_123", Duration::from_secs(5), None)
+            .execute_command("echo hello_world_123", Duration::from_secs(5), None, false)
             .expect("execute should succeed");
         assert_eq!(exit_code, 0);
         assert!(output.contains("hello_world_123"), "output was: {}", output);
@@ -3787,13 +3845,13 @@ mod tests {
         let mut pty = PersistentPty::start(&cwd, 24, 80).expect("start should succeed");
 
         let (out1, code1) = pty
-            .execute_command("echo first", Duration::from_secs(5), None)
+            .execute_command("echo first", Duration::from_secs(5), None, false)
             .expect("cmd1");
         assert_eq!(code1, 0);
         assert!(out1.contains("first"));
 
         let (out2, code2) = pty
-            .execute_command("echo second", Duration::from_secs(5), None)
+            .execute_command("echo second", Duration::from_secs(5), None, false)
             .expect("cmd2");
         assert_eq!(code2, 0);
         assert!(out2.contains("second"));

--- a/crates/aish-pty/src/persistent.rs
+++ b/crates/aish-pty/src/persistent.rs
@@ -29,6 +29,43 @@ const INTERACTIVE_COMMANDS: &[&str] = &[
     "more", "most", "man", "screen", "tmux", "mc", "ranger",
 ];
 
+fn write_all_with_retry<F>(buf: &[u8], mut write_once: F)
+where
+    F: FnMut(&[u8]) -> Result<usize, i32>,
+{
+    let mut remaining = buf;
+    while !remaining.is_empty() {
+        match write_once(remaining) {
+            Ok(0) => break,
+            Ok(written) => remaining = &remaining[written.min(remaining.len())..],
+            Err(errno) if errno == libc::EINTR => continue,
+            Err(errno) => {
+                debug!(errno, "failed to forward PTY output to stdout");
+                break;
+            }
+        }
+    }
+}
+
+fn write_stdout_all(buf: &[u8]) {
+    write_all_with_retry(buf, |remaining| {
+        let rc = unsafe {
+            libc::write(
+                libc::STDOUT_FILENO,
+                remaining.as_ptr() as *const libc::c_void,
+                remaining.len(),
+            )
+        };
+        if rc < 0 {
+            Err(std::io::Error::last_os_error()
+                .raw_os_error()
+                .unwrap_or(libc::EIO))
+        } else {
+            Ok(rc as usize)
+        }
+    });
+}
+
 /// Persistent PTY session managing a single long-lived bash process.
 pub struct PersistentPty {
     master_fd: RawFd,
@@ -290,13 +327,7 @@ impl PersistentPty {
                 } {
                     n if n > 0 && self.exec_mode.load(Ordering::SeqCst) => {
                         if display_output {
-                            unsafe {
-                                libc::write(
-                                    libc::STDOUT_FILENO,
-                                    tmp.as_ptr() as *const libc::c_void,
-                                    n as usize,
-                                );
-                            }
+                            write_stdout_all(&tmp[..n as usize]);
                         }
                         self.exec_buffer
                             .lock()
@@ -3802,6 +3833,19 @@ mod tests {
         let raw = "sudo ls /root\r\n请输入密码：\r\n验证成功\r\nconfig.yaml\r\n";
         let cleaned = clean_pty_output(raw, "sudo ls /root");
         assert_eq!(cleaned, "config.yaml");
+    }
+
+    #[test]
+    fn test_write_all_with_retry_retries_eintr_and_partial_writes() {
+        let mut calls = Vec::new();
+        let mut results = vec![Err(libc::EINTR), Ok(2usize), Ok(1usize), Ok(2usize)].into_iter();
+
+        write_all_with_retry(b"hello", |chunk| {
+            calls.push(String::from_utf8(chunk.to_vec()).unwrap());
+            results.next().expect("expected another write result")
+        });
+
+        assert_eq!(calls, vec!["hello", "hello", "llo", "lo"]);
     }
 
     #[test]

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -646,7 +646,14 @@ impl AishShell {
                                 .get("tool_name")
                                 .and_then(|n| n.as_str())
                                 .unwrap_or("");
-                            if tool_name == "bash" && !preview.is_empty() {
+                            let interactive_bash = tool_name == "bash"
+                                && event
+                                    .data
+                                    .get("tool_args")
+                                    .and_then(|args| args.get("command"))
+                                    .and_then(|command| command.as_str())
+                                    .is_some_and(aish_tools::bash::command_needs_interactive);
+                            if tool_name == "bash" && !preview.is_empty() && !interactive_bash {
                                 let content = strip_tool_output_xml(preview);
                                 if !content.is_empty() {
                                     let collapsed = collapse_display_lines(&content, 2);
@@ -1702,6 +1709,7 @@ impl AishShell {
             command,
             std::time::Duration::from_secs(5),
             None,
+            false,
         );
     }
 
@@ -2442,6 +2450,10 @@ impl AishShell {
                         Err(std::sync::mpsc::TryRecvError::Disconnected) => break None,
                         Err(std::sync::mpsc::TryRecvError::Empty) => {}
                     }
+                    if aish_tools::bash::interactive_input_active() {
+                        std::thread::sleep(std::time::Duration::from_millis(50));
+                        continue;
+                    }
                     // Check for Ctrl+C on stdin (non-blocking)
                     let mut rfds: nix::libc::fd_set = unsafe { std::mem::zeroed() };
                     unsafe {
@@ -2958,7 +2970,7 @@ impl AishShell {
                                         .and_then(|p| p.as_str())
                                         .unwrap_or("?");
                                     use std::io::Write;
-                                    print!("\x1b[90m📖 read_file({})\x1b[0m\n", path);
+                                    println!("\x1b[90m📖 read_file({})\x1b[0m", path);
                                     let _ = std::io::stdout().flush();
                                 }
                             }
@@ -2981,7 +2993,7 @@ impl AishShell {
                                             .and_then(|p| p.as_str())
                                             .unwrap_or("error");
                                         use std::io::Write;
-                                        print!("\x1b[31m{}\x1b[0m\n", preview);
+                                        println!("\x1b[31m{}\x1b[0m", preview);
                                         let _ = std::io::stdout().flush();
                                     }
                                 }
@@ -3165,6 +3177,10 @@ impl AishShell {
                     }
                     Err(std::sync::mpsc::TryRecvError::Disconnected) => break None,
                     Err(std::sync::mpsc::TryRecvError::Empty) => {}
+                }
+                if aish_tools::bash::interactive_input_active() {
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                    continue;
                 }
                 // Check for Ctrl+C on stdin (non-blocking)
                 let mut rfds: nix::libc::fd_set = unsafe { std::mem::zeroed() };
@@ -3384,6 +3400,8 @@ impl AishShell {
 static TOOL_XML_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
 /// Cached regex for removing multi-line offload blocks (<offload>...</offload>).
 static TOOL_XML_OFFLOAD_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+/// Cached regex for removing multi-line return_code blocks.
+static TOOL_XML_RETURN_CODE_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
 /// Cached regex for removing incomplete tags from truncation.
 static TOOL_XML_INCOMPLETE_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
 
@@ -3395,6 +3413,12 @@ fn strip_tool_output_xml(output: &str) -> String {
     let re_offload = TOOL_XML_OFFLOAD_RE
         .get_or_init(|| regex::Regex::new(r"(?s)<offload>.*?</offload>").unwrap());
     let cleaned = re_offload.replace_all(output, "").to_string();
+    // Remove multi-line <return_code>...</return_code> blocks completely.
+    let re_return_code = TOOL_XML_RETURN_CODE_RE.get_or_init(|| {
+        regex::Regex::new(r"(?s)<(?:return_code|exit-code)>.*?</(?:return_code|exit-code)>")
+            .unwrap()
+    });
+    let cleaned = re_return_code.replace_all(&cleaned, "").to_string();
     // Remove incomplete tags (e.g. "<stdo" from truncation)
     let re_incomplete =
         TOOL_XML_INCOMPLETE_RE.get_or_init(|| regex::Regex::new(r"<[^>]*$").unwrap());
@@ -3463,6 +3487,12 @@ pub fn collapse_output(
 #[cfg(test)]
 mod collapsing_tests {
     use super::*;
+
+    #[test]
+    fn test_strip_tool_output_xml_removes_return_code_block() {
+        let output = "<stdout>\nconfig.yaml\n</stdout>\n<return_code>\n0\n</return_code>";
+        assert_eq!(strip_tool_output_xml(output), "config.yaml");
+    }
 
     #[test]
     fn test_collapse_output_short() {

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -3398,10 +3398,8 @@ impl AishShell {
 
 /// Cached regex for stripping complete XML tags from tool output.
 static TOOL_XML_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
-/// Cached regex for removing multi-line offload blocks (<offload>...</offload>).
-static TOOL_XML_OFFLOAD_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
-/// Cached regex for removing multi-line return_code blocks.
-static TOOL_XML_RETURN_CODE_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+/// Cached regex for removing trailing tool metadata blocks.
+static TOOL_XML_TRAILING_METADATA_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
 /// Cached regex for removing incomplete tags from truncation.
 static TOOL_XML_INCOMPLETE_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
 
@@ -3409,16 +3407,20 @@ static TOOL_XML_INCOMPLETE_RE: std::sync::OnceLock<regex::Regex> = std::sync::On
 /// Handles multi-line <offload>JSON</offload> blocks, <return_code>, <stdout>,
 /// <stderr>, and any incomplete tags from truncation.
 fn strip_tool_output_xml(output: &str) -> String {
-    // Remove multi-line <offload>...</offload> blocks first (may span multiple lines)
-    let re_offload = TOOL_XML_OFFLOAD_RE
-        .get_or_init(|| regex::Regex::new(r"(?s)<offload>.*?</offload>").unwrap());
-    let cleaned = re_offload.replace_all(output, "").to_string();
-    // Remove multi-line <return_code>...</return_code> blocks completely.
-    let re_return_code = TOOL_XML_RETURN_CODE_RE.get_or_init(|| {
-        regex::Regex::new(r"(?s)<(?:return_code|exit-code)>.*?</(?:return_code|exit-code)>")
-            .unwrap()
+    let re_trailing_metadata = TOOL_XML_TRAILING_METADATA_RE.get_or_init(|| {
+        regex::Regex::new(
+            r"(?ms)(?:^|\n)<(?:offload|return_code|exit-code)>\n.*?\n</(?:offload|return_code|exit-code)>\s*$",
+        )
+        .unwrap()
     });
-    let cleaned = re_return_code.replace_all(&cleaned, "").to_string();
+    let mut cleaned = output.trim().to_string();
+    loop {
+        let next = re_trailing_metadata.replace(&cleaned, "").to_string();
+        if next == cleaned {
+            break;
+        }
+        cleaned = next.trim_end().to_string();
+    }
     // Remove incomplete tags (e.g. "<stdo" from truncation)
     let re_incomplete =
         TOOL_XML_INCOMPLETE_RE.get_or_init(|| regex::Regex::new(r"<[^>]*$").unwrap());
@@ -3492,6 +3494,12 @@ mod collapsing_tests {
     fn test_strip_tool_output_xml_removes_return_code_block() {
         let output = "<stdout>\nconfig.yaml\n</stdout>\n<return_code>\n0\n</return_code>";
         assert_eq!(strip_tool_output_xml(output), "config.yaml");
+    }
+
+    #[test]
+    fn test_strip_tool_output_xml_preserves_return_code_text_in_stdout() {
+        let output = "<stdout>\nliteral <return_code>\n0\n</return_code> block\n</stdout>\n<return_code>\n0\n</return_code>";
+        assert_eq!(strip_tool_output_xml(output), "literal \n0\n block");
     }
 
     #[test]

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -3399,7 +3399,8 @@ impl AishShell {
 /// Cached regex for stripping complete XML tags from tool output.
 static TOOL_XML_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
 /// Cached regex for removing trailing tool metadata blocks.
-static TOOL_XML_TRAILING_METADATA_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+static TOOL_XML_TRAILING_METADATA_RE: std::sync::OnceLock<regex::Regex> =
+    std::sync::OnceLock::new();
 /// Cached regex for removing incomplete tags from truncation.
 static TOOL_XML_INCOMPLETE_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
 

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -88,7 +88,7 @@ impl ShellHelper {
         let escaped_line = aish_pty::shell_quote_escape(line);
         let cmd = format!("__aish_query_completions {} {}", escaped_line, pos);
 
-        match pty.execute_command(&cmd, COMPLETION_TIMEOUT, None) {
+        match pty.execute_command(&cmd, COMPLETION_TIMEOUT, None, false) {
             Ok((output, _exit_code)) => output
                 .lines()
                 .filter(|l| !l.is_empty())

--- a/crates/aish-tools/src/bash.rs
+++ b/crates/aish-tools/src/bash.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -55,10 +55,29 @@ pub fn command_needs_interactive(command: &str) -> bool {
 /// None = fall back to PtyExecutor (one-shot PTY).
 pub type PtySlot = Arc<Mutex<Option<Arc<Mutex<aish_pty::PersistentPty>>>>>;
 
-static INTERACTIVE_INPUT_ACTIVE: AtomicBool = AtomicBool::new(false);
+static INTERACTIVE_INPUT_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 pub fn interactive_input_active() -> bool {
-    INTERACTIVE_INPUT_ACTIVE.load(Ordering::SeqCst)
+    INTERACTIVE_INPUT_COUNT.load(Ordering::SeqCst) > 0
+}
+
+struct InteractiveInputGuard;
+
+impl InteractiveInputGuard {
+    fn acquire() -> Self {
+        INTERACTIVE_INPUT_COUNT.fetch_add(1, Ordering::SeqCst);
+        Self
+    }
+}
+
+impl Drop for InteractiveInputGuard {
+    fn drop(&mut self) {
+        let previous = INTERACTIVE_INPUT_COUNT.fetch_sub(1, Ordering::SeqCst);
+        debug_assert!(previous > 0, "interactive input guard count underflow");
+        if previous == 0 {
+            INTERACTIVE_INPUT_COUNT.store(0, Ordering::SeqCst);
+        }
+    }
 }
 
 /// Tool for executing bash commands via PTY.
@@ -263,14 +282,9 @@ impl BashTool {
 
         let mut pty = pty_arc.lock().unwrap();
         let command_timeout = Duration::from_secs(timeout_secs.unwrap_or(365 * 24 * 60 * 60));
-        if interactive {
-            INTERACTIVE_INPUT_ACTIVE.store(true, Ordering::SeqCst);
-        }
+        let _interactive_guard = interactive.then(InteractiveInputGuard::acquire);
         let result =
             pty.execute_command(command, command_timeout, Some(&cancel_token), interactive);
-        if interactive {
-            INTERACTIVE_INPUT_ACTIVE.store(false, Ordering::SeqCst);
-        }
         done.store(true, Ordering::SeqCst);
 
         match result {
@@ -346,13 +360,8 @@ impl BashTool {
         }
 
         let env_vars: std::collections::HashMap<String, String> = std::env::vars().collect();
-        if interactive {
-            INTERACTIVE_INPUT_ACTIVE.store(true, Ordering::SeqCst);
-        }
+        let _interactive_guard = interactive.then(InteractiveInputGuard::acquire);
         let result = executor.execute_blocking(command, env_vars, &cancel_token);
-        if interactive {
-            INTERACTIVE_INPUT_ACTIVE.store(false, Ordering::SeqCst);
-        }
         done.store(true, Ordering::SeqCst);
 
         match result {
@@ -565,6 +574,23 @@ mod tests {
             timeout["description"].as_str(),
             Some("Timeout in seconds. If omitted, the command runs until completion or cancellation.")
         );
+    }
+
+    #[test]
+    fn test_interactive_input_guard_counts_overlapping_sessions() {
+        INTERACTIVE_INPUT_COUNT.store(0, Ordering::SeqCst);
+
+        let guard_one = InteractiveInputGuard::acquire();
+        assert!(interactive_input_active());
+
+        let guard_two = InteractiveInputGuard::acquire();
+        assert!(interactive_input_active());
+
+        drop(guard_one);
+        assert!(interactive_input_active());
+
+        drop(guard_two);
+        assert!(!interactive_input_active());
     }
 
     #[test]

--- a/crates/aish-tools/src/bash.rs
+++ b/crates/aish-tools/src/bash.rs
@@ -47,9 +47,19 @@ fn needs_interactive(command: &str) -> bool {
     false
 }
 
+pub fn command_needs_interactive(command: &str) -> bool {
+    needs_interactive(command)
+}
+
 /// Shared slot for injecting a PersistentPty reference after tool creation.
 /// None = fall back to PtyExecutor (one-shot PTY).
 pub type PtySlot = Arc<Mutex<Option<Arc<Mutex<aish_pty::PersistentPty>>>>>;
+
+static INTERACTIVE_INPUT_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+pub fn interactive_input_active() -> bool {
+    INTERACTIVE_INPUT_ACTIVE.load(Ordering::SeqCst)
+}
 
 /// Tool for executing bash commands via PTY.
 pub struct BashTool {
@@ -222,6 +232,7 @@ impl BashTool {
         timeout_secs: Option<u64>,
         pty_arc: Arc<Mutex<aish_pty::PersistentPty>>,
     ) -> ToolResult {
+        let interactive = needs_interactive(command);
         let cancel_token = Arc::new(CancelToken::new());
 
         if let Some(timeout_secs) = timeout_secs {
@@ -252,7 +263,14 @@ impl BashTool {
 
         let mut pty = pty_arc.lock().unwrap();
         let command_timeout = Duration::from_secs(timeout_secs.unwrap_or(365 * 24 * 60 * 60));
-        let result = pty.execute_command(command, command_timeout, Some(&cancel_token));
+        if interactive {
+            INTERACTIVE_INPUT_ACTIVE.store(true, Ordering::SeqCst);
+        }
+        let result =
+            pty.execute_command(command, command_timeout, Some(&cancel_token), interactive);
+        if interactive {
+            INTERACTIVE_INPUT_ACTIVE.store(false, Ordering::SeqCst);
+        }
         done.store(true, Ordering::SeqCst);
 
         match result {
@@ -294,7 +312,8 @@ impl BashTool {
 
     /// Execute via one-shot PtyExecutor — original behavior.
     fn execute_via_pty_executor(&self, command: &str, timeout_secs: Option<u64>) -> ToolResult {
-        let executor = if needs_interactive(command) {
+        let interactive = needs_interactive(command);
+        let executor = if interactive {
             PtyExecutor::new(CAPTURE_KEEP_BYTES)
         } else {
             PtyExecutor::new_silent(CAPTURE_KEEP_BYTES)
@@ -327,7 +346,13 @@ impl BashTool {
         }
 
         let env_vars: std::collections::HashMap<String, String> = std::env::vars().collect();
+        if interactive {
+            INTERACTIVE_INPUT_ACTIVE.store(true, Ordering::SeqCst);
+        }
         let result = executor.execute_blocking(command, env_vars, &cancel_token);
+        if interactive {
+            INTERACTIVE_INPUT_ACTIVE.store(false, Ordering::SeqCst);
+        }
         done.store(true, Ordering::SeqCst);
 
         match result {


### PR DESCRIPTION
## Background

AI-triggered interactive bash commands had two regressions on the Rust shell path:

- `sudo` password prompts could lose stdin ownership while the shell was still polling for AI events
- interactive bash output could be rendered twice, once from the live PTY stream and again from the tool preview path

## Changes

- route interactive bash commands through the PTY-backed path when stdin takeover is required
- propagate bash tool arguments through `ToolExecutionEnd` so the shell UI can recognize interactive bash completions
- skip duplicate bash preview rendering when output was already shown live in the terminal
- keep readline aligned with the PTY execution signature used by interactive commands
- filter auth-interaction noise from captured PTY output before passing tool results back to the model

## Validation

- `cargo test -p aish-pty test_clean_pty_output --lib -- --nocapture`
- `cargo test -p aish-llm tool_execution_end_event_includes_tool_args --lib -- --nocapture`
- `cargo test -p aish-shell collapsing_tests:: --lib -- --nocapture`
- `cargo build -p aish-cli`

## Risk

The main risk is divergence between interactive and non-interactive bash execution behavior, especially around PTY cleanup and tool preview rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed authentication and password-related noise from command output
  * Improved handling of interactive bash commands to prevent output interference
  * Tool output displays without multi-line return code blocks for cleaner formatting

* **New Features**
  * Tool execution events now include command input arguments for better visibility
  * Commands requiring interactive input are automatically detected and handled appropriately

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/186)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->