### PR TITLE
chore: prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-26
+
+### Added
+
+- Added nested SSH session detection with stronger interrupt handling so remote interactive sessions can be identified and interrupted more reliably.
+- Added a host dossier pipeline and the `host_note` AI tool so per-host notes and profile data can persist across sessions.
+
+### Changed
+
+- Changed the Rust PTY and secure-bash flow to better support nested remote session execution and follow-up tool work.
+
+### Fixed
+
+- Fixed `host_note` persistence so profile-save failures are surfaced instead of being reported as success.
+- Fixed Rust CI and clippy regressions introduced by the SSH and host-dossier changes.
+
 ## [Unreleased]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "aish-cli"
-version = "0.3.0-beta.3"
+version = "0.3.0"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "aish-config"
-version = "0.3.0-beta.3"
+version = "0.3.0"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "aish-context"
-version = "0.3.0-beta.3"
+version = "0.3.0"
 dependencies = [
  "aish-core",
  "serde",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "aish-core"
-version = "0.3.0-beta.3"
+version = "0.3.0"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "aish-hosts"
-version = "0.3.0-beta.3"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "aish-i18n"
-version = "0.3.0-beta.3"
+version = "0.3.0"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "aish-llm"
-version = "0.3.0-beta.3"
+version = "0.3.0"
 dependencies = [
  "aish-context",
  "aish-core",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "aish-memory"
-version = "0.3.0-beta.3"
+version = "0.3.0"
 dependencies = [
  "aish-core",
  "chrono",
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "aish-prompts"
-version = "0.3.0-beta.3"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "aish-pty"
-version = "0.3.0-beta.3"
+version = "0.3.0"
 dependencies = [
  "aish-core",
  "aish-hosts",
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "aish-scripts"
-version = "0.3.0-beta.3"
+version = "0.3.0"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "aish-security"
-version = "0.3.0-beta.3"
+version = "0.3.0"
 dependencies = [
  "libc",
  "regex",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "aish-session"
-version = "0.3.0-beta.3"
+version = "0.3.0"
 dependencies = [
  "aish-core",
  "chrono",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "aish-shell"
-version = "0.3.0-beta.3"
+version = "0.3.0"
 dependencies = [
  "aish-config",
  "aish-context",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "aish-skills"
-version = "0.3.0-beta.3"
+version = "0.3.0"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "aish-tools"
-version = "0.3.0-beta.3"
+version = "0.3.0"
 dependencies = [
  "aish-core",
  "aish-i18n",
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "aish-ui"
-version = "0.3.0-beta.3"
+version = "0.3.0"
 dependencies = [
  "crossterm 0.28.1",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0-beta.3"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 rust-version = "1.80"

--- a/packaging/scripts/update_release_files.py
+++ b/packaging/scripts/update_release_files.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -19,6 +18,9 @@ SEMVER_RE = re.compile(
 )
 CARGO_VERSION_RE = re.compile(r'^(version\s*=\s*")([^"]+)("\s*$)', re.MULTILINE)
 CHANGELOG_SECTION_RE = re.compile(r"^## \[", re.MULTILINE)
+CHANGELOG_VERSION_HEADING_RE = re.compile(r"^## \[([^\]]+)\](?: - .*)?$", re.MULTILINE)
+UNRELEASED_HEADING_RE = re.compile(r"^## \[Unreleased\](?: - .*)?$", re.MULTILINE)
+UNRELEASED_PLACEHOLDER = "### Added\n\n- No unreleased changes yet.\n"
 
 
 def _update_cargo_toml(version: str) -> None:
@@ -54,10 +56,65 @@ def _update_cargo_lock(version: str) -> None:
     if not cargo_lock.exists():
         return
 
-    try:
-        subprocess.check_call(["cargo", "generate-lockfile"], cwd=ROOT_DIR)
-    except (OSError, subprocess.CalledProcessError) as exc:
-        print(f"Warning: cargo generate-lockfile failed: {exc}", file=sys.stderr)
+    original = cargo_lock.read_text(encoding="utf-8")
+    package_re = re.compile(
+        r'(\[\[package\]\]\nname = "aish-[^"]+"\nversion = ")([^"]+)(")',
+        re.MULTILINE,
+    )
+    updated, replacements = package_re.subn(rf'\g<1>{version}\g<3>', original)
+    if replacements == 0:
+        print("Warning: Cargo.lock does not contain any aish-* packages to update", file=sys.stderr)
+        return
+
+    cargo_lock.write_text(updated, encoding="utf-8")
+
+
+def _find_section_bounds(content: str, heading_re: re.Pattern[str]) -> tuple[int, int, int] | None:
+    match = heading_re.search(content)
+    if match is None:
+        return None
+
+    next_match = CHANGELOG_SECTION_RE.search(content, match.end())
+    end = next_match.start() if next_match else len(content)
+    return match.start(), match.end(), end
+
+
+def _normalize_section_body(body: str) -> str:
+    return body.strip("\n")
+
+
+def _is_placeholder_body(body: str) -> bool:
+    return _normalize_section_body(body) == UNRELEASED_PLACEHOLDER.strip()
+
+
+def _extract_release_body(original: str, version: str) -> str | None:
+    unreleased_bounds = _find_section_bounds(original, UNRELEASED_HEADING_RE)
+    if unreleased_bounds is not None:
+        _, unreleased_heading_end, unreleased_end = unreleased_bounds
+        unreleased_body = original[unreleased_heading_end:unreleased_end]
+        normalized = _normalize_section_body(unreleased_body)
+        if normalized and not _is_placeholder_body(unreleased_body):
+            return normalized
+
+    if "-" in version:
+        return None
+
+    stable_base = version
+    for match in CHANGELOG_VERSION_HEADING_RE.finditer(original):
+        candidate = match.group(1)
+        if candidate.startswith(f"{stable_base}-"):
+            bounds = _find_section_bounds(
+                original,
+                re.compile(rf"^## \[{re.escape(candidate)}\](?: - .*)?$", re.MULTILINE),
+            )
+            if bounds is None:
+                continue
+            _, heading_end, end = bounds
+            normalized = _normalize_section_body(original[heading_end:end])
+            if normalized:
+                return normalized
+
+    return None
 
 
 def _update_changelog(version: str, release_date: str) -> None:
@@ -65,13 +122,31 @@ def _update_changelog(version: str, release_date: str) -> None:
     if f"## [{version}] - {release_date}" in original or f"## [{version}]" in original:
         raise ValueError(f"Changelog already contains a section for version {version}")
 
-    new_section = f"## [{version}] - {release_date}\n\n"
-    match = CHANGELOG_SECTION_RE.search(original)
-    if match is None:
-        separator = "" if original.endswith("\n\n") else "\n\n"
-        updated = f"{original.rstrip()}{separator}{new_section}"
+    release_body = _extract_release_body(original, version)
+    if release_body is None:
+        raise ValueError(
+            "Could not determine release notes for the new changelog section. "
+            "Add notes under [Unreleased] or ensure a matching prerelease section exists."
+        )
+
+    new_section = f"## [{version}] - {release_date}\n\n{release_body}\n\n"
+    unreleased_bounds = _find_section_bounds(original, UNRELEASED_HEADING_RE)
+    if unreleased_bounds is not None:
+        unreleased_start, _, unreleased_end = unreleased_bounds
+        unreleased_section = f"## [Unreleased]\n\n{UNRELEASED_PLACEHOLDER}\n"
+        updated = (
+            f"{original[:unreleased_start]}"
+            f"{new_section}"
+            f"{unreleased_section}"
+            f"{original[unreleased_end:]}"
+        )
     else:
-        updated = f"{original[:match.start()]}{new_section}{original[match.start():]}"
+        match = CHANGELOG_SECTION_RE.search(original)
+        if match is None:
+            separator = "" if original.endswith("\n\n") else "\n\n"
+            updated = f"{original.rstrip()}{separator}{new_section}"
+        else:
+            updated = f"{original[:match.start()]}{new_section}{original[match.start():]}"
 
     CHANGELOG_PATH.write_text(updated, encoding="utf-8")
 

--- a/packaging/tests/release_scripts_smoke.sh
+++ b/packaging/tests/release_scripts_smoke.sh
@@ -18,8 +18,26 @@ cat > "$SANDBOX/Cargo.toml" <<'EOF'
 version = "0.2.0"
 EOF
 
+cat > "$SANDBOX/Cargo.lock" <<'EOF'
+[[package]]
+name = "aish-core"
+version = "0.2.0"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "demo"
+EOF
+
 cat > "$SANDBOX/CHANGELOG.md" <<'EOF'
 # Changelog
+
+## [Unreleased]
+
+### Added
+
+- Upcoming beta release note
 
 ## [0.2.0] - 2026-04-03
 
@@ -34,6 +52,11 @@ EOF
 
 grep -Fq 'version = "1.0.0-beta.1"' "$SANDBOX/Cargo.toml"
 grep -Fq '## [1.0.0-beta.1] - 2026-05-09' "$SANDBOX/CHANGELOG.md"
+grep -Fq 'Upcoming beta release note' "$SANDBOX/CHANGELOG.md"
+grep -Fq 'name = "aish-core"' "$SANDBOX/Cargo.lock"
+grep -Fq 'version = "1.0.0-beta.1"' "$SANDBOX/Cargo.lock"
+grep -Fq 'name = "serde"' "$SANDBOX/Cargo.lock"
+grep -Fq 'version = "1.0.228"' "$SANDBOX/Cargo.lock"
 
 if "$PYTHON_BIN" "$SANDBOX/packaging/scripts/update_release_files.py" \
   --version 1.0.0-beta.1 \
@@ -42,6 +65,36 @@ if "$PYTHON_BIN" "$SANDBOX/packaging/scripts/update_release_files.py" \
   exit 1
 fi
 grep -Fq 'already contains a section for version 1.0.0-beta.1' "$TMP_DIR/duplicate.out"
+
+cat > "$SANDBOX/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- No unreleased changes yet.
+
+## [1.0.0-beta.1] - 2026-05-09
+
+### Changed
+
+- Beta release note
+EOF
+
+"$PYTHON_BIN" "$SANDBOX/packaging/scripts/update_release_files.py" \
+  --version 1.0.0 \
+  --date 2026-05-10
+
+grep -Fq '## [1.0.0] - 2026-05-10' "$SANDBOX/CHANGELOG.md"
+grep -Fq 'Beta release note' "$SANDBOX/CHANGELOG.md"
+grep -Fq '## [Unreleased]' "$SANDBOX/CHANGELOG.md"
+grep -Fq -- '- No unreleased changes yet.' "$SANDBOX/CHANGELOG.md"
+
+cat > "$SANDBOX/Cargo.toml" <<'EOF'
+[workspace.package]
+version = "1.0.0-beta.1"
+EOF
 
 cat > "$SANDBOX/CHANGELOG.md" <<'EOF'
 # Changelog


### PR DESCRIPTION
## Background
Prepare the formal v0.3.0 release branch after the Rust-to-main migration was merged.

## Changes
- bump the workspace version from 0.3.0-beta.3 to 0.3.0
- add the v0.3.0 changelog section and reset Unreleased to the placeholder
- fix release file generation so stable releases inherit notes from the matching prerelease when Unreleased is empty
- update release script smoke coverage and keep Cargo.lock changes scoped to aish package version lines only

## Validation
- python3 packaging/scripts/release_metadata.py --version 0.3.0
- ./packaging/tests/release_scripts_smoke.sh
- make ci-check

## Risk
- release preparation scripting changed around changelog section promotion and lockfile rewriting, so the main risk is release metadata drift if future prerelease/stable transitions differ from the current assumptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Bumped version to `0.3.0` for stable release
- Updated release metadata and changelog
- Enhanced release tooling for improved version and changelog handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->