### PR TITLE
fix: guard ask_user from competing stdin readers

### DIFF
--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -2985,6 +2985,10 @@ impl AishShell {
                                     if wait_start.elapsed() >= wait_timeout {
                                         break;
                                     }
+                                    if aish_tools::bash::interactive_input_active() {
+                                        std::thread::sleep(std::time::Duration::from_millis(50));
+                                        continue;
+                                    }
                                     let mut rfds: nix::libc::fd_set =
                                         unsafe { std::mem::zeroed() };
                                     unsafe {
@@ -4186,6 +4190,10 @@ impl AishShell {
                                                     if done_start.elapsed() >= chain_timeout {
                                                         break;
                                                     }
+                                                    if aish_tools::bash::interactive_input_active() {
+                                                        std::thread::sleep(std::time::Duration::from_millis(50));
+                                                        continue;
+                                                    }
                                                     let mut dfds: nix::libc::fd_set =
                                                         unsafe { std::mem::zeroed() };
                                                     unsafe {
@@ -4313,6 +4321,10 @@ impl AishShell {
                                             break;
                                         }
                                         Err(std::sync::mpsc::TryRecvError::Empty) => {}
+                                    }
+                                    if aish_tools::bash::interactive_input_active() {
+                                        std::thread::sleep(std::time::Duration::from_millis(50));
+                                        continue;
                                     }
                                     let mut rfds: nix::libc::fd_set = unsafe { std::mem::zeroed() };
                                     unsafe {

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -4190,8 +4190,11 @@ impl AishShell {
                                                     if done_start.elapsed() >= chain_timeout {
                                                         break;
                                                     }
-                                                    if aish_tools::bash::interactive_input_active() {
-                                                        std::thread::sleep(std::time::Duration::from_millis(50));
+                                                    if aish_tools::bash::interactive_input_active()
+                                                    {
+                                                        std::thread::sleep(
+                                                            std::time::Duration::from_millis(50),
+                                                        );
                                                         continue;
                                                     }
                                                     let mut dfds: nix::libc::fd_set =

--- a/crates/aish-shell/src/esc_watcher.rs
+++ b/crates/aish-shell/src/esc_watcher.rs
@@ -1,8 +1,10 @@
 use std::os::fd::BorrowedFd;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use aish_llm::CancellationToken;
+use aish_tools::bash::interactive_input_active;
 use nix::sys::termios::{tcgetattr, tcsetattr, SetArg, Termios};
 
 /// Watches for ESC and Ctrl+C keypresses on stdin during AI operations.
@@ -75,6 +77,11 @@ impl EscWatcher {
                 loop {
                     if stop_clone.load(Ordering::Relaxed) {
                         return;
+                    }
+
+                    if interactive_input_active() {
+                        std::thread::sleep(Duration::from_millis(50));
+                        continue;
                     }
 
                     // Use select() with 100ms timeout so we can check

--- a/crates/aish-tools/src/ask_user.rs
+++ b/crates/aish-tools/src/ask_user.rs
@@ -10,6 +10,8 @@ use aish_i18n;
 use aish_llm::{Tool, ToolResult};
 use aish_ui::{ChoiceOutcome, ChoicePanel, PanelOutcome, PanelRuntime, SearchSelectItem};
 
+use crate::bash::acquire_interactive_input_guard;
+
 /// Cached translated description.
 static DESCRIPTION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
 
@@ -118,6 +120,11 @@ impl Tool for AskUserTool {
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
         let min_length = args.get("min_length").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+
+        let _interactive_input_guard = match kind {
+            "choice_or_text" | "text_input" => Some(acquire_interactive_input_guard()),
+            _ => None,
+        };
 
         match kind {
             "choice_or_text" => {

--- a/crates/aish-tools/src/bash.rs
+++ b/crates/aish-tools/src/bash.rs
@@ -63,11 +63,22 @@ pub fn interactive_input_active() -> bool {
     INTERACTIVE_INPUT_COUNT.load(Ordering::SeqCst) > 0
 }
 
-struct InteractiveInputGuard;
+pub(crate) fn acquire_interactive_input_guard() -> InteractiveInputGuard {
+    InteractiveInputGuard::acquire()
+}
+
+#[must_use]
+pub(crate) struct InteractiveInputGuard;
 
 impl InteractiveInputGuard {
     fn acquire() -> Self {
-        INTERACTIVE_INPUT_COUNT.fetch_add(1, Ordering::SeqCst);
+        let previous = INTERACTIVE_INPUT_COUNT.fetch_add(1, Ordering::SeqCst);
+        if previous == 0 {
+            // Background stdin readers poll with 100ms timeouts. Wait a bit
+            // longer on the first acquisition so they can observe the guard
+            // before the foreground prompt starts querying the terminal.
+            std::thread::sleep(Duration::from_millis(150));
+        }
         Self
     }
 }


### PR DESCRIPTION
## Background
`ask_user` would intermittently fall back to the plain stdin prompt because panel initialization could lose the terminal cursor-position response to background stdin readers.

## Changes
- acquire the shared interactive-input guard before `ask_user` enters `choice_or_text` and `text_input`
- reuse the existing guard in `bash.rs` as the single ownership point for foreground interactive stdin
- pause `EscWatcher` while foreground interactive input is active
- pause additional shell stdin polling loops in `app.rs` while foreground interactive input is active
- add a short first-acquire delay so existing 100ms polling readers can observe the guard before panel startup

## Validation
- `cargo build -p aish-cli`
- repeated same-session manual `ask_user` verification in `./target/debug/aish`

## Risk
- foreground interactive prompts now introduce a one-time 150ms delay on first guard acquisition to reduce stdin polling races
- this change is scoped to interactive stdin coordination and keeps existing fallback paths intact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better coordination of interactive input during command chaining and remote forwarding so prompts and background tasks no longer clash.
  * Keyboard handling (ESC/Ctrl+C) now pauses while interactive prompts are active to avoid accidental cancellation.
  * Improved timing when entering interactive prompts so stdin readers settle first, yielding more responsive and reliable user input.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->