### PR TITLE
fix: handle non-standard streaming tool call formats

### DIFF
--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -659,10 +659,14 @@ impl LlmSession {
                                                             )
                                                         });
                                                     if let Some(i) = id {
-                                                        entry.0 = i;
+                                                        if !i.is_empty() {
+                                                            entry.0 = i;
+                                                        }
                                                     }
                                                     if let Some(n) = name {
-                                                        entry.1 = n;
+                                                        if !n.is_empty() {
+                                                            entry.1 = n;
+                                                        }
                                                     }
                                                     if let Some(a) = arguments {
                                                         entry.2.push_str(&a);
@@ -774,8 +778,15 @@ impl LlmSession {
                     let tool_calls: Vec<ToolCall> = sorted_calls
                         .into_iter()
                         .enumerate()
-                        .filter_map(|(seq_idx, (_, (id, name, args)))| {
-                            if id.is_empty() || name.is_empty() {
+                        .filter_map(|(seq_idx, (orig_idx, (id, name, args)))| {
+                            // Some providers omit the id in streaming deltas.
+                            // Fall back to a synthetic id so the tool call can still execute.
+                            let id = if id.is_empty() {
+                                format!("tc_{orig_idx}")
+                            } else {
+                                id
+                            };
+                            if name.is_empty() {
                                 missing_ids.push(seq_idx);
                                 None
                             } else {
@@ -790,7 +801,7 @@ impl LlmSession {
 
                     if !missing_ids.is_empty() {
                         tracing::warn!(
-                            "Dropping tool calls with missing id/name at indexes: {:?}",
+                            "Dropping tool calls with missing name at indexes: {:?}",
                             missing_ids
                         );
                         // Emit error event for malformed tool calls
@@ -799,7 +810,7 @@ impl LlmSession {
                             data: serde_json::json!({
                                 "error_type": "stream_chunk_builder_error",
                                 "error_message": format!(
-                                    "tool_calls missing id/name at indexes: {:?}",
+                                    "tool_calls missing name at indexes: {:?}",
                                     missing_ids
                                 ),
                             }),

--- a/crates/aish-llm/src/streaming.rs
+++ b/crates/aish-llm/src/streaming.rs
@@ -151,7 +151,12 @@ impl StreamParser {
         {
             for tc in tcs {
                 let index = tc.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as usize;
-                let id = tc.get("id").and_then(|i| i.as_str()).map(|s| s.to_string());
+                // Some providers send tool-call id as a number instead of a string.
+                let id = tc.get("id").and_then(|i| match i {
+                    serde_json::Value::String(s) => Some(s.clone()),
+                    serde_json::Value::Number(n) => Some(n.to_string()),
+                    _ => None,
+                });
                 let name = tc
                     .get("function")
                     .and_then(|f| f.get("name"))


### PR DESCRIPTION
## Summary
- Accept both string and number types for tool call `id` in SSE streaming deltas
- Skip empty-string `id`/`name` during accumulation to prevent overwriting valid values from earlier chunks
- Generate fallback `tc_{index}` id when provider omits id entirely

Fixes #189

## Root Cause
Some providers send streaming tool call deltas in a non-standard format:
1. First chunk has correct `id` and `name` (e.g. `"bash"`)
2. Subsequent chunks send `function.name` as `""` (empty string, not null), which overwrites the accumulated name
3. `id` may be a number type instead of string

```
// chunk 1: correct
{"tool_calls":[{"id":"call_xxx","function":{"name":"bash","arguments":""},"index":0}]}
// chunk 2: name="" overwrites "bash"
{"tool_calls":[{"function":{"name":"","arguments":"{"},"index":0}]}
```

## Test plan
- [x] Verified with `deepseek-v4-flash` via ai.getdeepin.org — tool calls now execute correctly
- [x] `cargo test -p aish-llm` passes (15/15)
- [x] `cargo build --release` passes
- [ ] Test with standard OpenAI-format providers to confirm no regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streamed tool-call reliability by preventing unintended overwriting of fields during assembly.
  * Added automatic fallback ID generation when tool-call providers omit IDs.
  * Extended tool-call ID parsing to accept both string and numeric formats.
  * Refined error messaging to better identify malformed tool calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->