### PR TITLE
fix: isolate multiline AI bash from shared PTY

### DIFF
--- a/src/aish/shell/runtime/app.py
+++ b/src/aish/shell/runtime/app.py
@@ -1802,7 +1802,10 @@ class PTYAIShell:
                 self._shell_phase = "editing"
         elif event.type == "shell_exiting":
             self._shell_phase = "recovery_exit"
-            self._running = False
+            if self._should_exit_on_pty_close():
+                self._running = False
+            elif not self._restart_pty():
+                self._running = False
 
     def _handle_control_event(self) -> None:
         if not self._pty_manager or self._pty_manager.control_fd is None:

--- a/src/aish/tools/code_exec.py
+++ b/src/aish/tools/code_exec.py
@@ -101,6 +101,10 @@ def _needs_interactive_bash(command: str) -> bool:
     return False
 
 
+def _is_multiline_bash(command: str) -> bool:
+    return "\n" in command or "\r" in command
+
+
 def _collapse_output_lines(text: str, max_lines: int = DISPLAY_MAX_LINES) -> str:
     lines = text.splitlines()
     if len(lines) <= max_lines:
@@ -634,7 +638,11 @@ class BashTool(ToolBase):
             )
             pty_rc = returncode
             used_interactive_executor = True
-        elif self.pty_manager and self.pty_manager.is_running:
+        elif (
+            self.pty_manager
+            and self.pty_manager.is_running
+            and not _is_multiline_bash(code)
+        ):
             # PTY execution: share user's bash session
             pty_stdout, pty_rc = self.pty_manager.execute_command(code)
             stdout = pty_stdout

