### PR TITLE
feat: add PyPI publishing via maturin (pip install aish-cli)

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,74 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      test_pypi:
+        description: 'Publish to TestPyPI instead of PyPI'
+        type: boolean
+        default: false
+
+jobs:
+  build-wheels:
+    name: Build wheel (${{ matrix.platform.target }})
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            arch: amd64
+          - runner: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            arch: arm64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist
+          manylinux: auto
+          docker-options: -e CI=true
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v6
+        with:
+          name: wheel-${{ matrix.platform.arch }}
+          path: dist/*.whl
+          if-no-files-found: error
+
+  publish-pypi:
+    name: Publish to ${{ github.event.inputs.test_pypi == 'true' && 'TestPyPI' || 'PyPI' }}
+    needs: build-wheels
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Download wheels
+        uses: actions/download-artifact@v6
+        with:
+          pattern: wheel-*
+          path: dist
+          merge-multiple: true
+
+      - name: List wheels
+        run: ls -la dist/
+
+      - name: Publish to TestPyPI
+        if: github.event.inputs.test_pypi == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Publish to PyPI
+        if: github.event.inputs.test_pypi != 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "aish-cli"
+dynamic = ["version"]
+description = "AI Shell - An intelligent shell assistant powered by LLM"
+requires-python = ">=3.7"
+license = "MIT"
+authors = [{ name = "aish contributors" }]
+keywords = ["shell", "ai", "llm", "terminal"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Rust",
+    "Topic :: Terminals",
+]
+
+[project.urls]
+Homepage = "https://github.com/AI-Shell-Team/aish"
+Repository = "https://github.com/AI-Shell-Team/aish"
+
+[tool.maturin]
+bindings = "bin"
+manifest-path = "crates/aish-cli/Cargo.toml"
+strip = true


### PR DESCRIPTION
## Summary
- Add `pyproject.toml` with maturin bin bindings configuration for packaging the `aish` binary as a Python wheel
- Add `.github/workflows/pypi.yml` for automated wheel building and PyPI publishing on tag push
- Supports Linux x86_64 and aarch64 manylinux wheels

## Test plan
- [ ] Verify wheel builds locally: `pip install maturin && maturin build --release`
- [ ] Manually trigger workflow via `workflow_dispatch` to test build (publish to TestPyPI)
- [ ] End-to-end: `pip install -i https://test.pypi.org/simple/ aish-cli && aish --help`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated Python package publishing pipeline supporting both production and test PyPI environments with manual control options.
  * Established project configuration including package metadata, build system, and distribution settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->