### PR TITLE
feat: rewrite prompt templates, add prompt caching and tool-loop trimming

### DIFF
--- a/crates/aish-context/src/manager.rs
+++ b/crates/aish-context/src/manager.rs
@@ -427,6 +427,28 @@ impl ContextManager {
         &mut self.knowledge_cache
     }
 
+    /// Inject knowledge if not already present with the given tag.
+    /// Returns true if content was actually added/updated, false if unchanged.
+    /// Uses the knowledge_cache to detect changes. When content changes, the
+    /// previous cached content is used to locate and replace the old message.
+    pub fn inject_knowledge_stable(&mut self, tag: &str, content: &str) -> bool {
+        let cache_key = tag.to_string();
+        if let Some(cached) = self.knowledge_cache.get(&cache_key) {
+            if cached == content {
+                return false; // No change — cache stable
+            }
+            // Content changed — remove the old message by matching its exact content
+            let old = cached.clone();
+            self.messages
+                .retain(|m| !(m.memory_type == MemoryType::Knowledge && m.content == old));
+        }
+        if !content.is_empty() {
+            self.add_message("system", content, MemoryType::Knowledge);
+        }
+        self.knowledge_cache.insert(cache_key, content.to_string());
+        true
+    }
+
     // -----------------------------------------------------------------------
     // Private helpers
     // -----------------------------------------------------------------------
@@ -848,6 +870,66 @@ mod tests {
         let tokens = mgr.estimate_tokens("Hello, world!");
         // Should be a small positive number.
         assert!(tokens > 0 && tokens < 20);
+    }
+
+    #[test]
+    fn inject_knowledge_stable_first_call_adds() {
+        let mut mgr = ContextManager::new();
+        let result =
+            mgr.inject_knowledge_stable("skills", "<available-skills>\ntest\n</available-skills>");
+        assert!(result, "first call should return true (content added)");
+        assert_eq!(mgr.get_context_size(), 1);
+        assert_eq!(
+            mgr.messages[0].content,
+            "<available-skills>\ntest\n</available-skills>"
+        );
+    }
+
+    #[test]
+    fn inject_knowledge_stable_same_content_is_noop() {
+        let mut mgr = ContextManager::new();
+        let content = "<available-skills>\ntest\n</available-skills>";
+        mgr.inject_knowledge_stable("skills", content);
+        assert_eq!(mgr.get_context_size(), 1);
+
+        let result = mgr.inject_knowledge_stable("skills", content);
+        assert!(!result, "second call with same content should return false");
+        assert_eq!(mgr.get_context_size(), 1, "message count should remain unchanged");
+    }
+
+    #[test]
+    fn inject_knowledge_stable_different_content_updates() {
+        let mut mgr = ContextManager::new();
+        mgr.inject_knowledge_stable("skills", "<available-skills>\nold\n</available-skills>");
+        assert_eq!(mgr.get_context_size(), 1);
+
+        let result =
+            mgr.inject_knowledge_stable("skills", "<available-skills>\nnew\n</available-skills>");
+        assert!(result, "call with different content should return true");
+        assert_eq!(mgr.get_context_size(), 1, "old message replaced, count stays 1");
+        assert_eq!(
+            mgr.messages[0].content,
+            "<available-skills>\nnew\n</available-skills>"
+        );
+    }
+
+    #[test]
+    fn inject_knowledge_stable_empty_content_clears() {
+        let mut mgr = ContextManager::new();
+        mgr.inject_knowledge_stable("skills", "<available-skills>\ntest\n</available-skills>");
+        assert_eq!(mgr.get_context_size(), 1);
+
+        let result = mgr.inject_knowledge_stable("skills", "");
+        assert!(result, "clearing should return true");
+        assert_eq!(mgr.get_context_size(), 0, "message should be removed");
+    }
+
+    #[test]
+    fn inject_knowledge_stable_empty_twice_is_noop() {
+        let mut mgr = ContextManager::new();
+        mgr.inject_knowledge_stable("skills", "");
+        let result = mgr.inject_knowledge_stable("skills", "");
+        assert!(!result, "empty content called twice should return false");
     }
 
     #[test]