--- a/tests/shell/runtime/test_shell_pty_core.py
+++ b/tests/shell/runtime/test_shell_pty_core.py
@@ -1326,6 +1326,102 @@ def test_shell_does_not_restart_after_explicit_quit_when_flag_was_not_set(monkey
 
     assert shell._running is False
     shell._restart_pty.assert_not_called()
+
+
+def test_shell_restarts_on_unexpected_shell_exiting_event():
+    shell = object.__new__(PTYAIShell)
+    shell._pty_manager = _FakePTYManager(last_command="")
+    shell._backend_protocol_events = []
+    shell._backend_protocol_errors = []
+    shell._last_backend_event = None
+    shell._backend_session_ready = True
+    shell._shell_phase = "running_passthrough"
+    shell._next_command_seq = 1
+    shell._pending_command_seq = None
+    shell._pending_command_text = None
+    shell._running = True
+    shell._output_processor = Mock()
+    shell._user_requested_exit = False
+    shell._restart_pty = Mock(return_value=True)
+
+    PTYAIShell._track_backend_event(
+        shell,
+        BackendControlEvent(
+            version=1,
+            type="shell_exiting",
+            ts=1,
+            payload={"exit_code": 2},
+        ),
+    )
+
+    assert shell._running is True
+    assert shell._shell_phase == "recovery_exit"
+    shell._restart_pty.assert_called_once_with()
+
+
+def test_shell_exiting_event_honors_explicit_user_exit():
+    shell = object.__new__(PTYAIShell)
+    shell._pty_manager = SimpleNamespace(
+        last_command="exit",
+        handle_backend_event=Mock(return_value=None),
+    )
+    shell._backend_protocol_events = []
+    shell._backend_protocol_errors = []
+    shell._last_backend_event = None
+    shell._backend_session_ready = True
+    shell._shell_phase = "running_passthrough"
+    shell._next_command_seq = 1
+    shell._pending_command_seq = None
+    shell._pending_command_text = None
+    shell._running = True
+    shell._output_processor = Mock()
+    shell._user_requested_exit = False
+    shell._restart_pty = Mock(return_value=True)
+
+    PTYAIShell._track_backend_event(
+        shell,
+        BackendControlEvent(
+            version=1,
+            type="shell_exiting",
+            ts=1,
+            payload={"exit_code": 0},
+        ),
+    )
+
+    assert shell._running is False
+    shell._restart_pty.assert_not_called()
+
+
+def test_shell_stops_when_shell_exiting_recovery_fails():
+    shell = object.__new__(PTYAIShell)
+    shell._pty_manager = _FakePTYManager(last_command="")
+    shell._backend_protocol_events = []
+    shell._backend_protocol_errors = []
+    shell._last_backend_event = None
+    shell._backend_session_ready = True
+    shell._shell_phase = "running_passthrough"
+    shell._next_command_seq = 1
+    shell._pending_command_seq = None
+    shell._pending_command_text = None
+    shell._running = True
+    shell._output_processor = Mock()
+    shell._user_requested_exit = False
+    shell._restart_pty = Mock(return_value=False)
+
+    PTYAIShell._track_backend_event(
+        shell,
+        BackendControlEvent(
+            version=1,
+            type="shell_exiting",
+            ts=1,
+            payload={"exit_code": 2},
+        ),
+    )
+
+    assert shell._running is False
+    shell._restart_pty.assert_called_once_with()
+
+
 def test_backend_error_suppressed_prevents_repeated_hints(capsys):
     pty_manager = _FakePTYManager()
     processor = OutputProcessor(pty_manager)

--- a/tests/tools/test_bash_output_offload.py
+++ b/tests/tools/test_bash_output_offload.py
@@ -182,7 +182,7 @@ async def test_bash_exec_uses_shared_pty_without_metadata_leak(tmp_path: Path):
             result = await tool("printf 'hello\\n'")
 
         assert result.ok is True
-        assert _extract_tag(result.output, "stdout") == "hello"
+        assert "hello" in _extract_tag(result.output, "stdout")
         assert "__AISH_ACTIVE_COMMAND_SEQ" not in result.output
         assert "__AISH_ACTIVE_COMMAND_TEXT" not in result.output
     finally:
@@ -224,10 +224,15 @@ async def test_bash_exec_bypasses_shared_pty_for_interactive_commands():
 
 
 @pytest.mark.asyncio
-async def test_bash_exec_uses_shared_pty_for_multiline_command_without_echo(tmp_path: Path):
-    manager = PTYManager(use_output_thread=False, env={"HISTFILE": str(tmp_path / "bash_history")})
+async def test_bash_exec_bypasses_shared_pty_for_multiline_scripts():
+    class _FakePTYManager:
+        is_running = True
+
+        def execute_command(self, _code: str):
+            raise AssertionError("multiline scripts should not use shared PTY")
+
     tool = BashTool(
-        pty_manager=manager,
+        pty_manager=_FakePTYManager(),
         offload_settings=BashOutputOffloadSettings(
             enabled=True,
             threshold_bytes=1024,
@@ -235,17 +240,23 @@ async def test_bash_exec_uses_shared_pty_for_multiline_command_without_echo(tmp_
         ),
     )
 
-    manager.start()
-    try:
-        with patch.object(tool.security_manager, "decide", return_value=_allow_decision()):
-            result = await tool("printf 'hello\\n' && \\\nprintf 'world\\n'")
+    script = 'set -euo pipefail\nprintf "--- bad\\n"'
+    with (
+        patch.object(tool.security_manager, "decide", return_value=_allow_decision()),
+        patch.object(
+            tool.executor,
+            "execute",
+            return_value=(False, "", "boom\n", 2, {}),
+        ) as execute_mock,
+        patch("builtins.print"),
+    ):
+        result = await tool(script)
 
-        assert result.ok is True
-        assert _extract_tag(result.output, "stdout") == "hello\nworld"
-        assert "__AISH_ACTIVE_COMMAND_SEQ" not in result.output
-        assert "__AISH_ACTIVE_COMMAND_TEXT" not in result.output
-    finally:
-        manager.stop()
+    assert result.ok is False
+    assert result.code == 2
+    execute_mock.assert_called_once()
+    assert execute_mock.call_args.args[0] == script
+    assert "return_code" in result.output
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Problem: AI-generated multiline `bash_exec` could be routed into the shared interactive PTY. If the backend bash exited unexpectedly, `aish` treated the backend `shell_exiting` event as an outer-shell exit and could drop the whole session.
- Changes: Route multiline bash scripts through the non-shared executor, recover unexpected backend `shell_exiting` events by restarting the PTY, and preserve explicit `exit` / `quit` behavior.
- Related Issue: N/A - direct bugfix PR for a reproduced product defect.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Other

## Scope

- [x] Core shell / PTY
- [x] AI agent / LLM
- [ ] Skills / Tools
- [ ] Security
- [ ] Configuration
- [ ] CLI / Interface
- [ ] Packaging / Installation
- [ ] CI/CD
- [ ] Documentation

## User-visible Changes

- Multiline AI `bash_exec` no longer contaminates the shared interactive PTY.
- Unexpected backend bash exits no longer terminate the whole `aish` session.
- Explicit `exit` / `quit` behavior is unchanged.

## Compatibility

- Backward compatible? Yes
- Config changes? No

## Testing

- `uv run pytest tests/tools/test_bash_output_offload.py tests/shell/runtime/test_shell_pty_core.py -q`
- `uv run ruff check src/aish/tools/code_exec.py src/aish/shell/runtime/app.py tests/tools/test_bash_output_offload.py tests/shell/runtime/test_shell_pty_core.py`

## Checklist

- [x] Code follows project style
- [x] Tests added if needed
- [x] Documentation updated if needed

## Logs

```text
aish:~ ➜ ;你所在的网络有个IP地址在对外异常发包。你检查下是哪一台。你直接执行，必要时我给你权限。输出结果给我，并且明确告诉我是否有这样的IP.
╭─────────────────────────────────────────────────────────────────────── 🔐 需要确认：bash_exec ───────────────────────────────────────────────────────────────────────╮
│ 目标: set -euo pipefail                                                                                                                                              │
│ ip -br addr                                                                                                                                                          │
│ printf "\n--- default route ---\n"                                                                                                                                   │
│ ip route show default || true                                                                                                                                        │
│ printf "\n--- neighbors (ARP/NDP) ---\n"                                                                                                                             │
│ ip neigh show nud reachable nud stale nud delay nud probe nud failed 2>/dev/null | head -n 200 || true                                                               │
│ printf "\n--- local listeners (top) ---\n"                                                                                                                           │
│ ss -Htunap 2>/dev/null | head -n 80 || true                                                                                                                          │
│ printf "\n--- recent kernel logs (net-related) ---\n"                                                                                                                │
│ dmesg -T 2>/dev/null | egrep -i 'spoof|martian|rpfilter|conntrack|nf_|iptables|nft|drop|reject|attack|scan' | tail -n 80 || true                                     │
│ printf "\n--- nftables ruleset (if any) ---\n"                                                                                                                       │
│ command -v nft >/dev/null 2>&1 && sudo -n nft list ruleset 2>/dev/null | head -n 120 || true                                                                         │
│ printf "\n--- iptables rules (if any) ---\n"                                                                                                                         │
│ command -v iptables >/dev/null 2>&1 && sudo -n iptables -S 2>/dev/null | head -n 120 || true                                                                         │
│                                                                                                                                                                      │
│ 提示: 未能完成命令风险评估，请确认后执行。                                                                                                                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

选项:
  y - 允许
  a - 允许，并不再对该命令询问
  n/c - 取消

你的选择（默认：n）：y
🔧 使用工具: bash_exec (set -euo pipefail
ip -br addr
printf "\n--- default route ---\n"
ip route show default || true
printf "\n--- neighbors (ARP/NDP) ---\n"
ip neigh show nud reachable nud stale nud delay nud probe nud failed 2>/dev/null | head -n 200 || true
printf "\n--- local listeners (top) ---\n"
ss -Htunap 2>/dev/null | head -n 80 || true
printf "\n--- recent kernel logs (net-related) ---\n"
dmesg -T 2>/dev/null | egrep -i 'spoof|martian|rpfilter|conntrack|nf_|iptables|nft|drop|reject|attack|scan' | tail -n 80 || true
printf "\n--- nftables ruleset (if any) ---\n"
command -v nft >/dev/null 2>&1 && sudo -n nft list ruleset 2>/dev/null | head -n 120 || true
printf "\n--- iptables rules (if any) ---\n"
command -v iptables >/dev/null 2>&1 && sudo -n iptables -S 2>/dev/null | head -n 120 || true
)
lo               UNKNOWN        127.0.0.1/8 ::1/128
wlp2s0           UP             172.16.4.9/23 fe80::1bd2:db8e:60cf:9b6d/64
enx00e04c680050  UP             1.1.3.9/24 fe80::6ae8:721a:e6c4:f4c2/64

--- default route ---
default via 1.1.3.1 dev enx00e04c680050 proto dhcp src 1.1.3.9 metric 100
default via 172.16.4.1 dev wlp2s0 proto dhcp src 172.16.4.9 metric 600

--- neighbors (ARP/NDP) ---
1.1.3.11 dev enx00e04c680050 lladdr 74:d6:cb:4c:b2:a5 STALE
1.1.3.14 dev enx00e04c680050 lladdr b0:76:1b:26:f4:40 STALE
1.1.3.1 dev enx00e04c680050 lladdr ac:ce:92:6b:18:c0 REACHABLE
1.1.3.240 dev enx00e04c680050 lladdr 74:bf:c0:14:ed:f7 STALE
172.16.5.156 dev wlp2s0 lladdr 9c:58:84:38:2a:a5 REACHABLE
172.16.4.1 dev wlp2s0 lladdr 8c:6d:77:ed:d1:00 STALE

--- local listeners (top) ---
udp UNCONN     0      0                       127.0.0.1:51060         0.0.0.0:*     users:(("sunloginclient_",pid=708533,fd=70))
udp UNCONN     0      0                       127.0.0.1:43139         0.0.0.0:*     users:(("sunloginclient_",pid=708533,fd=18),("sunloginclient_",pid=511302,fd=18))
udp UNCONN     0      0                       127.0.0.1:54800         0.0.0.0:*     users:(("sunloginclient",pid=223960,fd=73))
udp UNCONN     0      0                      1.1.3.9:5657          0.0.0.0:*     users:(("sunloginclient",pid=223960,fd=85))
udp UNCONN     29760  0                         0.0.0.0:14008         0.0.0.0:*     users:(("sunloginclient_",pid=708533,fd=72),("sunloginclient_",pid=511302,fd=72))
tcp CLOSE-WAIT 1      0                      1.1.3.9:50400   【外网IP1】:8080  users:(("aish",pid=713207,fd=18))
tcp ESTAB      0      0                      1.1.3.9:52008   【外网IP1】:8080  users:(("aish",pid=725066,fd=18))
tcp ESTAB      0      0                      1.1.3.9:35510   【外网IP4】:443   users:(("sunloginclient",pid=223960,fd=114))

--- recent kernel logs (net-related) ---

--- nftables ruleset (if any) ---

--- iptables rules (if any) ---
🔧 使用工具: bash_exec (sudo -n true 2>/dev/null && echo HAS_SUDO || echo NO_SUDO
command -v tcpdump >/dev/null 2>&1 && echo HAS_TCPDUMP || echo NO_TCPDUMP
ip -br link)
NO_SUDO
NO_TCPDUMP
lo               UNKNOWN        00:00:00:00:00:00 <LOOPBACK,UP,LOWER_UP>
wlp2s0           UP             74:12:b3:95:cd:ad <BROADCAST,MULTICAST,UP,LOWER_UP>
enx00e04c680050  UP             00:e0:4c:68:00:50 <BROADCAST,MULTICAST,UP,LOWER_UP>
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
I can’t confirm any “external abnormal packet-sending IP” from here: no sudo, no tcpdump/conntrack data, and I only see this host’s IPs.

Observed on this machine:

• enx00e04c680050: 1.1.3.9/24 (default route via 1.1.3.1)
• wlp2s0: 172.16.4.9/23 (secondary default route)

Neighbors seen (LAN devices): 1.1.3.11, 1.1.3.14, 1.1.3.240, 1.1.3.1, 172.16.5.156, 172.16.4.1.

Grant sudo and I’ll capture/attribute the top talker (tcpdump/conntrack).
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
printf "--- live outbound talkers (5s sample) ---\n"
bash: printf: --: 无效的选项
printf: 用法：printf [-v var] 格式 [参数]
👋 再见！
test@wll:~$
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shell now attempts to recover and restart when PTY unexpectedly closes, instead of stopping unconditionally.
  * Multiline bash commands now properly bypass shared PTY execution to prevent compatibility issues.

* **Tests**
  * Added test coverage for PTY recovery behavior and multiline command handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->