### PR TITLE
fix: install rustfmt for PyPI wheel build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,7 @@ jobs:
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+          components: clippy,rustfmt
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0


### PR DESCRIPTION
## Background

The `v0.3.1-beta.1` release workflow failed in `Build PyPI wheel (amd64)` during the `Build PyPI wheel` step. `maturin` invokes `cargo metadata`, which caused `rustup` to try to install the components declared in `rust-toolchain.toml` on demand. On the amd64 runner that implicit install collided with an existing `cargo-fmt` binary and aborted the wheel build.

## Changes

- install `clippy,rustfmt` explicitly in the PyPI wheel build job's `dtolnay/rust-toolchain` step

## Validation

- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/release.yml').read_text()); print('yaml-ok')"`
- confirmed the PyPI wheel build job now matches the existing CI pattern that already installs `clippy,rustfmt` up front

## Risk

- the already-pushed `v0.3.1-beta.1` tag points to the pre-fix commit, so after this PR merges the tag will need to be recreated on the new `main` commit before re-running the release


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. Internal build infrastructure improvements have been made to enhance development tooling and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->