### PR TITLE
feat: add context auto-compaction flow

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -69,6 +69,7 @@ aish run --config ~/work/ai-shell-config.yaml
 | `max_shell_messages` | integer | `20` | Shell 历史条目最大保留数量 | 值 > 0 |
 | `context_token_budget` | integer/null | `null` | 可选的上下文 token 预算限制 | 如：4000，为 null 则仅使用消息数量限制 |
 | `enable_token_estimation` | boolean | `true` | 启用基于 tiktoken 的 token 估算 | true/false |
+| `context_auto_compact` | object | 见下方 | 自动上下文压缩配置，面向 shell/tool 输出控量 | 可选 |
 
 ### 工具输出配置
 
@@ -134,6 +135,40 @@ tool_arg_preview:
     max_items: 4
 ```
 
+#### context_auto_compact
+
+自动上下文压缩用于在发送给模型前控制 shell/tool 输出占用。默认策略偏保守：先做确定性的 microcompact，清理旧命令输出、旧 tool result、preview 和冗长 reasoning；只有在 microcompact 后仍接近窗口上限时，才启用模型生成的 full compact summary。full compact 会额外发起一次无工具、低温、非流式的摘要请求，失败时会记录失败次数并回退到最终 trim，不阻塞普通发送路径。
+
+AI Shell 不会根据模型名前缀推断 context window。对于自定义模型或不同 provider，请优先显式设置 `context_auto_compact.context_window_tokens`，或在 `context_auto_compact.model_context_windows` 中为模型 ID 配置精确窗口；否则会使用 `context_token_budget`，再回退到保守默认值。启动时会记录窗口来源、有效 reserve 和触发阈值，便于排查为什么提前压缩。
+
+| 字段 | 类型 | 默认值 | 描述 |
+|------|------|--------|------|
+| `enabled` | boolean | `true` | 启用自动上下文压力处理 |
+| `full_compact_enabled` | boolean | `true` | 允许在高压时调用模型生成结构化 summary；可关闭为 microcompact-only |
+| `context_window_tokens` | integer/null | `null` | 显式 context window 覆盖，优先级高于 `context_token_budget` |
+| `model_context_windows` | map[string, integer] | `{}` | 按精确模型 ID 配置 context window，优先级低于 `context_window_tokens`，高于 `context_token_budget` |
+| `reserved_output_tokens` | integer/null | `null` | 为模型输出和 summary 预留的 token 数 |
+| `auto_compact_buffer_tokens` | integer/null | `null` | effective window 内触发 auto compact 的保守缓冲 |
+| `warning_buffer_tokens` | integer/null | `null` | warning 阈值相对 auto compact 的提前量 |
+| `blocking_buffer_tokens` | integer/null | `null` | blocking 阈值相对 effective window 的保留量 |
+| `micro_keep_recent_messages` | integer | `6` | microcompact 时保留的最近消息数量 |
+| `shell_keep_recent_commands` | integer | `8` | microcompact 时完整保留的最近 shell 上下文条数 |
+| `max_consecutive_failures` | integer | `3` | full compact 连续失败熔断阈值 |
+| `summary_max_tokens` | integer | `4000` | 模型生成结构化 summary 的最大输出预算 |
+
+示例：
+```yaml
+context_auto_compact:
+  enabled: true
+  full_compact_enabled: true
+  context_window_tokens: null
+  model_context_windows:
+    openai/glm-5.1: 128000
+  micro_keep_recent_messages: 6
+  shell_keep_recent_commands: 8
+  max_consecutive_failures: 3
+```
+
 ## terminal_resize_mode 说明
 
 - `full`：PTY 命令、ask_user 弹层、Live 渲染都跟随终端 resize（默认）
@@ -168,6 +203,19 @@ max_llm_messages: 50
 max_shell_messages: 20
 context_token_budget: null
 enable_token_estimation: true
+context_auto_compact:
+  enabled: true
+  full_compact_enabled: true
+  context_window_tokens: null
+  model_context_windows: {}
+  reserved_output_tokens: null
+  auto_compact_buffer_tokens: null
+  warning_buffer_tokens: null
+  blocking_buffer_tokens: null
+  micro_keep_recent_messages: 6
+  shell_keep_recent_commands: 8
+  max_consecutive_failures: 3
+  summary_max_tokens: 4000
 
 # 工具输出配置
 pty_output_keep_bytes: 4096

--- a/crates/aish-config/src/model.rs
+++ b/crates/aish-config/src/model.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
@@ -42,6 +44,22 @@ fn default_history_size() -> usize {
 
 fn default_terminal_resize_mode() -> String {
     "full".into()
+}
+
+fn default_micro_keep_recent_messages() -> usize {
+    6
+}
+
+fn default_shell_keep_recent_commands() -> usize {
+    8
+}
+
+fn default_max_consecutive_compact_failures() -> usize {
+    3
+}
+
+fn default_summary_max_tokens() -> usize {
+    4000
 }
 
 // ---------------------------------------------------------------------------
@@ -104,6 +122,50 @@ impl Default for ToolArgPreviewConfig {
 #[serde(default)]
 pub struct OutputOffloadConfig {
     pub base_dir: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Context auto-compact sub-config
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ContextAutoCompactConfig {
+    pub enabled: bool,
+    pub full_compact_enabled: bool,
+    pub context_window_tokens: Option<usize>,
+    pub model_context_windows: HashMap<String, usize>,
+    pub reserved_output_tokens: Option<usize>,
+    pub auto_compact_buffer_tokens: Option<usize>,
+    pub warning_buffer_tokens: Option<usize>,
+    pub blocking_buffer_tokens: Option<usize>,
+    #[serde(default = "default_micro_keep_recent_messages")]
+    pub micro_keep_recent_messages: usize,
+    #[serde(default = "default_shell_keep_recent_commands")]
+    pub shell_keep_recent_commands: usize,
+    #[serde(default = "default_max_consecutive_compact_failures")]
+    pub max_consecutive_failures: usize,
+    #[serde(default = "default_summary_max_tokens")]
+    pub summary_max_tokens: usize,
+}
+
+impl Default for ContextAutoCompactConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            full_compact_enabled: true,
+            context_window_tokens: None,
+            model_context_windows: HashMap::new(),
+            reserved_output_tokens: None,
+            auto_compact_buffer_tokens: None,
+            warning_buffer_tokens: None,
+            blocking_buffer_tokens: None,
+            micro_keep_recent_messages: default_micro_keep_recent_messages(),
+            shell_keep_recent_commands: default_shell_keep_recent_commands(),
+            max_consecutive_failures: default_max_consecutive_compact_failures(),
+            summary_max_tokens: default_summary_max_tokens(),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -188,6 +250,10 @@ pub struct ConfigModel {
     #[serde(default = "default_true")]
     pub enable_token_estimation: bool,
 
+    /// Automatic context pressure handling and compaction settings
+    #[serde(default)]
+    pub context_auto_compact: ContextAutoCompactConfig,
+
     /// Enable script system (hooks, hot-reload, custom prompts)
     #[serde(default = "default_true")]
     pub enable_scripts: bool,
@@ -237,6 +303,7 @@ impl Default for ConfigModel {
             max_shell_messages: default_max_shell_messages(),
             context_token_budget: None,
             enable_token_estimation: default_true(),
+            context_auto_compact: ContextAutoCompactConfig::default(),
             enable_scripts: default_true(),
             history_size: default_history_size(),
             terminal_resize_mode: default_terminal_resize_mode(),
@@ -325,6 +392,10 @@ api_key: sk-test
         assert_eq!(config.max_shell_messages, 20);
         assert!(config.context_token_budget.is_none());
         assert!(config.enable_token_estimation);
+        assert!(config.context_auto_compact.enabled);
+        assert!(config.context_auto_compact.full_compact_enabled);
+        assert_eq!(config.context_auto_compact.micro_keep_recent_messages, 6);
+        assert_eq!(config.context_auto_compact.shell_keep_recent_commands, 8);
         assert!(config.enable_scripts);
         assert_eq!(config.history_size, 1000);
         assert_eq!(config.terminal_resize_mode, "full");
@@ -346,6 +417,20 @@ max_llm_messages: 30
 max_shell_messages: 10
 context_token_budget: 8000
 enable_token_estimation: false
+context_auto_compact:
+    enabled: true
+    full_compact_enabled: false
+    context_window_tokens: 32000
+    model_context_windows:
+      openai/glm-5.1: 128000
+    reserved_output_tokens: 4000
+    auto_compact_buffer_tokens: 3000
+    warning_buffer_tokens: 2000
+    blocking_buffer_tokens: 500
+    micro_keep_recent_messages: 4
+    shell_keep_recent_commands: 3
+    max_consecutive_failures: 2
+    summary_max_tokens: 1200
 enable_scripts: false
 history_size: 500
 terminal_resize_mode: pty_only
@@ -359,6 +444,39 @@ terminal_resize_mode: pty_only
         assert_eq!(config.max_shell_messages, 10);
         assert_eq!(config.context_token_budget, Some(8000));
         assert!(!config.enable_token_estimation);
+        assert!(config.context_auto_compact.enabled);
+        assert!(!config.context_auto_compact.full_compact_enabled);
+        assert_eq!(
+            config.context_auto_compact.context_window_tokens,
+            Some(32000)
+        );
+        assert_eq!(
+            config
+                .context_auto_compact
+                .model_context_windows
+                .get("openai/glm-5.1"),
+            Some(&128000)
+        );
+        assert_eq!(
+            config.context_auto_compact.reserved_output_tokens,
+            Some(4000)
+        );
+        assert_eq!(
+            config.context_auto_compact.auto_compact_buffer_tokens,
+            Some(3000)
+        );
+        assert_eq!(
+            config.context_auto_compact.warning_buffer_tokens,
+            Some(2000)
+        );
+        assert_eq!(
+            config.context_auto_compact.blocking_buffer_tokens,
+            Some(500)
+        );
+        assert_eq!(config.context_auto_compact.micro_keep_recent_messages, 4);
+        assert_eq!(config.context_auto_compact.shell_keep_recent_commands, 3);
+        assert_eq!(config.context_auto_compact.max_consecutive_failures, 2);
+        assert_eq!(config.context_auto_compact.summary_max_tokens, 1200);
         assert!(!config.enable_scripts);
         assert_eq!(config.history_size, 500);
         assert_eq!(config.terminal_resize_mode, "pty_only");
@@ -380,8 +498,25 @@ api_key: sk-test
         assert_eq!(config.max_shell_messages, 20);
         assert!(config.context_token_budget.is_none());
         assert!(config.enable_token_estimation);
+        assert!(config.context_auto_compact.enabled);
+        assert!(config.context_auto_compact.full_compact_enabled);
+        assert!(config.context_auto_compact.context_window_tokens.is_none());
+        assert!(config.context_auto_compact.model_context_windows.is_empty());
         assert!(config.enable_scripts);
         assert_eq!(config.history_size, 1000);
         assert_eq!(config.terminal_resize_mode, "full");
+    }
+
+    #[test]
+    fn test_context_auto_compact_defaults() {
+        let compact = ContextAutoCompactConfig::default();
+        assert!(compact.enabled);
+        assert!(compact.full_compact_enabled);
+        assert!(compact.context_window_tokens.is_none());
+        assert!(compact.model_context_windows.is_empty());
+        assert_eq!(compact.micro_keep_recent_messages, 6);
+        assert_eq!(compact.shell_keep_recent_commands, 8);
+        assert_eq!(compact.max_consecutive_failures, 3);
+        assert_eq!(compact.summary_max_tokens, 4000);
     }
 }

--- a/crates/aish-context/src/budget.rs
+++ b/crates/aish-context/src/budget.rs
@@ -146,9 +146,7 @@ pub fn effective_reserved_output_tokens(
     reserved_output_tokens: usize,
 ) -> usize {
     let context_window_tokens = context_window_tokens.max(1);
-    let min_prompt_budget = (context_window_tokens / 2)
-        .max(1)
-        .min(MIN_PROMPT_BUDGET_TOKENS);
+    let min_prompt_budget = (context_window_tokens / 2).clamp(1, MIN_PROMPT_BUDGET_TOKENS);
     let max_reserve = context_window_tokens.saturating_sub(min_prompt_budget);
     reserved_output_tokens.min(max_reserve)
 }
@@ -219,12 +217,11 @@ pub fn calculate_budget_state(
     policy: &ContextBudgetPolicy,
 ) -> ContextBudgetState {
     let thresholds = calculate_thresholds(policy);
-    let percent_used = if thresholds.effective_context_window == 0 {
-        100
-    } else {
-        ((estimated_tokens.saturating_mul(100)) / thresholds.effective_context_window).min(100)
-            as u8
-    };
+    let percent_used = estimated_tokens
+        .saturating_mul(100)
+        .checked_div(thresholds.effective_context_window)
+        .unwrap_or(100)
+        .min(100) as u8;
     let percent_left = 100u8.saturating_sub(percent_used);
 
     let is_at_blocking_limit = estimated_tokens >= thresholds.blocking_threshold;

--- a/crates/aish-context/src/budget.rs
+++ b/crates/aish-context/src/budget.rs
@@ -1,0 +1,348 @@
+/// Default conservative context window used when no explicit budget is configured.
+pub const DEFAULT_CONTEXT_WINDOW_TOKENS: usize = 100_000;
+const DEFAULT_RESERVED_OUTPUT_TOKENS: usize = 20_000;
+const DEFAULT_AUTO_COMPACT_BUFFER_TOKENS: usize = 13_000;
+const DEFAULT_WARNING_BUFFER_TOKENS: usize = 20_000;
+const DEFAULT_BLOCKING_BUFFER_TOKENS: usize = 3_000;
+const MIN_EFFECTIVE_CONTEXT_WINDOW_TOKENS: usize = 1_000;
+const MIN_PROMPT_BUDGET_TOKENS: usize = 8_000;
+const CONTEXT_WINDOW_WARN_BELOW_TOKENS: usize = 8_000;
+const CONTEXT_WINDOW_HARD_MIN_TOKENS: usize = 4_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextPressureLevel {
+    Normal,
+    Warning,
+    AutoCompact,
+    Blocking,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextWindowSource {
+    AutoCompactOverride,
+    ModelConfig,
+    LegacyContextTokenBudget,
+    Default,
+}
+
+impl ContextWindowSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::AutoCompactOverride => "context_auto_compact.context_window_tokens",
+            Self::ModelConfig => "context_auto_compact.model_context_windows",
+            Self::LegacyContextTokenBudget => "context_token_budget",
+            Self::Default => "default",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextWindowResolution {
+    pub tokens: usize,
+    pub source: ContextWindowSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextBudgetPolicy {
+    pub enabled: bool,
+    pub full_compact_enabled: bool,
+    pub context_window_tokens: usize,
+    pub context_window_source: ContextWindowSource,
+    pub reserved_output_tokens: usize,
+    pub auto_compact_buffer_tokens: usize,
+    pub warning_buffer_tokens: usize,
+    pub blocking_buffer_tokens: usize,
+    pub micro_keep_recent_messages: usize,
+    pub shell_keep_recent_commands: usize,
+    pub max_consecutive_failures: usize,
+    pub summary_max_tokens: usize,
+    pub enable_token_estimation: bool,
+}
+
+impl Default for ContextBudgetPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            full_compact_enabled: true,
+            context_window_tokens: DEFAULT_CONTEXT_WINDOW_TOKENS,
+            context_window_source: ContextWindowSource::Default,
+            reserved_output_tokens: DEFAULT_RESERVED_OUTPUT_TOKENS,
+            auto_compact_buffer_tokens: DEFAULT_AUTO_COMPACT_BUFFER_TOKENS,
+            warning_buffer_tokens: DEFAULT_WARNING_BUFFER_TOKENS,
+            blocking_buffer_tokens: DEFAULT_BLOCKING_BUFFER_TOKENS,
+            micro_keep_recent_messages: 6,
+            shell_keep_recent_commands: 8,
+            max_consecutive_failures: 3,
+            summary_max_tokens: 4_000,
+            enable_token_estimation: true,
+        }
+    }
+}
+
+impl ContextBudgetPolicy {
+    pub fn from_optional_budget(
+        context_token_budget: Option<usize>,
+        enable_token_estimation: bool,
+    ) -> Self {
+        let mut policy = Self::default();
+        if let Some(budget) = context_token_budget {
+            policy.context_window_tokens = budget.max(MIN_EFFECTIVE_CONTEXT_WINDOW_TOKENS);
+            policy.context_window_source = ContextWindowSource::LegacyContextTokenBudget;
+        }
+        policy.enable_token_estimation = enable_token_estimation;
+        policy
+    }
+
+    pub fn effective_context_window(&self) -> usize {
+        effective_context_window(self.context_window_tokens, self.reserved_output_tokens)
+    }
+
+    pub fn thresholds(&self) -> ContextBudgetThresholds {
+        calculate_thresholds(self)
+    }
+
+    pub fn state_for_tokens(&self, estimated_tokens: usize) -> ContextBudgetState {
+        calculate_budget_state(estimated_tokens, self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContextBudgetThresholds {
+    pub effective_context_window: usize,
+    pub warning_threshold: usize,
+    pub auto_compact_threshold: usize,
+    pub blocking_threshold: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextBudgetState {
+    pub estimated_tokens: usize,
+    pub effective_context_window: usize,
+    pub warning_threshold: usize,
+    pub auto_compact_threshold: usize,
+    pub blocking_threshold: usize,
+    pub percent_used: u8,
+    pub percent_left: u8,
+    pub pressure: ContextPressureLevel,
+    pub is_above_warning_threshold: bool,
+    pub is_above_auto_compact_threshold: bool,
+    pub is_at_blocking_limit: bool,
+}
+
+pub fn effective_context_window(
+    context_window_tokens: usize,
+    reserved_output_tokens: usize,
+) -> usize {
+    context_window_tokens
+        .saturating_sub(effective_reserved_output_tokens(
+            context_window_tokens,
+            reserved_output_tokens,
+        ))
+        .max(MIN_EFFECTIVE_CONTEXT_WINDOW_TOKENS)
+}
+
+pub fn effective_reserved_output_tokens(
+    context_window_tokens: usize,
+    reserved_output_tokens: usize,
+) -> usize {
+    let context_window_tokens = context_window_tokens.max(1);
+    let min_prompt_budget = (context_window_tokens / 2)
+        .max(1)
+        .min(MIN_PROMPT_BUDGET_TOKENS);
+    let max_reserve = context_window_tokens.saturating_sub(min_prompt_budget);
+    reserved_output_tokens.min(max_reserve)
+}
+
+pub fn resolve_context_window_tokens(
+    auto_compact_override: Option<usize>,
+    model_config_tokens: Option<usize>,
+    legacy_context_token_budget: Option<usize>,
+) -> ContextWindowResolution {
+    if let Some(tokens) = auto_compact_override {
+        return ContextWindowResolution {
+            tokens: tokens.max(MIN_EFFECTIVE_CONTEXT_WINDOW_TOKENS),
+            source: ContextWindowSource::AutoCompactOverride,
+        };
+    }
+    if let Some(tokens) = model_config_tokens {
+        return ContextWindowResolution {
+            tokens: tokens.max(MIN_EFFECTIVE_CONTEXT_WINDOW_TOKENS),
+            source: ContextWindowSource::ModelConfig,
+        };
+    }
+    if let Some(tokens) = legacy_context_token_budget {
+        return ContextWindowResolution {
+            tokens: tokens.max(MIN_EFFECTIVE_CONTEXT_WINDOW_TOKENS),
+            source: ContextWindowSource::LegacyContextTokenBudget,
+        };
+    }
+    ContextWindowResolution {
+        tokens: DEFAULT_CONTEXT_WINDOW_TOKENS,
+        source: ContextWindowSource::Default,
+    }
+}
+
+pub fn context_window_warn_below_tokens() -> usize {
+    CONTEXT_WINDOW_WARN_BELOW_TOKENS
+}
+
+pub fn context_window_hard_min_tokens() -> usize {
+    CONTEXT_WINDOW_HARD_MIN_TOKENS
+}
+
+pub fn calculate_thresholds(policy: &ContextBudgetPolicy) -> ContextBudgetThresholds {
+    let effective = policy.effective_context_window();
+    let auto_buffer = policy.auto_compact_buffer_tokens.min(effective / 3);
+    let warning_buffer = policy.warning_buffer_tokens.min(effective / 3);
+    let blocking_buffer = policy.blocking_buffer_tokens.min(effective / 10).max(1);
+
+    let auto_compact_threshold = effective.saturating_sub(auto_buffer).max(1);
+    let warning_threshold = auto_compact_threshold
+        .saturating_sub(warning_buffer)
+        .max(1)
+        .min(auto_compact_threshold);
+    let blocking_threshold = effective
+        .saturating_sub(blocking_buffer)
+        .max(auto_compact_threshold)
+        .min(effective);
+
+    ContextBudgetThresholds {
+        effective_context_window: effective,
+        warning_threshold,
+        auto_compact_threshold,
+        blocking_threshold,
+    }
+}
+
+pub fn calculate_budget_state(
+    estimated_tokens: usize,
+    policy: &ContextBudgetPolicy,
+) -> ContextBudgetState {
+    let thresholds = calculate_thresholds(policy);
+    let percent_used = if thresholds.effective_context_window == 0 {
+        100
+    } else {
+        ((estimated_tokens.saturating_mul(100)) / thresholds.effective_context_window).min(100)
+            as u8
+    };
+    let percent_left = 100u8.saturating_sub(percent_used);
+
+    let is_at_blocking_limit = estimated_tokens >= thresholds.blocking_threshold;
+    let is_above_auto_compact_threshold =
+        policy.enabled && estimated_tokens >= thresholds.auto_compact_threshold;
+    let is_above_warning_threshold =
+        policy.enabled && estimated_tokens >= thresholds.warning_threshold;
+
+    let pressure = if is_at_blocking_limit {
+        ContextPressureLevel::Blocking
+    } else if is_above_auto_compact_threshold {
+        ContextPressureLevel::AutoCompact
+    } else if is_above_warning_threshold {
+        ContextPressureLevel::Warning
+    } else {
+        ContextPressureLevel::Normal
+    };
+
+    ContextBudgetState {
+        estimated_tokens,
+        effective_context_window: thresholds.effective_context_window,
+        warning_threshold: thresholds.warning_threshold,
+        auto_compact_threshold: thresholds.auto_compact_threshold,
+        blocking_threshold: thresholds.blocking_threshold,
+        percent_used,
+        percent_left,
+        pressure,
+        is_above_warning_threshold,
+        is_above_auto_compact_threshold,
+        is_at_blocking_limit,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thresholds_are_ordered_for_default_policy() {
+        let policy = ContextBudgetPolicy::default();
+        let thresholds = policy.thresholds();
+        assert!(thresholds.warning_threshold <= thresholds.auto_compact_threshold);
+        assert!(thresholds.auto_compact_threshold <= thresholds.blocking_threshold);
+        assert!(thresholds.blocking_threshold <= thresholds.effective_context_window);
+    }
+
+    #[test]
+    fn small_windows_are_clamped_and_ordered() {
+        let policy = ContextBudgetPolicy {
+            context_window_tokens: 2_000,
+            reserved_output_tokens: 20_000,
+            auto_compact_buffer_tokens: 13_000,
+            warning_buffer_tokens: 20_000,
+            blocking_buffer_tokens: 3_000,
+            ..ContextBudgetPolicy::default()
+        };
+        let thresholds = policy.thresholds();
+        assert_eq!(thresholds.effective_context_window, 1_000);
+        assert!(thresholds.warning_threshold <= thresholds.auto_compact_threshold);
+        assert!(thresholds.auto_compact_threshold <= thresholds.blocking_threshold);
+    }
+
+    #[test]
+    fn resolve_context_window_tokens_reports_source() {
+        assert_eq!(
+            resolve_context_window_tokens(Some(32_000), Some(64_000), Some(8_000)).source,
+            ContextWindowSource::AutoCompactOverride
+        );
+        assert_eq!(
+            resolve_context_window_tokens(None, Some(64_000), Some(8_000)).source,
+            ContextWindowSource::ModelConfig
+        );
+        assert_eq!(
+            resolve_context_window_tokens(None, None, Some(8_000)).source,
+            ContextWindowSource::LegacyContextTokenBudget
+        );
+        assert_eq!(
+            resolve_context_window_tokens(None, None, None).tokens,
+            DEFAULT_CONTEXT_WINDOW_TOKENS
+        );
+    }
+
+    #[test]
+    fn reserve_tokens_keep_prompt_budget_for_small_windows() {
+        assert_eq!(effective_reserved_output_tokens(2_000, 20_000), 1_000);
+        assert_eq!(effective_context_window(2_000, 20_000), 1_000);
+        assert_eq!(effective_reserved_output_tokens(16_000, 20_000), 8_000);
+        assert_eq!(effective_context_window(100_000, 20_000), 80_000);
+    }
+
+    #[test]
+    fn state_reports_warning_auto_and_blocking() {
+        let policy = ContextBudgetPolicy {
+            context_window_tokens: 10_000,
+            reserved_output_tokens: 1_000,
+            auto_compact_buffer_tokens: 1_000,
+            warning_buffer_tokens: 1_000,
+            blocking_buffer_tokens: 500,
+            ..ContextBudgetPolicy::default()
+        };
+        let thresholds = policy.thresholds();
+        assert_eq!(
+            policy
+                .state_for_tokens(thresholds.warning_threshold)
+                .pressure,
+            ContextPressureLevel::Warning
+        );
+        assert_eq!(
+            policy
+                .state_for_tokens(thresholds.auto_compact_threshold)
+                .pressure,
+            ContextPressureLevel::AutoCompact
+        );
+        assert_eq!(
+            policy
+                .state_for_tokens(thresholds.blocking_threshold)
+                .pressure,
+            ContextPressureLevel::Blocking
+        );
+    }
+}

--- a/crates/aish-context/src/lib.rs
+++ b/crates/aish-context/src/lib.rs
@@ -13,9 +13,18 @@
     clippy::too_many_arguments
 )]
 
+pub mod budget;
 pub mod manager;
 pub mod types;
 
-pub use manager::ContextManager;
-pub use manager::ContextStats;
+pub use budget::{
+    calculate_budget_state, calculate_thresholds, context_window_hard_min_tokens,
+    context_window_warn_below_tokens, effective_reserved_output_tokens,
+    resolve_context_window_tokens, ContextBudgetPolicy, ContextBudgetState,
+    ContextBudgetThresholds, ContextPressureLevel, ContextWindowResolution, ContextWindowSource,
+    DEFAULT_CONTEXT_WINDOW_TOKENS,
+};
+pub use manager::{
+    ContextCompactReport, ContextManager, ContextStats, FullCompactReport, MicrocompactReport,
+};
 pub use types::ContextMessage;

--- a/crates/aish-context/src/manager.rs
+++ b/crates/aish-context/src/manager.rs
@@ -1,9 +1,16 @@
 use std::collections::HashMap;
 
 use aish_core::MemoryType;
+use aish_core::{PlanModeState, PlanPhase};
 use tracing::debug;
 
+use crate::budget::{ContextBudgetPolicy, ContextBudgetState, ContextPressureLevel};
 use crate::types::ContextMessage;
+
+const CLEARED_SHELL_OUTPUT: &str =
+    "[old shell/tool output cleared by context microcompact; key metadata retained]";
+const CLEARED_LLM_OUTPUT: &str = "[old low-value output cleared by context microcompact]";
+const SUMMARY_TAG: &str = "<conversation-summary";
 
 /// Statistics about the current context state.
 #[derive(Debug, Clone)]
@@ -16,6 +23,30 @@ pub struct ContextStats {
     pub estimated_tokens: usize,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MicrocompactReport {
+    pub changed_messages: usize,
+    pub reclaimed_tokens: usize,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FullCompactReport {
+    pub compacted_messages: usize,
+    pub reclaimed_tokens: usize,
+    pub summary_tokens: usize,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ContextCompactReport {
+    pub before_tokens: usize,
+    pub after_tokens: usize,
+    pub pressure_before: Option<ContextPressureLevel>,
+    pub pressure_after: Option<ContextPressureLevel>,
+    pub microcompact: MicrocompactReport,
+    pub full_compact: Option<FullCompactReport>,
+    pub skipped_full_compact_due_to_fuse: bool,
+}
+
 /// Manages the conversation context window with per-type message limits and
 /// optional token budget.
 pub struct ContextManager {
@@ -26,6 +57,8 @@ pub struct ContextManager {
     token_budget: Option<usize>,
     model: String,
     knowledge_cache: HashMap<String, String>,
+    budget_policy: ContextBudgetPolicy,
+    compact_consecutive_failures: usize,
 }
 
 impl Default for ContextManager {
@@ -48,6 +81,8 @@ impl ContextManager {
             token_budget: None,
             model: String::new(),
             knowledge_cache: HashMap::new(),
+            budget_policy: ContextBudgetPolicy::default(),
+            compact_consecutive_failures: 0,
         }
     }
 
@@ -61,6 +96,8 @@ impl ContextManager {
             token_budget: None,
             model: String::new(),
             knowledge_cache: HashMap::new(),
+            budget_policy: ContextBudgetPolicy::default(),
+            compact_consecutive_failures: 0,
         }
     }
 
@@ -115,15 +152,30 @@ impl ContextManager {
             .collect()
     }
 
+    pub fn messages_snapshot(&self) -> Vec<ContextMessage> {
+        self.messages.clone()
+    }
+
+    pub fn replace_messages(&mut self, messages: Vec<ContextMessage>) {
+        self.messages = messages;
+    }
+
     /// Estimate the token count for a piece of text using the cl100k_base
     /// tokenizer.
     ///
     /// Falls back to a rough `len / 4` heuristic when the tokenizer is
     /// unavailable.
     pub fn estimate_tokens(&self, text: &str) -> usize {
+        if !self.budget_policy.enable_token_estimation {
+            return estimate_tokens_rough(text);
+        }
         let bpe = tiktoken_rs::cl100k_base_singleton();
         let guard = bpe.lock();
         guard.encode_with_special_tokens(text).len()
+    }
+
+    pub fn estimate_message_tokens(&self, msg: &ContextMessage) -> usize {
+        self.estimate_tokens(&msg.content)
     }
 
     /// Return the total number of stored messages.
@@ -155,6 +207,172 @@ impl ContextManager {
         }
 
         stats
+    }
+
+    pub fn budget_state(&self) -> ContextBudgetState {
+        let estimated_tokens: usize = self
+            .messages
+            .iter()
+            .map(|m| self.estimate_message_tokens(m))
+            .sum();
+        self.budget_policy.state_for_tokens(estimated_tokens)
+    }
+
+    pub fn budget_policy(&self) -> &ContextBudgetPolicy {
+        &self.budget_policy
+    }
+
+    pub fn set_budget_policy(&mut self, policy: ContextBudgetPolicy) {
+        self.budget_policy = policy;
+    }
+
+    pub fn compact_consecutive_failures(&self) -> usize {
+        self.compact_consecutive_failures
+    }
+
+    pub fn record_compact_failure(&mut self) {
+        self.compact_consecutive_failures = self.compact_consecutive_failures.saturating_add(1);
+    }
+
+    pub fn reset_compact_failures(&mut self) {
+        self.compact_consecutive_failures = 0;
+    }
+
+    pub fn full_compact_candidate_messages(&self) -> Vec<ContextMessage> {
+        let keep_recent = self.budget_policy.micro_keep_recent_messages.max(2);
+        let recent_start = self.messages.len().saturating_sub(keep_recent);
+        self.messages
+            .iter()
+            .take(recent_start)
+            .filter(|m| m.role != "system" && !m.content.starts_with(SUMMARY_TAG))
+            .cloned()
+            .collect()
+    }
+
+    pub fn apply_full_compact_summary(
+        &mut self,
+        summary: String,
+    ) -> Result<FullCompactReport, String> {
+        self.rewrite_with_summary(summary, self.full_compact_candidate_messages())
+    }
+
+    pub fn compact_for_send(&mut self, plan_state: Option<&PlanModeState>) -> ContextCompactReport {
+        let before_state = self.budget_state();
+        let before_tokens = before_state.estimated_tokens;
+        let mut report = ContextCompactReport {
+            before_tokens,
+            pressure_before: Some(before_state.pressure),
+            ..ContextCompactReport::default()
+        };
+
+        if !self.budget_policy.enabled {
+            report.after_tokens = before_tokens;
+            report.pressure_after = Some(before_state.pressure);
+            return report;
+        }
+
+        if matches!(
+            before_state.pressure,
+            ContextPressureLevel::Warning
+                | ContextPressureLevel::AutoCompact
+                | ContextPressureLevel::Blocking
+        ) {
+            report.microcompact = self.microcompact();
+        }
+
+        let after_micro_state = self.budget_state();
+        if after_micro_state.is_above_auto_compact_threshold
+            && self.budget_policy.full_compact_enabled
+        {
+            if self.compact_consecutive_failures >= self.budget_policy.max_consecutive_failures {
+                report.skipped_full_compact_due_to_fuse = true;
+                tracing::warn!(
+                    failures = self.compact_consecutive_failures,
+                    "context full compact skipped because failure fuse is open"
+                );
+            } else {
+                match self.full_compact(plan_state) {
+                    Ok(full_report) => {
+                        self.reset_compact_failures();
+                        report.full_compact = Some(full_report);
+                    }
+                    Err(err) => {
+                        self.record_compact_failure();
+                        tracing::warn!(
+                            error = %err,
+                            failures = self.compact_consecutive_failures,
+                            "context full compact failed; keeping original context"
+                        );
+                    }
+                }
+            }
+        }
+
+        let after_state = self.budget_state();
+        report.after_tokens = after_state.estimated_tokens;
+        report.pressure_after = Some(after_state.pressure);
+        report
+    }
+
+    pub fn microcompact(&mut self) -> MicrocompactReport {
+        let before_tokens = self.total_estimated_tokens();
+        let mut changed_messages = 0usize;
+        let keep_recent_messages = self.budget_policy.micro_keep_recent_messages;
+        let recent_start = self.messages.len().saturating_sub(keep_recent_messages);
+
+        let shell_indices: Vec<usize> = self
+            .messages
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, msg)| {
+                (msg.memory_type == MemoryType::Shell && msg.role != "system").then_some(idx)
+            })
+            .collect();
+        let shell_keep_start = shell_indices
+            .len()
+            .saturating_sub(self.budget_policy.shell_keep_recent_commands);
+        let shell_keep: std::collections::HashSet<usize> = shell_indices
+            .iter()
+            .skip(shell_keep_start)
+            .copied()
+            .collect();
+
+        for idx in 0..self.messages.len() {
+            let msg = &mut self.messages[idx];
+            if msg.role == "system" || msg.content.starts_with(SUMMARY_TAG) {
+                continue;
+            }
+
+            let replacement = if msg.memory_type == MemoryType::Shell && !shell_keep.contains(&idx)
+            {
+                compact_shell_content(&msg.content)
+            } else if idx < recent_start && is_low_value_output(&msg.content) {
+                compact_low_value_content(&msg.content)
+            } else {
+                None
+            };
+
+            if let Some(content) = replacement {
+                if content.len() < msg.content.len() {
+                    msg.content = content;
+                    changed_messages += 1;
+                }
+            }
+        }
+
+        let after_tokens = self.total_estimated_tokens();
+        let reclaimed_tokens = before_tokens.saturating_sub(after_tokens);
+        if changed_messages > 0 {
+            tracing::info!(
+                changed_messages,
+                reclaimed_tokens,
+                "context microcompact completed"
+            );
+        }
+        MicrocompactReport {
+            changed_messages,
+            reclaimed_tokens,
+        }
     }
 
     /// Auto-trim messages per type when the configured limit is exceeded, and
@@ -286,6 +504,282 @@ impl ContextManager {
             keep
         });
     }
+
+    fn total_estimated_tokens(&self) -> usize {
+        self.messages
+            .iter()
+            .map(|m| self.estimate_message_tokens(m))
+            .sum()
+    }
+
+    fn full_compact(
+        &mut self,
+        plan_state: Option<&PlanModeState>,
+    ) -> Result<FullCompactReport, String> {
+        let old_messages = self.full_compact_candidate_messages();
+
+        if old_messages.is_empty() {
+            return Err("no old messages available for full compact".to_string());
+        }
+
+        let summary = build_ops_summary(
+            &old_messages,
+            plan_state,
+            self.budget_policy.summary_max_tokens,
+        );
+        if summary.trim().is_empty() {
+            return Err("compact summary is empty".to_string());
+        }
+
+        self.rewrite_with_summary(summary, old_messages)
+    }
+
+    fn rewrite_with_summary(
+        &mut self,
+        summary: String,
+        old_messages: Vec<ContextMessage>,
+    ) -> Result<FullCompactReport, String> {
+        if old_messages.is_empty() {
+            return Err("no old messages available for full compact".to_string());
+        }
+        let summary = normalize_summary(summary);
+        if summary.trim().is_empty() {
+            return Err("compact summary is empty".to_string());
+        }
+
+        let before_tokens = self.total_estimated_tokens();
+        let keep_recent = self.budget_policy.micro_keep_recent_messages.max(2);
+        let recent_start = self.messages.len().saturating_sub(keep_recent);
+
+        let mut new_messages = Vec::new();
+        for (idx, msg) in self.messages.iter().enumerate() {
+            if idx >= recent_start {
+                break;
+            }
+            if msg.role == "system" && !msg.content.starts_with(SUMMARY_TAG) {
+                new_messages.push(msg.clone());
+            }
+        }
+        new_messages.push(ContextMessage {
+            role: "system".to_string(),
+            content: summary,
+            memory_type: MemoryType::Knowledge,
+            name: None,
+            tool_call_id: None,
+        });
+        new_messages.extend(self.messages.iter().skip(recent_start).cloned());
+
+        self.messages = new_messages;
+        let after_tokens = self.total_estimated_tokens();
+        let summary_tokens = self
+            .messages
+            .iter()
+            .find(|m| m.content.starts_with(SUMMARY_TAG))
+            .map(|m| self.estimate_message_tokens(m))
+            .unwrap_or_default();
+        let reclaimed_tokens = before_tokens.saturating_sub(after_tokens);
+        tracing::info!(
+            compacted_messages = old_messages.len(),
+            reclaimed_tokens,
+            "context full compact completed"
+        );
+
+        Ok(FullCompactReport {
+            compacted_messages: old_messages.len(),
+            reclaimed_tokens,
+            summary_tokens,
+        })
+    }
+}
+
+fn normalize_summary(summary: String) -> String {
+    let trimmed = summary.trim();
+    if trimmed.starts_with(SUMMARY_TAG) {
+        return trimmed.to_string();
+    }
+    format!(
+        "<conversation-summary source=\"model_auto_compact\">\n{}\n</conversation-summary>",
+        trimmed
+    )
+}
+
+fn estimate_tokens_rough(text: &str) -> usize {
+    (text.len() / 4).max(1)
+}
+
+fn is_low_value_output(content: &str) -> bool {
+    content.contains("<stdout>")
+        || content.contains("<stderr>")
+        || content.contains("<offload>")
+        || content.contains("</stdout>")
+        || content.contains("</stderr>")
+        || content.len() > 8_000
+}
+
+fn compact_shell_content(content: &str) -> Option<String> {
+    if content.len() <= 512 && !is_low_value_output(content) {
+        return None;
+    }
+    let mut retained = Vec::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("Command:")
+            || trimmed.starts_with("Exit code:")
+            || trimmed.contains("<return_code>")
+            || trimmed.contains("</return_code>")
+            || trimmed.contains("<offload>")
+            || trimmed.contains("</offload>")
+            || trimmed.contains("path")
+        {
+            retained.push(trimmed.to_string());
+        }
+    }
+    let stderr_tail = extract_tag_tail(content, "stderr", 12);
+    if !stderr_tail.is_empty() {
+        retained.push("stderr tail:".to_string());
+        retained.extend(stderr_tail);
+    }
+    if retained.is_empty() {
+        retained.push(CLEARED_SHELL_OUTPUT.to_string());
+    } else {
+        retained.insert(0, CLEARED_SHELL_OUTPUT.to_string());
+    }
+    Some(retained.join("\n"))
+}
+
+fn compact_low_value_content(content: &str) -> Option<String> {
+    if !is_low_value_output(content) {
+        return None;
+    }
+    let mut retained = vec![CLEARED_LLM_OUTPUT.to_string()];
+    let stderr_tail = extract_tag_tail(content, "stderr", 8);
+    if !stderr_tail.is_empty() {
+        retained.push("stderr tail:".to_string());
+        retained.extend(stderr_tail);
+    }
+    Some(retained.join("\n"))
+}
+
+fn extract_tag_tail(content: &str, tag: &str, max_lines: usize) -> Vec<String> {
+    let open = format!("<{}>", tag);
+    let close = format!("</{}>", tag);
+    let Some(start) = content.find(&open) else {
+        return Vec::new();
+    };
+    let body_start = start + open.len();
+    let body_end = content[body_start..]
+        .find(&close)
+        .map(|idx| body_start + idx)
+        .unwrap_or(content.len());
+    let lines: Vec<&str> = content[body_start..body_end]
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect();
+    lines
+        .iter()
+        .rev()
+        .take(max_lines)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .map(|line| (*line).to_string())
+        .collect()
+}
+
+fn build_ops_summary(
+    old_messages: &[ContextMessage],
+    plan_state: Option<&PlanModeState>,
+    summary_max_tokens: usize,
+) -> String {
+    let mut user_items = Vec::new();
+    let mut assistant_items = Vec::new();
+    let mut shell_items = Vec::new();
+
+    for msg in old_messages {
+        let preview = summarize_line(&msg.content, 220);
+        match msg.memory_type {
+            MemoryType::Shell => shell_items.push(preview),
+            MemoryType::Knowledge => {}
+            MemoryType::Llm => match msg.role.as_str() {
+                "user" => user_items.push(preview),
+                "assistant" => assistant_items.push(preview),
+                _ => {}
+            },
+        }
+    }
+
+    let mut lines = Vec::new();
+    lines.push("<conversation-summary source=\"auto_compact\">".to_string());
+    lines.push("Summary:".to_string());
+    lines.push(format!(
+        "- Compacted older context messages: {}.",
+        old_messages.len()
+    ));
+    if let Some(state) = plan_state {
+        if state.phase == PlanPhase::Planning {
+            lines.push(format!(
+                "- Plan mode is active; plan_id={:?}, artifact_path={:?}, draft_revision={}.",
+                state.plan_id, state.artifact_path, state.draft_revision
+            ));
+        }
+    }
+    append_summary_section(&mut lines, "Earlier user requests", &user_items, 6);
+    append_summary_section(
+        &mut lines,
+        "Earlier assistant responses",
+        &assistant_items,
+        4,
+    );
+    append_summary_section(&mut lines, "Older shell observations", &shell_items, 8);
+    lines.push("</conversation-summary>".to_string());
+
+    let mut summary = lines.join("\n");
+    let max_chars = summary_max_tokens.saturating_mul(4).max(512);
+    if summary.len() > max_chars {
+        let mut end = max_chars.min(summary.len());
+        while end > 0 && !summary.is_char_boundary(end) {
+            end -= 1;
+        }
+        summary.truncate(end);
+        summary.push_str("\n</conversation-summary>");
+    }
+    summary
+}
+
+fn append_summary_section(lines: &mut Vec<String>, title: &str, items: &[String], limit: usize) {
+    if items.is_empty() {
+        return;
+    }
+    lines.push(format!("{}:", title));
+    for item in items
+        .iter()
+        .rev()
+        .take(limit)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+    {
+        lines.push(format!("- {}", item));
+    }
+}
+
+fn summarize_line(content: &str, max_chars: usize) -> String {
+    let one_line = content
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .take(6)
+        .collect::<Vec<_>>()
+        .join(" | ");
+    if one_line.len() <= max_chars {
+        return one_line;
+    }
+    let mut end = max_chars.min(one_line.len());
+    while end > 0 && !one_line.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &one_line[..end])
 }
 
 #[cfg(test)]
@@ -372,5 +866,115 @@ mod tests {
         assert_eq!(stats.knowledge_messages, 1);
         assert_eq!(stats.system_messages, 2);
         assert!(stats.estimated_tokens > 0);
+    }
+
+    #[test]
+    fn budget_state_uses_policy_thresholds() {
+        let mut cm = ContextManager::new();
+        cm.set_budget_policy(ContextBudgetPolicy {
+            context_window_tokens: 2_000,
+            reserved_output_tokens: 200,
+            auto_compact_buffer_tokens: 200,
+            warning_buffer_tokens: 200,
+            blocking_buffer_tokens: 100,
+            enable_token_estimation: false,
+            ..ContextBudgetPolicy::default()
+        });
+        cm.add_message("user", &"x".repeat(7_000), MemoryType::Llm);
+        let state = cm.budget_state();
+        assert!(matches!(
+            state.pressure,
+            ContextPressureLevel::Warning
+                | ContextPressureLevel::AutoCompact
+                | ContextPressureLevel::Blocking
+        ));
+    }
+
+    #[test]
+    fn microcompact_clears_old_shell_output_but_keeps_recent() {
+        let mut cm = ContextManager::new();
+        cm.set_budget_policy(ContextBudgetPolicy {
+            shell_keep_recent_commands: 1,
+            enable_token_estimation: false,
+            ..ContextBudgetPolicy::default()
+        });
+        cm.add_message(
+            "user",
+            &format!(
+                "Command: journalctl\n<stdout>{}</stdout>\n<return_code>0</return_code>",
+                "old noisy output\n".repeat(200)
+            ),
+            MemoryType::Shell,
+        );
+        cm.add_message(
+            "user",
+            "Command: uptime\n<stdout>recent output should stay</stdout>\n<return_code>0</return_code>",
+            MemoryType::Shell,
+        );
+
+        let report = cm.microcompact();
+        assert_eq!(report.changed_messages, 1);
+        assert!(cm.messages[0]
+            .content
+            .contains("old shell/tool output cleared"));
+        assert!(cm.messages[1].content.contains("recent output should stay"));
+    }
+
+    #[test]
+    fn full_compact_rewrites_old_history_into_summary() {
+        let mut cm = ContextManager::new();
+        cm.set_budget_policy(ContextBudgetPolicy {
+            context_window_tokens: 2_000,
+            reserved_output_tokens: 200,
+            auto_compact_buffer_tokens: 200,
+            warning_buffer_tokens: 200,
+            blocking_buffer_tokens: 100,
+            micro_keep_recent_messages: 2,
+            shell_keep_recent_commands: 1,
+            enable_token_estimation: false,
+            ..ContextBudgetPolicy::default()
+        });
+        cm.add_message("system", "system prompt", MemoryType::Llm);
+        for idx in 0..8 {
+            cm.add_message(
+                "user",
+                &format!("investigate service failure {idx} {}", "x".repeat(1200)),
+                MemoryType::Llm,
+            );
+        }
+        cm.add_message("assistant", "recent answer", MemoryType::Llm);
+        cm.add_message("user", "recent follow up", MemoryType::Llm);
+
+        let report = cm.compact_for_send(None);
+        assert!(report.full_compact.is_some());
+        assert!(cm
+            .messages
+            .iter()
+            .any(|m| m.content.starts_with(SUMMARY_TAG)));
+        assert_eq!(cm.messages.last().unwrap().content, "recent follow up");
+    }
+
+    #[test]
+    fn full_compact_failure_increments_fuse() {
+        let mut cm = ContextManager::new();
+        cm.set_budget_policy(ContextBudgetPolicy {
+            context_window_tokens: 1_500,
+            reserved_output_tokens: 100,
+            auto_compact_buffer_tokens: 100,
+            warning_buffer_tokens: 100,
+            blocking_buffer_tokens: 50,
+            micro_keep_recent_messages: 10,
+            max_consecutive_failures: 1,
+            enable_token_estimation: false,
+            ..ContextBudgetPolicy::default()
+        });
+        cm.add_message("system", "system prompt", MemoryType::Llm);
+        cm.add_message("user", &"x".repeat(10_000), MemoryType::Llm);
+
+        let first = cm.compact_for_send(None);
+        assert!(first.full_compact.is_none());
+        assert_eq!(cm.compact_consecutive_failures(), 1);
+        let second = cm.compact_for_send(None);
+        assert!(second.skipped_full_compact_due_to_fuse);
     }
 }

--- a/crates/aish-core/src/types.rs
+++ b/crates/aish-core/src/types.rs
@@ -155,6 +155,8 @@ impl Default for PlanModeState {
 pub enum LlmEventType {
     OpStart,
     OpEnd,
+    ContextCompactionStart,
+    ContextCompactionEnd,
     GenerationStart,
     GenerationEnd,
     ContentDelta,

--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -235,8 +235,13 @@ shell:
       custom_input: "Sie können auch einen beliebigen benutzerdefinierten Wert eingeben."
       how_to: "Antworten Sie mit einem Optionswert (oder einer Nummer) oder geben Sie ; continue with default ein (Standard: {default})."
   diagnose_cancelled: "  └─ ❌ Systemdiagnose abgebrochen"
+
+  compaction:
+    completed: "Kontext komprimiert"
+    completed_with_tokens: "Kontext komprimiert, etwa {tokens} Tokens freigegeben"
   status:
     thinking: "Denkt nach"
+    compacting_context: "Kontext wird komprimiert"
     thinking_now: "Denkt nach"
     processing: "Verarbeitet"
     analyzing: "  Analysiert..."

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -480,8 +480,13 @@ shell:
 
   diagnose_cancelled: "  └─ ❌ System diagnosis cancelled"
 
+  compaction:
+    completed: "Context compacted"
+    completed_with_tokens: "Context compacted, reclaimed about {tokens} tokens"
+
   status:
     thinking: "Thinking"
+    compacting_context: "Compacting context"
     thinking_now: "Thinking"
     processing: "Processing"
     analyzing: "  Analyzing..."

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -235,8 +235,13 @@ shell:
       custom_input: "También puedes responder con cualquier valor personalizado."
       how_to: "Responde con un valor de opción (o un número), o escribe ; continue with default (predeterminado: {default})."
   diagnose_cancelled: "  └─ ❌ Diagnóstico del sistema cancelado"
+
+  compaction:
+    completed: "Contexto comprimido"
+    completed_with_tokens: "Contexto comprimido, se liberaron aproximadamente {tokens} tokens"
   status:
     thinking: "Pensando"
+    compacting_context: "Comprimiendo contexto"
     thinking_now: "Pensando"
     processing: "Procesando"
     analyzing: "  Analizando..."

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -235,8 +235,13 @@ shell:
       custom_input: "Vous pouvez aussi repondre avec n'importe quelle valeur personnalisee."
       how_to: "Repondez avec une valeur d'option (ou un numero) ou tapez ; continue with default (par defaut : {default})."
   diagnose_cancelled: "  └─ ❌ Diagnostic systeme annule"
+
+  compaction:
+    completed: "Contexte compressé"
+    completed_with_tokens: "Contexte compressé, environ {tokens} tokens récupérés"
   status:
     thinking: "Reflexion"
+    compacting_context: "Compression du contexte"
     thinking_now: "Reflexion"
     processing: "Traitement"
     analyzing: "  Analyse..."

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -235,8 +235,13 @@ shell:
       custom_input: "任意の値を自由入力することもできます。"
       how_to: "選択肢の値（または番号）で返信するか、; continue with default と入力してください（既定値: {default}）。"
   diagnose_cancelled: "  └─ ❌ システム診断をキャンセルしました"
+
+  compaction:
+    completed: "コンテキストを圧縮しました"
+    completed_with_tokens: "コンテキストを圧縮し、約 {tokens} トークンを確保しました"
   status:
     thinking: "考え中"
+    compacting_context: "コンテキストを圧縮中"
     thinking_now: "考え中"
     processing: "処理中"
     analyzing: "  解析中..."

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -480,8 +480,13 @@ shell:
 
   diagnose_cancelled: "  └─ ❌ 系统诊断已取消"
 
+  compaction:
+    completed: "上下文已压缩"
+    completed_with_tokens: "上下文已压缩，约释放 {tokens} tokens"
+
   status:
     thinking: "思考中"
+    compacting_context: "正在压缩上下文"
     thinking_now: "正在思考"
     processing: "处理中"
     analyzing: "  分析中..."

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -1476,18 +1476,14 @@ fn estimate_chat_tokens(messages: &[ChatMessage], policy: &ContextBudgetPolicy) 
         .sum()
 }
 
-fn estimate_one_chat_message(message: &ChatMessage, policy: &ContextBudgetPolicy) -> usize {
+fn estimate_one_chat_message(message: &ChatMessage, _policy: &ContextBudgetPolicy) -> usize {
     let content_len = message.content.as_ref().map(|c| c.len()).unwrap_or(0);
     let reasoning_len = message
         .reasoning_content
         .as_ref()
         .map(|c| c.len())
         .unwrap_or(0);
-    if policy.enable_token_estimation {
-        ((content_len + reasoning_len) / 4).max(1)
-    } else {
-        ((content_len + reasoning_len) / 4).max(1)
-    }
+    ((content_len + reasoning_len) / 4).max(1)
 }
 
 fn microcompact_chat_messages(

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use aish_core::{AishError, LlmEvent, LlmEventType, PlanModeState, PlanPhase};
+use aish_context::{ContextBudgetPolicy, ContextMessage, ContextPressureLevel, MicrocompactReport};
+use aish_core::{AishError, LlmEvent, LlmEventType, MemoryType, PlanModeState, PlanPhase};
 
 use crate::client::{LlmClient, LlmResponse};
 use crate::langfuse::LangfuseClient;
@@ -20,6 +21,8 @@ fn is_short_circuit_result(result: &ToolResult) -> bool {
 /// Maximum consecutive tool failures before pausing for user confirmation.
 const MAX_CONSECUTIVE_FAILURES: usize = 3;
 
+const COMPACT_SUMMARY_SYSTEM_PROMPT: &str = "You summarize old AI Shell context for a shell operations assistant. Respond with TEXT ONLY. Do not call tools. Preserve operational facts, commands, failures, important stderr, environment constraints, plan state, and pending user intent. Output a concise <conversation-summary> block with stable section headings.";
+
 /// Main LLM session that orchestrates the chat loop with tool calling.
 pub struct LlmSession {
     client: LlmClient,
@@ -36,6 +39,8 @@ pub struct LlmSession {
     langfuse: Option<LangfuseClient>,
     /// Maximum context token budget. Messages are trimmed when exceeded.
     max_context_tokens: usize,
+    context_budget_policy: ContextBudgetPolicy,
+    compact_consecutive_failures: std::sync::Mutex<usize>,
     /// Plan mode state for dynamic tool filtering.
     plan_state: Arc<Mutex<PlanModeState>>,
     /// Cumulative token usage statistics for this session.
@@ -62,6 +67,8 @@ impl LlmSession {
             max_tokens,
             langfuse: None,
             max_context_tokens: 100_000,
+            context_budget_policy: ContextBudgetPolicy::default(),
+            compact_consecutive_failures: std::sync::Mutex::new(0),
             plan_state: Arc::new(Mutex::new(PlanModeState::default())),
             token_stats: std::sync::Mutex::new(crate::usage::TokenStats::default()),
         }
@@ -115,6 +122,11 @@ impl LlmSession {
     /// Set the maximum context token budget for message trimming.
     pub fn set_max_context_tokens(&mut self, max: usize) {
         self.max_context_tokens = max;
+    }
+
+    pub fn set_context_budget_policy(&mut self, policy: ContextBudgetPolicy) {
+        self.max_context_tokens = policy.effective_context_window();
+        self.context_budget_policy = policy;
     }
 
     /// Set an optional Langfuse client for observability tracing.
@@ -186,6 +198,17 @@ impl LlmSession {
             .await
     }
 
+    pub async fn summarize_context_messages(
+        &self,
+        messages: &[ContextMessage],
+        plan_state: Option<&PlanModeState>,
+        summary_max_tokens: usize,
+    ) -> Result<String, AishError> {
+        let prompt = build_context_summary_prompt(messages, plan_state, summary_max_tokens);
+        self.generate_compact_summary(prompt, summary_max_tokens)
+            .await
+    }
+
     /// Execute a tool call by its [`ToolCall`] descriptor (public wrapper).
     pub async fn execute_tool_external(&self, tool_call: &ToolCall) -> ToolResult {
         self.execute_tool(tool_call).await
@@ -253,8 +276,7 @@ impl LlmSession {
         messages.extend_from_slice(context_messages);
         messages.push(ChatMessage::user(prompt));
 
-        // Trim messages if they exceed the context token budget
-        messages = trim_messages(messages, self.max_context_tokens, 5);
+        messages = self.prepare_messages_for_send(messages).await;
         let initial_len = messages.len();
 
         let tool_specs = self.filtered_tool_specs();
@@ -311,6 +333,8 @@ impl LlmSession {
                 }
             }
             iterations += 1;
+
+            messages = self.prepare_messages_for_send(messages).await;
 
             // Emit generation start BEFORE the API call so the display layer
             // can show a thinking animation while the request is in flight.
@@ -1072,6 +1096,8 @@ impl LlmSession {
             max_tokens: self.max_tokens,
             langfuse: self.langfuse.clone(),
             max_context_tokens: self.max_context_tokens,
+            context_budget_policy: self.context_budget_policy.clone(),
+            compact_consecutive_failures: std::sync::Mutex::new(0),
             plan_state: Arc::new(Mutex::new(PlanModeState::default())),
             token_stats: std::sync::Mutex::new(crate::usage::TokenStats::default()),
         }
@@ -1118,6 +1144,196 @@ impl LlmSession {
             metadata: None,
         });
     }
+
+    pub fn emit_context_compaction_start(&self, scope: &str, mode: &str) {
+        self.emit_event(LlmEvent {
+            event_type: LlmEventType::ContextCompactionStart,
+            data: serde_json::json!({
+                "scope": scope,
+                "mode": mode,
+            }),
+            timestamp: now_timestamp(),
+            metadata: None,
+        });
+    }
+
+    pub fn emit_context_compaction_end(
+        &self,
+        scope: &str,
+        mode: &str,
+        before_tokens: usize,
+        after_tokens: usize,
+        changed: bool,
+    ) {
+        self.emit_event(LlmEvent {
+            event_type: LlmEventType::ContextCompactionEnd,
+            data: serde_json::json!({
+                "scope": scope,
+                "mode": mode,
+                "changed": changed,
+                "before_tokens": before_tokens,
+                "after_tokens": after_tokens,
+                "reclaimed_tokens": before_tokens.saturating_sub(after_tokens),
+            }),
+            timestamp: now_timestamp(),
+            metadata: None,
+        });
+    }
+
+    async fn prepare_messages_for_send(&self, mut messages: Vec<ChatMessage>) -> Vec<ChatMessage> {
+        let policy = &self.context_budget_policy;
+        if !policy.enabled {
+            return trim_messages(messages, self.max_context_tokens, 5);
+        }
+
+        let before_tokens = estimate_chat_tokens(&messages, policy);
+        let before_state = policy.state_for_tokens(before_tokens);
+        let mut compaction_changed = false;
+        let mut emitted_compaction_start = false;
+        let mut compaction_mode = "microcompact";
+
+        if matches!(
+            before_state.pressure,
+            ContextPressureLevel::Warning
+                | ContextPressureLevel::AutoCompact
+                | ContextPressureLevel::Blocking
+        ) {
+            let report = microcompact_chat_messages(&mut messages, policy);
+            if report.changed_messages > 0 {
+                compaction_changed = true;
+                tracing::info!(
+                    changed_messages = report.changed_messages,
+                    reclaimed_tokens = report.reclaimed_tokens,
+                    "send-path context microcompact completed"
+                );
+            }
+        }
+
+        let after_micro_tokens = estimate_chat_tokens(&messages, policy);
+        let after_micro_state = policy.state_for_tokens(after_micro_tokens);
+        if after_micro_state.is_above_auto_compact_threshold && policy.full_compact_enabled {
+            self.emit_context_compaction_start("send_path", "full_compact");
+            emitted_compaction_start = true;
+            compaction_mode = "full_compact";
+            let failures = *self.compact_consecutive_failures.lock().unwrap();
+            if failures >= policy.max_consecutive_failures {
+                tracing::warn!(
+                    failures,
+                    "send-path full compact skipped because failure fuse is open"
+                );
+            } else {
+                match self
+                    .full_compact_chat_messages_with_model(messages.clone(), policy)
+                    .await
+                {
+                    Ok(compacted) => {
+                        *self.compact_consecutive_failures.lock().unwrap() = 0;
+                        compaction_changed = true;
+                        messages = compacted;
+                    }
+                    Err(err) => {
+                        let mut guard = self.compact_consecutive_failures.lock().unwrap();
+                        *guard = (*guard).saturating_add(1);
+                        tracing::warn!(
+                            error = %err,
+                            failures = *guard,
+                            "send-path full compact failed; falling back to final trim"
+                        );
+                    }
+                }
+            }
+        }
+
+        if emitted_compaction_start || compaction_changed {
+            let after_tokens = estimate_chat_tokens(&messages, policy);
+            self.emit_context_compaction_end(
+                "send_path",
+                compaction_mode,
+                before_tokens,
+                after_tokens,
+                compaction_changed,
+            );
+        }
+
+        trim_messages(
+            messages,
+            self.max_context_tokens,
+            policy.micro_keep_recent_messages.max(5),
+        )
+    }
+
+    async fn full_compact_chat_messages_with_model(
+        &self,
+        messages: Vec<ChatMessage>,
+        policy: &ContextBudgetPolicy,
+    ) -> Result<Vec<ChatMessage>, String> {
+        let keep_recent = policy.micro_keep_recent_messages.max(2);
+        let recent_start = messages.len().saturating_sub(keep_recent);
+        let old_messages: Vec<ChatMessage> = messages
+            .iter()
+            .take(recent_start)
+            .filter(|m| m.role != "system")
+            .cloned()
+            .collect();
+        if old_messages.is_empty() {
+            return Err("no old chat messages available for full compact".to_string());
+        }
+
+        let prompt = build_chat_summary_prompt(&old_messages, policy.summary_max_tokens);
+        let summary = self
+            .generate_compact_summary(prompt, policy.summary_max_tokens)
+            .await
+            .map_err(|err| err.to_string())?;
+
+        let mut compacted = Vec::new();
+        for (idx, msg) in messages.iter().enumerate() {
+            if idx >= recent_start {
+                break;
+            }
+            if msg.role == "system" {
+                compacted.push(msg.clone());
+            }
+        }
+        compacted.push(ChatMessage::system(summary));
+        compacted.extend(messages.into_iter().skip(recent_start));
+        tracing::info!(
+            compacted_messages = old_messages.len(),
+            "send-path model full compact completed"
+        );
+        Ok(compacted)
+    }
+
+    async fn generate_compact_summary(
+        &self,
+        user_prompt: String,
+        summary_max_tokens: usize,
+    ) -> Result<String, AishError> {
+        let messages = vec![
+            ChatMessage::system(COMPACT_SUMMARY_SYSTEM_PROMPT),
+            ChatMessage::user(user_prompt),
+        ];
+        let max_tokens = summary_max_tokens.min(u32::MAX as usize) as u32;
+        let response = self
+            .client
+            .chat_completion(&messages, None, false, Some(0.1), Some(max_tokens))
+            .await?;
+        match response {
+            LlmResponse::Json(json) => {
+                let (content, _reasoning, _tool_calls, usage) = StreamParser::parse_response(&json);
+                if let Some(u) = usage {
+                    self.record_usage(u);
+                }
+                let summary = format_compact_summary(content.unwrap_or_default());
+                if summary.trim().is_empty() {
+                    return Err(AishError::Llm("compact summary is empty".to_string()));
+                }
+                Ok(summary)
+            }
+            LlmResponse::Stream(_) => Err(AishError::Llm(
+                "compact summary unexpectedly returned a stream".to_string(),
+            )),
+        }
+    }
 }
 
 /// Helper: current time as a UNIX timestamp in seconds (f64).
@@ -1126,6 +1342,322 @@ fn now_timestamp() -> f64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs_f64()
+}
+
+fn build_context_summary_prompt(
+    messages: &[ContextMessage],
+    plan_state: Option<&PlanModeState>,
+    summary_max_tokens: usize,
+) -> String {
+    let mut prompt = String::new();
+    prompt.push_str("Summarize the older persistent AI Shell context below.\n");
+    prompt.push_str("Focus on shell operations facts: user goal, important commands, exit codes, failures, stderr clues, paths, hosts, cwd, memory/skill hints, and pending next steps.\n");
+    prompt.push_str(
+        "Do not include low-value full stdout. Keep offload paths and return codes when present.\n",
+    );
+    prompt.push_str(&format!(
+        "Target summary budget: about {} tokens.\n\n",
+        summary_max_tokens
+    ));
+    if let Some(state) = plan_state {
+        if state.phase == PlanPhase::Planning {
+            prompt.push_str("Current plan mode state:\n");
+            prompt.push_str(&format!(
+                "- plan_id={:?}, artifact_path={:?}, draft_revision={}, approval_status={:?}\n\n",
+                state.plan_id, state.artifact_path, state.draft_revision, state.approval_status
+            ));
+        }
+    }
+    prompt.push_str(
+        "Return exactly one <conversation-summary> block with these sections when applicable:\n",
+    );
+    prompt.push_str("Summary, Current Goal, Important Commands, Failures And Evidence, Environment Facts, Pending Next Steps.\n\n");
+    prompt.push_str("Older context messages:\n");
+    for (idx, msg) in messages.iter().enumerate() {
+        prompt.push_str(&format!(
+            "\n<message index=\"{}\" role=\"{}\" memory_type=\"{}\">\n{}\n</message>\n",
+            idx,
+            msg.role,
+            memory_type_label(&msg.memory_type),
+            truncate_for_summary_prompt(&msg.content, 4_000)
+        ));
+    }
+    prompt
+}
+
+fn build_chat_summary_prompt(messages: &[ChatMessage], summary_max_tokens: usize) -> String {
+    let mut prompt = String::new();
+    prompt.push_str("Summarize the older in-flight chat/tool context below for AI Shell.\n");
+    prompt.push_str("Preserve user intent, command/tool results, failures, important stderr, and pending next steps. Drop verbose stdout and repeated low-value details.\n");
+    prompt.push_str(&format!(
+        "Target summary budget: about {} tokens.\n\n",
+        summary_max_tokens
+    ));
+    prompt.push_str("Return exactly one <conversation-summary> block.\n\n");
+    for (idx, msg) in messages.iter().enumerate() {
+        let content = msg.content.as_deref().unwrap_or("");
+        prompt.push_str(&format!(
+            "\n<message index=\"{}\" role=\"{}\">\n{}\n</message>\n",
+            idx,
+            msg.role,
+            truncate_for_summary_prompt(content, 4_000)
+        ));
+        if let Some(reasoning) = &msg.reasoning_content {
+            prompt.push_str(&format!(
+                "<reasoning index=\"{}\">\n{}\n</reasoning>\n",
+                idx,
+                truncate_for_summary_prompt(reasoning, 1_000)
+            ));
+        }
+    }
+    prompt
+}
+
+fn memory_type_label(memory_type: &MemoryType) -> &'static str {
+    match memory_type {
+        MemoryType::Llm => "llm",
+        MemoryType::Shell => "shell",
+        MemoryType::Knowledge => "knowledge",
+    }
+}
+
+fn truncate_for_summary_prompt(content: &str, max_chars: usize) -> String {
+    if content.len() <= max_chars {
+        return content.to_string();
+    }
+    let mut end = max_chars.min(content.len());
+    while end > 0 && !content.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}\n[truncated]", &content[..end])
+}
+
+fn format_compact_summary(summary: String) -> String {
+    let mut text = strip_tag_block(&summary, "analysis");
+    if let Some(inner) = extract_tag_inner(&text, "summary") {
+        text = inner;
+    }
+    let trimmed = text.trim();
+    if trimmed.starts_with("<conversation-summary") {
+        trimmed.to_string()
+    } else {
+        format!(
+            "<conversation-summary source=\"model_auto_compact\">\n{}\n</conversation-summary>",
+            trimmed
+        )
+    }
+}
+
+fn strip_tag_block(text: &str, tag: &str) -> String {
+    let open = format!("<{}>", tag);
+    let close = format!("</{}>", tag);
+    let Some(start) = text.find(&open) else {
+        return text.to_string();
+    };
+    let Some(end_rel) = text[start + open.len()..].find(&close) else {
+        return text.to_string();
+    };
+    let end = start + open.len() + end_rel + close.len();
+    format!("{}{}", &text[..start], &text[end..])
+}
+
+fn extract_tag_inner(text: &str, tag: &str) -> Option<String> {
+    let open = format!("<{}>", tag);
+    let close = format!("</{}>", tag);
+    let start = text.find(&open)? + open.len();
+    let end = text[start..].find(&close).map(|idx| start + idx)?;
+    Some(text[start..end].trim().to_string())
+}
+
+fn estimate_chat_tokens(messages: &[ChatMessage], policy: &ContextBudgetPolicy) -> usize {
+    messages
+        .iter()
+        .map(|m| estimate_one_chat_message(m, policy))
+        .sum()
+}
+
+fn estimate_one_chat_message(message: &ChatMessage, policy: &ContextBudgetPolicy) -> usize {
+    let content_len = message.content.as_ref().map(|c| c.len()).unwrap_or(0);
+    let reasoning_len = message
+        .reasoning_content
+        .as_ref()
+        .map(|c| c.len())
+        .unwrap_or(0);
+    if policy.enable_token_estimation {
+        ((content_len + reasoning_len) / 4).max(1)
+    } else {
+        ((content_len + reasoning_len) / 4).max(1)
+    }
+}
+
+fn microcompact_chat_messages(
+    messages: &mut [ChatMessage],
+    policy: &ContextBudgetPolicy,
+) -> MicrocompactReport {
+    let before_tokens = estimate_chat_tokens(messages, policy);
+    let recent_start = messages
+        .len()
+        .saturating_sub(policy.micro_keep_recent_messages);
+    let mut changed_messages = 0usize;
+
+    for (idx, msg) in messages.iter_mut().enumerate() {
+        if idx >= recent_start || msg.role == "system" {
+            continue;
+        }
+
+        let mut changed = false;
+        if msg.role == "tool" {
+            if let Some(content) = &msg.content {
+                if content.len() > 256 || is_low_value_chat_output(content) {
+                    let mut replacement = String::from(
+                        "[old tool output cleared by context microcompact; key metadata retained]",
+                    );
+                    if let Some(id) = &msg.tool_call_id {
+                        replacement.push_str(&format!("\ntool_call_id: {}", id));
+                    }
+                    if let Some(return_code) = extract_return_code(content) {
+                        replacement.push_str(&format!("\nreturn_code: {}", return_code));
+                    }
+                    msg.content = Some(replacement);
+                    changed = true;
+                }
+            }
+        }
+
+        if msg
+            .reasoning_content
+            .as_ref()
+            .is_some_and(|s| s.len() > 512)
+        {
+            msg.reasoning_content =
+                Some("[old reasoning content cleared by context microcompact]".to_string());
+            changed = true;
+        }
+
+        if changed {
+            changed_messages += 1;
+        }
+    }
+
+    let after_tokens = estimate_chat_tokens(messages, policy);
+    MicrocompactReport {
+        changed_messages,
+        reclaimed_tokens: before_tokens.saturating_sub(after_tokens),
+    }
+}
+
+#[cfg(test)]
+fn full_compact_chat_messages(
+    messages: Vec<ChatMessage>,
+    policy: &ContextBudgetPolicy,
+) -> Result<Vec<ChatMessage>, String> {
+    let keep_recent = policy.micro_keep_recent_messages.max(2);
+    let recent_start = messages.len().saturating_sub(keep_recent);
+    let old_messages: Vec<ChatMessage> = messages
+        .iter()
+        .take(recent_start)
+        .filter(|m| m.role != "system")
+        .cloned()
+        .collect();
+    if old_messages.is_empty() {
+        return Err("no old chat messages available for full compact".to_string());
+    }
+
+    let summary = build_chat_summary(&old_messages, policy.summary_max_tokens);
+    if summary.trim().is_empty() {
+        return Err("chat compact summary is empty".to_string());
+    }
+
+    let mut compacted = Vec::new();
+    for (idx, msg) in messages.iter().enumerate() {
+        if idx >= recent_start {
+            break;
+        }
+        if msg.role == "system" {
+            compacted.push(msg.clone());
+        }
+    }
+    compacted.push(ChatMessage::system(summary));
+    compacted.extend(messages.into_iter().skip(recent_start));
+    tracing::info!(
+        compacted_messages = old_messages.len(),
+        "send-path full compact completed"
+    );
+    Ok(compacted)
+}
+
+#[cfg(test)]
+fn build_chat_summary(old_messages: &[ChatMessage], summary_max_tokens: usize) -> String {
+    let mut lines = vec![
+        "<conversation-summary source=\"send_path_auto_compact\">".to_string(),
+        "Summary:".to_string(),
+        format!("- Compacted older chat messages: {}.", old_messages.len()),
+    ];
+    for msg in old_messages
+        .iter()
+        .rev()
+        .take(10)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+    {
+        let content = msg.content.as_deref().unwrap_or("");
+        lines.push(format!(
+            "- {}: {}",
+            msg.role,
+            summarize_chat_line(content, 220)
+        ));
+    }
+    lines.push("</conversation-summary>".to_string());
+    let mut summary = lines.join("\n");
+    let max_chars = summary_max_tokens.saturating_mul(4).max(512);
+    if summary.len() > max_chars {
+        let mut end = max_chars.min(summary.len());
+        while end > 0 && !summary.is_char_boundary(end) {
+            end -= 1;
+        }
+        summary.truncate(end);
+        summary.push_str("\n</conversation-summary>");
+    }
+    summary
+}
+
+#[cfg(test)]
+fn summarize_chat_line(content: &str, max_chars: usize) -> String {
+    let one_line = content
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .take(4)
+        .collect::<Vec<_>>()
+        .join(" | ");
+    if one_line.len() <= max_chars {
+        return one_line;
+    }
+    let mut end = max_chars.min(one_line.len());
+    while end > 0 && !one_line.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &one_line[..end])
+}
+
+fn is_low_value_chat_output(content: &str) -> bool {
+    content.contains("<stdout>")
+        || content.contains("<stderr>")
+        || content.contains("<offload>")
+        || content.len() > 8_000
+}
+
+fn extract_return_code(content: &str) -> Option<String> {
+    let open = "<return_code>";
+    let close = "</return_code>";
+    let start = content.find(open)? + open.len();
+    let end = content[start..]
+        .find(close)
+        .map(|idx| start + idx)
+        .unwrap_or(content.len());
+    let value = content[start..end].trim();
+    (!value.is_empty()).then(|| value.to_string())
 }
 
 /// Trim messages to fit within a token budget.
@@ -1257,6 +1789,113 @@ mod tests {
         assert_eq!(
             result.last().unwrap().content.as_deref(),
             Some("message number 19 with padding content here")
+        );
+    }
+
+    #[test]
+    fn test_microcompact_chat_messages_clears_old_tool_output() {
+        let policy = ContextBudgetPolicy {
+            micro_keep_recent_messages: 1,
+            enable_token_estimation: false,
+            ..ContextBudgetPolicy::default()
+        };
+        let mut msgs = vec![
+            make_msg("system", "sys"),
+            ChatMessage::tool_result(
+                "call-old",
+                "<stdout>very noisy output</stdout>\n<return_code>0</return_code>",
+            ),
+            ChatMessage::tool_result("call-new", "<stdout>recent output</stdout>"),
+        ];
+
+        let report = microcompact_chat_messages(&mut msgs, &policy);
+        assert_eq!(report.changed_messages, 1);
+        assert!(msgs[1]
+            .content
+            .as_deref()
+            .unwrap()
+            .contains("old tool output cleared"));
+        assert!(msgs[2]
+            .content
+            .as_deref()
+            .unwrap()
+            .contains("recent output"));
+    }
+
+    #[test]
+    fn test_full_compact_chat_messages_adds_summary_and_preserves_recent() {
+        let policy = ContextBudgetPolicy {
+            micro_keep_recent_messages: 2,
+            summary_max_tokens: 200,
+            ..ContextBudgetPolicy::default()
+        };
+        let msgs = vec![
+            make_msg("system", "sys"),
+            make_msg("user", "old request"),
+            make_msg("assistant", "old answer"),
+            make_msg("user", "recent request"),
+            make_msg("assistant", "recent answer"),
+        ];
+
+        let result = full_compact_chat_messages(msgs, &policy).unwrap();
+        assert_eq!(result[0].role, "system");
+        assert!(result.iter().any(|m| m
+            .content
+            .as_deref()
+            .unwrap_or("")
+            .contains("conversation-summary")));
+        assert_eq!(
+            result.last().unwrap().content.as_deref(),
+            Some("recent answer")
+        );
+    }
+
+    #[test]
+    fn test_format_compact_summary_wraps_model_text() {
+        let formatted = format_compact_summary(
+            "<analysis>scratch</analysis><summary>Current Goal:\n- Diagnose nginx</summary>"
+                .to_string(),
+        );
+        assert!(formatted.starts_with("<conversation-summary"));
+        assert!(formatted.contains("Diagnose nginx"));
+        assert!(!formatted.contains("scratch"));
+    }
+
+    #[tokio::test]
+    async fn test_prepare_messages_for_send_triggers_microcompact_without_model() {
+        let mut session = LlmSession::new("http://localhost", "key", "model", None, None);
+        session.set_context_budget_policy(ContextBudgetPolicy {
+            context_window_tokens: 2_000,
+            reserved_output_tokens: 200,
+            auto_compact_buffer_tokens: 200,
+            warning_buffer_tokens: 200,
+            blocking_buffer_tokens: 100,
+            micro_keep_recent_messages: 2,
+            full_compact_enabled: false,
+            enable_token_estimation: false,
+            ..ContextBudgetPolicy::default()
+        });
+
+        let mut msgs = vec![make_msg("system", "sys")];
+        msgs.push(ChatMessage::tool_result(
+            "call-old",
+            format!(
+                "<stdout>{}</stdout>\n<return_code>1</return_code>",
+                "old noisy output\n".repeat(400)
+            ),
+        ));
+        msgs.push(make_msg("user", "recent request"));
+        msgs.push(make_msg("assistant", "recent answer"));
+
+        let prepared = session.prepare_messages_for_send(msgs).await;
+        assert!(prepared.iter().any(|m| m
+            .content
+            .as_deref()
+            .unwrap_or("")
+            .contains("old tool output cleared")));
+        assert_eq!(
+            prepared.last().unwrap().content.as_deref(),
+            Some("recent answer")
         );
     }
 

--- a/crates/aish-llm/src/streaming.rs
+++ b/crates/aish-llm/src/streaming.rs
@@ -34,10 +34,7 @@ impl StreamParser {
         if let Some(choices) = choices {
             if let Some(choice) = choices.first() {
                 let message = choice.get("message");
-                let content = message
-                    .and_then(|m| m.get("content"))
-                    .and_then(|c| c.as_str())
-                    .map(|s| s.to_string());
+                let content = extract_message_text(message.and_then(|m| m.get("content")));
                 let reasoning_content = message
                     .and_then(|m| m.get("reasoning_content"))
                     .and_then(|c| c.as_str())
@@ -129,10 +126,7 @@ impl StreamParser {
         let mut events = Vec::new();
 
         // Content delta
-        if let Some(content) = delta
-            .and_then(|d| d.get("content"))
-            .and_then(|c| c.as_str())
-        {
+        if let Some(content) = extract_message_text(delta.and_then(|d| d.get("content"))) {
             if !content.is_empty() {
                 events.push(SseEvent::ContentDelta(content.to_string()));
                 return (events, None);
@@ -187,5 +181,80 @@ impl StreamParser {
         }
 
         (Vec::new(), None)
+    }
+}
+
+fn extract_message_text(content: Option<&serde_json::Value>) -> Option<String> {
+    match content {
+        None => None,
+        Some(serde_json::Value::String(text)) => {
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }
+        Some(serde_json::Value::Array(items)) => {
+            let parts: Vec<String> = items
+                .iter()
+                .filter_map(|item| match item {
+                    serde_json::Value::String(text) => Some(text.clone()),
+                    serde_json::Value::Object(obj) => obj
+                        .get("text")
+                        .or_else(|| obj.get("content"))
+                        .and_then(|value| value.as_str())
+                        .map(|text| text.to_string()),
+                    _ => None,
+                })
+                .map(|part| part.trim().to_string())
+                .filter(|part| !part.is_empty())
+                .collect();
+
+            if parts.is_empty() {
+                None
+            } else {
+                Some(parts.join("\n"))
+            }
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SseEvent, StreamParser};
+
+    #[test]
+    fn parse_response_accepts_array_content() {
+        let response = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": [
+                        {"type": "output_text", "text": "第一段"},
+                        {"type": "output_text", "text": "第二段"}
+                    ]
+                }
+            }]
+        });
+
+        let (content, reasoning, tool_calls, usage) = StreamParser::parse_response(&response);
+        assert_eq!(content.as_deref(), Some("第一段\n第二段"));
+        assert!(reasoning.is_none());
+        assert!(tool_calls.is_empty());
+        assert!(usage.is_none());
+    }
+
+    #[test]
+    fn parse_sse_chunk_accepts_array_content_delta() {
+        let line = r#"data: {"choices":[{"delta":{"content":[{"type":"output_text","text":"总结已生成"}]}}]}"#;
+
+        let (events, usage) = StreamParser::parse_sse_chunk(line);
+        assert!(usage.is_none());
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            SseEvent::ContentDelta(text) => assert_eq!(text, "总结已生成"),
+            other => panic!("unexpected event: {:?}", other),
+        }
     }
 }

--- a/crates/aish-shell/src/ai_handler.rs
+++ b/crates/aish-shell/src/ai_handler.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, Mutex};
 
 use aish_config::MemoryConfig;
-use aish_context::ContextManager;
+use aish_context::{
+    ContextBudgetPolicy, ContextCompactReport, ContextManager, ContextPressureLevel,
+};
 use aish_core::{LlmEvent, MemoryCategory, MemoryType, PlanModeState, PlanPhase};
 use aish_llm::{ChatMessage, LlmCallbackResult, LlmSession};
 use aish_memory::MemoryManager;
@@ -180,6 +182,7 @@ impl AiHandler {
         max_llm_messages: usize,
         max_shell_messages: usize,
         token_budget: Option<usize>,
+        context_budget_policy: ContextBudgetPolicy,
     ) -> Self {
         let mut context_manager = ContextManager::with_limits(
             max_llm_messages,
@@ -187,6 +190,7 @@ impl AiHandler {
             10, // max_knowledge_messages
         );
         context_manager.set_token_budget(token_budget);
+        context_manager.set_budget_policy(context_budget_policy);
         Self {
             llm_session,
             context_manager,
@@ -341,7 +345,21 @@ impl AiHandler {
         // Step 3: Inject loaded skills into context as knowledge
         self.inject_skills();
 
-        // Step 4: Build context and system messages
+        // Step 4: Compact persistent context before building messages.
+        let plan_state = self.plan_state();
+        let compact_report = self.compact_context_before_send(&plan_state).await;
+        if compact_report.microcompact.changed_messages > 0 || compact_report.full_compact.is_some()
+        {
+            tracing::info!(
+                before_tokens = compact_report.before_tokens,
+                after_tokens = compact_report.after_tokens,
+                micro_changed = compact_report.microcompact.changed_messages,
+                full_compact = compact_report.full_compact.is_some(),
+                "AI context compacted before question send"
+            );
+        }
+
+        // Step 5: Build context and system messages
         let context_messages = self.build_context_messages();
         let system_message = self.system_message();
 
@@ -357,17 +375,17 @@ impl AiHandler {
             .await?;
         let response = process_result.text;
 
-        // Step 6: Store the exchange in context
+        // Step 7: Store the exchange in context
         self.context_manager
             .add_message("user", &question_processed, MemoryType::Llm);
         self.context_manager
             .add_message("assistant", &response, MemoryType::Llm);
         self.context_manager.trim();
 
-        // Step 7: Auto-retain user preferences/facts
+        // Step 8: Auto-retain user preferences/facts
         self.auto_retain_memory(&question_processed, &response);
 
-        // Step 8: Persist token usage delta to disk
+        // Step 9: Persist token usage delta to disk
         self.persist_token_usage();
 
         Ok(response)
@@ -387,6 +405,8 @@ impl AiHandler {
             command, exit_code
         );
 
+        let plan_state = self.plan_state();
+        let _ = self.compact_context_before_send(&plan_state).await;
         let context_messages = self.build_context_messages();
         let system_message = self.error_correction_system_message(command, exit_code, stderr);
 
@@ -400,6 +420,113 @@ impl AiHandler {
         self.persist_token_usage();
 
         Ok(parse_error_correction_response(&response))
+    }
+
+    async fn compact_context_before_send(
+        &mut self,
+        plan_state: &PlanModeState,
+    ) -> ContextCompactReport {
+        let before_state = self.context_manager.budget_state();
+        let before_tokens = before_state.estimated_tokens;
+        let mut emitted_compaction_start = false;
+        let mut report = ContextCompactReport {
+            before_tokens,
+            pressure_before: Some(before_state.pressure),
+            ..ContextCompactReport::default()
+        };
+
+        let policy = self.context_manager.budget_policy().clone();
+        if !policy.enabled {
+            report.after_tokens = before_tokens;
+            report.pressure_after = Some(before_state.pressure);
+            return report;
+        }
+
+        if matches!(
+            before_state.pressure,
+            ContextPressureLevel::Warning
+                | ContextPressureLevel::AutoCompact
+                | ContextPressureLevel::Blocking
+        ) {
+            report.microcompact = self.context_manager.microcompact();
+        }
+
+        let after_micro_state = self.context_manager.budget_state();
+        if after_micro_state.is_above_auto_compact_threshold && policy.full_compact_enabled {
+            self.llm_session
+                .emit_context_compaction_start("persistent_context", "full_compact");
+            emitted_compaction_start = true;
+            if self.context_manager.compact_consecutive_failures()
+                >= policy.max_consecutive_failures
+            {
+                report.skipped_full_compact_due_to_fuse = true;
+                tracing::warn!(
+                    failures = self.context_manager.compact_consecutive_failures(),
+                    "persistent context model compact skipped because failure fuse is open"
+                );
+            } else {
+                let candidates = self.context_manager.full_compact_candidate_messages();
+                if candidates.is_empty() {
+                    self.context_manager.record_compact_failure();
+                } else {
+                    match self
+                        .llm_session
+                        .summarize_context_messages(
+                            &candidates,
+                            Some(plan_state),
+                            policy.summary_max_tokens,
+                        )
+                        .await
+                    {
+                        Ok(summary) => {
+                            match self.context_manager.apply_full_compact_summary(summary) {
+                                Ok(full_report) => {
+                                    self.context_manager.reset_compact_failures();
+                                    report.full_compact = Some(full_report);
+                                }
+                                Err(err) => {
+                                    self.context_manager.record_compact_failure();
+                                    tracing::warn!(
+                                        error = %err,
+                                        failures = self.context_manager.compact_consecutive_failures(),
+                                        "persistent context model compact summary could not be applied"
+                                    );
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            self.context_manager.record_compact_failure();
+                            tracing::warn!(
+                                error = %err,
+                                failures = self.context_manager.compact_consecutive_failures(),
+                                "persistent context model compact failed; falling back to final trim"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        let after_state = self.context_manager.budget_state();
+        report.after_tokens = after_state.estimated_tokens;
+        report.pressure_after = Some(after_state.pressure);
+        let compaction_changed =
+            report.microcompact.changed_messages > 0 || report.full_compact.is_some();
+        if emitted_compaction_start || compaction_changed {
+            let mode = if report.full_compact.is_some() {
+                "full_compact"
+            } else {
+                "microcompact"
+            };
+            self.llm_session.emit_context_compaction_end(
+                "persistent_context",
+                mode,
+                before_tokens,
+                report.after_tokens,
+                compaction_changed,
+            );
+        }
+        report
     }
 
     /// Extract @skill_name references and inject skill prefix.

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -2309,13 +2309,13 @@ impl AishShell {
                         }
                         use aish_core::LlmEventType;
                         match event.event_type {
-                            LlmEventType::ContextCompactionStart => {
+                            LlmEventType::ContextCompactionStart
                                 if !compaction_active
-                                    .swap(true, std::sync::atomic::Ordering::SeqCst)
-                                {
-                                    anim.start(&t("shell.status.compacting_context"));
-                                }
+                                    .swap(true, std::sync::atomic::Ordering::SeqCst) =>
+                            {
+                                anim.start(&t("shell.status.compacting_context"));
                             }
+                            LlmEventType::ContextCompactionStart => {}
                             LlmEventType::ContextCompactionEnd => {
                                 compaction_active.store(false, std::sync::atomic::Ordering::SeqCst);
                                 anim.stop();
@@ -2988,13 +2988,13 @@ impl AishShell {
                         }
                         use aish_core::LlmEventType;
                         match event.event_type {
-                            LlmEventType::ContextCompactionStart => {
+                            LlmEventType::ContextCompactionStart
                                 if !compaction_active
-                                    .swap(true, std::sync::atomic::Ordering::SeqCst)
-                                {
-                                    anim.start(&t("shell.status.compacting_context"));
-                                }
+                                    .swap(true, std::sync::atomic::Ordering::SeqCst) =>
+                            {
+                                anim.start(&t("shell.status.compacting_context"));
                             }
+                            LlmEventType::ContextCompactionStart => {}
                             LlmEventType::ContextCompactionEnd => {
                                 compaction_active.store(false, std::sync::atomic::Ordering::SeqCst);
                                 anim.stop();
@@ -3156,7 +3156,7 @@ impl AishShell {
                                         .and_then(|p| p.as_str())
                                         .unwrap_or("?");
                                     use std::io::Write;
-                                    print!("\x1b[90m📖 read_file({})\x1b[0m\n", path);
+                                    println!("\x1b[90m📖 read_file({})\x1b[0m", path);
                                     let _ = std::io::stdout().flush();
                                 }
                             }
@@ -3179,7 +3179,7 @@ impl AishShell {
                                             .and_then(|p| p.as_str())
                                             .unwrap_or("error");
                                         use std::io::Write;
-                                        print!("\x1b[31m{}\x1b[0m\n", preview);
+                                        println!("\x1b[31m{}\x1b[0m", preview);
                                         let _ = std::io::stdout().flush();
                                     }
                                 }

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -2317,8 +2317,7 @@ impl AishShell {
                                 }
                             }
                             LlmEventType::ContextCompactionEnd => {
-                                compaction_active
-                                    .store(false, std::sync::atomic::Ordering::SeqCst);
+                                compaction_active.store(false, std::sync::atomic::Ordering::SeqCst);
                                 anim.stop();
                                 if !compaction_notice_shown
                                     .swap(true, std::sync::atomic::Ordering::SeqCst)
@@ -2329,8 +2328,7 @@ impl AishShell {
                                 }
                             }
                             LlmEventType::GenerationStart => {
-                                compaction_active
-                                    .store(false, std::sync::atomic::Ordering::SeqCst);
+                                compaction_active.store(false, std::sync::atomic::Ordering::SeqCst);
                                 anim.stop();
                                 reasoning_active.store(false, std::sync::atomic::Ordering::SeqCst);
                                 reasoning_frame.store(0, std::sync::atomic::Ordering::SeqCst);
@@ -2998,8 +2996,7 @@ impl AishShell {
                                 }
                             }
                             LlmEventType::ContextCompactionEnd => {
-                                compaction_active
-                                    .store(false, std::sync::atomic::Ordering::SeqCst);
+                                compaction_active.store(false, std::sync::atomic::Ordering::SeqCst);
                                 anim.stop();
                                 if !compaction_notice_shown
                                     .swap(true, std::sync::atomic::Ordering::SeqCst)
@@ -3010,8 +3007,7 @@ impl AishShell {
                                 }
                             }
                             LlmEventType::GenerationStart => {
-                                compaction_active
-                                    .store(false, std::sync::atomic::Ordering::SeqCst);
+                                compaction_active.store(false, std::sync::atomic::Ordering::SeqCst);
                                 anim.stop();
                                 reasoning_active.store(false, std::sync::atomic::Ordering::SeqCst);
                                 reasoning_frame.store(0, std::sync::atomic::Ordering::SeqCst);

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -4,6 +4,10 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use aish_config::ConfigModel;
+use aish_context::{
+    context_window_hard_min_tokens, context_window_warn_below_tokens,
+    effective_reserved_output_tokens, resolve_context_window_tokens, ContextBudgetPolicy,
+};
 use aish_core::{LlmEvent, LlmEventType, MemoryCategory};
 use aish_i18n::{t, t_with_args};
 use aish_llm::{
@@ -61,6 +65,130 @@ async fn poll_cancelled(token: *const CancellationToken) {
 
 /// Braille spinner frames used in the reasoning overlay.
 const DOTS_FRAMES: &[&str] = &["⠁", "⠂", "⠄", "⡀", "⢀", "⠠", "⠐", "⠈"];
+
+fn context_compaction_notice(event: &LlmEvent) -> Option<String> {
+    let changed = event
+        .data
+        .get("changed")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    if !changed {
+        return None;
+    }
+
+    Some(t("shell.compaction.completed"))
+}
+
+fn context_budget_policy_from_config(config: &ConfigModel) -> ContextBudgetPolicy {
+    let compact = &config.context_auto_compact;
+    let model_config_tokens = compact.model_context_windows.get(&config.model).copied();
+    let context_window = resolve_context_window_tokens(
+        compact.context_window_tokens,
+        model_config_tokens,
+        config.context_token_budget,
+    );
+    let mut policy =
+        ContextBudgetPolicy::from_optional_budget(None, config.enable_token_estimation);
+    policy.enabled = compact.enabled;
+    policy.full_compact_enabled = compact.full_compact_enabled;
+    policy.context_window_tokens = context_window.tokens;
+    policy.context_window_source = context_window.source;
+    if let Some(value) = compact.reserved_output_tokens {
+        policy.reserved_output_tokens = value;
+    }
+    if let Some(value) = compact.auto_compact_buffer_tokens {
+        policy.auto_compact_buffer_tokens = value;
+    }
+    if let Some(value) = compact.warning_buffer_tokens {
+        policy.warning_buffer_tokens = value;
+    }
+    if let Some(value) = compact.blocking_buffer_tokens {
+        policy.blocking_buffer_tokens = value;
+    }
+    policy.micro_keep_recent_messages = compact.micro_keep_recent_messages.max(1);
+    policy.shell_keep_recent_commands = compact.shell_keep_recent_commands.max(1);
+    policy.max_consecutive_failures = compact.max_consecutive_failures.max(1);
+    policy.summary_max_tokens = compact.summary_max_tokens.max(256);
+    if policy.context_window_tokens < context_window_hard_min_tokens() {
+        if policy.full_compact_enabled {
+            tracing::warn!(
+                model = %config.model,
+                context_window_tokens = policy.context_window_tokens,
+                source = policy.context_window_source.as_str(),
+                hard_min_tokens = context_window_hard_min_tokens(),
+                "context window is too small for model-generated full compact; falling back to microcompact-only"
+            );
+        }
+        policy.full_compact_enabled = false;
+    } else if policy.context_window_tokens < context_window_warn_below_tokens() {
+        tracing::warn!(
+            model = %config.model,
+            context_window_tokens = policy.context_window_tokens,
+            source = policy.context_window_source.as_str(),
+            warn_below_tokens = context_window_warn_below_tokens(),
+            "context window is small; context compaction may trigger early"
+        );
+    }
+    let thresholds = policy.thresholds();
+    tracing::info!(
+        model = %config.model,
+        context_window_tokens = policy.context_window_tokens,
+        context_window_source = policy.context_window_source.as_str(),
+        reserved_output_tokens = policy.reserved_output_tokens,
+        effective_reserved_output_tokens = effective_reserved_output_tokens(
+            policy.context_window_tokens,
+            policy.reserved_output_tokens,
+        ),
+        effective_context_window = thresholds.effective_context_window,
+        warning_threshold = thresholds.warning_threshold,
+        auto_compact_threshold = thresholds.auto_compact_threshold,
+        blocking_threshold = thresholds.blocking_threshold,
+        full_compact_enabled = policy.full_compact_enabled,
+        "resolved context auto-compact budget"
+    );
+    policy
+}
+
+#[cfg(test)]
+mod context_budget_tests {
+    use super::*;
+
+    #[test]
+    fn model_context_window_mapping_sets_source() {
+        let mut config = ConfigModel::default();
+        config.model = "openai/glm-5.1".to_string();
+        config.context_token_budget = Some(8_000);
+        config
+            .context_auto_compact
+            .model_context_windows
+            .insert(config.model.clone(), 128_000);
+
+        let policy = context_budget_policy_from_config(&config);
+
+        assert_eq!(policy.context_window_tokens, 128_000);
+        assert_eq!(
+            policy.context_window_source,
+            aish_context::ContextWindowSource::ModelConfig
+        );
+        assert!(policy.full_compact_enabled);
+    }
+
+    #[test]
+    fn tiny_context_window_disables_model_full_compact() {
+        let mut config = ConfigModel::default();
+        config.context_auto_compact.context_window_tokens = Some(2_000);
+        config.context_auto_compact.full_compact_enabled = true;
+
+        let policy = context_budget_policy_from_config(&config);
+
+        assert_eq!(policy.context_window_tokens, 2_000);
+        assert_eq!(
+            policy.context_window_source,
+            aish_context::ContextWindowSource::AutoCompactOverride
+        );
+        assert!(!policy.full_compact_enabled);
+    }
+}
 
 /// Shell lifecycle phases.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -161,6 +289,8 @@ impl AishShell {
             Some(config.temperature),
             config.max_tokens,
         );
+        let context_budget_policy = context_budget_policy_from_config(&config);
+        llm_session.set_context_budget_policy(context_budget_policy.clone());
 
         // Initialize Langfuse observability if configured
         if config.enable_langfuse {
@@ -421,6 +551,10 @@ impl AishShell {
         let reasoning_frame_ref = reasoning_frame.clone();
         let reasoning_lines_displayed = Arc::new(AtomicUsize::new(0));
         let reasoning_lines_displayed_ref = reasoning_lines_displayed.clone();
+        let compaction_active = Arc::new(AtomicBool::new(false));
+        let compaction_active_ref = compaction_active.clone();
+        let compaction_notice_shown = Arc::new(AtomicBool::new(false));
+        let compaction_notice_shown_ref = compaction_notice_shown.clone();
         let event_callback: Arc<dyn Fn(LlmEvent) -> Option<LlmCallbackResult> + Send + Sync> =
             Arc::new(move |event: LlmEvent| {
                 // Helper: clear multi-line reasoning overlay and reset state.
@@ -446,6 +580,8 @@ impl AishShell {
                         reasoning_frame_ref.store(0, Ordering::SeqCst);
                         reasoning_lines_displayed_ref.store(0, Ordering::SeqCst);
                         reasoning_active_ref.store(false, Ordering::SeqCst);
+                        compaction_active_ref.store(false, Ordering::SeqCst);
+                        compaction_notice_shown_ref.store(false, Ordering::SeqCst);
                         animation_ref.start(&t("shell.status.thinking"));
                     }
                     LlmEventType::OpEnd => {
@@ -462,7 +598,22 @@ impl AishShell {
                         }
                         *thinking_start_ref.lock().unwrap() = None;
                     }
+                    LlmEventType::ContextCompactionStart => {
+                        if !compaction_active_ref.swap(true, Ordering::SeqCst) {
+                            animation_ref.start(&t("shell.status.compacting_context"));
+                        }
+                    }
+                    LlmEventType::ContextCompactionEnd => {
+                        compaction_active_ref.store(false, Ordering::SeqCst);
+                        animation_ref.stop();
+                        if !compaction_notice_shown_ref.swap(true, Ordering::SeqCst) {
+                            if let Some(message) = context_compaction_notice(&event) {
+                                println!("\x1b[2m{}\x1b[0m", message);
+                            }
+                        }
+                    }
                     LlmEventType::GenerationStart => {
+                        compaction_active_ref.store(false, Ordering::SeqCst);
                         animation_ref.stop();
                         clear_reasoning();
                         // Reset streamed flag so it only reflects the CURRENT
@@ -801,6 +952,7 @@ impl AishShell {
             config.max_llm_messages,
             config.max_shell_messages,
             config.context_token_budget,
+            context_budget_policy,
         );
 
         // Note: event_callback is already set on the LlmSession before AiHandler takes ownership
@@ -2125,6 +2277,10 @@ impl AishShell {
                         std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
                     let reasoning_lines_displayed = reasoning_lines_cb.clone();
                     let reasoning_buf = std::sync::Mutex::new(String::new());
+                    let compaction_active =
+                        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+                    let compaction_notice_shown =
+                        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
                     let thinking_start_followup =
                         std::sync::Arc::new(std::sync::Mutex::new(Some(std::time::Instant::now())));
                     session.set_event_callback(std::sync::Arc::new(move |event| {
@@ -2153,7 +2309,28 @@ impl AishShell {
                         }
                         use aish_core::LlmEventType;
                         match event.event_type {
+                            LlmEventType::ContextCompactionStart => {
+                                if !compaction_active
+                                    .swap(true, std::sync::atomic::Ordering::SeqCst)
+                                {
+                                    anim.start(&t("shell.status.compacting_context"));
+                                }
+                            }
+                            LlmEventType::ContextCompactionEnd => {
+                                compaction_active
+                                    .store(false, std::sync::atomic::Ordering::SeqCst);
+                                anim.stop();
+                                if !compaction_notice_shown
+                                    .swap(true, std::sync::atomic::Ordering::SeqCst)
+                                {
+                                    if let Some(message) = context_compaction_notice(&event) {
+                                        println!("\x1b[2m{}\x1b[0m", message);
+                                    }
+                                }
+                            }
                             LlmEventType::GenerationStart => {
+                                compaction_active
+                                    .store(false, std::sync::atomic::Ordering::SeqCst);
                                 anim.stop();
                                 reasoning_active.store(false, std::sync::atomic::Ordering::SeqCst);
                                 reasoning_frame.store(0, std::sync::atomic::Ordering::SeqCst);
@@ -2782,6 +2959,10 @@ impl AishShell {
                         std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
                     let reasoning_lines_displayed = reasoning_lines_cb.clone();
                     let reasoning_buf = std::sync::Mutex::new(String::new());
+                    let compaction_active =
+                        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+                    let compaction_notice_shown =
+                        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
                     let thinking_start_r = thinking_start_thread.clone();
                     session.set_event_callback(std::sync::Arc::new(move |event| {
                         // Helper: clear reasoning overlay from terminal
@@ -2809,7 +2990,28 @@ impl AishShell {
                         }
                         use aish_core::LlmEventType;
                         match event.event_type {
+                            LlmEventType::ContextCompactionStart => {
+                                if !compaction_active
+                                    .swap(true, std::sync::atomic::Ordering::SeqCst)
+                                {
+                                    anim.start(&t("shell.status.compacting_context"));
+                                }
+                            }
+                            LlmEventType::ContextCompactionEnd => {
+                                compaction_active
+                                    .store(false, std::sync::atomic::Ordering::SeqCst);
+                                anim.stop();
+                                if !compaction_notice_shown
+                                    .swap(true, std::sync::atomic::Ordering::SeqCst)
+                                {
+                                    if let Some(message) = context_compaction_notice(&event) {
+                                        println!("\x1b[2m{}\x1b[0m", message);
+                                    }
+                                }
+                            }
                             LlmEventType::GenerationStart => {
+                                compaction_active
+                                    .store(false, std::sync::atomic::Ordering::SeqCst);
                                 anim.stop();
                                 reasoning_active.store(false, std::sync::atomic::Ordering::SeqCst);
                                 reasoning_frame.store(0, std::sync::atomic::Ordering::SeqCst);


### PR DESCRIPTION
## Background
This PR adds the first end-to-end context auto-compaction flow on the Rust branch and includes the parser normalization needed to avoid empty compact summaries when providers return array-form content blocks.

## Changes
- normalize string and array-form `message.content` / `delta.content` in the LLM response parser
- add context budget policy calculation, pressure levels, and full/micro compaction behavior
- compact old shell/tool output while preserving recent context needed for follow-up turns
- emit compaction lifecycle events and wire the shell/app UI, config, docs, and i18n strings

## Validation
- `cargo test -p aish-llm streaming::tests:: -- --nocapture`
- `cargo test -p aish-context --lib -- --nocapture`
- `cargo test -p aish-llm test_prepare_messages_for_send_triggers_microcompact_without_model -- --nocapture`
- `cargo build -p aish-cli`

## Risk
Main risk is behavior tuning around compaction thresholds and how aggressively older shell/tool output is collapsed under pressure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic context compaction with configurable compression strategies
  * Context window budget management and pressure level monitoring
  * Real-time status notifications during context optimization

* **Documentation**
  * Added comprehensive configuration guide for context auto-compact settings

* **Localization**
  * Added context compaction UI messages in German, Spanish, French, Japanese, and Chinese

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/187)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->