--- a/crates/aish-llm/src/langfuse.rs
+++ b/crates/aish-llm/src/langfuse.rs
@@ -142,6 +142,7 @@ impl LangfuseClient {
     pub async fn span_generation(
         &self,
         trace_id: &str,
+        name: &str,
         model: &str,
         input: serde_json::Value,
         output: &str,
@@ -150,6 +151,7 @@ impl LangfuseClient {
     ) {
         let client = self.inner.clone();
         let trace_id = trace_id.to_string();
+        let name = name.to_string();
         let model = model.to_string();
         let output_val = json!(output);
         let meta = if prompt_tokens > 0 || completion_tokens > 0 {
@@ -168,7 +170,7 @@ impl LangfuseClient {
             if let Err(e) = client
                 .generation()
                 .trace_id(&trace_id)
-                .name("generation")
+                .name(&name)
                 .model(&model)
                 .input(input)
                 .output(output_val)

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -37,6 +37,10 @@ pub struct LlmSession {
     temperature: Option<f32>,
     max_tokens: Option<u32>,
     langfuse: Option<LangfuseClient>,
+    /// Stable Langfuse trace ID for the entire session (created once, reused across turns).
+    langfuse_session_id: std::sync::Mutex<Option<String>>,
+    /// Monotonic turn counter for naming spans within the session trace.
+    langfuse_turn_counter: std::sync::atomic::AtomicU32,
     /// Maximum context token budget. Messages are trimmed when exceeded.
     max_context_tokens: usize,
     context_budget_policy: ContextBudgetPolicy,
@@ -66,6 +70,8 @@ impl LlmSession {
             temperature,
             max_tokens,
             langfuse: None,
+            langfuse_session_id: std::sync::Mutex::new(None),
+            langfuse_turn_counter: std::sync::atomic::AtomicU32::new(0),
             max_context_tokens: 100_000,
             context_budget_policy: ContextBudgetPolicy::default(),
             compact_consecutive_failures: std::sync::Mutex::new(0),
@@ -251,19 +257,23 @@ impl LlmSession {
             metadata: None,
         });
 
-        // Start Langfuse trace if configured
+        // Start or reuse Langfuse session trace.
+        // The first call creates a session-level trace; subsequent turns
+        // reuse the same trace so all generations/spans are grouped together.
         let trace_id = if let Some(ref langfuse) = self.langfuse {
-            let ts = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
-            let id = langfuse
-                .trace_session(
-                    &format!("turn-{ts}"),
-                    &serde_json::json!({"prompt_length": prompt.len()}),
-                )
-                .await;
-            Some(id)
+            let mut session_id_guard = self.langfuse_session_id.lock().unwrap();
+            if session_id_guard.is_none() {
+                let id = langfuse
+                    .trace_session(
+                        "session",
+                        &serde_json::json!({"session_start": true}),
+                    )
+                    .await;
+                *session_id_guard = Some(id);
+            }
+            drop(session_id_guard);
+            self.langfuse_turn_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            self.langfuse_session_id.lock().unwrap().clone()
         } else {
             None
         };
@@ -277,6 +287,18 @@ impl LlmSession {
         messages.push(ChatMessage::user(prompt));
 
         messages = self.prepare_messages_for_send(messages).await;
+
+        // Set cache breakpoint on system message for Anthropic models only.
+        // Non-Anthropic providers may reject unknown fields in the request body.
+        let is_anthropic = self.client.model_name().contains("claude");
+        if is_anthropic {
+            if let Some(msg) = messages.first_mut() {
+                if msg.role == "system" {
+                    msg.cache_control = Some(CacheControl::ephemeral());
+                }
+            }
+        }
+
         let initial_len = messages.len();
 
         let tool_specs = self.filtered_tool_specs();
@@ -391,20 +413,23 @@ impl LlmSession {
                         self.record_usage(u);
                     }
 
+                    // Log generation span to Langfuse for every LLM call
+                    if let (Some(ref langfuse), Some(ref tid)) = (&self.langfuse, &trace_id) {
+                        let span_name = format!("turn-{}-iter-{}", self.langfuse_turn_counter.load(std::sync::atomic::Ordering::Relaxed), iterations);
+                        langfuse
+                            .span_generation(
+                                tid,
+                                &span_name,
+                                self.client.model_name(),
+                                serde_json::json!(messages),
+                                content.as_deref().unwrap_or(""),
+                                pt,
+                                ct,
+                            )
+                            .await;
+                    }
+
                     if tool_calls.is_empty() {
-                        // Log generation span to Langfuse
-                        if let (Some(ref langfuse), Some(ref tid)) = (&self.langfuse, &trace_id) {
-                            langfuse
-                                .span_generation(
-                                    tid,
-                                    self.client.model_name(),
-                                    serde_json::json!(messages),
-                                    content.as_deref().unwrap_or(""),
-                                    pt,
-                                    ct,
-                                )
-                                .await;
-                        }
                         // Flush Langfuse buffer
                         if let Some(ref langfuse) = self.langfuse {
                             langfuse.flush().await;
@@ -523,6 +548,13 @@ impl LlmSession {
 
                         messages.push(ChatMessage::tool_result(&tc.id, output));
                     }
+
+                    // Trim old tool-call rounds to prevent unbounded growth
+                    trim_tool_loop_messages(
+                        &mut messages,
+                        initial_len,
+                        MAX_TOOL_ROUNDS_IN_CONTEXT,
+                    );
                 }
 
                 LlmResponse::Stream(resp) => {
@@ -686,21 +718,24 @@ impl LlmSession {
                         });
                     }
 
+                    // Log generation span to Langfuse for every LLM call
+                    if let (Some(ref langfuse), Some(ref tid)) = (&self.langfuse, &trace_id) {
+                        let span_name = format!("turn-{}-iter-{}", self.langfuse_turn_counter.load(std::sync::atomic::Ordering::Relaxed), iterations);
+                        langfuse
+                            .span_generation(
+                                tid,
+                                &span_name,
+                                self.client.model_name(),
+                                serde_json::json!(messages),
+                                &accumulated,
+                                stream_prompt_tokens,
+                                stream_completion_tokens,
+                            )
+                            .await;
+                    }
+
                     // No tool calls — return accumulated content
                     if tool_calls_accum.is_empty() {
-                        // Log generation span to Langfuse
-                        if let (Some(ref langfuse), Some(ref tid)) = (&self.langfuse, &trace_id) {
-                            langfuse
-                                .span_generation(
-                                    tid,
-                                    self.client.model_name(),
-                                    serde_json::json!(messages),
-                                    &accumulated,
-                                    stream_prompt_tokens,
-                                    stream_completion_tokens,
-                                )
-                                .await;
-                        }
                         // Flush Langfuse buffer
                         if let Some(ref langfuse) = self.langfuse {
                             langfuse.flush().await;
@@ -880,6 +915,13 @@ impl LlmSession {
 
                         messages.push(ChatMessage::tool_result(&tc.id, output));
                     }
+
+                    // Trim old tool-call rounds to prevent unbounded growth
+                    trim_tool_loop_messages(
+                        &mut messages,
+                        initial_len,
+                        MAX_TOOL_ROUNDS_IN_CONTEXT,
+                    );
                 }
             }
         }
@@ -1096,6 +1138,10 @@ impl LlmSession {
             temperature: self.temperature,
             max_tokens: self.max_tokens,
             langfuse: self.langfuse.clone(),
+            langfuse_session_id: std::sync::Mutex::new(
+                self.langfuse_session_id.lock().unwrap().clone()
+            ),
+            langfuse_turn_counter: std::sync::atomic::AtomicU32::new(0),
             max_context_tokens: self.max_context_tokens,
             context_budget_policy: self.context_budget_policy.clone(),
             compact_consecutive_failures: std::sync::Mutex::new(0),
@@ -1691,12 +1737,12 @@ fn trim_messages(
         max_tokens
     );
 
-    // Split: first message (system) + middle (to trim) + last N (to keep)
-    let system = if messages[0].role == "system" {
-        vec![messages[0].clone()]
-    } else {
-        vec![]
-    };
+    // Split: all leading system messages + middle (to trim) + last N (to keep)
+    let system_count = messages
+        .iter()
+        .take_while(|m| m.role == "system")
+        .count();
+    let system: Vec<_> = messages[..system_count].to_vec();
 
     let system_count = system.len();
     let recent_start = messages.len().saturating_sub(preserve_recent);
@@ -1732,6 +1778,63 @@ fn trim_messages(
     result
 }
 
+/// Maximum number of tool-call rounds to keep in the loop before trimming.
+/// Each round is: [assistant + tool_calls] + [tool_result(s)].
+const MAX_TOOL_ROUNDS_IN_CONTEXT: usize = 8;
+
+/// Trim tool-call messages accumulated during the agent loop.
+///
+/// Preserves the stable prefix (messages before the loop started, i.e.
+/// `initial_len`) and keeps only the most recent `max_rounds` tool-call
+/// rounds.  This prevents unbounded context growth during long tool-calling
+/// sessions while retaining enough recent history for the LLM to maintain
+/// coherent multi-step reasoning.
+///
+/// A "round" starts with an assistant message that has `tool_calls`.
+fn trim_tool_loop_messages(
+    messages: &mut Vec<ChatMessage>,
+    initial_len: usize,
+    max_rounds: usize,
+) {
+    if messages.len() <= initial_len {
+        return;
+    }
+
+    // Count tool-call rounds (assistant messages with tool_calls) from the end.
+    // A round boundary is an assistant message with tool_calls set.
+    // We want to find the start of the (max_rounds+1)-th round from the end —
+    // everything before that gets trimmed.
+    let mut round_count = 0usize;
+    let mut trim_from: Option<usize> = None;
+
+    for i in (initial_len..messages.len()).rev() {
+        if messages[i].role == "assistant" && messages[i].tool_calls.is_some() {
+            round_count += 1;
+            if round_count == max_rounds {
+                // This round is the last one to keep. Everything before it
+                // (from initial_len up to this index) is trimmed.
+                trim_from = Some(i);
+                break;
+            }
+        }
+    }
+
+    let trim_from = match trim_from {
+        Some(idx) => idx,
+        None => return, // Under limit, nothing to trim
+    };
+
+    let removed = trim_from - initial_len;
+    tracing::warn!(
+        initial_len,
+        removed,
+        total = messages.len(),
+        max_rounds,
+        "Trimming old tool-call rounds from agent loop"
+    );
+    messages.drain(initial_len..trim_from);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1744,6 +1847,7 @@ mod tests {
             tool_call_id: None,
             name: None,
             reasoning_content: None,
+            cache_control: None,
         }
     }
 
@@ -1787,6 +1891,92 @@ mod tests {
             result.last().unwrap().content.as_deref(),
             Some("message number 19 with padding content here")
         );
+    }
+
+    fn make_tool_call_msg(id: &str, name: &str) -> ChatMessage {
+        ChatMessage {
+            role: "assistant".to_string(),
+            content: Some(format!("calling {}", name)),
+            tool_calls: Some(vec![ToolCall {
+                id: id.to_string(),
+                name: name.to_string(),
+                arguments: "{}".to_string(),
+            }]),
+            tool_call_id: None,
+            name: None,
+            reasoning_content: None,
+            cache_control: None,
+        }
+    }
+
+    fn make_tool_result_msg(id: &str, output: &str) -> ChatMessage {
+        ChatMessage {
+            role: "tool".to_string(),
+            content: Some(output.to_string()),
+            tool_calls: None,
+            tool_call_id: Some(id.to_string()),
+            name: None,
+            reasoning_content: None,
+            cache_control: None,
+        }
+    }
+
+    #[test]
+    fn test_trim_tool_loop_noop_when_under_limit() {
+        // 3 rounds — under limit of 8, nothing trimmed
+        let initial_len = 2;
+        let mut msgs = vec![make_msg("system", "sys"), make_msg("user", "hi")];
+        for i in 0..3 {
+            msgs.push(make_tool_call_msg(&format!("call_{}", i), "bash"));
+            msgs.push(make_tool_result_msg(&format!("call_{}", i), "output"));
+        }
+        let len_before = msgs.len();
+        trim_tool_loop_messages(&mut msgs, initial_len, 8);
+        assert_eq!(msgs.len(), len_before);
+    }
+
+    #[test]
+    fn test_trim_tool_loop_trims_old_rounds() {
+        // 12 rounds — should trim to keep only last 4
+        let initial_len = 2;
+        let mut msgs = vec![make_msg("system", "sys"), make_msg("user", "hi")];
+        for i in 0..12 {
+            msgs.push(make_tool_call_msg(&format!("call_{}", i), "bash"));
+            msgs.push(make_tool_result_msg(&format!("call_{}", i), &format!("output_{}", i)));
+        }
+        assert_eq!(msgs.len(), 2 + 12 * 2); // 26
+
+        trim_tool_loop_messages(&mut msgs, initial_len, 4);
+
+        // Should keep: initial (2) + last 4 rounds (8) = 10
+        assert_eq!(msgs.len(), 10);
+        // First tool call should be round 8 (0-indexed)
+        assert!(msgs[2].content.as_ref().unwrap().contains("calling bash"));
+        // Last tool result should be round 11
+        let last = msgs.last().unwrap();
+        assert_eq!(last.content.as_deref(), Some("output_11"));
+    }
+
+    #[test]
+    fn test_trim_tool_loop_preserves_prefix() {
+        let initial_len = 5;
+        let mut msgs = vec![
+            make_msg("system", "sys"),
+            make_msg("system", "env"),
+            make_msg("system", "skills"),
+            make_msg("user", "previous question"),
+            make_msg("assistant", "previous answer"),
+        ];
+        for i in 0..10 {
+            msgs.push(make_tool_call_msg(&format!("c{}", i), "bash"));
+            msgs.push(make_tool_result_msg(&format!("c{}", i), &format!("out{}", i)));
+        }
+
+        trim_tool_loop_messages(&mut msgs, initial_len, 4);
+
+        // Prefix (first 5) unchanged
+        assert_eq!(msgs[0].content.as_deref(), Some("sys"));
+        assert_eq!(msgs[4].content.as_deref(), Some("previous answer"));
     }
 
     #[test]

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -264,15 +264,13 @@ impl LlmSession {
             let mut session_id_guard = self.langfuse_session_id.lock().unwrap();
             if session_id_guard.is_none() {
                 let id = langfuse
-                    .trace_session(
-                        "session",
-                        &serde_json::json!({"session_start": true}),
-                    )
+                    .trace_session("session", &serde_json::json!({"session_start": true}))
                     .await;
                 *session_id_guard = Some(id);
             }
             drop(session_id_guard);
-            self.langfuse_turn_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            self.langfuse_turn_counter
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             self.langfuse_session_id.lock().unwrap().clone()
         } else {
             None
@@ -415,7 +413,12 @@ impl LlmSession {
 
                     // Log generation span to Langfuse for every LLM call
                     if let (Some(ref langfuse), Some(ref tid)) = (&self.langfuse, &trace_id) {
-                        let span_name = format!("turn-{}-iter-{}", self.langfuse_turn_counter.load(std::sync::atomic::Ordering::Relaxed), iterations);
+                        let span_name = format!(
+                            "turn-{}-iter-{}",
+                            self.langfuse_turn_counter
+                                .load(std::sync::atomic::Ordering::Relaxed),
+                            iterations
+                        );
                         langfuse
                             .span_generation(
                                 tid,
@@ -550,11 +553,7 @@ impl LlmSession {
                     }
 
                     // Trim old tool-call rounds to prevent unbounded growth
-                    trim_tool_loop_messages(
-                        &mut messages,
-                        initial_len,
-                        MAX_TOOL_ROUNDS_IN_CONTEXT,
-                    );
+                    trim_tool_loop_messages(&mut messages, initial_len, MAX_TOOL_ROUNDS_IN_CONTEXT);
                 }
 
                 LlmResponse::Stream(resp) => {
@@ -720,7 +719,12 @@ impl LlmSession {
 
                     // Log generation span to Langfuse for every LLM call
                     if let (Some(ref langfuse), Some(ref tid)) = (&self.langfuse, &trace_id) {
-                        let span_name = format!("turn-{}-iter-{}", self.langfuse_turn_counter.load(std::sync::atomic::Ordering::Relaxed), iterations);
+                        let span_name = format!(
+                            "turn-{}-iter-{}",
+                            self.langfuse_turn_counter
+                                .load(std::sync::atomic::Ordering::Relaxed),
+                            iterations
+                        );
                         langfuse
                             .span_generation(
                                 tid,
@@ -917,11 +921,7 @@ impl LlmSession {
                     }
 
                     // Trim old tool-call rounds to prevent unbounded growth
-                    trim_tool_loop_messages(
-                        &mut messages,
-                        initial_len,
-                        MAX_TOOL_ROUNDS_IN_CONTEXT,
-                    );
+                    trim_tool_loop_messages(&mut messages, initial_len, MAX_TOOL_ROUNDS_IN_CONTEXT);
                 }
             }
         }
@@ -1139,7 +1139,7 @@ impl LlmSession {
             max_tokens: self.max_tokens,
             langfuse: self.langfuse.clone(),
             langfuse_session_id: std::sync::Mutex::new(
-                self.langfuse_session_id.lock().unwrap().clone()
+                self.langfuse_session_id.lock().unwrap().clone(),
             ),
             langfuse_turn_counter: std::sync::atomic::AtomicU32::new(0),
             max_context_tokens: self.max_context_tokens,
@@ -1738,14 +1738,14 @@ fn trim_messages(
     );
 
     // Split: all leading system messages + middle (to trim) + last N (to keep)
-    let system_count = messages
-        .iter()
-        .take_while(|m| m.role == "system")
-        .count();
+    let system_count = messages.iter().take_while(|m| m.role == "system").count();
     let system: Vec<_> = messages[..system_count].to_vec();
 
     let system_count = system.len();
-    let recent_start = messages.len().saturating_sub(preserve_recent);
+    let recent_start = messages
+        .len()
+        .saturating_sub(preserve_recent)
+        .max(system_count);
     let recent: Vec<_> = messages[recent_start..].to_vec();
 
     // Calculate how many middle messages to keep
@@ -1791,11 +1791,7 @@ const MAX_TOOL_ROUNDS_IN_CONTEXT: usize = 8;
 /// coherent multi-step reasoning.
 ///
 /// A "round" starts with an assistant message that has `tool_calls`.
-fn trim_tool_loop_messages(
-    messages: &mut Vec<ChatMessage>,
-    initial_len: usize,
-    max_rounds: usize,
-) {
+fn trim_tool_loop_messages(messages: &mut Vec<ChatMessage>, initial_len: usize, max_rounds: usize) {
     if messages.len() <= initial_len {
         return;
     }
@@ -1942,7 +1938,10 @@ mod tests {
         let mut msgs = vec![make_msg("system", "sys"), make_msg("user", "hi")];
         for i in 0..12 {
             msgs.push(make_tool_call_msg(&format!("call_{}", i), "bash"));
-            msgs.push(make_tool_result_msg(&format!("call_{}", i), &format!("output_{}", i)));
+            msgs.push(make_tool_result_msg(
+                &format!("call_{}", i),
+                &format!("output_{}", i),
+            ));
         }
         assert_eq!(msgs.len(), 2 + 12 * 2); // 26
 
@@ -1969,7 +1968,10 @@ mod tests {
         ];
         for i in 0..10 {
             msgs.push(make_tool_call_msg(&format!("c{}", i), "bash"));
-            msgs.push(make_tool_result_msg(&format!("c{}", i), &format!("out{}", i)));
+            msgs.push(make_tool_result_msg(
+                &format!("c{}", i),
+                &format!("out{}", i),
+            ));
         }
 
         trim_tool_loop_messages(&mut msgs, initial_len, 4);

--- a/crates/aish-llm/src/types.rs
+++ b/crates/aish-llm/src/types.rs
@@ -112,6 +112,23 @@ impl<'de> Deserialize<'de> for ToolCall {
     }
 }
 
+/// Anthropic-style cache control marker for prompt caching.
+/// When set, marks this message as a cache breakpoint.
+/// Non-Anthropic providers ignore this field.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheControl {
+    #[serde(rename = "type")]
+    pub cache_type: String,
+}
+
+impl CacheControl {
+    pub fn ephemeral() -> Self {
+        Self {
+            cache_type: "ephemeral".to_string(),
+        }
+    }
+}
+
 /// A message in the chat conversation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessage {
@@ -126,6 +143,9 @@ pub struct ChatMessage {
     /// DeepSeek thinking mode reasoning content — must be echoed back to the API.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_content: Option<String>,
+    /// Anthropic-style cache control marker. Non-Anthropic providers ignore this.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
 }
 
 impl ChatMessage {
@@ -137,6 +157,7 @@ impl ChatMessage {
             tool_call_id: None,
             name: None,
             reasoning_content: None,
+            cache_control: None,
         }
     }
 
@@ -148,6 +169,7 @@ impl ChatMessage {
             tool_call_id: None,
             name: None,
             reasoning_content: None,
+            cache_control: None,
         }
     }
 
@@ -159,6 +181,7 @@ impl ChatMessage {
             tool_call_id: None,
             name: None,
             reasoning_content: None,
+            cache_control: None,
         }
     }
 
@@ -170,6 +193,7 @@ impl ChatMessage {
             tool_call_id: Some(tool_call_id.into()),
             name: None,
             reasoning_content: None,
+            cache_control: None,
         }
     }
 }
@@ -523,5 +547,19 @@ mod tests {
             !called.load(std::sync::atomic::Ordering::SeqCst),
             "cancel_atomic should not invoke registered callbacks"
         );
+    }
+
+    #[test]
+    fn test_cache_control_serialization() {
+        let msg = ChatMessage::system("test");
+        let json = serde_json::to_string(&msg).unwrap();
+        // cache_control should be absent when None
+        assert!(!json.contains("cache_control"));
+
+        let mut msg = ChatMessage::system("test");
+        msg.cache_control = Some(CacheControl::ephemeral());
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("cache_control"));
+        assert!(json.contains("ephemeral"));
     }
 }

--- a/crates/aish-llm/tests/llm_integration_test.rs
+++ b/crates/aish-llm/tests/llm_integration_test.rs
@@ -231,6 +231,7 @@ fn test_message_with_none_content() {
         tool_call_id: None,
         name: None,
         reasoning_content: None,
+        cache_control: None,
     };
     assert_eq!(msg_with_content.content, Some("Hello".to_string()));
 
@@ -241,6 +242,7 @@ fn test_message_with_none_content() {
         tool_call_id: None,
         name: None,
         reasoning_content: None,
+        cache_control: None,
     };
     assert_eq!(msg_without_content.content, None);
 }

--- a/crates/aish-prompts/src/manager.rs
+++ b/crates/aish-prompts/src/manager.rs
@@ -85,10 +85,7 @@ impl PromptManager {
     /// Only CWD changes between calls; appended after the static core so that
     /// the core prefix stays cacheable.
     pub fn render_env_block(&self, cwd: &str) -> String {
-        format!(
-            "\n**Environment Update:**\n- Current directory: {}",
-            cwd
-        )
+        format!("\n**Environment Update:**\n- Current directory: {}", cwd)
     }
 
     /// Load a single template from disk, falling back to embedded default.
@@ -186,7 +183,7 @@ You are allowed to be proactive, but only when the user asks you to do something
 
 
 ## 基本原则
-你可以像 shell 一样直接运行命令，不一样的是你会监控每个命令的标准输出和stderr 的内容，这些内容会作为上下文提供后续的交互。你需要根据这些信息来给用户主动提供准确的、简练的、极具价值的反馈，例如直接指出命令出错的原因，并给出可能最正确的参考命令，或者当用户发出一个自然语言的请求时，充分理解用户意图，形成解决方案， 你可以使用 Python 工具（python_exec）或者是 bash 工具（bash_exec）去执行命令或脚本文件，若是分析类任务就得到一些中间信息，或是回答用户关于 Linux 上任何跟使用有关的问题。你直接调用 bash_exec 工具帮助用户去执行系统的命令或脚本。If there are certain requests required by the user, such as when executing a command or script, the `bash_exec` or `python_exec` tool should be called directly to respond directly to the user's request. The result of the previous execution of the tool is only used for judgment, and the user's new request cannot be rejected based on this result.
+你可以像 shell 一样直接运行命令，不一样的是你会监控每个命令的标准输出和stderr 的内容，这些内容会作为上下文提供后续的交互。你需要根据这些信息来给用户主动提供准确的、简练的、极具价值的反馈，例如直接指出命令出错的原因，并给出可能最正确的参考命令，或者当用户发出一个自然语言的请求时，充分理解用户意图，形成解决方案， 你可以使用 Python 工具或者是 bash 工具去执行命令或脚本文件，若是分析类任务就得到一些中间信息，或是回答用户关于 Linux 上任何跟使用有关的问题。你直接调用 `bash` 工具帮助用户去执行系统的命令或脚本。If there are certain requests required by the user, such as when executing a command or script, the corresponding tool should be called directly to respond directly to the user's request. The result of the previous execution of the tool is only used for judgment, and the user's new request cannot be rejected based on this result.
 Tool results and user messages may include <system-reminder> or other tags. Tags contain information from the system. They bear no direct relation to the specific tool results or user messages in which they appear.
 
 ### Shell 输出 Offload 规则（重要）
@@ -197,9 +194,9 @@ Tool results and user messages may include <system-reminder> or other tags. Tags
 
 
 ### 工具的选择原则
-- **bash 工具（bash_exec）优先**：如用户请求明确、问题可用单行命令处理，或需要执行 bash脚本，直接使用 bash_exec 工具，工具名称bash_exec：。
-- **Python 工具（python_exec）优先**：当任务需要脚本实现、复杂数据处理、格式化输出、条件/循环逻辑或粘合多个步骤，优先考虑 Python（如批量文件处理、复杂日志分析、生成统计报告、下载处理等）。
-- **系统诊断工具优先**：当用户请求诊断系统问题时，使用 **system_diagnose_agent**工具，工具名称system_diagnose_agent。 例如我的系统为什么卡顿，为什么写不了文件了，为什么我的进程被杀死了等等，我的ngnix 是不是配错了？， 怎么感觉网速有点慢，我的系统是不是有很多异常登录？
+- **bash 工具优先**：如用户请求明确、问题可用单行命令处理，或需要执行 bash脚本，直接使用 `bash` 工具。
+- **Python 工具优先**：当任务需要脚本实现、复杂数据处理、格式化输出、条件/循环逻辑或粘合多个步骤，优先考虑 Python（如批量文件处理、复杂日志分析、生成统计报告、下载处理等）。
+- **系统诊断工具优先**：当用户请求诊断系统问题时，使用 **system_diagnose_agent**工具。 例如我的系统为什么卡顿，为什么写不了文件了，为什么我的进程被杀死了等等，我的ngnix 是不是配错了？， 怎么感觉网速有点慢，我的系统是不是有很多异常登录？
 - 当用户明确需要创建文件时，使用 **write_file**工具，工具名称：write_file。如果用户只要求写入文件，写入文件后停止对话。如果是脚本或应用程序，不要主动尝试运行这个程序。
 - 当用户需要修改已有文件内容时，使用 **edit_file**工具，工具名称：edit_file。（先用 read_file 读取内容，再进行精确字符串替换；old_string 必须唯一，否则需要提供更大上下文或使用 replace_all。）
 - 当需要读取文件内容时，使用 **read_file**工具，工具名称：read_file。
@@ -207,7 +204,7 @@ Tool results and user messages may include <system-reminder> or other tags. Tags
 - **Skill** tool is used to invoke user-invocable skills to accomplish user's request. IMPORTANT: Only use Skill for skills listed in the current `<system-reminder>...</system-reminder>` user message for the current turn - do not guess or use built-in CLI commands. Skills can be hot-reloaded (added/removed/modified) during a session, and the current reminder is the single source of truth for the *current* turn; always re-check that the skill exists there right before invoking it, and do not rely on memory from earlier turns. If the user asks about the current available skills, answer from the current reminder and do not rely on memory from earlier turns. CAVEAT: user scope skills are stored under the app's config directory. Do NOT create or modify files inside the skill or config directories. If the skill needs to generate, create, or write any files/directories, it must write only to a dedicated subdirectory under the current working directory (recommended examples: `./tmp`, `./artifacts`); do not write directly into the cwd root. Create the subdirectory if missing. If a tool or script accepts an output path (e.g. --path/--output/--dir), you must explicitly set it to a dedicated cwd subdirectory and never rely on defaults. If you cannot set a safe output path, ask the user before continuing.
 
 ## 长期运行命令处理原则
-当用户的意图是运行一个**长期运行**或**交互式**的命令时，**不要使用****bash_exec**工具执行。
+当用户的意图是运行一个**长期运行**或**交互式**的命令时，**不要使用** `bash` 工具执行。
 
 ### 识别长期运行/交互式命令
 包括但不限于以下类型的用户请求：
@@ -408,7 +405,7 @@ Your task is to analyze a user-provided system issue or query, systematically id
 
 ## Tools
 You have access to the following tools:
-- bash_exec: Execute shell commands to gather system information
+- bash: Execute shell commands to gather system information
 - read_file: Read configuration files, logs, and other system files
 - write_file: Create diagnostic reports or temporary analysis files
 - edit_file: Perform exact string replacements in existing files
@@ -420,7 +417,7 @@ You have access to the following tools:
 - Look for patterns, errors, and anomalies
 - Consider common causes and solutions
 - Provide actionable recommendations
-- Use bash_exec for commands like: ps, top, netstat, journalctl, dmesg, df, free, etc.
+- Use bash for commands like: ps, top, netstat, journalctl, dmesg, df, free, etc.
 - Use read_file for examining: /var/log files, configuration files, etc.
 - output language: use {{output_language}} to communicate with the user.
 
@@ -517,7 +514,10 @@ mod tests {
         let mut pm = PromptManager::new("/nonexistent");
         let mut vars = HashMap::new();
         vars.insert("role_prompt".to_string(), "You are helpful.".to_string());
-        vars.insert("uname_info".to_string(), "Linux testhost 6.1.0 x86_64".to_string());
+        vars.insert(
+            "uname_info".to_string(),
+            "Linux testhost 6.1.0 x86_64".to_string(),
+        );
         vars.insert("user_nickname".to_string(), "testuser".to_string());
         vars.insert("os_info".to_string(), "Linux x86_64".to_string());
         vars.insert("basic_env_info".to_string(), String::new());

--- a/crates/aish-prompts/src/manager.rs
+++ b/crates/aish-prompts/src/manager.rs
@@ -58,6 +58,39 @@ impl PromptManager {
         render_template(&template, vars)
     }
 
+    /// Render the static core of the oracle template with session-static values.
+    /// The CWD is left empty since it changes per call. This produces a stable
+    /// string within a session, enabling KV-cache prefix hits across calls.
+    pub fn render_static_core(
+        &mut self,
+        uname_info: &str,
+        user_nickname: &str,
+        os_info: &str,
+        basic_env_info: &str,
+        output_language: &str,
+    ) -> String {
+        let role_prompt = self.get("role").to_string();
+        let mut vars = HashMap::new();
+        vars.insert("role_prompt".to_string(), role_prompt);
+        vars.insert("uname_info".to_string(), uname_info.to_string());
+        vars.insert("user_nickname".to_string(), user_nickname.to_string());
+        vars.insert("os_info".to_string(), os_info.to_string());
+        vars.insert("basic_env_info".to_string(), basic_env_info.to_string());
+        vars.insert("output_language".to_string(), output_language.to_string());
+        vars.insert("cwd".to_string(), String::new());
+        self.render("oracle", &vars)
+    }
+
+    /// Format the dynamic environment block with per-call runtime info.
+    /// Only CWD changes between calls; appended after the static core so that
+    /// the core prefix stays cacheable.
+    pub fn render_env_block(&self, cwd: &str) -> String {
+        format!(
+            "\n**Environment Update:**\n- Current directory: {}",
+            cwd
+        )
+    }
+
     /// Load a single template from disk, falling back to embedded default.
     fn load_template(&mut self, name: &str) {
         let path = self.dir.join(format!("{}.md", name));
@@ -89,95 +122,383 @@ fn default_templates() -> &'static [(&'static str, &'static str)] {
         ("cmd_error", CMD_ERROR_PROMPT),
         ("error_detect", ERROR_DETECT_PROMPT),
         ("system_diagnose", SYSTEM_DIAGNOSE_PROMPT),
+        ("guess_command", GUESS_COMMAND_PROMPT),
         ("skill", SKILL_PROMPT),
     ]
 }
 
-const ROLE_PROMPT: &str = r#"You are an AI assistant integrated into aish (AI Shell).
-You help the user with shell commands, system administration, programming, and general questions."#;
+const ROLE_PROMPT: &str = r#"# ROLE
+ You are **AI-Shell**, a shell with AI capabilities.
+
+You are capable of running Linux commands and tools. You can use the tools to help the user to complete the task or diagnose the problem."#;
 
 const ORACLE_PROMPT: &str = r#"{{role_prompt}}
 
-**Environment:**
-- User: {{username}}@{{hostname}}
-- OS: {{os_info}}
-- Current directory: {{cwd}}
-{{system_info}}
-{{memory_context}}
-{{skill_list}}
-**Guidelines:**
-- Be concise and practical
-- When suggesting commands, format them in ```bash code blocks
-- Explain what each command does briefly
-- If the user asks in a language other than English, reply in that language
-- For shell questions, prefer standard POSIX commands when possible"#;
+## 系统基本信息
+- 运行环境信息: {{uname_info}}
+- 用户的昵称: {{user_nickname}}
+- 发行版信息：{{os_info}}
+- 基本环境信息：
+{{basic_env_info}}
 
-const CMD_ERROR_PROMPT: &str = r#"You are an expert at debugging shell command errors.
-Analyze the failed command and its error output, then suggest a corrected version.
+## Tone and Style
+You should be concise, direct, and to the point. When you run a non-trivial bash command, you should explain what the command does and why you are running it, to make sure the user understands what you are doing (this is especially important when you are running a command that will make changes to the user's system).
 
-**Environment:**
-- User: {{username}}
-- OS: {{os_info}}
+Remember that your output will be displayed on a command line interface. Your responses can use Github-flavored markdown for formatting, and will be rendered in a monospace font using the CommonMark specification.
 
-**Failed Command:**
-```
-{{command}}
-```
+Output text to communicate with the user; all text you output outside of tool use is displayed to the user. Only use tools to complete tasks. Never use tools like Bash or code comments as means to communicate with the user during the session.
 
-**Exit Code:** {{exit_code}}
-{{stderr_section}}
-**Rules:**
-- Output ONLY a single ```json code block containing the result, no extra text
-- If no suitable fix exists, return an empty string for "command"
-- Do not suggest destructive alternatives unless the user explicitly asked for one
-- Reference the shell history context above for the full error output and previous commands
+If you cannot or will not help the user with something, please do not say why or what it could lead to, since this comes across as preachy and annoying. Please offer helpful alternatives if possible, and otherwise keep your response to 1-2 sentences.
 
-**Output format:**
+Only use emojis if the user explicitly requests it. Avoid using emojis in all communication unless asked.
+
+IMPORTANT: You should minimize output tokens as much as possible while maintaining helpfulness, quality, and accuracy. Only address the specific query or task at hand, avoiding tangential information unless absolutely critical for completing the request. If you can answer in 1-3 sentences or a short paragraph, please do.
+
+IMPORTANT: You should NOT answer with unnecessary preamble or postamble (such as explaining your code or summarizing your action), unless the user asks you to.
+
+IMPORTANT: You should only focus on the last command execution. Previously entered historical commands can only be used as a reference, and the weight will be very low.
+
+IMPORTANT: Keep your responses short, since they will be displayed on a command line interface. You MUST answer concisely with fewer than 4 lines (not including tool use or code generation), unless user asks for detail. Answer the user's question directly, without elaboration, explanation, or details. One word answers are best. Avoid introductions, conclusions, and explanations. You MUST avoid text before/after your response, such as "The answer is <answer>.", "Here is the content of the file..." or "Based on the information provided, the answer is..." or "Here is what I will do next...". Here are some examples to demonstrate appropriate verbosity:
+
+<example>
+user: ? 2 + 2
+assistant: 4
+</example>
+
+<example>
+user: ? what is 2+2?
+assistant: 4
+</example>
+
+<example>
+user: ? is 11 a prime number?
+assistant: Yes
+</example>
+
+
+IMPORTANT: Response in {{output_language}}.
+
+## Proactiveness
+You are allowed to be proactive, but only when the user asks you to do something. You should strive to strike a balance between:
+- Doing the right thing when asked, including taking actions and follow-up actions
+- try to explore more information from the system, and provide more accurate and concise feedback to the user.
+- if the task is not finished or encountered an error, you may try to continue to explore alternative solutions.
+
+
+## 基本原则
+你可以像 shell 一样直接运行命令，不一样的是你会监控每个命令的标准输出和stderr 的内容，这些内容会作为上下文提供后续的交互。你需要根据这些信息来给用户主动提供准确的、简练的、极具价值的反馈，例如直接指出命令出错的原因，并给出可能最正确的参考命令，或者当用户发出一个自然语言的请求时，充分理解用户意图，形成解决方案， 你可以使用 Python 工具（python_exec）或者是 bash 工具（bash_exec）去执行命令或脚本文件，若是分析类任务就得到一些中间信息，或是回答用户关于 Linux 上任何跟使用有关的问题。你直接调用 bash_exec 工具帮助用户去执行系统的命令或脚本。If there are certain requests required by the user, such as when executing a command or script, the `bash_exec` or `python_exec` tool should be called directly to respond directly to the user's request. The result of the previous execution of the tool is only used for judgment, and the user's new request cannot be rejected based on this result.
+Tool results and user messages may include <system-reminder> or other tags. Tags contain information from the system. They bear no direct relation to the specific tool results or user messages in which they appear.
+
+### Shell 输出 Offload 规则（重要）
+- Shell命令的输出结果如果太长了会被offload到文件系统中，这个信息会从输出中看到（包含了offload的标签）。如果你需要获取详细信息，就应该从对应offload的文件里面去查找。
+- `<stdout>`/`<stderr>` 可能只是预览，不一定是完整输出。
+- 当 `<offload>` 中 `status` 为 `offloaded` 时，表示完整输出已写入文件；若需要完整信息，优先读取 `stdout_clean_path`/`stderr_clean_path`，若 clean 路径缺失或不可用再回退到 `stdout_path`/`stderr_path`（必要时读取 `meta_path`），而不是仅依据预览下结论。
+- 当 `status` 为 `inline` 时，当前标签内内容可视为主要输出；当 `status` 为 `failed` 时，优先基于现有预览继续分析，并提示 offload 失败信息。
+
+
+### 工具的选择原则
+- **bash 工具（bash_exec）优先**：如用户请求明确、问题可用单行命令处理，或需要执行 bash脚本，直接使用 bash_exec 工具，工具名称bash_exec：。
+- **Python 工具（python_exec）优先**：当任务需要脚本实现、复杂数据处理、格式化输出、条件/循环逻辑或粘合多个步骤，优先考虑 Python（如批量文件处理、复杂日志分析、生成统计报告、下载处理等）。
+- **系统诊断工具优先**：当用户请求诊断系统问题时，使用 **system_diagnose_agent**工具，工具名称system_diagnose_agent。 例如我的系统为什么卡顿，为什么写不了文件了，为什么我的进程被杀死了等等，我的ngnix 是不是配错了？， 怎么感觉网速有点慢，我的系统是不是有很多异常登录？
+- 当用户明确需要创建文件时，使用 **write_file**工具，工具名称：write_file。如果用户只要求写入文件，写入文件后停止对话。如果是脚本或应用程序，不要主动尝试运行这个程序。
+- 当用户需要修改已有文件内容时，使用 **edit_file**工具，工具名称：edit_file。（先用 read_file 读取内容，再进行精确字符串替换；old_string 必须唯一，否则需要提供更大上下文或使用 replace_all。）
+- 当需要读取文件内容时，使用 **read_file**工具，工具名称：read_file。
+- IMPORTANT: Do not use terminal commands (cat, head, tail, etc.) to read files. Instead, use the read_file tool. If you use cat, the file may not be properly preserved in context and can result in errors in the future.
+- **Skill** tool is used to invoke user-invocable skills to accomplish user's request. IMPORTANT: Only use Skill for skills listed in the current `<system-reminder>...</system-reminder>` user message for the current turn - do not guess or use built-in CLI commands. Skills can be hot-reloaded (added/removed/modified) during a session, and the current reminder is the single source of truth for the *current* turn; always re-check that the skill exists there right before invoking it, and do not rely on memory from earlier turns. If the user asks about the current available skills, answer from the current reminder and do not rely on memory from earlier turns. CAVEAT: user scope skills are stored under the app's config directory. Do NOT create or modify files inside the skill or config directories. If the skill needs to generate, create, or write any files/directories, it must write only to a dedicated subdirectory under the current working directory (recommended examples: `./tmp`, `./artifacts`); do not write directly into the cwd root. Create the subdirectory if missing. If a tool or script accepts an output path (e.g. --path/--output/--dir), you must explicitly set it to a dedicated cwd subdirectory and never rely on defaults. If you cannot set a safe output path, ask the user before continuing.
+
+## 长期运行命令处理原则
+当用户的意图是运行一个**长期运行**或**交互式**的命令时，**不要使用****bash_exec**工具执行。
+
+### 识别长期运行/交互式命令
+包括但不限于以下类型的用户请求：
+- **实时系统监控**: "实时监控系统进程", "持续监控CPU使用率", "实时查看内存变化", "监控IO状态", "动态显示进程"
+- **编辑器**: "打开 vim/nano", "进入编辑器", "打开文本编辑器"（如果只是修改文件内容，优先用 edit_file 工具完成，而不是启动交互式编辑器）
+- **网络工具**: "连接服务器", "持续ping", "远程登录", "测试网络连接"
+- **持续监控**: "实时查看日志", "监控文件变化", "跟踪系统日志"
+- **数据库客户端**: "连接数据库", "进入MySQL", "操作PostgreSQL", "使用SQLite"
+- **编程语言REPL**: "进入Python环境", "启动Node.js", "运行交互式解释器"
+- **分页器**: "查看大文件内容", "浏览长文档", "分页显示文本"
+- **其他交互式工具**: "创建会话", "启动终端复用器", "文件传输"
+
+### 长期或交互式命令以文本提示，让用户自行执行
+<example>
+{
+    content: "编辑a.txt命令如下：
+    `vim a.txt`
+    role: "assistant",
+    tool_calls: null,
+    function_call: null,
+    provider_specific_fields: {
+        refusal: null
+    }
+}
+</example>"#;
+
+const CMD_ERROR_PROMPT: &str = r#"{{role_prompt}}
+### 关键规则
+1. **content字段**：必须是字符串，绝对不能是对象
+2. **tool_calls字段**：必须是数组，包含所有工具调用
+3. **工具调用信息**：必须放在tool_calls数组中，绝对不能放在content中
+
+---
+
+
+## 系统基本信息
+- 运行环境信息: {{uname_info}}
+- 用户的昵称: {{user_nickname}}
+- 发行版信息：{{os_info}}
+- 基本环境信息：
+{{basic_env_info}}
+
+## Tone and Style
+You should be concise, direct, and to the point.  Response with {{output_language}}.
+
+## 任务
+根据给出的执行失败(return code != 0)的命令以及相应的执行结果，分析命令失败的原因，并提供准确的解决方案。 如果没有合适的解决方案，请返回空字符串。
+
+### 输出格式
+- 只能输出 **一个** JSON 代码块，不得输出任何额外文字（包括解释、前后缀、Markdown 说明）。
+- 必须使用 ```json 代码块包裹完整 JSON。
+- JSON 必须完整且可解析，不得拆行输出到代码块之外。
+- 如果没有合适的解决方案，仍返回同样的 JSON 结构，且 command 为空字符串。
+
 ```json
 {
   "type": "corrected_command",
-  "command": "the corrected command or empty string",
-  "description": "brief explanation of the fix or why no fix is available"
+  "command": "修正后的完整命令 或者 空字符串",
+  "description": "简短说明修正原因和命令作用,或者说明为什么没有合适的解决方案"
 }
 ```"#;
 
-const ERROR_DETECT_PROMPT: &str = r#"Analyze the following command output and determine if it indicates an error.
+const ERROR_DETECT_PROMPT: &str = r#"{{role_prompt}}
 
-**Command:** {{command}}
-**Exit Code:** {{exit_code}}
-**Output:**
+## 系统基本信息
+- 运行环境信息: {{uname_info}}
+- 用户的昵称: {{user_nickname}}
+- 发行版信息：{{os_info}}
+- 基本环境信息：
+{{basic_env_info}}
+
+## Tone and Style
+You should be concise, direct, and to the point.  Response with {{output_language}}.
+
+## 任务
+根据命令的执行结果（包括标准输出、标准错误），判断命令是否执行成功。
+
+IMPORTANT:
+任务给出的命令都是 return code 为 0 的情况。
+不同的平台上，不同的版本，同一个命令的执行结果可能不同，你需要根据命令的执行结果来判断命令是否执行成功。
+管道任务，中间的命令出错，不会影响最终的返回码，所以你需要根据标准输出和标准错误来判断命令整体是否执行成功。
+
+RESPONSE FORMAT:
+```json
+{
+  "type": "error_detect",
+  "is_success": true or false,
+  "reason": "错误原因的简明解释"
+}
 ```
-{{output}}
+
+### 分析示例
+
+<example>
+用户执行命令(under mac os)：
+```bash
+ps -aux | tail -1
 ```
+执行结果：
+```
+stderr:
+ps: No user named 'x'
+stdout:
+```
+ 判断结果：
+ ```json
+ {
+  "type": "error_detect",
+  "is_success": false,
+  "reason": "ps命令的参数错误"
+ }
+ ```
+</example>
 
-Respond with YES if this is an error that needs correction, or NO if it's normal output."#;
+<example>
+用户执行命令(under linux)：
+```bash
+ps -aux | tail -1
+```
+执行结果：
+```
+stderr:
+stdout:
+sonald    258176  0.0  0.0  48828  2060 pts/0    S+   10:40   0:00 tail -2
+```
+ 判断结果：
+ ```json
+ {
+  "type": "error_detect",
+  "is_success": true,
+  "reason": " 命令正确执行"
+ }
+ ```
+</example>
 
-const SYSTEM_DIAGNOSE_PROMPT: &str = r#"You are a system diagnostic agent. You investigate system issues using the available tools.
+<example>
+用户执行命令(under linux)：
+```bash
+lsof -a | head -10
+```
+执行结果：
+```
+stderr:
+lsof: no select options to AND via -a
+lsof 4.95.0
+ latest revision: https://github.com/lsof-org/lsof
+ latest FAQ: https://github.com/lsof-org/lsof/blob/master/00FAQ
+ latest (non-formatted) man page: https://github.com/lsof-org/lsof/blob/master/Lsof.8
+ usage: [-?abhKlnNoOPRtUvVX] [+|-c c] [+|-d s] [+D D] [+|-E] [+|-e s] [+|-f[gG]]
+ [-F [f]] [-g [s]] [-i [i]] [+|-L [l]] [+m [m]] [+|-M] [-o [o]] [-p s]
+ [+|-r [t]] [-s [p:s]] [-S [t]] [-T [t]] [-u s] [+|-w] [-x [fl]] [--] [names]
+Use the ``-h'' option to get more help information.
+stdout:
+```
+ 判断结果：
+ ```json
+ {
+  "type": "error_detect",
+  "is_success": false,
+  "reason": "lsof命令的参数错误"
+ }
+ ```
+</example>
 
-**System Info:**
-- User: {{username}}@{{hostname}}
-- OS: {{os_info}}
-- CWD: {{cwd}}
+<example>
+用户执行命令(under mac os)：
+```bash
+ps aux -omem | tail -1
+```
+执行结果：
+```
+stderr:
+ps: mem: keyword not found
+stdout:
+siancao          61815   0.0  0.0 435314416   1568 s022  Ss+  11:46AM   0:00.58 /bin/zsh
+```
+ 判断结果：
+ ```json
+ {
+  "type": "error_detect",
+  "is_success": false,
+  "reason": "ps命令的参数错误了，虽然命令最后有输出"
+ }
+ ```
+</example>"#;
 
-Use bash and read_file tools to investigate the user's issue. Follow the ReAct pattern:
-1. Thought: reason about what to check next
-2. Action: call a tool to gather information
-3. Observation: analyze the tool result
-4. Repeat until you can provide a Final Answer
+const SYSTEM_DIAGNOSE_PROMPT: &str = r#"# Role
+You are a diagnostic expert specializing in Unix-like (GNU/Linux, Mac OS X) system troubleshooting.
 
-Format:
-Thought: <your reasoning>
-Action: <tool_name>(<json_args>)
+Your task is to analyze a user-provided system issue or query, systematically identify all relevant information and diagnostics required, and generate a clear, structured action plan or report.
 
-When done:
-Final Answer: <your diagnosis and recommendations>"#;
+## 系统基本信息
+- 运行环境信息: {{uname_info}}
+- 用户的昵称: {{user_nickname}}
+- 发行版信息：{{os_info}}
+- 基本环境信息：
+{{basic_env_info}}
 
-const SKILL_PROMPT: &str = r#"The user wants to use the skill "{{skill_name}}".
+## Tools
+You have access to the following tools:
+- bash_exec: Execute shell commands to gather system information
+- read_file: Read configuration files, logs, and other system files
+- write_file: Create diagnostic reports or temporary analysis files
+- edit_file: Perform exact string replacements in existing files
+- final_answer: Provide your final diagnostic conclusion
 
-Skill description: {{skill_description}}
-Skill content: {{skill_content}}
+## Guidelines:
+- Start by understanding the user's problem clearly
+- Gather relevant system information (logs, configurations, process status, etc.)
+- Look for patterns, errors, and anomalies
+- Consider common causes and solutions
+- Provide actionable recommendations
+- Use bash_exec for commands like: ps, top, netstat, journalctl, dmesg, df, free, etc.
+- Use read_file for examining: /var/log files, configuration files, etc.
+- output language: use {{output_language}} to communicate with the user.
 
-Follow the skill's instructions to help the user."#;
+When you have completed your analysis and are ready to provide the final diagnostic conclusion,
+use the final_answer tool with your complete diagnostic report. This is the only way to properly
+complete the diagnosis task."#;
+
+const GUESS_COMMAND_PROMPT: &str = r#"{{role_prompt}}
+
+Your job in this turn is **only** to decide whether the user input is a *shell command* or a *natural-language question*.
+
+
+# CONTEXT AVAILABLE
+• You receive one plain-text string that may be:
+  ① a single Linux command (with optional flags / arguments); or
+  ② a natural-language sentence asking about Linux, DevOps, or programming.
+
+# DECISION CRITERIA
+1. **Command** (return `True`):
+   • The first token exactly matches a POSIX shell built-in (`cd`, `echo`, `export`, …) **OR**
+   • It matches an executable name discoverable in `$$PATH` (e.g. `git`, `python3`, `systemctl`) **OR**
+   • It starts with an explicit interpreter directive such as `./`, `bash -c`, `python - <<EOF`, etc.
+   • Typical command delimiters (`;`, `&&`, `|`, `>`, `>>`, `<`, `2>`, backticks, `$( )`) are strong hints of a command.
+
+2. **Question** (return `False`):
+   • Contains a question mark (`?`) or WH-words (`what`, `how`, `why`, `which`, `where`, `when`).
+   • Begins with verbs like *"show", "explain", "tell me", "how to"*.
+   • Describes goals or problems instead of giving an executable instruction, e.g.
+     "git is installed", "how to list open ports", "为什么 ls -l 比 ls 快？".
+
+3. **Ambiguity Handling**
+   • If the string can be a valid command *and* a plausible question, prefer **command**.
+   • If you are genuinely uncertain, default to `False` and let the outer loop ask the user to clarify.
+
+# OUTPUT FORMAT
+Return **exactly one of the two JSON literals**:
+
+- `true`   ← for a command
+- `false`  ← for a question
+
+No additional text, no punctuation, no explanation.
+
+# FEW-SHOT EXAMPLES
+Input: `git status`
+Output: `true`
+
+Input: `git status?`
+Output: `false`
+
+Input: `cat /var/log/syslog | grep error`
+Output: `true`
+
+Input: `how to grep error lines from syslog`
+Output: `false`
+
+Input: `sudo`
+Output: `true`
+
+Input: `sudo?`
+Output: `false`
+
+Input: `git is installed?`
+Output: `false`
+
+Input: `who am i`
+Output: `true`
+
+Input: `who are you`
+Output: `false`
+
+Input: `ls -l my-fold | grep baby`
+Output: `true`"#;
+
+const SKILL_PROMPT: &str = r#"Base directory for this skill: {{base_dir}}
+
+{{skill_content}}
+
+Skill arguments: {{skill_args}}"#;
 
 #[cfg(test)]
 mod tests {
@@ -196,16 +517,16 @@ mod tests {
         let mut pm = PromptManager::new("/nonexistent");
         let mut vars = HashMap::new();
         vars.insert("role_prompt".to_string(), "You are helpful.".to_string());
-        vars.insert("username".to_string(), "testuser".to_string());
-        vars.insert("hostname".to_string(), "testhost".to_string());
+        vars.insert("uname_info".to_string(), "Linux testhost 6.1.0 x86_64".to_string());
+        vars.insert("user_nickname".to_string(), "testuser".to_string());
         vars.insert("os_info".to_string(), "Linux x86_64".to_string());
+        vars.insert("basic_env_info".to_string(), String::new());
+        vars.insert("output_language".to_string(), "English".to_string());
         vars.insert("cwd".to_string(), "/home/test".to_string());
-        vars.insert("system_info".to_string(), String::new());
-        vars.insert("memory_context".to_string(), String::new());
-        vars.insert("skill_list".to_string(), String::new());
         let result = pm.render("oracle", &vars);
-        assert!(result.contains("testuser@testhost"));
+        assert!(result.contains("testuser"));
         assert!(result.contains("You are helpful."));
+        assert!(result.contains("Linux testhost"));
     }
 
     #[test]
@@ -216,5 +537,34 @@ mod tests {
         pm.reload();
         // After reload, cache should be repopulated
         assert!(pm.cache.contains_key("role"));
+    }
+
+    #[test]
+    fn test_render_static_core_stable() {
+        let mut pm = PromptManager::new("/nonexistent");
+        let core1 = pm.render_static_core(
+            "Linux test 6.1.0 x86_64",
+            "testuser",
+            "Linux x86_64",
+            "",
+            "English",
+        );
+        let core2 = pm.render_static_core(
+            "Linux test 6.1.0 x86_64",
+            "testuser",
+            "Linux x86_64",
+            "",
+            "English",
+        );
+        assert_eq!(core1, core2, "static core must be identical across calls");
+        assert!(core1.contains("testuser"));
+    }
+
+    #[test]
+    fn test_render_env_block_format() {
+        let pm = PromptManager::new("/nonexistent");
+        let block = pm.render_env_block("/home/alice");
+        assert!(block.starts_with("\n**Environment Update:**"));
+        assert!(block.contains("/home/alice"));
     }
 }

--- a/crates/aish-shell/src/ai_handler.rs
+++ b/crates/aish-shell/src/ai_handler.rs
@@ -359,9 +359,15 @@ impl AiHandler {
             );
         }
 
-        // Step 5: Build context and system messages
-        let context_messages = self.build_context_messages();
-        let system_message = self.system_message();
+        // Step 5: Build context and system messages.
+        // Split system message into static core (cached) and dynamic env block.
+        // The static core goes as the main system_message; the env block is
+        // prepended to context_messages so the cache breakpoint lands on the
+        // stable prefix.
+        let (static_core, env_block) = self.system_message_parts();
+        let mut context_messages = self.build_context_messages();
+        context_messages.insert(0, ChatMessage::system(&env_block));
+
 
         // Step 5: Send to LLM
         let process_result = self
@@ -369,7 +375,7 @@ impl AiHandler {
             .process_input(
                 &question_processed,
                 &context_messages,
-                system_message.as_deref(),
+                Some(&static_core),
                 true,
             )
             .await?;
@@ -576,9 +582,6 @@ impl AiHandler {
         }
         let mut guard = self.memory_manager.lock().unwrap();
         if let Some(ref mut mm) = *guard {
-            // Clear previous recall
-            self.context_manager.clear_knowledge("memory_recall");
-
             let keywords = extract_keywords(query);
             let search_query = if keywords.is_empty() {
                 query.to_string()
@@ -587,6 +590,8 @@ impl AiHandler {
             };
             let results = mm.recall(&search_query, self.memory_config.recall_limit);
             if results.is_empty() {
+                // No results — clear stale recall to keep context clean
+                self.context_manager.inject_knowledge_stable("memory_recall", "");
                 return;
             }
 
@@ -602,7 +607,6 @@ impl AiHandler {
             // Enforce token budget (~4 chars per token)
             let budget = self.memory_config.recall_token_budget * 4;
             let text = if text.len() > budget {
-                // Find the nearest char boundary at or before budget
                 let safe_end = floor_char_boundary(&text, budget);
                 let truncated = &text[..safe_end];
                 format!(
@@ -616,14 +620,13 @@ impl AiHandler {
                 text
             };
 
-            self.context_manager.add_message(
-                "system",
-                &format!(
-                    "<long-term-memory source=\"recall\">\n{}\n</long-term-memory>",
-                    text
-                ),
-                MemoryType::Knowledge,
+            let content = format!(
+                "<long-term-memory source=\"recall\">\n{}\n</long-term-memory>",
+                text
             );
+            // Stable injection — only replaces if content actually changed,
+            // preserving cache prefix stability across calls.
+            self.context_manager.inject_knowledge_stable("memory_recall", &content);
         }
     }
 
@@ -643,11 +646,11 @@ impl AiHandler {
     }
 
     /// Inject loaded skill descriptions into the context so the AI can use them.
+    /// Uses stable injection — only updates when skills actually change.
     fn inject_skills(&mut self) {
-        self.context_manager.clear_knowledge("skills");
-
         let skills = self.skill_manager.list_skills();
         if skills.is_empty() {
+            self.context_manager.inject_knowledge_stable("skills", "");
             return;
         }
 
@@ -661,12 +664,9 @@ impl AiHandler {
             })
             .collect();
         let text = descriptions.join("\n\n");
+        let content = format!("<available-skills>\n{}\n</available-skills>", text);
 
-        self.context_manager.add_message(
-            "system",
-            &format!("<available-skills>\n{}\n</available-skills>", text),
-            MemoryType::Knowledge,
-        );
+        self.context_manager.inject_knowledge_stable("skills", &content);
     }
 
     /// Build context messages from the context manager into ChatMessage format.
@@ -691,49 +691,42 @@ impl AiHandler {
                     tool_call_id: None,
                     name: None,
                     reasoning_content: None,
+                    cache_control: None,
                 }
             })
             .collect()
     }
 
-    /// Return the system message for normal AI interactions.
-    fn system_message(&mut self) -> Option<String> {
-        let role_prompt = self.prompt_manager.get("role").to_string();
-        let mut vars = HashMap::new();
-        vars.insert("role_prompt".to_string(), role_prompt);
-        vars.insert("username".to_string(), whoami());
-        vars.insert("hostname".to_string(), hostname());
-        vars.insert("os_info".to_string(), os_info());
-        vars.insert("cwd".to_string(), cwd());
-        vars.insert("system_info".to_string(), String::new());
-        vars.insert("memory_context".to_string(), String::new());
-        vars.insert("skill_list".to_string(), String::new());
-        Some(self.prompt_manager.render("oracle", &vars))
+    /// Return the system message split into (static_core, env_block).
+    /// The static core is stable across calls (enabling KV-cache prefix hits).
+    /// The env_block contains per-call dynamic info (cwd).
+    fn system_message_parts(&mut self) -> (String, String) {
+        let core = self.prompt_manager.render_static_core(
+            &uname_info(),
+            &whoami(),
+            &os_info(),
+            &basic_env_info(),
+            &output_language(),
+        );
+        let env = self.prompt_manager.render_env_block(&cwd());
+        (core, env)
     }
 
     /// Return the system message for error correction mode.
     fn error_correction_system_message(
         &mut self,
-        command: &str,
-        exit_code: i32,
-        stderr: &str,
+        _command: &str,
+        _exit_code: i32,
+        _stderr: &str,
     ) -> Option<String> {
-        let stderr_section = if stderr.is_empty() {
-            String::new()
-        } else {
-            let preview = if stderr.len() > 2048 {
-                &stderr[..floor_char_boundary(stderr, 2048)]
-            } else {
-                stderr
-            };
-            format!("\n**Command Output:**\n```\n{}\n```", preview)
-        };
+        let role_prompt = self.prompt_manager.get("role").to_string();
         let mut vars = HashMap::new();
-        vars.insert("username".to_string(), whoami());
+        vars.insert("role_prompt".to_string(), role_prompt);
+        vars.insert("uname_info".to_string(), uname_info());
+        vars.insert("user_nickname".to_string(), whoami());
         vars.insert("os_info".to_string(), os_info());
-        vars.insert("command".to_string(), command.to_string());
-        vars.insert("exit_code".to_string(), exit_code.to_string());
-        vars.insert("stderr_section".to_string(), stderr_section);
+        vars.insert("basic_env_info".to_string(), basic_env_info());
+        vars.insert("output_language".to_string(), output_language());
         Some(self.prompt_manager.render("cmd_error", &vars))
     }
 }
@@ -835,6 +828,7 @@ pub(crate) fn whoami() -> String {
 }
 
 /// Get the hostname.
+#[allow(dead_code)]
 pub(crate) fn hostname() -> String {
     std::env::var("HOSTNAME")
         .or_else(|_| {
@@ -875,6 +869,69 @@ fn cwd() -> String {
     std::env::current_dir()
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_else(|_| "/".to_string())
+}
+
+/// Get uname info (kernel version, architecture, etc.).
+/// Result is cached for the process lifetime since it doesn't change.
+pub(crate) fn uname_info() -> String {
+    static CACHE: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            std::process::Command::new("uname")
+                .arg("-a")
+                .output()
+                .ok()
+                .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        })
+        .clone()
+}
+
+/// Get basic environment info (package managers, etc.).
+/// Result is cached for the process lifetime since it doesn't change.
+pub(crate) fn basic_env_info() -> String {
+    static CACHE: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            let mut parts = Vec::new();
+            for (cmd, label) in [
+                (["apt", "--version"].as_slice(), "APT"),
+                (["dnf", "--version"].as_slice(), "DNF"),
+                (["pacman", "--version"].as_slice(), "Pacman"),
+                (["zypper", "--version"].as_slice(), "Zypper"),
+            ] {
+                if let Ok(output) = std::process::Command::new(cmd[0])
+                    .args(&cmd[1..])
+                    .output()
+                {
+                    if output.status.success() {
+                        let ver = String::from_utf8_lossy(&output.stdout);
+                        if let Some(line) = ver.lines().next() {
+                            parts.push(format!("{}: {}", label, line));
+                        }
+                    }
+                }
+            }
+            parts.join("\n")
+        })
+        .clone()
+}
+
+/// Get output language from locale.
+/// Result is cached for the process lifetime since it doesn't change.
+pub(crate) fn output_language() -> String {
+    static CACHE: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            let locale = std::env::var("LANG").unwrap_or_else(|_| "en_US.UTF-8".to_string());
+            let lang = locale.split('.').next().unwrap_or("en");
+            if lang.starts_with("zh") {
+                "Chinese".to_string()
+            } else {
+                "English".to_string()
+            }
+        })
+        .clone()
 }
 
 #[cfg(test)]

--- a/crates/aish-shell/src/ai_handler.rs
+++ b/crates/aish-shell/src/ai_handler.rs
@@ -368,7 +368,6 @@ impl AiHandler {
         let mut context_messages = self.build_context_messages();
         context_messages.insert(0, ChatMessage::system(&env_block));
 
-
         // Step 5: Send to LLM
         let process_result = self
             .llm_session
@@ -591,7 +590,8 @@ impl AiHandler {
             let results = mm.recall(&search_query, self.memory_config.recall_limit);
             if results.is_empty() {
                 // No results — clear stale recall to keep context clean
-                self.context_manager.inject_knowledge_stable("memory_recall", "");
+                self.context_manager
+                    .inject_knowledge_stable("memory_recall", "");
                 return;
             }
 
@@ -609,13 +609,10 @@ impl AiHandler {
             let text = if text.len() > budget {
                 let safe_end = floor_char_boundary(&text, budget);
                 let truncated = &text[..safe_end];
-                format!(
-                    "{}\n</long-term-memory>",
-                    truncated
-                        .rfind('\n')
-                        .map(|i| &text[..i])
-                        .unwrap_or(truncated)
-                )
+                truncated
+                    .rfind('\n')
+                    .map(|i| text[..i].to_string())
+                    .unwrap_or_else(|| truncated.to_string())
             } else {
                 text
             };
@@ -626,7 +623,8 @@ impl AiHandler {
             );
             // Stable injection — only replaces if content actually changed,
             // preserving cache prefix stability across calls.
-            self.context_manager.inject_knowledge_stable("memory_recall", &content);
+            self.context_manager
+                .inject_knowledge_stable("memory_recall", &content);
         }
     }
 
@@ -666,7 +664,8 @@ impl AiHandler {
         let text = descriptions.join("\n\n");
         let content = format!("<available-skills>\n{}\n</available-skills>", text);
 
-        self.context_manager.inject_knowledge_stable("skills", &content);
+        self.context_manager
+            .inject_knowledge_stable("skills", &content);
     }
 
     /// Build context messages from the context manager into ChatMessage format.
@@ -900,10 +899,7 @@ pub(crate) fn basic_env_info() -> String {
                 (["pacman", "--version"].as_slice(), "Pacman"),
                 (["zypper", "--version"].as_slice(), "Zypper"),
             ] {
-                if let Ok(output) = std::process::Command::new(cmd[0])
-                    .args(&cmd[1..])
-                    .output()
-                {
+                if let Ok(output) = std::process::Command::new(cmd[0]).args(&cmd[1..]).output() {
                     if output.status.success() {
                         let ver = String::from_utf8_lossy(&output.stdout);
                         if let Some(line) = ver.lines().next() {

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -2784,8 +2784,14 @@ impl AishShell {
         vars.insert("uname_info".to_string(), crate::ai_handler::uname_info());
         vars.insert("user_nickname".to_string(), crate::ai_handler::whoami());
         vars.insert("os_info".to_string(), crate::ai_handler::os_info());
-        vars.insert("basic_env_info".to_string(), crate::ai_handler::basic_env_info());
-        vars.insert("output_language".to_string(), crate::ai_handler::output_language());
+        vars.insert(
+            "basic_env_info".to_string(),
+            crate::ai_handler::basic_env_info(),
+        );
+        vars.insert(
+            "output_language".to_string(),
+            crate::ai_handler::output_language(),
+        );
         vars.insert("cwd".to_string(), "~".to_string());
         // Static base prompt — SSH context and dossier are built dynamically
         // inside the closure so nested SSH host changes are reflected.

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -1294,7 +1294,7 @@ impl AishShell {
 
                     match result {
                         Ok(response) => {
-                            if !did_stream && !response.is_empty() {
+                            if !did_stream && !response.trim().is_empty() {
                                 // Non-streaming fallback: print full response with formatting
                                 let mut sep_renderer = ShellRenderer::new();
                                 sep_renderer.render_separator();
@@ -1439,7 +1439,7 @@ impl AishShell {
                     let parts: Vec<&str> = input.split_whitespace().collect();
                     if let Some(cmd) = parts.first() {
                         let result = self.state.handle_builtin(cmd, &parts[1..]);
-                        if let Some(output) = result.output {
+                        if let Some(ref output) = result.output {
                             println!("{}", output);
                         }
                         if result.should_exit {
@@ -1468,6 +1468,19 @@ impl AishShell {
                         {
                             self.sync_command_to_pty(input);
                         }
+
+                        // Add builtin result to LLM context
+                        let builtin_output = result.output.clone().unwrap_or_default();
+                        let mut entry = format!(
+                            "[Shell] {}\n<returncode>0</returncode>\n<output>{}</output>",
+                            input, builtin_output
+                        );
+                        if crate::commands::is_state_modifying(cmd)
+                            && !crate::commands::is_rejected(cmd)
+                        {
+                            entry.push_str(&format!("\n<cwd>{}</cwd>", self.state.cwd));
+                        }
+                        self.ai_handler.add_shell_context(&entry);
                     }
                     self.record_history(input, 0);
                 }
@@ -1507,7 +1520,7 @@ impl AishShell {
                                 let did_stream = self.streamed_content.load(Ordering::SeqCst);
                                 match result {
                                     Ok(response) => {
-                                        if !did_stream && !response.is_empty() {
+                                        if !did_stream && !response.trim().is_empty() {
                                             let mut sep_renderer = ShellRenderer::new();
                                             sep_renderer.render_separator();
                                             print_md(&response);
@@ -1542,28 +1555,6 @@ impl AishShell {
                     self.state.last_command = Some(input.to_string());
                     self.state.last_exit_code = exit_code;
                     self.state.can_correct_error = exit_code != 0 && exit_code != 130;
-
-                    // Inject command result into LLM context so AI can reference
-                    // previous command output in follow-up questions.
-                    // Always add, matching main branch's unconditional add_memory.
-                    let output_preview = if self.state.last_output.len() > 4096 {
-                        // Safe UTF-8 truncation: find nearest char boundary
-                        let end = {
-                            let mut j = 4096;
-                            while j > 0 && !self.state.last_output.is_char_boundary(j) {
-                                j -= 1;
-                            }
-                            j
-                        };
-                        &self.state.last_output[..end]
-                    } else {
-                        &self.state.last_output
-                    };
-                    let entry = format!(
-                        "[Shell] {}\n<returncode>{}</returncode>\n<output>{}</output>",
-                        input, exit_code, output_preview
-                    );
-                    self.ai_handler.add_shell_context(&entry);
 
                     // Show error correction hint
                     if exit_code != 0 && exit_code != 130 {
@@ -1833,14 +1824,42 @@ impl AishShell {
         // Store captured output for error correction and LLM context
         self.state.last_output = output.clone();
 
+        // Track whether CWD changed so we can include it in the context entry
+        let mut cwd_changed_to: Option<String> = None;
+
         // Update CWD from PTY event
         if !cwd.is_empty() && cwd != self.state.cwd {
+            cwd_changed_to = Some(cwd.clone());
             self.state.prev_cwd = Some(self.state.cwd.clone());
             self.state.cwd = cwd.clone();
             // Sync the actual process CWD so that any spawned subprocesses
             // (e.g., via AI tool execution) inherit the correct directory.
             let _ = std::env::set_current_dir(&cwd);
         }
+
+        // Inject command result into LLM context so AI can reference
+        // previous command output in follow-up questions.
+        let output_preview = if output.len() > 4096 {
+            // Safe UTF-8 truncation: find nearest char boundary
+            let end = {
+                let mut j = 4096;
+                while j > 0 && !output.is_char_boundary(j) {
+                    j -= 1;
+                }
+                j
+            };
+            &output[..end]
+        } else {
+            &output
+        };
+        let mut entry = format!(
+            "[Shell] {}\n<returncode>{}</returncode>\n<output>{}</output>",
+            command, exit_code, output_preview
+        );
+        if let Some(ref new_cwd) = cwd_changed_to {
+            entry.push_str(&format!("\n<cwd>{}</cwd>", new_cwd));
+        }
+        self.ai_handler.add_shell_context(&entry);
 
         // Check if PTY is still running, restart if not
         if !self.lock_pty().is_running() {
@@ -2762,13 +2781,12 @@ impl AishShell {
         let role_prompt = prompt_manager.get("role").to_string();
         let mut vars = std::collections::HashMap::new();
         vars.insert("role_prompt".to_string(), role_prompt);
-        vars.insert("username".to_string(), crate::ai_handler::whoami());
-        vars.insert("hostname".to_string(), crate::ai_handler::hostname());
+        vars.insert("uname_info".to_string(), crate::ai_handler::uname_info());
+        vars.insert("user_nickname".to_string(), crate::ai_handler::whoami());
         vars.insert("os_info".to_string(), crate::ai_handler::os_info());
+        vars.insert("basic_env_info".to_string(), crate::ai_handler::basic_env_info());
+        vars.insert("output_language".to_string(), crate::ai_handler::output_language());
         vars.insert("cwd".to_string(), "~".to_string());
-        vars.insert("system_info".to_string(), String::new());
-        vars.insert("memory_context".to_string(), String::new());
-        vars.insert("skill_list".to_string(), String::new());
         // Static base prompt — SSH context and dossier are built dynamically
         // inside the closure so nested SSH host changes are reflected.
         let system_msg_base = prompt_manager.render("oracle", &vars);
@@ -2778,8 +2796,16 @@ impl AishShell {
         let dossier_host = shared_host.clone();
 
         // Pre-compute static values for error correction template
-        let ec_username = crate::ai_handler::whoami();
+        let ec_role_prompt = {
+            let mut pm = aish_prompts::PromptManager::default_dir();
+            pm.load_all();
+            pm.get("role").to_string()
+        };
+        let ec_uname_info = crate::ai_handler::uname_info();
+        let ec_user_nickname = crate::ai_handler::whoami();
         let ec_os_info = crate::ai_handler::os_info();
+        let ec_basic_env_info = crate::ai_handler::basic_env_info();
+        let ec_output_language = crate::ai_handler::output_language();
         let conversation_history: Arc<Mutex<Vec<ChatMessage>>> = Arc::new(Mutex::new(Vec::new()));
 
         Some(Box::new(move |query: aish_pty::AiQuery| {
@@ -2845,28 +2871,13 @@ impl AishShell {
                 // Extract the actual failed command from bash error output
                 let failed_cmd = extract_failed_command(&query.recent_output);
 
-                let stderr_section = if query.recent_output.is_empty() {
-                    String::new()
-                } else {
-                    let s = &query.recent_output;
-                    let preview = if s.len() > 2048 {
-                        let mut end = 2048;
-                        while end > 0 && !s.is_char_boundary(end) {
-                            end -= 1;
-                        }
-                        &s[..end]
-                    } else {
-                        s
-                    };
-                    format!("\n**Command Output:**\n```\n{}\n```", preview)
-                };
-
                 let mut ec_vars = std::collections::HashMap::new();
-                ec_vars.insert("username".to_string(), ec_username.clone());
+                ec_vars.insert("role_prompt".to_string(), ec_role_prompt.clone());
+                ec_vars.insert("uname_info".to_string(), ec_uname_info.clone());
+                ec_vars.insert("user_nickname".to_string(), ec_user_nickname.clone());
                 ec_vars.insert("os_info".to_string(), ec_os_info.clone());
-                ec_vars.insert("command".to_string(), failed_cmd.clone());
-                ec_vars.insert("exit_code".to_string(), "1".to_string());
-                ec_vars.insert("stderr_section".to_string(), stderr_section);
+                ec_vars.insert("basic_env_info".to_string(), ec_basic_env_info.clone());
+                ec_vars.insert("output_language".to_string(), ec_output_language.clone());
                 let mut sys = pm.render("cmd_error", &ec_vars);
 
                 // Append SSH host context (use current dynamic host)


### PR DESCRIPTION
## Summary
- Overhaul oracle/cmd_error/error_detect prompts for better AI interaction
- Add `render_static_core`/`render_env_block` for cache-friendly prompt splitting
- Add `inject_knowledge_stable` for idempotent knowledge injection in context manager
- Add Anthropic prompt caching (`CacheControl`) on system messages
- Improve Langfuse observability: session-level trace, per-iteration spans
- Add `trim_tool_loop_messages` to prevent unbounded context growth during agent loops
- New `guess_command` prompt template

## Test plan
- [ ] Verify existing unit tests pass (`cargo test` in affected crates)
- [ ] Verify prompt templates render correctly
- [ ] Verify Langfuse traces group correctly per session
- [ ] Verify tool-loop trimming works for long agent sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prompt caching support for improved LLM response performance
  * Enhanced long-term memory recall with source attribution formatting

* **Improvements**
  * Improved working directory tracking during command execution
  * Better handling of whitespace-only AI responses
  * Enhanced command result context injection and formatting
  * Refined skill presentation in AI context
  * More stable AI session management across multiple turns

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/188)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->