### PR TITLE
fix: handle multi-byte UTF-8 chars in path abbreviation and body truncation

### DIFF
--- a/crates/aish-shell/src/prompt.rs
+++ b/crates/aish-shell/src/prompt.rs
@@ -63,9 +63,9 @@ fn abbreviate_path(path: &str, home: &str) -> String {
         } else if i == parts.len() - 1 {
             result.push('/');
             result.push_str(part);
-        } else if !part.is_empty() {
+        } else if let Some(ch) = part.chars().next() {
             result.push('/');
-            result.push_str(&part[..1]);
+            result.push(ch);
         }
     }
     result
@@ -319,6 +319,15 @@ mod tests {
         let path = "/home/user/projects";
         let result = abbreviate_path(path, home);
         assert_eq!(result, "~/projects");
+    }
+
+    #[test]
+    fn test_abbreviate_path_chinese() {
+        // Chinese characters are 3 bytes in UTF-8, must use char-based indexing
+        let home = "/home/user";
+        let path = "/home/user/桌面/测试目录/项目文件";
+        let result = abbreviate_path(path, home);
+        assert_eq!(result, "~/桌/测/项目文件");
     }
 
     #[test]

--- a/crates/aish-shell/src/wizard/model_fetch.rs
+++ b/crates/aish-shell/src/wizard/model_fetch.rs
@@ -66,7 +66,11 @@ pub fn fetch_models_from_api(
         if !status.is_success() {
             let body = response.text().unwrap_or_default();
             let detail = if body.len() > 200 {
-                format!("{}...", &body[..200])
+                let mut end = 200;
+                while !body.is_char_boundary(end) {
+                    end -= 1;
+                }
+                format!("{}...", &body[..end])
             } else {
                 body
             };

--- a/crates/aish-shell/src/wizard/verification.rs
+++ b/crates/aish-shell/src/wizard/verification.rs
@@ -103,7 +103,11 @@ pub fn check_connectivity(
                 // Try to extract error body for a better message.
                 let body_text = resp.text().unwrap_or_default();
                 let detail = if body_text.len() > 300 {
-                    format!("{}...", &body_text[..300])
+                    let mut end = 300;
+                    while !body_text.is_char_boundary(end) {
+                        end -= 1;
+                    }
+                    format!("{}...", &body_text[..end])
                 } else {
                     body_text
                 };
@@ -204,7 +208,11 @@ pub fn check_tool_support(
                 let status_code = status.as_u16();
                 let body_text = resp.text().unwrap_or_default();
                 let detail = if body_text.len() > 300 {
-                    format!("{}...", &body_text[..300])
+                    let mut end = 300;
+                    while !body_text.is_char_boundary(end) {
+                        end -= 1;
+                    }
+                    format!("{}...", &body_text[..end])
                 } else {
                     body_text
                 };


### PR DESCRIPTION
Fixes #209

## Summary
- Fix `abbreviate_path` panic when directory names start with Chinese characters — `&part[..1]` byte slicing replaced with `part.chars().next()` char-based approach
- Fix HTTP error body truncation in wizard connectivity checks (`verification.rs`, `model_fetch.rs`) — added `is_char_boundary()` fallback to prevent slicing inside multi-byte UTF-8 characters

## Test plan
- [x] Added `test_abbreviate_path_chinese` test case covering Chinese directory names
- [x] All 20 existing tests pass
- [x] Verified no other unsafe byte-slicing patterns in the codebase