### PR TITLE
fix: refresh prompt cwd after ai bash cd

### DIFF
--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -2578,5 +2578,4 @@ mod tests {
             Some("sudo ls /root")
         );
     }
-
 }

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -2578,4 +2578,5 @@ mod tests {
             Some("sudo ls /root")
         );
     }
+
 }

--- a/crates/aish-pty/src/persistent.rs
+++ b/crates/aish-pty/src/persistent.rs
@@ -211,7 +211,7 @@ impl PersistentPty {
         timeout: Duration,
         cancel_token: Option<&CancelToken>,
         display_output: bool,
-    ) -> aish_core::Result<(String, i32)> {
+    ) -> aish_core::Result<(String, i32, String)> {
         let seq = self.allocate_backend_seq();
 
         // Enter exec mode: buffer output.
@@ -241,6 +241,7 @@ impl PersistentPty {
 
         let deadline = std::time::Instant::now() + timeout;
         let mut result_exit_code: i32 = -1;
+        let mut result_cwd = String::new();
         let mut cancelled = false;
         // Select-based I/O loop.
         'select_loop: while std::time::Instant::now() < deadline {
@@ -372,6 +373,9 @@ impl PersistentPty {
                             if let BackendControlEvent::ShellExiting { .. } = event {
                                 self.running.store(false, Ordering::SeqCst);
                             }
+                            if let BackendControlEvent::PromptReady { cwd, .. } = event {
+                                result_cwd = cwd.clone();
+                            }
                             if let Some(r) = self.command_state.handle_event(event) {
                                 if r.command_seq == Some(seq) {
                                     result_exit_code = r.exit_code;
@@ -413,10 +417,10 @@ impl PersistentPty {
 
         if cancelled {
             let cleaned = clean_pty_output(&raw_str, command);
-            Ok((cleaned, -1))
+            Ok((cleaned, -1, result_cwd))
         } else {
             let cleaned = clean_pty_output(&raw_str, command);
-            Ok((cleaned, result_exit_code))
+            Ok((cleaned, result_exit_code, result_cwd))
         }
     }
 }
@@ -4219,10 +4223,11 @@ mod tests {
             .unwrap_or_else(|_| "/tmp".to_string());
         let mut pty = PersistentPty::start(&cwd, 24, 80).expect("start should succeed");
 
-        let (output, exit_code) = pty
+        let (output, exit_code, result_cwd) = pty
             .execute_command("echo hello_world_123", Duration::from_secs(5), None, false)
             .expect("execute should succeed");
         assert_eq!(exit_code, 0);
+        assert_eq!(result_cwd, cwd);
         assert!(output.contains("hello_world_123"), "output was: {}", output);
 
         pty.stop();
@@ -4235,18 +4240,56 @@ mod tests {
             .unwrap_or_else(|_| "/tmp".to_string());
         let mut pty = PersistentPty::start(&cwd, 24, 80).expect("start should succeed");
 
-        let (out1, code1) = pty
+        let (out1, code1, cwd1) = pty
             .execute_command("echo first", Duration::from_secs(5), None, false)
             .expect("cmd1");
         assert_eq!(code1, 0);
+        assert_eq!(cwd1, cwd);
         assert!(out1.contains("first"));
 
-        let (out2, code2) = pty
+        let (out2, code2, cwd2) = pty
             .execute_command("echo second", Duration::from_secs(5), None, false)
             .expect("cmd2");
         assert_eq!(code2, 0);
+        assert_eq!(cwd2, cwd);
         assert!(out2.contains("second"));
 
         pty.stop();
+    }
+
+    #[test]
+    fn test_execute_command_persists_cwd_for_following_commands() {
+        let cwd = std::env::current_dir()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| "/tmp".to_string());
+        let mut pty = PersistentPty::start(&cwd, 24, 80).expect("start should succeed");
+
+        let tempdir = std::env::temp_dir().join(format!(
+            "aish-pty-cwd-persist-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&tempdir).expect("create tempdir");
+        let target = tempdir.display().to_string();
+
+        let (_output, exit_code, result_cwd) = pty
+            .execute_command(
+                &format!("cd {}", shell_quote_escape(&target)),
+                Duration::from_secs(5),
+                None,
+                false,
+            )
+            .expect("cd should succeed");
+        assert_eq!(exit_code, 0);
+        assert_eq!(result_cwd, target);
+
+        let (pwd_output, pwd_exit_code, pwd_cwd) = pty
+            .execute_command("pwd", Duration::from_secs(5), None, false)
+            .expect("pwd should succeed");
+        assert_eq!(pwd_exit_code, 0);
+        assert_eq!(pwd_cwd, target);
+        assert_eq!(pwd_output.trim(), target);
+
+        pty.stop();
+        let _ = std::fs::remove_dir_all(&tempdir);
     }
 }

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -1539,6 +1539,7 @@ impl AishShell {
                     });
                     esc_watcher.stop();
                     Self::restore_ai_sigint_handler(old_sigint);
+                    self.sync_state_from_pty_cwd();
 
                     let did_stream = self.streamed_content.load(Ordering::SeqCst);
 
@@ -1779,6 +1780,7 @@ impl AishShell {
                                 });
                                 esc_watcher.stop();
                                 Self::restore_ai_sigint_handler(old_sigint);
+                                self.sync_state_from_pty_cwd();
 
                                 let did_stream = self.streamed_content.load(Ordering::SeqCst);
                                 match result {
@@ -2373,6 +2375,29 @@ impl AishShell {
             None,
             false,
         );
+    }
+
+    fn sync_state_from_pty_cwd(&mut self) {
+        if !self.lock_pty().is_running() {
+            return;
+        }
+
+        let result = self.pty.lock().unwrap().execute_command(
+            "pwd",
+            std::time::Duration::from_secs(2),
+            None,
+            false,
+        );
+
+        let Ok((_output, _exit_code, cwd)) = result else {
+            return;
+        };
+
+        if !cwd.is_empty() && cwd != self.state.cwd {
+            self.state.prev_cwd = Some(self.state.cwd.clone());
+            self.state.cwd = cwd.clone();
+            let _ = std::env::set_current_dir(&cwd);
+        }
     }
 
     /// Restart the PTY session (e.g., after bash exits or crashes).

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -2382,12 +2382,9 @@ impl AishShell {
             return;
         }
 
-        let result = self.pty.lock().unwrap().execute_command(
-            "pwd",
-            std::time::Duration::from_secs(2),
-            None,
-            false,
-        );
+        let result =
+            self.lock_pty()
+                .execute_command("pwd", std::time::Duration::from_secs(2), None, false);
 
         let Ok((_output, _exit_code, cwd)) = result else {
             return;
@@ -2583,6 +2580,7 @@ impl AishShell {
                     let rt = tokio::runtime::Runtime::new().unwrap();
                     match rt.block_on(self.ai_handler.handle_question(prompt_str)) {
                         Ok(response) => {
+                            self.sync_state_from_pty_cwd();
                             print_md(&response);
                             self.persist_session_snapshot();
                             script_env.insert("AISH_LAST_OUTPUT".to_string(), response);

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -109,7 +109,7 @@ impl ShellHelper {
         let cmd = format!("__aish_query_completions {} {}", escaped_line, pos);
 
         match pty.execute_command(&cmd, COMPLETION_TIMEOUT, None, false) {
-            Ok((output, _exit_code)) => output
+            Ok((output, _exit_code, _cwd)) => output
                 .lines()
                 .filter(|l| !l.is_empty())
                 .map(|l| l.to_string())

--- a/crates/aish-tools/src/bash.rs
+++ b/crates/aish-tools/src/bash.rs
@@ -342,7 +342,10 @@ impl BashTool {
         done.store(true, Ordering::SeqCst);
 
         match result {
-            Ok((output, exit_code)) => {
+            Ok((output, exit_code, cwd)) => {
+                if !cwd.is_empty() {
+                    let _ = std::env::set_current_dir(&cwd);
+                }
                 let raw_line_count = output.lines().count();
                 let session_uuid = uuid::Uuid::new_v4().to_string();
                 let cwd = std::env::current_dir()


### PR DESCRIPTION
## Background
Fix the case where an AI-triggered bash cd changed directories successfully but left the next AISH prompt showing the old cwd.

## Changes
- return the post-command cwd from PersistentPty::execute_command
- resync shell cwd from the main PTY after AI turns that may run bash tools
- update call sites for the execute_command signature and add a focused PTY regression test

## Validation
- cargo check -p aish-llm -p aish-shell -p aish-tools -p aish-pty
- cargo test -p aish-pty test_execute_command_persists_cwd_for_following_commands --lib

## Risk
- PTY cwd resync after AI turns is localized, but any future tool flow that intentionally diverges from the main PTY cwd will need to keep this behavior in mind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed working directory tracking to correctly persist across command execution
  * Shell now properly synchronizes its tracked working directory with the PTY after AI operations to prevent state misalignment
<!-- end of auto-generated comment: release notes by coderabbit.ai -->