### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- No unreleased changes yet.
+
+## [0.3.1] - 2026-05-29
+
+### Fixed
+
+- Fixed competing stdin readers around `ask_user` and related interactive flows so prompts no longer fight with shell input watchers.
+- Fixed UTF-8 slicing bugs that could panic on non-ASCII paths or truncated error bodies during setup and prompt rendering.
+
 ## [0.3.0] - 2026-05-26
 
 ### Added
@@ -22,12 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed `host_note` persistence so profile-save failures are surfaced instead of being reported as success.
 - Fixed Rust CI and clippy regressions introduced by the SSH and host-dossier changes.
-
-## [Unreleased]
-
-### Added
-
-- No unreleased changes yet.
 
 ## [0.3.0-beta.3] - 2026-05-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "aish-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "aish-config"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "aish-context"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aish-core",
  "serde",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "aish-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "aish-hosts"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "aish-i18n"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "aish-llm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aish-context",
  "aish-core",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "aish-memory"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aish-core",
  "chrono",
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "aish-prompts"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "aish-pty"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aish-core",
  "aish-hosts",
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "aish-scripts"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "aish-security"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "libc",
  "regex",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "aish-session"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aish-core",
  "chrono",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "aish-shell"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aish-config",
  "aish-context",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "aish-skills"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "aish-tools"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aish-core",
  "aish-i18n",
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "aish-ui"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "crossterm 0.28.1",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT"
 rust-version = "1.80"


### PR DESCRIPTION
## Version

- 0.3.1

## Changelog Summary

- Fixed competing stdin readers around ask_user and related interactive flows so prompts no longer fight with shell input watchers.
- Fixed UTF-8 slicing bugs that could panic on non-ASCII paths or truncated error bodies during setup and prompt rendering.

## Local Validation

- make prepare-release-files VERSION=0.3.1 DATE=2026-05-29
- make packaging-test
- make test
- make build-bundle
- bundle install smoke from dist/release/aish-0.3.1-linux-amd64.tar.gz

## Notes

- One early make test run saw a transient aish-security sandbox test failure with Text file busy; the focused rerun passed and a subsequent full make test rerun passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Version 0.3.1

* **Bug Fixes**
  * Resolved competing stdin reader conflicts occurring during interactive prompts
  * Fixed potential panic errors from UTF-8 handling issues with non-ASCII paths and truncated error messages during setup and prompt rendering

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Shell-Team/aish/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->