### PR TITLE
Release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2026-06-03
+
+### Added
+
+- Added a slash-command suggestion popup and a built-in `/feedback` command so interactive command discovery is faster inside the shell.
+- Added ESC interrupt handling, richer keyboard events, and improved inline dialogs and panels for interactive shell flows.
+
+### Changed
+
+- Changed `ask_user` interactions to use the new dialog flow with clearer validation, cancel handling, and localized prompt copy.
+
+### Fixed
+
+- Fixed PTY cleanup on shell shutdown so background terminal resources are released more reliably.
+- Fixed prompt cwd refresh after `ai bash` changes directory so the shell prompt stays in sync.
+- Fixed `ask_user` default matching and validation reporting so trimmed defaults and structured errors behave consistently.
+- Fixed slash popup anchoring so the menu stays attached to the active prompt line.
+
 ## [Unreleased]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "aish-cli"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "aish-config"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "aish-context"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aish-core",
  "serde",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "aish-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "aish-hosts"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "aish-i18n"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "aish-llm"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aish-context",
  "aish-core",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "aish-memory"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aish-core",
  "chrono",
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "aish-prompts"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "aish-pty"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aish-core",
  "aish-hosts",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "aish-scripts"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "aish-security"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "libc",
  "regex",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aish-session"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aish-core",
  "chrono",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "aish-shell"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aish-config",
  "aish-context",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "aish-skills"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "aish-tools"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aish-core",
  "aish-i18n",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "aish-ui"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "crossterm 0.28.1",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 license = "MIT"
 rust-version = "1.80"


### PR DESCRIPTION
## Background

Prepare the v0.3.3 release candidate from main.

## Changes

- bump workspace version and Cargo.lock to 0.3.3
- add the 0.3.3 changelog section for slash command popup and /feedback, ESC and keyboard improvements, ask_user dialog updates, and PTY/cwd fixes

## Validation

- make packaging-test
- cargo test --workspace --quiet
- make format-check
- make lint
- make build-bundle
- local bundle install smoke with staging root
- python3 packaging/scripts/release_metadata.py --expected-version v0.3.3 --print-json
- installed bundle binary: aish --version

## Risk

- full two-arch bundle validation, live smoke, and final publish still depend on the GitHub Actions release workflows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added slash-command suggestion UI
  * Added built-in `/feedback` command

* **Improvements**
  * Enhanced keyboard and dialog handling with ESC key support
  * Improved dialog interaction flow

* **Bug Fixes**
  * Fixed prompt interaction issues
  * Fixed command suggestion popup positioning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->