### PR TITLE
fix: prevent ask_user stdin contention

### DIFF
--- a/crates/aish-shell/src/esc_watcher.rs
+++ b/crates/aish-shell/src/esc_watcher.rs
@@ -77,6 +77,11 @@ impl EscWatcher {
                         return;
                     }
 
+                    if aish_ui::terminal_input_active() {
+                        std::thread::sleep(std::time::Duration::from_millis(25));
+                        continue;
+                    }
+
                     // Use select() with 100ms timeout so we can check
                     // stop_flag periodically without blocking indefinitely.
                     let mut read_fds: libc::fd_set = unsafe { std::mem::zeroed() };

--- a/crates/aish-tools/src/ask_user.rs
+++ b/crates/aish-tools/src/ask_user.rs
@@ -8,7 +8,9 @@ use std::io::{self, Write};
 
 use aish_i18n;
 use aish_llm::{Tool, ToolResult};
-use aish_ui::{ChoiceOutcome, ChoicePanel, PanelOutcome, PanelRuntime, SearchSelectItem};
+use aish_ui::{
+    claim_terminal_input, ChoiceOutcome, ChoicePanel, PanelOutcome, PanelRuntime, SearchSelectItem,
+};
 
 /// Cached translated description.
 static DESCRIPTION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
@@ -118,6 +120,7 @@ impl Tool for AskUserTool {
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
         let min_length = args.get("min_length").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+        let _input_claim = claim_terminal_input();
 
         match kind {
             "choice_or_text" => {

--- a/crates/aish-ui/src/lib.rs
+++ b/crates/aish-ui/src/lib.rs
@@ -3,5 +3,8 @@ mod runtime;
 mod select;
 
 pub use choice::{ChoiceOutcome, ChoicePanel};
-pub use runtime::{PanelComponent, PanelError, PanelEvent, PanelOutcome, PanelRuntime};
+pub use runtime::{
+    claim_terminal_input, terminal_input_active, PanelComponent, PanelError, PanelEvent,
+    PanelOutcome, PanelRuntime, TerminalInputClaim,
+};
 pub use select::{SearchSelectItem, SearchSelectOutcome, SearchSelectPanel};

--- a/crates/aish-ui/src/runtime.rs
+++ b/crates/aish-ui/src/runtime.rs
@@ -1,11 +1,33 @@
 use std::{
     io::{self, Write},
+    sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
 };
 
 use crossterm::{cursor, event, execute, terminal};
 use ratatui::{backend::CrosstermBackend, layout::Rect, Terminal, TerminalOptions, Viewport};
 use thiserror::Error;
+
+static TERMINAL_INPUT_CLAIMS: AtomicUsize = AtomicUsize::new(0);
+
+#[must_use]
+#[derive(Debug)]
+pub struct TerminalInputClaim;
+
+pub fn claim_terminal_input() -> TerminalInputClaim {
+    TERMINAL_INPUT_CLAIMS.fetch_add(1, Ordering::SeqCst);
+    TerminalInputClaim
+}
+
+pub fn terminal_input_active() -> bool {
+    TERMINAL_INPUT_CLAIMS.load(Ordering::SeqCst) > 0
+}
+
+impl Drop for TerminalInputClaim {
+    fn drop(&mut self) {
+        TERMINAL_INPUT_CLAIMS.fetch_sub(1, Ordering::SeqCst);
+    }
+}
 
 pub trait PanelComponent {
     type Output;
@@ -46,6 +68,7 @@ impl PanelRuntime {
     where
         C: PanelComponent,
     {
+        let _input_claim = claim_terminal_input();
         let (cols, rows) = terminal::size()?;
         let height = component.desired_height(cols, rows).clamp(1, rows.max(1));
         let _guard = TerminalGuard::enter()?;
@@ -99,5 +122,29 @@ impl Drop for TerminalGuard {
         let _ = execute!(io::stdout(), cursor::Show);
         let _ = terminal::disable_raw_mode();
         let _ = io::stdout().flush();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_input_claim_tracks_nested_guards() {
+        assert!(!terminal_input_active());
+
+        {
+            let _first_claim = claim_terminal_input();
+            assert!(terminal_input_active());
+
+            {
+                let _second_claim = claim_terminal_input();
+                assert!(terminal_input_active());
+            }
+
+            assert!(terminal_input_active());
+        }
+
+        assert!(!terminal_input_active());
     }
 }


### PR DESCRIPTION
## Background

`ask_user` could hang on `main` after the Rust runtime merge because `EscWatcher` continued reading and discarding `stdin` while local interactive prompts were trying to read terminal input.

## Changes

- add a shared terminal input claim in `aish-ui`
- make `PanelRuntime` automatically claim terminal input while a panel is active
- make local `AskUserTool` claim terminal input for all input paths, including `text_input` and stdin fallbacks
- pause `EscWatcher` reads while terminal input is claimed

## Validation

- `cargo fmt --manifest-path /home/lixin/workspace/aishell/aish/Cargo.toml --all -- --check`
- `cargo test --manifest-path /home/lixin/workspace/aishell/aish/Cargo.toml -p aish-ui`
- `cargo check --manifest-path /home/lixin/workspace/aishell/aish/Cargo.toml -p aish-tools -p aish-shell`
- `cargo clippy --manifest-path /home/lixin/workspace/aishell/aish/Cargo.toml -p aish-ui -p aish-tools -p aish-shell --all-targets -- -D warnings`

## Risk

Low. The change is scoped to terminal input ownership during interactive prompts and adds a small unit test for nested claims. Manual interactive smoke testing for `ask_user` was not run in this session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal input coordination to prevent conflicts when the application is actively handling user input.
  * The escape key watcher now properly detects and respects active terminal input, reducing interference with user interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->