### PR TITLE
fix: align rust CI and local toolchain baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Read pinned Rust toolchain
+        id: rust_toolchain
+        run: |
+          channel="$(sed -n 's/^channel = "\(.*\)"$/\1/p' rust-toolchain.toml)"
+          test -n "$channel"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
-          components: clippy, rustfmt
+          toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+          components: clippy,rustfmt
 
       - name: Cache Cargo registry
         uses: actions/cache@v4
@@ -84,10 +92,10 @@ jobs:
             ${{ runner.os }}-cargo-${{ env.CACHE_KEY_SUFFIX }}-
 
       - name: Check formatting
-        run: cargo fmt --all -- --check
+        run: make format-check
 
       - name: Run clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: make lint
 
       - name: Run tests
         run: cargo test --workspace
@@ -96,7 +104,7 @@ jobs:
         run: ./packaging/tests/release_scripts_smoke.sh
 
       - name: Install musl tools
-        run: sudo apt-get update && sudo apt-get install -y musl-tools && rustup target add x86_64-unknown-linux-musl
+        run: sudo apt-get update && sudo apt-get install -y musl-tools && rustup target add x86_64-unknown-linux-musl --toolchain "${{ steps.rust_toolchain.outputs.channel }}"
 
       - name: Build release binary (musl)
         run: cargo build --release --target x86_64-unknown-linux-musl
@@ -123,9 +131,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Read pinned Rust toolchain
+        id: rust_toolchain
+        run: |
+          channel="$(sed -n 's/^channel = "\(.*\)"$/\1/p' rust-toolchain.toml)"
+          test -n "$channel"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ steps.rust_toolchain.outputs.channel }}
           targets: x86_64-unknown-linux-musl
 
       - name: Install musl tools

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,10 @@ Welcome to make Shell smarter!
 - Test locally with the Rust binary: `cargo run --bin aish -- --help`
 - Run Rust tests: `cargo test --workspace`
 - Run packaging script smoke tests: `./packaging/tests/release_scripts_smoke.sh`
-- Run formatting: `cargo fmt --all`
-- Run linting: `cargo clippy --all-targets -- -D warnings`
+- Use the pinned repo toolchain from `rust-toolchain.toml` for local validation
+- Run formatting: `make format`
+- Run linting: `make lint`
+- Run the full local CI baseline: `make ci-check`
 - Ensure CI checks pass (if configured)
 - Keep PRs focused (one thing per PR; do not mix unrelated concerns)
 - Describe what & why in your PR description

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test packaging-test prepare-release-files lint format build build-binary build-bundle install clean
+.PHONY: help test packaging-test prepare-release-files lint format format-check ci-check build build-binary build-bundle install clean
 
 PREFIX ?= /usr
 BINDIR ?= $(PREFIX)/bin
@@ -28,6 +28,7 @@ help:
 	@echo "  make lint           Run clippy"
 	@echo "  make format         Format code"
 	@echo "  make format-check   Check code formatting"
+	@echo "  make ci-check       Run the same local validation gates as CI"
 	@echo "  make clean          Clean build artifacts"
 
 test:
@@ -49,6 +50,8 @@ format:
 
 format-check:
 	cargo fmt --all -- --check
+
+ci-check: format-check lint test
 
 build:
 	./build.sh

--- a/packaging/scripts/setup-ci-env.sh
+++ b/packaging/scripts/setup-ci-env.sh
@@ -23,6 +23,21 @@ default_build_target() {
 
 TARGET="${AISH_BUILD_TARGET:-$(default_build_target)}"
 
+resolve_rust_toolchain() {
+    local toolchain_file="${AISH_RUST_TOOLCHAIN_FILE:-rust-toolchain.toml}"
+
+    if [[ -n "${AISH_RUST_TOOLCHAIN:-}" ]]; then
+        printf '%s\n' "$AISH_RUST_TOOLCHAIN"
+        return 0
+    fi
+
+    if [[ -f "$toolchain_file" ]]; then
+        sed -n 's/^channel = "\(.*\)"$/\1/p' "$toolchain_file" | head -n 1
+    fi
+}
+
+RUST_TOOLCHAIN="$(resolve_rust_toolchain)"
+
 run_as_root() {
     if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
         "$@"
@@ -54,9 +69,14 @@ target_cc_wrapper_name() {
 
 ensure_rust_target() {
     local target="$1"
+    local toolchain="${2:-}"
 
     if command -v rustup >/dev/null 2>&1; then
-        rustup target add "$target"
+        if [[ -n "$toolchain" ]]; then
+            rustup target add "$target" --toolchain "$toolchain"
+        else
+            rustup target add "$target"
+        fi
         return 0
     fi
 
@@ -142,7 +162,16 @@ if [[ -n "${GITHUB_PATH:-}" && -d "$HOME/.cargo/bin" ]]; then
     echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 fi
 
-ensure_rust_target "$TARGET"
+if [[ -n "$RUST_TOOLCHAIN" ]] && command -v rustup >/dev/null 2>&1; then
+    rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+    export RUSTUP_TOOLCHAIN="$RUST_TOOLCHAIN"
+fi
+
+if [[ -n "${GITHUB_ENV:-}" && -n "$RUST_TOOLCHAIN" ]]; then
+    echo "RUSTUP_TOOLCHAIN=$RUST_TOOLCHAIN" >> "$GITHUB_ENV"
+fi
+
+ensure_rust_target "$TARGET" "$RUST_TOOLCHAIN"
 configure_musl_cc "$TARGET"
 
 cargo --version

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+profile = "minimal"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Background
Rust PRs targeting the rust branch were intermittently failing in CI while passing locally because rustfmt and clippy were running against a floating stable toolchain. Historical failures showed both formatting drift and newer clippy lints appearing only on the runner.

## Changes
- pin the Rust toolchain in rust-toolchain.toml
- make CI read the pinned channel before installing rustfmt, clippy, and musl targets
- add a shared local ci-check target so local validation matches CI entrypoints
- update setup-ci-env.sh to install targets for the same pinned toolchain
- document the pinned-toolchain local validation flow

## Validation
- make format-check
- make lint
- make ci-check

## Risk
Low. This change narrows toolchain drift and keeps existing validation commands, but CI will now intentionally follow the repository-pinned Rust version instead of runner latest stable.