### PR TITLE
feat: add ESC key interrupt for AI streaming responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "crossterm 0.28.1",
  "dirs 5.0.1",
  "inquire",
+ "libc",
  "nix 0.29.0",
  "ratatui",
  "regex",

--- a/crates/aish-pty/src/persistent.rs
+++ b/crates/aish-pty/src/persistent.rs
@@ -1124,6 +1124,66 @@ impl PersistentPty {
                                             );
                                         }
                                         skip_leading_newline = true;
+                                    } else if followup_capturing && byte == 0x1b {
+                                        // ESC during followup capturing —
+                                        // check for standalone ESC vs
+                                        // arrow/function key sequence.
+                                        let mut ffds: libc::fd_set = unsafe { std::mem::zeroed() };
+                                        unsafe {
+                                            libc::FD_ZERO(&mut ffds);
+                                            libc::FD_SET(stdin_fd, &mut ffds);
+                                        }
+                                        let mut ftv = libc::timeval {
+                                            tv_sec: 0,
+                                            tv_usec: 50_000,
+                                        };
+                                        let fsel = unsafe {
+                                            libc::select(
+                                                stdin_fd + 1,
+                                                &mut ffds,
+                                                std::ptr::null_mut(),
+                                                std::ptr::null_mut(),
+                                                &mut ftv,
+                                            )
+                                        };
+                                        if fsel == 0 {
+                                            // Standalone ESC — hard abort
+                                            ai_cancelled = true;
+                                            followup_capturing = false;
+                                            followup_captured.clear();
+                                            if let Some(followup) = pending_followup.take() {
+                                                std::thread::spawn(move || {
+                                                    let _ =
+                                                        followup("Command cancelled by user", None);
+                                                });
+                                            }
+                                            if let Some(offloader) = followup_offloader.take() {
+                                                offloader.cancel();
+                                            }
+                                            let cancel_msg = format!(
+                                                "\r\n\x1b[33m{}\x1b[0m\r\n",
+                                                aish_i18n::t("shell.command_cancelled"),
+                                            );
+                                            unsafe {
+                                                libc::write(
+                                                    libc::STDOUT_FILENO,
+                                                    cancel_msg.as_ptr() as *const libc::c_void,
+                                                    cancel_msg.len(),
+                                                );
+                                            }
+                                            skip_leading_newline = true;
+                                        } else {
+                                            // Follow-up bytes exist (arrow/function
+                                            // key) — consume and discard them.
+                                            let mut discard = [0u8; 16];
+                                            unsafe {
+                                                libc::read(
+                                                    stdin_fd,
+                                                    discard.as_mut_ptr() as *mut libc::c_void,
+                                                    discard.len(),
+                                                );
+                                            }
+                                        }
                                     } else if followup_capturing && byte == 0x1A {
                                         // Ctrl+Z: keep countdown behavior
                                         followup_interrupt_countdown =

--- a/crates/aish-shell/Cargo.toml
+++ b/crates/aish-shell/Cargo.toml
@@ -37,6 +37,7 @@ inquire = "0.9.4"
 unicode-width = "0.2"
 which = "8.0.2"
 nix.workspace = true
+libc.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -24,6 +24,7 @@ use aish_tools::ToolRegistry;
 use crate::ai_handler::{AiHandler, SharedMemoryManager};
 use crate::animation::SharedAnimation;
 use crate::environment;
+use crate::esc_watcher::EscWatcher;
 use crate::input;
 use crate::prompt;
 use crate::readline::ShellReadline;
@@ -1205,6 +1206,8 @@ impl AishShell {
                     if question.is_empty() && self.state.can_correct_error {
                         if let Some(ref cmd) = self.state.last_command.clone() {
                             let old_sigint = self.install_ai_sigint_handler();
+                            let mut esc_watcher =
+                                EscWatcher::start(self.ai_handler.cancellation_token_arc());
                             let token_ptr =
                                 self.ai_handler.cancellation_token() as *const CancellationToken;
                             let result = runtime.block_on(async {
@@ -1219,6 +1222,7 @@ impl AishShell {
                                     }
                                 }
                             });
+                            esc_watcher.stop();
                             Self::restore_ai_sigint_handler(old_sigint);
 
                             match result {
@@ -1346,6 +1350,8 @@ impl AishShell {
                     }
 
                     let old_sigint = self.install_ai_sigint_handler();
+                    let mut esc_watcher =
+                        EscWatcher::start(self.ai_handler.cancellation_token_arc());
                     let token_ptr =
                         self.ai_handler.cancellation_token() as *const CancellationToken;
                     let result = runtime.block_on(async {
@@ -1356,6 +1362,7 @@ impl AishShell {
                             }
                         }
                     });
+                    esc_watcher.stop();
                     Self::restore_ai_sigint_handler(old_sigint);
 
                     let did_stream = self.streamed_content.load(Ordering::SeqCst);
@@ -1573,6 +1580,8 @@ impl AishShell {
                                 // Route to AI
                                 let question = input.trim().to_string();
                                 let old_sigint = self.install_ai_sigint_handler();
+                                let mut esc_watcher =
+                                    EscWatcher::start(self.ai_handler.cancellation_token_arc());
                                 let token_ptr = self.ai_handler.cancellation_token()
                                     as *const CancellationToken;
                                 let result = runtime.block_on(async {
@@ -1583,6 +1592,7 @@ impl AishShell {
                                         }
                                     }
                                 });
+                                esc_watcher.stop();
                                 Self::restore_ai_sigint_handler(old_sigint);
 
                                 let did_stream = self.streamed_content.load(Ordering::SeqCst);
@@ -2691,6 +2701,8 @@ impl AishShell {
                             let osender = output_sender.clone();
                             let done_rx = std::sync::Mutex::new(llm_done_rx);
                             let cancelled_f = cancelled_fu.clone();
+                            let session_cancel_token_f = session_cancel_token.clone();
+                            let anim_fu = anim_f.clone();
                             let followup: Box<aish_pty::FollowupCallback> = Box::new(
                             move |captured_output: &str,
                                   offload_path: Option<&str>|
@@ -2709,11 +2721,141 @@ impl AishShell {
                                     offload_path: offload_path
                                         .map(|p| p.to_string()),
                                 });
-                                // Block until LLM thread finishes all rendering
-                                let _ = done_rx
-                                    .lock()
-                                    .unwrap()
-                                    .recv_timeout(std::time::Duration::from_secs(120));
+                                // Wait for LLM thread to finish rendering,
+                                // monitoring stdin for Ctrl+C/ESC.
+                                let wait_start = std::time::Instant::now();
+                                let wait_timeout =
+                                    std::time::Duration::from_secs(120);
+                                loop {
+                                    if done_rx
+                                        .lock()
+                                        .unwrap()
+                                        .try_recv()
+                                        .is_ok()
+                                    {
+                                        break;
+                                    }
+                                    if wait_start.elapsed() >= wait_timeout {
+                                        break;
+                                    }
+                                    let mut rfds: nix::libc::fd_set =
+                                        unsafe { std::mem::zeroed() };
+                                    unsafe {
+                                        nix::libc::FD_ZERO(&mut rfds);
+                                        nix::libc::FD_SET(
+                                            nix::libc::STDIN_FILENO,
+                                            &mut rfds,
+                                        );
+                                    }
+                                    let mut tv = nix::libc::timeval {
+                                        tv_sec: 0,
+                                        tv_usec: 100_000,
+                                    };
+                                    let sel = unsafe {
+                                        nix::libc::select(
+                                            nix::libc::STDIN_FILENO + 1,
+                                            &mut rfds,
+                                            std::ptr::null_mut(),
+                                            std::ptr::null_mut(),
+                                            &mut tv,
+                                        )
+                                    };
+                                    if sel > 0 {
+                                        let mut byte = [0u8; 1];
+                                        if unsafe {
+                                            nix::libc::read(
+                                                nix::libc::STDIN_FILENO,
+                                                byte.as_mut_ptr()
+                                                    as *mut nix::libc::c_void,
+                                                1,
+                                            )
+                                        } == 1
+                                        {
+                                            if byte[0] == 0x03 {
+                                                cancelled_f.store(
+                                                    true,
+                                                    std::sync::atomic::Ordering::SeqCst,
+                                                );
+                                                if let Some(ref token) =
+                                                    session_cancel_token_f
+                                                {
+                                                    token.cancel();
+                                                }
+                                                anim_fu.stop();
+                                                let msg = format!(
+                                                    "\r\x1b[33m{}\x1b[0m\r\n",
+                                                    t("shell.command_cancelled")
+                                                );
+                                                unsafe {
+                                                    nix::libc::write(
+                                                        nix::libc::STDOUT_FILENO,
+                                                        msg.as_ptr()
+                                                            as *mut nix::libc::c_void,
+                                                        msg.len(),
+                                                    );
+                                                }
+                                                break;
+                                            } else if byte[0] == 0x1b {
+                                                let mut ffds: nix::libc::fd_set =
+                                                    unsafe { std::mem::zeroed() };
+                                                unsafe {
+                                                    nix::libc::FD_ZERO(&mut ffds);
+                                                    nix::libc::FD_SET(
+                                                        nix::libc::STDIN_FILENO,
+                                                        &mut ffds,
+                                                    );
+                                                }
+                                                let mut ftv = nix::libc::timeval {
+                                                    tv_sec: 0,
+                                                    tv_usec: 50_000,
+                                                };
+                                                let fsel = unsafe {
+                                                    nix::libc::select(
+                                                        nix::libc::STDIN_FILENO + 1,
+                                                        &mut ffds,
+                                                        std::ptr::null_mut(),
+                                                        std::ptr::null_mut(),
+                                                        &mut ftv,
+                                                    )
+                                                };
+                                                if fsel == 0 {
+                                                    cancelled_f.store(
+                                                        true,
+                                                        std::sync::atomic::Ordering::SeqCst,
+                                                    );
+                                                    if let Some(ref token) =
+                                                        session_cancel_token_f
+                                                    {
+                                                        token.cancel();
+                                                    }
+                                                    anim_fu.stop();
+                                                    let msg = format!(
+                                                        "\r\x1b[33m{}\x1b[0m\r\n",
+                                                        t("shell.command_cancelled")
+                                                    );
+                                                    unsafe {
+                                                        nix::libc::write(
+                                                            nix::libc::STDOUT_FILENO,
+                                                            msg.as_ptr()
+                                                                as *mut nix::libc::c_void,
+                                                            msg.len(),
+                                                        );
+                                                    }
+                                                    break;
+                                                }
+                                                let mut discard = [0u8; 16];
+                                                unsafe {
+                                                    nix::libc::read(
+                                                        nix::libc::STDIN_FILENO,
+                                                        discard.as_mut_ptr()
+                                                            as *mut nix::libc::c_void,
+                                                        discard.len(),
+                                                    );
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
                                 None
                             },
                         );
@@ -2759,23 +2901,78 @@ impl AishShell {
                                 1,
                             )
                         } == 1
-                            && byte[0] == 0x03
                         {
-                            cancelled.store(true, std::sync::atomic::Ordering::SeqCst);
-                            if let Some(ref token) = session_cancel_token {
-                                token.cancel();
-                            }
-                            anim_f.stop();
-                            let msg =
-                                format!("\r\n\x1b[33m{}\x1b[0m", t("shell.command_cancelled"));
-                            unsafe {
-                                nix::libc::write(
-                                    nix::libc::STDOUT_FILENO,
-                                    msg.as_ptr() as *mut nix::libc::c_void,
-                                    msg.len(),
+                            if byte[0] == 0x03 {
+                                // Ctrl+C — cancel
+                                cancelled.store(true, std::sync::atomic::Ordering::SeqCst);
+                                if let Some(ref token) = session_cancel_token {
+                                    token.cancel();
+                                }
+                                anim_f.stop();
+                                let msg = format!(
+                                    "\r\x1b[33m{}\x1b[0m\r\n",
+                                    t("shell.command_cancelled")
                                 );
+                                unsafe {
+                                    nix::libc::write(
+                                        nix::libc::STDOUT_FILENO,
+                                        msg.as_ptr() as *mut nix::libc::c_void,
+                                        msg.len(),
+                                    );
+                                }
+                                break None;
+                            } else if byte[0] == 0x1b {
+                                // ESC — check for follow-up bytes to
+                                // distinguish from arrow/function keys.
+                                let mut ffds: nix::libc::fd_set = unsafe { std::mem::zeroed() };
+                                unsafe {
+                                    nix::libc::FD_ZERO(&mut ffds);
+                                    nix::libc::FD_SET(nix::libc::STDIN_FILENO, &mut ffds);
+                                }
+                                let mut ftv = nix::libc::timeval {
+                                    tv_sec: 0,
+                                    tv_usec: 50_000,
+                                };
+                                let fsel = unsafe {
+                                    nix::libc::select(
+                                        nix::libc::STDIN_FILENO + 1,
+                                        &mut ffds,
+                                        std::ptr::null_mut(),
+                                        std::ptr::null_mut(),
+                                        &mut ftv,
+                                    )
+                                };
+                                if fsel == 0 {
+                                    // Standalone ESC — cancel
+                                    cancelled.store(true, std::sync::atomic::Ordering::SeqCst);
+                                    if let Some(ref token) = session_cancel_token {
+                                        token.cancel();
+                                    }
+                                    anim_f.stop();
+                                    let msg = format!(
+                                        "\r\x1b[33m{}\x1b[0m\r\n",
+                                        t("shell.command_cancelled")
+                                    );
+                                    unsafe {
+                                        nix::libc::write(
+                                            nix::libc::STDOUT_FILENO,
+                                            msg.as_ptr() as *mut nix::libc::c_void,
+                                            msg.len(),
+                                        );
+                                    }
+                                    break None;
+                                }
+                                // Follow-up bytes exist (ANSI escape
+                                // sequence) — consume and discard them.
+                                let mut discard = [0u8; 16];
+                                unsafe {
+                                    nix::libc::read(
+                                        nix::libc::STDIN_FILENO,
+                                        discard.as_mut_ptr() as *mut nix::libc::c_void,
+                                        discard.len(),
+                                    );
+                                }
                             }
-                            break None;
                         }
                     }
                     // Check timeout (60s)
@@ -3527,7 +3724,6 @@ impl AishShell {
                     )
                 };
                 if sel > 0 {
-                    // Read one byte to check for Ctrl+C
                     let mut byte = [0u8; 1];
                     if unsafe {
                         nix::libc::read(
@@ -3536,20 +3732,59 @@ impl AishShell {
                             1,
                         )
                     } == 1
-                        && byte[0] == 0x03
                     {
-                        // Ctrl+C pressed — cancel the LLM request
-                        cancelled.store(true, std::sync::atomic::Ordering::SeqCst);
-                        if let Some(ref token) = session_cancel_token {
-                            token.cancel();
+                        if byte[0] == 0x03 {
+                            // Ctrl+C pressed — cancel the LLM request
+                            cancelled.store(true, std::sync::atomic::Ordering::SeqCst);
+                            if let Some(ref token) = session_cancel_token {
+                                token.cancel();
+                            }
+                            animation.stop();
+                            println!("\x1b[33m{}\x1b[0m", t("shell.command_cancelled"));
+                            break None;
+                        } else if byte[0] == 0x1b {
+                            // ESC — check for follow-up bytes (arrow/function
+                            // keys send ESC + additional bytes).
+                            let mut ffds: nix::libc::fd_set = unsafe { std::mem::zeroed() };
+                            unsafe {
+                                nix::libc::FD_ZERO(&mut ffds);
+                                nix::libc::FD_SET(nix::libc::STDIN_FILENO, &mut ffds);
+                            }
+                            let mut ftv = nix::libc::timeval {
+                                tv_sec: 0,
+                                tv_usec: 50_000,
+                            };
+                            let fsel = unsafe {
+                                nix::libc::select(
+                                    nix::libc::STDIN_FILENO + 1,
+                                    &mut ffds,
+                                    std::ptr::null_mut(),
+                                    std::ptr::null_mut(),
+                                    &mut ftv,
+                                )
+                            };
+                            if fsel == 0 {
+                                cancelled.store(true, std::sync::atomic::Ordering::SeqCst);
+                                if let Some(ref token) = session_cancel_token {
+                                    token.cancel();
+                                }
+                                animation.stop();
+                                println!("\r\n\x1b[33m{}\x1b[0m", t("shell.command_cancelled"));
+                                break None;
+                            }
+                            // Follow-up bytes exist (ANSI escape
+                            // sequence) — consume and discard them.
+                            let mut discard = [0u8; 16];
+                            unsafe {
+                                nix::libc::read(
+                                    nix::libc::STDIN_FILENO,
+                                    discard.as_mut_ptr() as *mut nix::libc::c_void,
+                                    discard.len(),
+                                );
+                            }
                         }
-                        animation.stop();
-                        println!("\r\n\x1b[33m{}\x1b[0m", t("shell.command_cancelled"));
-                        break None;
+                        // Other bytes during AI processing — discard.
                     }
-                    // Non-Ctrl-C byte during AI processing — discard.
-                    // The user shouldn't be typing during AI processing;
-                    // any stray bytes are not recoverable here.
                 }
                 // Check timeout (60s)
                 if thinking_start
@@ -3615,6 +3850,7 @@ impl AishShell {
                         output_sender: std::sync::mpsc::Sender<aish_pty::BashExecResult>,
                         cancelled: std::sync::Arc<std::sync::atomic::AtomicBool>,
                         cancel_token: Option<std::sync::Arc<CancellationToken>>,
+                        animation: std::sync::Arc<crate::animation::SharedAnimation>,
                     ) -> Box<aish_pty::FollowupCallback> {
                         Box::new(
                             move |captured_output: &str,
@@ -3652,48 +3888,295 @@ impl AishShell {
                                     None => return None,
                                 };
 
-                                match rx.recv_timeout(std::time::Duration::from_secs(120)) {
-                                    Ok(aish_pty::AiEvent::BashExec {
-                                        command,
-                                        output_sender: new_sender,
-                                    }) => {
-                                        *event_rx.lock().unwrap() = Some(rx);
-                                        Some(aish_pty::AiResponse {
-                                            command: Some(command),
-                                            display_text: String::new(),
-                                            followup: Some(make_chain_followup(
-                                                event_rx.clone(),
-                                                done_rx.clone(),
-                                                answer_tx.clone(),
-                                                new_sender,
-                                                cancelled.clone(),
-                                                cancel_token.clone(),
-                                            )),
-                                            ask_user: None,
-                                        })
-                                    }
-                                    Ok(aish_pty::AiEvent::AskUser(request)) => {
-                                        Some(aish_pty::AiResponse {
-                                            command: None,
-                                            display_text: String::new(),
-                                            followup: None,
-                                            ask_user: Some((
-                                                request,
-                                                aish_pty::AskUserChannel {
-                                                    answer_sender: answer_tx.clone(),
-                                                    event_receiver: rx,
-                                                },
-                                            )),
-                                        })
-                                    }
-                                    Ok(aish_pty::AiEvent::Done(_)) | Err(_) => {
-                                        if let Some(drx) = done_rx.lock().unwrap().take() {
-                                            let _ = drx
-                                                .recv_timeout(std::time::Duration::from_secs(120));
+                                let chain_start = std::time::Instant::now();
+                                let chain_timeout = std::time::Duration::from_secs(120);
+                                let mut chain_result: Option<Option<aish_pty::AiResponse>> = None;
+                                while chain_start.elapsed() < chain_timeout {
+                                    match rx.try_recv() {
+                                        Ok(aish_pty::AiEvent::BashExec {
+                                            command,
+                                            output_sender: new_sender,
+                                        }) => {
+                                            *event_rx.lock().unwrap() = Some(rx);
+                                            chain_result = Some(Some(aish_pty::AiResponse {
+                                                command: Some(command),
+                                                display_text: String::new(),
+                                                followup: Some(make_chain_followup(
+                                                    event_rx.clone(),
+                                                    done_rx.clone(),
+                                                    answer_tx.clone(),
+                                                    new_sender,
+                                                    cancelled.clone(),
+                                                    cancel_token.clone(),
+                                                    animation.clone(),
+                                                )),
+                                                ask_user: None,
+                                            }));
+                                            break;
                                         }
-                                        None
+                                        Ok(aish_pty::AiEvent::AskUser(request)) => {
+                                            chain_result = Some(Some(aish_pty::AiResponse {
+                                                command: None,
+                                                display_text: String::new(),
+                                                followup: None,
+                                                ask_user: Some((
+                                                    request,
+                                                    aish_pty::AskUserChannel {
+                                                        answer_sender: answer_tx.clone(),
+                                                        event_receiver: rx,
+                                                    },
+                                                )),
+                                            }));
+                                            break;
+                                        }
+                                        Ok(aish_pty::AiEvent::Done(_)) => {
+                                            if let Some(drx) = done_rx.lock().unwrap().take() {
+                                                let done_start = std::time::Instant::now();
+                                                loop {
+                                                    if drx.try_recv().is_ok() {
+                                                        break;
+                                                    }
+                                                    if done_start.elapsed() >= chain_timeout {
+                                                        break;
+                                                    }
+                                                    let mut dfds: nix::libc::fd_set =
+                                                        unsafe { std::mem::zeroed() };
+                                                    unsafe {
+                                                        nix::libc::FD_ZERO(&mut dfds);
+                                                        nix::libc::FD_SET(
+                                                            nix::libc::STDIN_FILENO,
+                                                            &mut dfds,
+                                                        );
+                                                    }
+                                                    let mut dtv = nix::libc::timeval {
+                                                        tv_sec: 0,
+                                                        tv_usec: 100_000,
+                                                    };
+                                                    let dsel = unsafe {
+                                                        nix::libc::select(
+                                                            nix::libc::STDIN_FILENO + 1,
+                                                            &mut dfds,
+                                                            std::ptr::null_mut(),
+                                                            std::ptr::null_mut(),
+                                                            &mut dtv,
+                                                        )
+                                                    };
+                                                    if dsel > 0 {
+                                                        let mut byte = [0u8; 1];
+                                                        if unsafe {
+                                                            nix::libc::read(
+                                                                nix::libc::STDIN_FILENO,
+                                                                byte.as_mut_ptr()
+                                                                    as *mut nix::libc::c_void,
+                                                                1,
+                                                            )
+                                                        } == 1
+                                                        {
+                                                            if byte[0] == 0x03 {
+                                                                cancelled.store(
+                                                                    true,
+                                                                    std::sync::atomic::Ordering::SeqCst,
+                                                                );
+                                                                if let Some(ref token) =
+                                                                    cancel_token
+                                                                {
+                                                                    token.cancel();
+                                                                }
+                                                                animation.stop();
+                                                                let msg = format!(
+                                                                    "\r\x1b[33m{}\x1b[0m\r\n",
+                                                                    t("shell.command_cancelled")
+                                                                );
+                                                                unsafe {
+                                                                    nix::libc::write(
+                                                                        nix::libc::STDOUT_FILENO,
+                                                                        msg.as_ptr()
+                                                                            as *mut nix::libc::c_void,
+                                                                        msg.len(),
+                                                                    );
+                                                                }
+                                                                break;
+                                                            } else if byte[0] == 0x1b {
+                                                                let mut ffds: nix::libc::fd_set =
+                                                                    unsafe { std::mem::zeroed() };
+                                                                unsafe {
+                                                                    nix::libc::FD_ZERO(&mut ffds);
+                                                                    nix::libc::FD_SET(
+                                                                        nix::libc::STDIN_FILENO,
+                                                                        &mut ffds,
+                                                                    );
+                                                                }
+                                                                let mut ftv = nix::libc::timeval {
+                                                                    tv_sec: 0,
+                                                                    tv_usec: 50_000,
+                                                                };
+                                                                let fsel = unsafe {
+                                                                    nix::libc::select(
+                                                                        nix::libc::STDIN_FILENO + 1,
+                                                                        &mut ffds,
+                                                                        std::ptr::null_mut(),
+                                                                        std::ptr::null_mut(),
+                                                                        &mut ftv,
+                                                                    )
+                                                                };
+                                                                if fsel == 0 {
+                                                                    cancelled.store(
+                                                                        true,
+                                                                        std::sync::atomic::Ordering::SeqCst,
+                                                                    );
+                                                                    if let Some(ref token) =
+                                                                        cancel_token
+                                                                    {
+                                                                        token.cancel();
+                                                                    }
+                                                                    animation.stop();
+                                                                    let msg = format!(
+                                                                        "\r\x1b[33m{}\x1b[0m\r\n",
+                                                                        t("shell.command_cancelled")
+                                                                    );
+                                                                    unsafe {
+                                                                        nix::libc::write(
+                                                                            nix::libc::STDOUT_FILENO,
+                                                                            msg.as_ptr()
+                                                                                as *mut nix::libc::c_void,
+                                                                            msg.len(),
+                                                                        );
+                                                                    }
+                                                                    break;
+                                                                }
+                                                                let mut discard = [0u8; 16];
+                                                                unsafe {
+                                                                    nix::libc::read(
+                                                                        nix::libc::STDIN_FILENO,
+                                                                        discard.as_mut_ptr()
+                                                                            as *mut nix::libc::c_void,
+                                                                        discard.len(),
+                                                                    );
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            chain_result = Some(None);
+                                            break;
+                                        }
+                                        Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                                            chain_result = Some(None);
+                                            break;
+                                        }
+                                        Err(std::sync::mpsc::TryRecvError::Empty) => {}
+                                    }
+                                    let mut rfds: nix::libc::fd_set = unsafe { std::mem::zeroed() };
+                                    unsafe {
+                                        nix::libc::FD_ZERO(&mut rfds);
+                                        nix::libc::FD_SET(nix::libc::STDIN_FILENO, &mut rfds);
+                                    }
+                                    let mut tv = nix::libc::timeval {
+                                        tv_sec: 0,
+                                        tv_usec: 100_000,
+                                    };
+                                    let sel = unsafe {
+                                        nix::libc::select(
+                                            nix::libc::STDIN_FILENO + 1,
+                                            &mut rfds,
+                                            std::ptr::null_mut(),
+                                            std::ptr::null_mut(),
+                                            &mut tv,
+                                        )
+                                    };
+                                    if sel > 0 {
+                                        let mut byte = [0u8; 1];
+                                        if unsafe {
+                                            nix::libc::read(
+                                                nix::libc::STDIN_FILENO,
+                                                byte.as_mut_ptr() as *mut nix::libc::c_void,
+                                                1,
+                                            )
+                                        } == 1
+                                        {
+                                            if byte[0] == 0x03 {
+                                                cancelled.store(
+                                                    true,
+                                                    std::sync::atomic::Ordering::SeqCst,
+                                                );
+                                                if let Some(ref token) = cancel_token {
+                                                    token.cancel();
+                                                }
+                                                animation.stop();
+                                                let msg = format!(
+                                                    "\r\x1b[33m{}\x1b[0m\r\n",
+                                                    t("shell.command_cancelled")
+                                                );
+                                                unsafe {
+                                                    nix::libc::write(
+                                                        nix::libc::STDOUT_FILENO,
+                                                        msg.as_ptr() as *mut nix::libc::c_void,
+                                                        msg.len(),
+                                                    );
+                                                }
+                                                chain_result = Some(None);
+                                                break;
+                                            } else if byte[0] == 0x1b {
+                                                let mut ffds: nix::libc::fd_set =
+                                                    unsafe { std::mem::zeroed() };
+                                                unsafe {
+                                                    nix::libc::FD_ZERO(&mut ffds);
+                                                    nix::libc::FD_SET(
+                                                        nix::libc::STDIN_FILENO,
+                                                        &mut ffds,
+                                                    );
+                                                }
+                                                let mut ftv = nix::libc::timeval {
+                                                    tv_sec: 0,
+                                                    tv_usec: 50_000,
+                                                };
+                                                let fsel = unsafe {
+                                                    nix::libc::select(
+                                                        nix::libc::STDIN_FILENO + 1,
+                                                        &mut ffds,
+                                                        std::ptr::null_mut(),
+                                                        std::ptr::null_mut(),
+                                                        &mut ftv,
+                                                    )
+                                                };
+                                                if fsel == 0 {
+                                                    cancelled.store(
+                                                        true,
+                                                        std::sync::atomic::Ordering::SeqCst,
+                                                    );
+                                                    if let Some(ref token) = cancel_token {
+                                                        token.cancel();
+                                                    }
+                                                    animation.stop();
+                                                    let msg = format!(
+                                                        "\r\x1b[33m{}\x1b[0m\r\n",
+                                                        t("shell.command_cancelled")
+                                                    );
+                                                    unsafe {
+                                                        nix::libc::write(
+                                                            nix::libc::STDOUT_FILENO,
+                                                            msg.as_ptr() as *mut nix::libc::c_void,
+                                                            msg.len(),
+                                                        );
+                                                    }
+                                                    chain_result = Some(None);
+                                                    break;
+                                                }
+                                                let mut discard = [0u8; 16];
+                                                unsafe {
+                                                    nix::libc::read(
+                                                        nix::libc::STDIN_FILENO,
+                                                        discard.as_mut_ptr()
+                                                            as *mut nix::libc::c_void,
+                                                        discard.len(),
+                                                    );
+                                                }
+                                            }
+                                        }
                                     }
                                 }
+                                chain_result.unwrap_or(None)
                             },
                         )
                     }
@@ -3705,6 +4188,7 @@ impl AishShell {
                         output_sender,
                         cancelled_fu,
                         session_cancel_token,
+                        animation.clone(),
                     );
                     Some(aish_pty::AiResponse {
                         command: Some(command),

--- a/crates/aish-shell/src/esc_watcher.rs
+++ b/crates/aish-shell/src/esc_watcher.rs
@@ -1,0 +1,197 @@
+use std::os::fd::BorrowedFd;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use aish_llm::CancellationToken;
+use nix::sys::termios::{tcgetattr, tcsetattr, SetArg, Termios};
+
+/// Watches for ESC and Ctrl+C keypresses on stdin during AI operations.
+///
+/// On `start()`, saves the current terminal settings, switches stdin to raw
+/// mode, and spawns a listener thread. On standalone ESC (0x1b with no
+/// follow-up bytes within 50 ms) or Ctrl+C (0x03), calls
+/// `CancellationToken::cancel()`.
+///
+/// On `stop()`, signals the thread to exit, joins it, and restores the
+/// original terminal settings. If the watcher is dropped without calling
+/// `stop()` (e.g. due to a panic), `Drop` restores the terminal as a safety
+/// net.
+///
+/// **Note:** The listener thread reads and discards all stdin bytes that are
+/// not standalone ESC. User input during AI streaming is silently consumed.
+pub struct EscWatcher {
+    thread: Option<std::thread::JoinHandle<()>>,
+    saved_termios: Option<Termios>,
+    stop_flag: Arc<AtomicBool>,
+}
+
+impl EscWatcher {
+    /// Start watching for ESC keypresses.
+    ///
+    /// If the terminal cannot be switched to raw mode (e.g. stdin is not a
+    /// tty), returns a no-op watcher that does nothing on `stop()`.
+    pub fn start(token: Arc<CancellationToken>) -> Self {
+        let stdin_fd = libc::STDIN_FILENO;
+        let stdin_borrowed = unsafe { BorrowedFd::borrow_raw(stdin_fd) };
+
+        let saved_termios = match tcgetattr(stdin_borrowed) {
+            Ok(t) => t,
+            Err(_) => {
+                return Self {
+                    thread: None,
+                    saved_termios: None,
+                    stop_flag: Arc::new(AtomicBool::new(false)),
+                };
+            }
+        };
+
+        // Switch to raw mode: disable canonical mode, echo, and signal
+        // generation so we receive individual bytes including ESC.
+        let mut raw = saved_termios.clone();
+        use nix::sys::termios::{ControlFlags, InputFlags, LocalFlags};
+        raw.local_flags &= !(LocalFlags::ICANON | LocalFlags::ECHO | LocalFlags::ISIG);
+        raw.input_flags &= !InputFlags::ISTRIP;
+        raw.control_flags &= !ControlFlags::CSIZE;
+        raw.control_flags |= ControlFlags::CS8;
+        raw.control_chars[libc::VMIN] = 1;
+        raw.control_chars[libc::VTIME] = 0;
+        if tcsetattr(stdin_borrowed, SetArg::TCSANOW, &raw).is_err() {
+            return Self {
+                thread: None,
+                saved_termios: None,
+                stop_flag: Arc::new(AtomicBool::new(false)),
+            };
+        }
+
+        let stop_flag = Arc::new(AtomicBool::new(false));
+
+        let stop_clone = stop_flag.clone();
+        let token_clone = token.clone();
+        let handle = std::thread::Builder::new()
+            .name("esc-watcher".into())
+            .spawn(move || {
+                let mut buf = [0u8; 16];
+
+                loop {
+                    if stop_clone.load(Ordering::Relaxed) {
+                        return;
+                    }
+
+                    // Use select() with 100ms timeout so we can check
+                    // stop_flag periodically without blocking indefinitely.
+                    let mut read_fds: libc::fd_set = unsafe { std::mem::zeroed() };
+                    unsafe {
+                        libc::FD_ZERO(&mut read_fds);
+                        libc::FD_SET(stdin_fd, &mut read_fds);
+                    }
+                    let mut tv = libc::timeval {
+                        tv_sec: 0,
+                        tv_usec: 100_000, // 100 ms
+                    };
+                    let sel = unsafe {
+                        libc::select(
+                            stdin_fd + 1,
+                            &mut read_fds,
+                            std::ptr::null_mut(),
+                            std::ptr::null_mut(),
+                            &mut tv,
+                        )
+                    };
+
+                    if sel <= 0 {
+                        // Timeout or error — loop back to check stop_flag.
+                        continue;
+                    }
+
+                    // Read the byte(s) available on stdin.
+                    let n = unsafe {
+                        libc::read(stdin_fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len())
+                    };
+
+                    if n <= 0 {
+                        continue;
+                    }
+
+                    // Ctrl+C (0x03) — cancel immediately. Raw mode disables
+                    // ISIG so the kernel won't generate SIGINT; we handle it.
+                    if buf[0] == 0x03 {
+                        token_clone.cancel();
+                        return;
+                    }
+
+                    // Check for ESC (0x1b) as the first byte.
+                    if buf[0] != 0x1b {
+                        continue;
+                    }
+
+                    // If more than one byte was read, this is already a
+                    // complete escape sequence (e.g. arrow key), not a
+                    // standalone ESC.
+                    if n > 1 {
+                        continue;
+                    }
+
+                    // ESC received — wait 50 ms to see if follow-up bytes
+                    // arrive (arrow keys and function keys send ESC followed
+                    // by additional bytes, e.g. ESC [ A = up arrow).
+                    let mut follow_fds: libc::fd_set = unsafe { std::mem::zeroed() };
+                    unsafe {
+                        libc::FD_ZERO(&mut follow_fds);
+                        libc::FD_SET(stdin_fd, &mut follow_fds);
+                    }
+                    let mut follow_tv = libc::timeval {
+                        tv_sec: 0,
+                        tv_usec: 50_000, // 50 ms
+                    };
+                    let follow_sel = unsafe {
+                        libc::select(
+                            stdin_fd + 1,
+                            &mut follow_fds,
+                            std::ptr::null_mut(),
+                            std::ptr::null_mut(),
+                            &mut follow_tv,
+                        )
+                    };
+
+                    if follow_sel == 0 {
+                        // No follow-up bytes within 50 ms — standalone ESC.
+                        token_clone.cancel();
+                        return;
+                    }
+                    // Follow-up bytes exist (ANSI escape sequence) — ignore.
+                }
+            })
+            .ok();
+
+        Self {
+            thread: handle,
+            saved_termios: Some(saved_termios),
+            stop_flag,
+        }
+    }
+
+    /// Stop the listener thread and restore terminal settings.
+    pub fn stop(&mut self) {
+        self.cleanup();
+    }
+
+    fn cleanup(&mut self) {
+        self.stop_flag.store(true, Ordering::Relaxed);
+
+        if let Some(handle) = self.thread.take() {
+            let _ = handle.join();
+        }
+
+        if let Some(saved) = self.saved_termios.take() {
+            let stdin_fd = libc::STDIN_FILENO;
+            let stdin_borrowed = unsafe { BorrowedFd::borrow_raw(stdin_fd) };
+            let _ = tcsetattr(stdin_borrowed, SetArg::TCSANOW, &saved);
+        }
+    }
+}
+
+impl Drop for EscWatcher {
+    fn drop(&mut self) {
+        self.cleanup();
+    }
+}

--- a/crates/aish-shell/src/lib.rs
+++ b/crates/aish-shell/src/lib.rs
@@ -20,6 +20,7 @@ pub mod app;
 pub mod autosuggest;
 pub mod commands;
 pub mod environment;
+pub mod esc_watcher;
 pub mod input;
 pub mod nl_detect;
 pub mod prompt;


### PR DESCRIPTION
## Summary

- Add ESC key detection to interrupt AI streaming responses and return to shell prompt
- New `EscWatcher` component for local AI queries: switches stdin to raw mode, spawns a listener thread that detects standalone ESC (0x1b) with 50ms follow-up timeout to distinguish from arrow/function keys
- Inline ESC detection for SSH session AI callbacks (both initial `;` trigger and followup multi-round)
- Graceful degradation: falls back to Ctrl+C-only if raw mode setup fails

## Test plan

- [ ] Local: run `;` AI query, press ESC during streaming → AI stops, shows "Interrupted", returns to prompt
- [ ] Local: press arrow keys during AI streaming → no interruption (correctly distinguished from standalone ESC)
- [ ] SSH: connect to remote host, trigger AI with `;`, press ESC → AI stops correctly
- [ ] SSH: trigger AI followup (multi-round tool use), press ESC → followup stops correctly
- [ ] Ctrl+C still works as before in both local and SSH modes
- [ ] Non-interactive stdin (pipe) → no crash, Ctrl+C still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces an ESC watcher so ESC can cancel in-progress AI operations (alternative to Ctrl+C) during interactive AI sessions.

* **Bug Fixes**
  * Standalone ESC triggers cancellation; multi-byte escape sequences (e.g., arrow keys) are ignored.
  * Cancellation reliably stops ongoing AI requests, halts animations/outputs, and restores terminal/input state across local and remote flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->