### PR TITLE
fix: anchor slash popup to prompt line

### DIFF
--- a/crates/aish-ui/src/slash_input.rs
+++ b/crates/aish-ui/src/slash_input.rs
@@ -61,6 +61,13 @@ impl SlashInputSession {
     /// Run the session in raw mode. Returns the outcome.
     pub fn run(mut self) -> io::Result<SlashInputOutcome> {
         let _guard = RawModeGuard::enter()?;
+        // Rustyline appends a newline after returning on Cmd::Interrupt.
+        // Move back to the original prompt line before ratatui queries the
+        // cursor position for the inline viewport.
+        execute!(io::stdout(), cursor::MoveToColumn(0), cursor::MoveUp(1))?;
+        // Drain any stale keyboard events before ratatui issues DSR queries.
+        // Leftover bytes can corrupt the cursor position response parsing.
+        drain_pending_events()?;
         let backend = CrosstermBackend::new(io::stdout());
         let height = self.panel_height();
         let mut terminal = Terminal::with_options(
@@ -69,7 +76,6 @@ impl SlashInputSession {
                 viewport: Viewport::Inline(height),
             },
         )?;
-        drain_pending_events()?;
 
         let outcome = loop {
             terminal.draw(|frame| self.render(frame, frame.area()))?;


### PR DESCRIPTION
## Background
Rustyline appends a newline when the slash popup is triggered via `Cmd::Interrupt`, which can move the inline slash popup off the original prompt line and cause the extra-line behavior when re-opening slash completion after deleting input.

## Changes
- move the cursor back to the original prompt line before creating the inline slash popup viewport
- drain pending keyboard events before ratatui queries cursor position, so stale bytes do not corrupt the viewport anchor
- keep the fix localized to the slash popup session instead of compensating in the outer shell loop

## Validation
- `cargo fmt --all --check`
- `cargo test -p aish-shell --lib --no-run`
- manual interactive verification of slash popup reopen behavior after deleting input with Backspace

## Risk
- terminal-specific cursor movement behavior around the popup initialization path may still vary across environments, but the change is limited to slash popup startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved terminal cursor handling in the slash input feature by correcting cursor position restoration and clearing stale keyboard events to prevent cursor corruption during input processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->