### PR TITLE
feat: slash command popup, /feedback, and collection pre-allocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,7 @@ dependencies = [
  "inquire",
  "libc",
  "nix 0.29.0",
+ "open",
  "ratatui",
  "regex",
  "reqwest",
@@ -1756,6 +1757,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,6 +2296,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2318,6 +2349,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pem"

--- a/crates/aish-cli/src/update.rs
+++ b/crates/aish-cli/src/update.rs
@@ -366,7 +366,7 @@ fn download_with_progress(url: &str, dest: &Path, label: &str) -> Result<(), Ais
             let downloaded_mb = downloaded as f64 / 1_048_576.0;
             let total_mb = total as f64 / 1_048_576.0;
             print!("\r\x1b[2K\x1b[1;36m{}\x1b[0m", {
-                let mut args = std::collections::HashMap::new();
+                let mut args = std::collections::HashMap::with_capacity(4);
                 args.insert("label".to_string(), label.to_string());
                 args.insert("downloaded".to_string(), format!("{:.1}", downloaded_mb));
                 args.insert("total".to_string(), format!("{:.1}", total_mb));
@@ -376,7 +376,7 @@ fn download_with_progress(url: &str, dest: &Path, label: &str) -> Result<(), Ais
         } else {
             let downloaded_mb = downloaded as f64 / 1_048_576.0;
             print!("\r\x1b[2K\x1b[1;36m{}\x1b[0m", {
-                let mut args = std::collections::HashMap::new();
+                let mut args = std::collections::HashMap::with_capacity(2);
                 args.insert("label".to_string(), label.to_string());
                 args.insert("downloaded".to_string(), format!("{:.1}", downloaded_mb));
                 t_with_args("cli.update.progress_mb_no_total", &args)

--- a/crates/aish-context/src/manager.rs
+++ b/crates/aish-context/src/manager.rs
@@ -74,7 +74,7 @@ impl ContextManager {
     /// `max_knowledge_messages=10`.
     pub fn new() -> Self {
         Self {
-            messages: Vec::new(),
+            messages: Vec::with_capacity(64),
             max_llm_messages: 50,
             max_shell_messages: 20,
             max_knowledge_messages: 10,
@@ -573,7 +573,7 @@ impl ContextManager {
         let keep_recent = self.budget_policy.micro_keep_recent_messages.max(2);
         let recent_start = self.messages.len().saturating_sub(keep_recent);
 
-        let mut new_messages = Vec::new();
+        let mut new_messages = Vec::with_capacity(32);
         for (idx, msg) in self.messages.iter().enumerate() {
             if idx >= recent_start {
                 break;
@@ -714,9 +714,9 @@ fn build_ops_summary(
     plan_state: Option<&PlanModeState>,
     summary_max_tokens: usize,
 ) -> String {
-    let mut user_items = Vec::new();
-    let mut assistant_items = Vec::new();
-    let mut shell_items = Vec::new();
+    let mut user_items = Vec::with_capacity(32);
+    let mut assistant_items = Vec::with_capacity(32);
+    let mut shell_items = Vec::with_capacity(32);
 
     for msg in old_messages {
         let preview = summarize_line(&msg.content, 220);
@@ -731,7 +731,7 @@ fn build_ops_summary(
         }
     }
 
-    let mut lines = Vec::new();
+    let mut lines = Vec::with_capacity(32);
     lines.push("<conversation-summary source=\"auto_compact\">".to_string());
     lines.push("Summary:".to_string());
     lines.push(format!(

--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -143,6 +143,14 @@ shell:
     risk: "Von der KI erzeugte Inhalte können riskant sein; bitte sorgfältig prüfen."
     skills_loaded_suffix: " geladen"
 
+  slash:
+    model: "KI-Modell anzeigen oder wechseln"
+    setup: "Setup-Assistenten öffnen"
+    plan: "Planmodus steuern"
+    token: "Token-Nutzung anzeigen"
+    resume: "Vorherige Sitzung fortsetzen"
+    feedback: "GitHub Issues öffnen"
+
   security:
     panel_title:
       blocked: "🛑 Sicherheitsblockierung"

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -322,6 +322,15 @@ shell:
   unknown_command: "Unknown special command: {command}"
   config_save_warning: "Warning: could not save config: {error}"
 
+  # Slash command descriptions (for popup)
+  slash:
+    model: "Show or switch AI model"
+    setup: "Open setup wizard"
+    plan: "Plan mode control"
+    token: "Show token usage"
+    resume: "Resume previous session"
+    feedback: "Open GitHub Issues"
+
   # Model switching
   model_usage: "Usage: /model [model-name]"
   switching: "Validating model: {model}"

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -143,6 +143,14 @@ shell:
     risk: "El contenido generado por IA puede ser arriesgado; verificalo con cuidado."
     skills_loaded_suffix: " cargadas"
 
+  slash:
+    model: "Mostrar o cambiar modelo de IA"
+    setup: "Abrir asistente de configuración"
+    plan: "Control del modo plan"
+    token: "Mostrar uso de tokens"
+    resume: "Reanudar sesión anterior"
+    feedback: "Abrir GitHub Issues"
+
   security:
     panel_title:
       blocked: "🛑 Bloqueado por seguridad"

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -143,6 +143,14 @@ shell:
     risk: "Le contenu genere par l'IA peut etre risque ; verifiez-le attentivement."
     skills_loaded_suffix: " charges"
 
+  slash:
+    model: "Afficher ou changer le modèle IA"
+    setup: "Ouvrir l'assistant de configuration"
+    plan: "Contrôle du mode plan"
+    token: "Afficher l'utilisation des tokens"
+    resume: "Reprendre la session précédente"
+    feedback: "Ouvrir les Issues GitHub"
+
   security:
     panel_title:
       blocked: "🛑 Blocage de securite"

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -143,6 +143,14 @@ shell:
     risk: "AI が生成した内容にはリスクがあるため、必ず注意して確認してください。"
     skills_loaded_suffix: " 件読み込み済み"
 
+  slash:
+    model: "AI モデルの表示・切替"
+    setup: "セットアップウィザードを開く"
+    plan: "プランモードの制御"
+    token: "トークン使用量を表示"
+    resume: "前回のセッションを再開"
+    feedback: "GitHub Issues を開く"
+
   security:
     panel_title:
       blocked: "🛑 セキュリティによりブロック"

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -322,6 +322,15 @@ shell:
   unknown_command: "未知特殊命令: {command}"
   config_save_warning: "警告：无法保存配置: {error}"
 
+  # 斜杠命令描述（弹窗用）
+  slash:
+    model: "显示或切换 AI 模型"
+    setup: "打开设置向导"
+    plan: "计划模式控制"
+    token: "显示令牌用量"
+    resume: "恢复之前的会话"
+    feedback: "打开 GitHub Issues"
+
   # 模型切换
   model_usage: "用法: /model [模型名称]"
   switching: "正在验证模型: {model}"

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -61,7 +61,7 @@ impl LlmSession {
     ) -> Self {
         Self {
             client: LlmClient::new(api_base, api_key, model),
-            tools: HashMap::new(),
+            tools: HashMap::with_capacity(16),
             cancellation_token: Arc::new(CancellationToken::new()),
             event_callback: None,
             confirmation_callback: None,
@@ -556,13 +556,13 @@ impl LlmSession {
                 }
 
                 LlmResponse::Stream(resp) => {
-                    let mut accumulated = String::new();
-                    let mut reasoning_accumulated = String::new();
+                    let mut accumulated = String::with_capacity(4096);
+                    let mut reasoning_accumulated = String::with_capacity(1024);
                     let mut tool_calls_accum: HashMap<usize, (String, String, String)> =
-                        HashMap::new(); // index -> (id, name, args)
+                        HashMap::with_capacity(8); // index -> (id, name, args)
 
                     let mut stream_done = false;
-                    let mut text_buffer = String::new();
+                    let mut text_buffer = String::with_capacity(4096);
                     let mut stream = resp;
                     let mut reasoning_started = false;
                     // Track whether tool calls have been seen in this stream,
@@ -1176,7 +1176,7 @@ impl LlmSession {
                 self.client.api_key(),
                 self.client.model_name(),
             ),
-            tools: HashMap::new(),
+            tools: HashMap::with_capacity(16),
             cancellation_token: Arc::new(CancellationToken::new()),
             event_callback: self.event_callback.clone(),
             confirmation_callback: self.confirmation_callback.clone(),

--- a/crates/aish-memory/src/manager.rs
+++ b/crates/aish-memory/src/manager.rs
@@ -210,7 +210,10 @@ impl MemoryManager {
 
     /// Persist the full entry list to the MEMORY.md file.
     fn persist(&self) -> aish_core::Result<()> {
-        let mut out = String::from(HEADER);
+        // Pre-allocate: header + entries with average size ~100 chars each
+        let estimated_size = HEADER.len() + self.entries.len() * 100;
+        let mut out = String::with_capacity(estimated_size);
+        out.push_str(HEADER);
 
         for entry in &self.entries {
             let category = format_category(&entry.category);

--- a/crates/aish-pty/src/offload.rs
+++ b/crates/aish-pty/src/offload.rs
@@ -194,7 +194,7 @@ impl PtyOutputOffload {
         }
 
         // Copy data to write before mutating the buffer.
-        let mut overflow_data = Vec::new();
+        let mut overflow_data = Vec::with_capacity(excess);
         if from_buf > 0 {
             let buf = self.get_buf(stream);
             overflow_data.extend_from_slice(&buf[..from_buf]);
@@ -251,12 +251,14 @@ impl PtyOutputOffload {
         // stdout_buf holds the most recent keep_bytes retained in memory;
         // stdout_tail is extra data appended after the stream ended.
         let stdout_combined: Vec<u8> = {
-            let mut v = self.stdout_buf.clone();
+            let mut v = Vec::with_capacity(self.stdout_buf.len() + stdout_tail.len());
+            v.extend_from_slice(&self.stdout_buf);
             v.extend_from_slice(stdout_tail);
             v
         };
         let stderr_combined: Vec<u8> = {
-            let mut v = self.stderr_buf.clone();
+            let mut v = Vec::with_capacity(self.stderr_buf.len() + stderr_tail.len());
+            v.extend_from_slice(&self.stderr_buf);
             v.extend_from_slice(stderr_tail);
             v
         };

--- a/crates/aish-pty/src/persistent.rs
+++ b/crates/aish-pty/src/persistent.rs
@@ -144,7 +144,7 @@ impl PersistentPty {
             control_fd: control_raw,
             child_pid,
             command_state: CommandState::new(),
-            control_buffer: String::new(),
+            control_buffer: String::with_capacity(1024),
             output_callback: None,
             rows,
             cols,

--- a/crates/aish-security/src/policy.rs
+++ b/crates/aish-security/src/policy.rs
@@ -260,7 +260,7 @@ fn normalize_string_list(values: Vec<&Value>) -> Option<Vec<String>> {
 }
 
 fn parse_v2_rules(raw_rules: &[&Mapping]) -> Vec<PolicyRule> {
-    let mut rules = Vec::new();
+    let mut rules = Vec::with_capacity(raw_rules.len());
 
     for item in raw_rules {
         let patterns = normalize_string_list(ensure_list(mapping_get(item, "path")));
@@ -315,8 +315,9 @@ fn parse_v2_rules(raw_rules: &[&Mapping]) -> Vec<PolicyRule> {
 fn parse_invalid_fallback_rules(
     raw_rules: &[&Mapping],
 ) -> (Vec<InvalidFallbackRule>, Vec<ValidationIssue>) {
-    let mut invalid_rules = Vec::new();
-    let mut issues = Vec::new();
+    // Pre-allocate: estimate up to half of rules may be invalid
+    let mut invalid_rules = Vec::with_capacity(raw_rules.len() / 2);
+    let mut issues = Vec::with_capacity(raw_rules.len() / 2);
 
     for item in raw_rules {
         let patterns = normalize_string_list(ensure_list(mapping_get(item, "path")));

--- a/crates/aish-shell/Cargo.toml
+++ b/crates/aish-shell/Cargo.toml
@@ -40,6 +40,7 @@ unicode-width.workspace = true
 which = "8.0.2"
 nix.workspace = true
 libc.workspace = true
+open = "5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -311,6 +311,24 @@ impl AishShell {
         }
     }
 
+    /// Show inline slash command popup with real-time filtering.
+    fn run_slash_input_session(&self, prompt: &str) -> aish_ui::SlashInputOutcome {
+        let commands: Vec<(String, String)> = crate::readline::SLASH_COMMANDS
+            .iter()
+            .map(|(name, _desc)| {
+                let cmd = name
+                    .strip_prefix('/')
+                    .expect("slash commands must start with /");
+                let i18n_key = format!("shell.slash.{cmd}");
+                (name.to_string(), aish_i18n::t(&i18n_key))
+            })
+            .collect();
+        match aish_ui::SlashInputSession::new(commands, prompt.to_string()).run() {
+            Ok(outcome) => outcome,
+            Err(_) => aish_ui::SlashInputOutcome::Cancelled,
+        }
+    }
+
     /// Security gate: check AI input for secrets and prompt the user.
     /// Returns `true` to continue, `false` if the user aborted (caller should skip).
     /// When secrets are detected and the user chooses "Redact", `question` is
@@ -1379,6 +1397,120 @@ impl AishShell {
                         }
                         continue;
                     }
+                    // Check if `/` on empty line triggered slash command popup
+                    if matches!(e, rustyline::error::ReadlineError::Interrupted)
+                        && rl.was_slash_requested()
+                    {
+                        match self.run_slash_input_session(&prompt_str) {
+                            aish_ui::SlashInputOutcome::Command(cmd) => {
+                                // Execute the selected command directly (avoids raw mode
+                                // conflict between crossterm and rustyline).
+                                let input = cmd.trim();
+                                if !input.is_empty() {
+                                    self.state.history.push(input.to_string());
+                                    if self.handle_special_command(input) {
+                                        self.record_history(input, 0);
+                                    }
+                                }
+                            }
+                            aish_ui::SlashInputOutcome::Dismissed(text) => {
+                                // No match — pre-fill readline so user can continue
+                                // typing (e.g. /bin/ls).
+                                match rl.read_line_with_initial(&prompt_str, (&text, "")) {
+                                    Ok(Some(line)) => {
+                                        let input = line.trim();
+                                        if !input.is_empty() {
+                                            self.state.history.push(input.to_string());
+                                            match input::classify_input(input) {
+                                                crate::types::InputIntent::SpecialCommand => {
+                                                    if self.handle_special_command(input) {
+                                                        self.record_history(input, 0);
+                                                    }
+                                                }
+                                                crate::types::InputIntent::Command
+                                                | crate::types::InputIntent::OperatorCommand => {
+                                                    self.set_phase(ShellPhase::Running);
+                                                    let exit_code =
+                                                        self.execute_external_command(input);
+                                                    self.set_phase(ShellPhase::Editing);
+                                                    self.record_history(input, exit_code);
+                                                    self.reset_interruption();
+                                                }
+                                                crate::types::InputIntent::BuiltinCommand => {
+                                                    let parts: Vec<&str> =
+                                                        input.split_whitespace().collect();
+                                                    if let Some(cmd) = parts.first() {
+                                                        let result = self
+                                                            .state
+                                                            .handle_builtin(cmd, &parts[1..]);
+                                                        if let Some(ref output) = result.output {
+                                                            println!("{}", output);
+                                                        }
+                                                        if result.should_exit {
+                                                            self.record_history(input, 0);
+                                                            break;
+                                                        }
+                                                    }
+                                                    self.record_history(input, 0);
+                                                }
+                                                crate::types::InputIntent::Help => {
+                                                    let result =
+                                                        self.state.handle_builtin("help", &[]);
+                                                    if let Some(output) = result.output {
+                                                        println!("{}", output);
+                                                    }
+                                                    self.record_history(input, 0);
+                                                }
+                                                crate::types::InputIntent::ScriptCall => {
+                                                    let exit_code = self.execute_script(input);
+                                                    self.record_history(input, exit_code);
+                                                }
+                                                _ => {
+                                                    eprintln!("Unknown: {}", input);
+                                                }
+                                            }
+                                        }
+                                    }
+                                    Ok(None) => {}
+                                    Err(ref e)
+                                        if matches!(
+                                            e,
+                                            rustyline::error::ReadlineError::Interrupted
+                                        ) =>
+                                    {
+                                        if rl.was_slash_requested() {
+                                            // User pressed `/` inside the
+                                            // pre-filled readline — re-trigger
+                                            // the slash popup.
+                                            match self.run_slash_input_session(&prompt_str) {
+                                                aish_ui::SlashInputOutcome::Command(cmd) => {
+                                                    let input = cmd.trim();
+                                                    if !input.is_empty() {
+                                                        self.state.history.push(input.to_string());
+                                                        if self.handle_special_command(input) {
+                                                            self.record_history(input, 0);
+                                                        }
+                                                    }
+                                                }
+                                                aish_ui::SlashInputOutcome::Dismissed(text) => {
+                                                    let _ = rl.read_line_with_initial(
+                                                        &prompt_str,
+                                                        (&text, ""),
+                                                    );
+                                                }
+                                                aish_ui::SlashInputOutcome::Cancelled => {}
+                                            }
+                                        } else if self.handle_ctrl_c() {
+                                            break;
+                                        }
+                                    }
+                                    Err(_) => {}
+                                }
+                            }
+                            aish_ui::SlashInputOutcome::Cancelled => {}
+                        }
+                        continue;
+                    }
                     // Interrupt (Ctrl-C) — handle double-press exit
                     if matches!(e, rustyline::error::ReadlineError::Interrupted) {
                         if self.handle_ctrl_c() {
@@ -1899,6 +2031,14 @@ impl AishShell {
             Some("/resume") => {
                 self.handle_resume_command(&parts);
                 return false;
+            }
+            Some("/feedback") => {
+                let url = "https://github.com/AI-Shell-Team/aish/issues";
+                println!("Opening GitHub Issues...");
+                if let Err(e) = open::that(url) {
+                    eprintln!("Failed to open browser: {e}");
+                    println!("Visit: {url}");
+                }
             }
             _ => {
                 eprintln!("{}", {

--- a/crates/aish-shell/src/input.rs
+++ b/crates/aish-shell/src/input.rs
@@ -13,10 +13,11 @@ pub fn classify_input(input: &str) -> InputIntent {
         return InputIntent::Help;
     }
     if trimmed.starts_with('/')
-        && trimmed
-            .split_whitespace()
-            .next()
-            .is_some_and(|cmd| matches!(cmd, "/model" | "/setup" | "/plan" | "/token" | "/resume"))
+        && trimmed.split_whitespace().next().is_some_and(|cmd| {
+            crate::readline::SLASH_COMMANDS
+                .iter()
+                .any(|(name, _)| *name == cmd)
+        })
     {
         return InputIntent::SpecialCommand;
     }
@@ -95,6 +96,7 @@ mod tests {
         assert_eq!(classify_input("/token"), InputIntent::SpecialCommand);
         assert_eq!(classify_input("/resume"), InputIntent::SpecialCommand);
         assert_eq!(classify_input("/resume 1234"), InputIntent::SpecialCommand);
+        assert_eq!(classify_input("/feedback"), InputIntent::SpecialCommand);
     }
 
     #[test]

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use rustyline::completion::{Completer, FilenameCompleter, Pair};
+use rustyline::config::Configurer;
 use rustyline::highlight::Highlighter;
 use rustyline::hint::Hinter;
 use rustyline::validate::Validator;
@@ -21,8 +22,15 @@ const BUILTINS: &[&str] = &[
     "quit",
 ];
 
-/// Special commands starting with /.
-const SPECIALS: &[&str] = &["/model", "/setup"];
+/// Slash commands with descriptions for popup completion.
+pub const SLASH_COMMANDS: &[(&str, &str)] = &[
+    ("/model", "Show or switch AI model"),
+    ("/setup", "Open setup wizard"),
+    ("/plan", "Plan mode control"),
+    ("/token", "Show token usage"),
+    ("/resume", "Resume previous session"),
+    ("/feedback", "Open GitHub Issues"),
+];
 
 /// Timeout for PTY completion queries.
 const COMPLETION_TIMEOUT: Duration = Duration::from_millis(500);
@@ -36,6 +44,9 @@ static MODE_TOGGLE_REQUESTED: AtomicBool = AtomicBool::new(false);
 
 /// Flag set by `CtrlOHandler` when Ctrl+O is pressed.
 static CTRL_O_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+/// Flag set by `SlashHandler` when `/` is pressed on an empty line.
+static SLASH_REQUESTED: AtomicBool = AtomicBool::new(false);
 
 /// Event handler that sets a flag when Shift+Tab or F2 is pressed,
 /// then returns `Cmd::Interrupt` to break out of `read_line`.
@@ -68,6 +79,33 @@ impl ConditionalEventHandler for CtrlOHandler {
     ) -> Option<Cmd> {
         CTRL_O_REQUESTED.store(true, Ordering::SeqCst);
         Some(Cmd::Interrupt)
+    }
+}
+
+/// Event handler that sets a flag when `/` is typed on an empty line,
+/// then returns `Cmd::Interrupt` to break out of `read_line` for the
+/// slash command completion popup.
+struct SlashHandler;
+
+impl ConditionalEventHandler for SlashHandler {
+    fn handle(
+        &self,
+        evt: &Event,
+        _n_repeat: RepeatCount,
+        _positive: bool,
+        ctx: &EventContext<'_>,
+    ) -> Option<Cmd> {
+        // Only trigger for plain `/` key press (no modifiers)
+        if let Event::KeySeq(keys) = evt {
+            if let Some(key) = keys.first() {
+                if key.1 == Modifiers::NONE && key.0 == KeyCode::Char('/') && ctx.line().is_empty()
+                {
+                    SLASH_REQUESTED.store(true, Ordering::SeqCst);
+                    return Some(Cmd::Interrupt);
+                }
+            }
+        }
+        None
     }
 }
 
@@ -191,8 +229,8 @@ impl Completer for ShellHelper {
                 }
             }
 
-            // Special commands
-            for cmd in SPECIALS {
+            // Slash commands
+            for (cmd, _desc) in SLASH_COMMANDS {
                 if cmd.starts_with(word) {
                     candidates.push(Pair {
                         display: cmd.to_string(),
@@ -213,9 +251,12 @@ impl Completer for ShellHelper {
             if !word.is_empty() {
                 let pty_results = self.query_pty_completions(line, pos);
                 let builtin_set: Vec<&str> = BUILTINS.to_vec();
+                let slash_set: Vec<&str> = SLASH_COMMANDS.iter().map(|(c, _)| *c).collect();
                 for candidate in &pty_results {
-                    // Skip duplicates already covered by BUILTINS/SPECIALS
-                    if builtin_set.contains(&candidate.as_str()) {
+                    // Skip duplicates already covered by BUILTINS/SLASH_COMMANDS
+                    if builtin_set.contains(&candidate.as_str())
+                        || slash_set.contains(&candidate.as_str())
+                    {
                         continue;
                     }
                     candidates.push(Pair {
@@ -225,17 +266,16 @@ impl Completer for ShellHelper {
                 }
             }
 
-            if !candidates.is_empty() {
-                return Ok((word_start, candidates));
-            }
-
-            // Fall through to file completion for path-like tokens
+            // Merge file completions for path-like tokens so slash commands
+            // don't shadow absolute paths like /usr, /tmp, /proc, etc.
             if word.starts_with("./")
                 || word.starts_with("../")
                 || word.starts_with("/")
                 || word.starts_with("~/")
             {
-                return self.file_completer.complete(line, pos, ctx);
+                if let Ok((_, file_candidates)) = self.file_completer.complete(line, pos, ctx) {
+                    candidates.extend(file_candidates);
+                }
             }
 
             return Ok((word_start, candidates));
@@ -287,6 +327,7 @@ impl ShellReadline {
 
         let mut editor = Editor::with_config(config)?;
         editor.set_helper(Some(ShellHelper::new(pty, autosuggest.clone())));
+        editor.set_max_history_size(500)?;
 
         // Bind Shift+Tab (BackTab) and F2 for mode toggle
         editor.bind_sequence(
@@ -302,6 +343,12 @@ impl ShellReadline {
         editor.bind_sequence(
             KeyEvent(KeyCode::Char('O'), Modifiers::CTRL),
             EventHandler::Conditional(Box::new(CtrlOHandler)),
+        );
+
+        // Bind `/` on empty line for slash command completion popup
+        editor.bind_sequence(
+            KeyEvent(KeyCode::Char('/'), Modifiers::NONE),
+            EventHandler::Conditional(Box::new(SlashHandler)),
         );
 
         Ok(Self {
@@ -320,6 +367,26 @@ impl ShellReadline {
     /// The flag is consumed on read.
     pub fn was_ctrl_o_requested(&self) -> bool {
         CTRL_O_REQUESTED.swap(false, Ordering::SeqCst)
+    }
+
+    /// Check whether `/` on an empty line triggered the last `Interrupted` error.
+    /// The flag is consumed on read.
+    pub fn was_slash_requested(&self) -> bool {
+        SLASH_REQUESTED.swap(false, Ordering::SeqCst)
+    }
+
+    /// Read a line with initial text pre-filled, letting the user edit and
+    /// submit. Returns `None` on EOF (Ctrl-D).
+    pub fn read_line_with_initial(
+        &mut self,
+        prompt: &str,
+        initial: (&str, &str),
+    ) -> rustyline::Result<Option<String>> {
+        match self.editor.readline_with_initial(prompt, initial) {
+            Ok(line) => Ok(Some(line)),
+            Err(rustyline::error::ReadlineError::Eof) => Ok(None),
+            Err(e) => Err(e),
+        }
     }
 
     /// Read a line with the given prompt.
@@ -414,9 +481,18 @@ mod tests {
     }
 
     #[test]
-    fn test_specials_format() {
-        for cmd in SPECIALS {
-            assert!(cmd.starts_with('/'), "special must start with /: {}", cmd);
+    fn test_slash_commands_format() {
+        for (cmd, desc) in SLASH_COMMANDS {
+            assert!(
+                cmd.starts_with('/'),
+                "slash command must start with /: {}",
+                cmd
+            );
+            assert!(
+                !desc.is_empty(),
+                "description must not be empty for {}",
+                cmd
+            );
         }
     }
 }

--- a/crates/aish-tools/src/glob_tool.rs
+++ b/crates/aish-tools/src/glob_tool.rs
@@ -89,7 +89,7 @@ impl Tool for GlobTool {
             format!("{}/{}", root.display(), pattern)
         };
 
-        let mut matches: Vec<PathBuf> = Vec::new();
+        let mut matches: Vec<PathBuf> = Vec::with_capacity(DEFAULT_MAX_RESULTS);
         match glob::glob(&full_pattern) {
             Ok(paths) => {
                 for entry in paths.flatten() {

--- a/crates/aish-tools/src/grep_tool.rs
+++ b/crates/aish-tools/src/grep_tool.rs
@@ -106,7 +106,7 @@ impl Tool for GrepTool {
             .and_then(|g| g.as_str())
             .filter(|g| !g.trim().is_empty());
 
-        let mut matches: Vec<String> = Vec::new();
+        let mut matches: Vec<String> = Vec::with_capacity(DEFAULT_MAX_RESULTS);
         let files = walk_files(&root);
 
         for file_path in files {

--- a/crates/aish-ui/src/lib.rs
+++ b/crates/aish-ui/src/lib.rs
@@ -3,9 +3,11 @@ mod expand;
 mod history;
 mod runtime;
 mod select;
+mod slash_input;
 
 pub use choice::{ChoiceOutcome, ChoicePanel};
 pub use expand::ExpandPanel;
 pub use history::{HistoryOutcome, HistoryPanel, HistoryRecord};
 pub use runtime::{PanelComponent, PanelError, PanelEvent, PanelOutcome, PanelRuntime};
 pub use select::{SearchSelectItem, SearchSelectOutcome, SearchSelectPanel};
+pub use slash_input::{SlashInputOutcome, SlashInputSession};

--- a/crates/aish-ui/src/slash_input.rs
+++ b/crates/aish-ui/src/slash_input.rs
@@ -1,0 +1,405 @@
+use std::io::{self, Write};
+
+use crossterm::{
+    cursor, event,
+    event::{Event, KeyCode, KeyEventKind, KeyModifiers},
+    execute, terminal,
+};
+use ratatui::{
+    backend::CrosstermBackend,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Terminal, TerminalOptions, Viewport,
+};
+
+/// Outcome of the slash input session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlashInputOutcome {
+    /// User selected a slash command (e.g. "/model gpt-4").
+    Command(String),
+    /// Input no longer matches any command; return to normal readline with this text.
+    Dismissed(String),
+    /// User pressed Esc; cancel and return to empty readline.
+    Cancelled,
+}
+
+const MAX_VISIBLE_COMMANDS: usize = 8;
+const MAX_PANEL_HEIGHT: u16 = 10;
+
+/// Inline slash command autocomplete popup.
+///
+/// Renders the shell prompt + input on the first line, and a filtered
+/// command list below it — no focus mode switching, typing and popup
+/// navigation work simultaneously.
+pub struct SlashInputSession {
+    commands: Vec<(String, String)>,
+    prompt: String,
+    input: String,
+    cursor: usize,
+    selected: usize,
+    filtered: Vec<usize>,
+}
+
+impl SlashInputSession {
+    pub fn new(commands: Vec<(String, String)>, prompt: String) -> Self {
+        // Strip ANSI escape codes — ratatui renders via its own style system
+        let prompt = strip_ansi(&prompt);
+        let mut filtered = Vec::with_capacity(commands.len());
+        filtered.extend(0..commands.len());
+        Self {
+            commands,
+            prompt,
+            input: String::from("/"),
+            cursor: 1,
+            selected: 0,
+            filtered,
+        }
+    }
+
+    /// Run the session in raw mode. Returns the outcome.
+    pub fn run(mut self) -> io::Result<SlashInputOutcome> {
+        let _guard = RawModeGuard::enter()?;
+        let backend = CrosstermBackend::new(io::stdout());
+        let height = self.panel_height();
+        let mut terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(height),
+            },
+        )?;
+        drain_pending_events()?;
+
+        let outcome = loop {
+            terminal.draw(|frame| self.render(frame, frame.area()))?;
+
+            let event = event::read()?;
+            if let Some(result) = self.handle_event(event) {
+                break result;
+            }
+        };
+
+        // All terminal cleanup MUST happen while still in raw mode.
+        // If terminal is dropped after termios restore, its Drop impl may
+        // write escape sequences in cooked mode, corrupting the terminal
+        // and causing the next SlashInputSession invocation to hang.
+        let _ = terminal.clear();
+        drop(terminal);
+        drop(_guard);
+        let _ = io::stdout().flush();
+        Ok(outcome)
+    }
+
+    fn panel_height(&self) -> u16 {
+        let items = self.commands.len().clamp(1, MAX_VISIBLE_COMMANDS) as u16;
+        (1 + items).min(MAX_PANEL_HEIGHT)
+    }
+
+    fn update_filtered(&mut self) {
+        let query = self.input.to_lowercase();
+        self.filtered = self
+            .commands
+            .iter()
+            .enumerate()
+            .filter(|(_, (name, desc))| {
+                name.to_lowercase().starts_with(&query) || desc.to_lowercase().contains(&query)
+            })
+            .map(|(i, _)| i)
+            .collect();
+        self.clamp_selected();
+    }
+
+    fn clamp_selected(&mut self) {
+        if self.filtered.is_empty() {
+            self.selected = 0;
+        } else if self.selected >= self.filtered.len() {
+            self.selected = self.filtered.len() - 1;
+        }
+    }
+
+    /// Whether the current input is still a prefix of any command name.
+    fn has_command_prefix(&self) -> bool {
+        let query = self.input.to_lowercase();
+        self.commands
+            .iter()
+            .any(|(name, _)| name.to_lowercase().starts_with(&query))
+    }
+
+    /// Set input text and cursor to the currently selected command name.
+    fn sync_input_to_selected(&mut self) {
+        if let Some(&cmd_idx) = self.filtered.get(self.selected) {
+            let (name, _) = &self.commands[cmd_idx];
+            self.input = name.clone();
+            self.cursor = self.input.len();
+        }
+    }
+
+    /// Handle an event. Returns `Some(outcome)` when the session should end.
+    fn handle_event(&mut self, event: Event) -> Option<SlashInputOutcome> {
+        let Event::Key(key) = event else { return None };
+        if key.kind != KeyEventKind::Press && key.kind != KeyEventKind::Repeat {
+            return None;
+        }
+
+        // Ctrl+C always cancels
+        if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            return Some(SlashInputOutcome::Cancelled);
+        }
+
+        match key.code {
+            KeyCode::Char(ch)
+                if !key.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                self.input.insert(self.cursor, ch);
+                self.cursor += ch.len_utf8();
+                self.update_filtered();
+                // No longer a slash command prefix (e.g. /bin) → back to readline
+                if !self.has_command_prefix() {
+                    return Some(SlashInputOutcome::Dismissed(self.input.clone()));
+                }
+                None
+            }
+            KeyCode::Backspace => {
+                if self.cursor > 0 {
+                    let prev = self.input[..self.cursor]
+                        .char_indices()
+                        .last()
+                        .map(|(i, _)| i)
+                        .unwrap_or(0);
+                    self.input.drain(prev..self.cursor);
+                    self.cursor = prev;
+                    self.update_filtered();
+                    if self.input.is_empty() {
+                        return Some(SlashInputOutcome::Cancelled);
+                    }
+                    if !self.has_command_prefix() {
+                        return Some(SlashInputOutcome::Dismissed(self.input.clone()));
+                    }
+                }
+                None
+            }
+            KeyCode::Up => {
+                if !self.filtered.is_empty() && self.selected > 0 {
+                    self.selected -= 1;
+                    self.sync_input_to_selected();
+                }
+                None
+            }
+            KeyCode::Down => {
+                if !self.filtered.is_empty() {
+                    self.selected = (self.selected + 1).min(self.filtered.len() - 1);
+                    self.sync_input_to_selected();
+                }
+                None
+            }
+            KeyCode::Enter => {
+                let trimmed = self.input.trim();
+                let first_word = trimmed.split_whitespace().next().unwrap_or("");
+                let is_command = self
+                    .commands
+                    .iter()
+                    .any(|(name, _)| first_word == name || trimmed == name);
+                if is_command {
+                    return Some(SlashInputOutcome::Command(trimmed.to_string()));
+                }
+                // No match — dismiss to normal readline
+                Some(SlashInputOutcome::Dismissed(self.input.clone()))
+            }
+            KeyCode::Tab => {
+                // Complete to selected item and submit immediately
+                if let Some(&cmd_idx) = self.filtered.get(self.selected) {
+                    let (name, _) = &self.commands[cmd_idx];
+                    return Some(SlashInputOutcome::Command(name.clone()));
+                }
+                None
+            }
+            KeyCode::Home => {
+                self.cursor = 0;
+                None
+            }
+            KeyCode::End => {
+                self.cursor = self.input.len();
+                None
+            }
+            KeyCode::Left => {
+                if self.cursor > 0 {
+                    self.cursor = self.input[..self.cursor]
+                        .char_indices()
+                        .last()
+                        .map(|(i, _)| i)
+                        .unwrap_or(0);
+                }
+                None
+            }
+            KeyCode::Right => {
+                if self.cursor < self.input.len() {
+                    self.cursor += self.input[self.cursor..]
+                        .chars()
+                        .next()
+                        .map(|c| c.len_utf8())
+                        .unwrap_or(0);
+                }
+                None
+            }
+            KeyCode::Esc => Some(SlashInputOutcome::Cancelled),
+            _ => None,
+        }
+    }
+
+    fn render(&self, frame: &mut ratatui::Frame<'_>, area: Rect) {
+        let input_area = Rect::new(area.x, area.y, area.width, 1);
+        let list_area = Rect::new(
+            area.x,
+            area.y + 1,
+            area.width,
+            area.height.saturating_sub(1),
+        );
+
+        self.render_input_line(frame, input_area);
+        self.render_command_list(frame, list_area);
+    }
+
+    fn render_input_line(&self, frame: &mut ratatui::Frame<'_>, area: Rect) {
+        let prompt_style = Style::default().fg(Color::Green);
+        let input_style = Style::default().fg(Color::White);
+        let cursor_style = Style::default()
+            .fg(Color::Black)
+            .bg(Color::White)
+            .add_modifier(Modifier::BOLD);
+
+        let before = &self.input[..self.cursor];
+        let cursor_char = self.input[self.cursor..].chars().next();
+        let after_start = self.cursor + cursor_char.map_or(0, |c| c.len_utf8());
+        let after = &self.input[after_start..];
+
+        let mut spans = vec![Span::styled(self.prompt.clone(), prompt_style)];
+        spans.push(Span::styled(before.to_string(), input_style));
+        if let Some(ch) = cursor_char {
+            spans.push(Span::styled(ch.to_string(), cursor_style));
+            spans.push(Span::styled(after.to_string(), input_style));
+        } else {
+            spans.push(Span::styled(" ", cursor_style));
+        }
+        frame.render_widget(Paragraph::new(Line::from(spans)), area);
+    }
+
+    fn render_command_list(&self, frame: &mut ratatui::Frame<'_>, area: Rect) {
+        if self.filtered.is_empty() || area.height == 0 {
+            return;
+        }
+
+        let max_visible = area.height as usize;
+        let scroll = self.scroll_offset(max_visible);
+        let end = (scroll + max_visible).min(self.filtered.len());
+        let lines: Vec<Line> = self.filtered[scroll..end]
+            .iter()
+            .enumerate()
+            .map(|(row, &cmd_idx)| {
+                let absolute_row = scroll + row;
+                let (name, desc) = &self.commands[cmd_idx];
+                let is_selected = absolute_row == self.selected;
+                let marker = if is_selected { "▸ " } else { "  " };
+                let marker_style = if is_selected {
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(Color::DarkGray)
+                };
+                let name_style = if is_selected {
+                    Style::default()
+                        .fg(Color::LightCyan)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(Color::White)
+                };
+                let desc_style = Style::default().fg(Color::DarkGray);
+
+                Line::from(vec![
+                    Span::styled(marker, marker_style),
+                    Span::styled(name, name_style),
+                    Span::styled(format!("  {desc}"), desc_style),
+                ])
+            })
+            .collect();
+
+        frame.render_widget(Paragraph::new(lines), area);
+    }
+
+    fn scroll_offset(&self, max_visible: usize) -> usize {
+        if self.selected >= max_visible {
+            self.selected - max_visible + 1
+        } else {
+            0
+        }
+    }
+}
+
+struct RawModeGuard;
+
+impl RawModeGuard {
+    fn enter() -> io::Result<Self> {
+        terminal::enable_raw_mode()?;
+        if let Err(err) = execute!(io::stdout(), cursor::Hide) {
+            let _ = terminal::disable_raw_mode();
+            return Err(err);
+        }
+        Ok(Self)
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        let _ = execute!(io::stdout(), cursor::Show);
+        let _ = terminal::disable_raw_mode();
+        let _ = io::stdout().flush();
+    }
+}
+
+fn drain_pending_events() -> io::Result<()> {
+    while event::poll(std::time::Duration::from_millis(0))? {
+        let _ = event::read()?;
+    }
+    Ok(())
+}
+
+/// Strip ANSI CSI/OSC escape sequences from a string.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\x1b' {
+            match chars.peek() {
+                Some('[') => {
+                    chars.next();
+                    // CSI: skip until final byte (0x40..=0x7E)
+                    while let Some(&c) = chars.peek() {
+                        chars.next();
+                        if ('\x40'..='\x7e').contains(&c) {
+                            break;
+                        }
+                    }
+                }
+                Some(']') => {
+                    chars.next();
+                    // OSC: skip until BEL or ST
+                    while let Some(c) = chars.next() {
+                        if c == '\x07' {
+                            break;
+                        }
+                        if c == '\x1b' && chars.peek() == Some(&'\\') {
+                            chars.next();
+                            break;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}


### PR DESCRIPTION
## Summary

- Add interactive slash command popup triggered by typing `/` on empty line, with search/filter support
- Add `/feedback` command that opens GitHub Issues in the browser via the `open` crate
- Replace `Vec::new()`/`HashMap::new()`/`String::new()` with `with_capacity()` across context, llm, memory, pty, security, and tools crates for reduced reallocation overhead
- Set max readline history size to 500 entries

## Test plan

- [ ] Type `/` on an empty input line — popup should appear with all slash commands
- [ ] Search/filter in the popup, select a command with Enter
- [ ] Run `/feedback` — browser should open GitHub Issues page
- [ ] Verify `cargo test` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive inline slash-command picker: press `/` on an empty line to browse, filter, and insert commands via a popup UI (supports prefill, Tab/Enter completion, Esc/Ctrl+C cancel)
  * Slash-command completions with localized labels and a new `/feedback` action that opens the project Issues page (with fallback message on failure)

* **Chores**
  * Widespread performance/memory improvements to reduce reallocations and improve responsiveness
<!-- end of auto-generated comment: release notes by coderabbit.ai -->