### PR TITLE
feat: enrich feedback template with bug report sections

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback_auto.md
+++ b/.github/ISSUE_TEMPLATE/feedback_auto.md
@@ -1,0 +1,22 @@
+---
+name: Auto feedback
+description: Auto-generated issue from /feedback command
+title: "[Bug]: "
+labels: []
+---
+
+## Summary
+
+
+
+## Environment
+
+- AISH version:
+- Operating system:
+- AI Model / Provider:
+
+## Logs
+
+```
+
+```

--- a/.github/ISSUE_TEMPLATE/feedback_auto.md
+++ b/.github/ISSUE_TEMPLATE/feedback_auto.md
@@ -9,6 +9,20 @@ labels: []
 
 
 
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+
+
+## Actual behavior
+
+
+
 ## Environment
 
 - AISH version:

--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -149,7 +149,23 @@ shell:
     plan: "Planmodus steuern"
     token: "Token-Nutzung anzeigen"
     resume: "Vorherige Sitzung fortsetzen"
-    feedback: "GitHub Issues öffnen"
+    feedback: "Feedback geben"
+
+  feedback:
+    select_type: "Feedback-Typ auswählen"
+    type_bug: "Fehlerbericht"
+    type_feature: "Feature-Wunsch"
+    type_question: "Frage"
+    confirm_title: "Gesammelte Informationen überprüfen"
+    confirm_question: "Die folgenden Informationen werden an das Issue angehängt. Protokolle können sensible Daten enthalten."
+    confirm: "Bestätigen und öffnen"
+    without_logs: "Ohne Protokolle öffnen"
+    cancel: "Abbrechen"
+    opening: "GitHub Issue wird geöffnet..."
+    failed: "Browser konnte nicht geöffnet werden: {error}"
+    visit: "Besuchen: {url}"
+    log_unavailable: "(Protokolldatei nicht gefunden)"
+    logs_included: "enthalten (letzte 30 Zeilen, bereinigt)"
 
   security:
     panel_title:

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -329,7 +329,23 @@ shell:
     plan: "Plan mode control"
     token: "Show token usage"
     resume: "Resume previous session"
-    feedback: "Open GitHub Issues"
+    feedback: "Submit feedback"
+
+  feedback:
+    select_type: "Select feedback type"
+    type_bug: "Bug Report"
+    type_feature: "Feature Request"
+    type_question: "Question"
+    confirm_title: "Review collected information"
+    confirm_question: "The following information will be attached to the issue. Logs may contain sensitive information."
+    confirm: "Confirm and open"
+    without_logs: "Open without logs"
+    cancel: "Cancel"
+    opening: "Opening GitHub Issue..."
+    failed: "Failed to open browser: {error}"
+    visit: "Visit: {url}"
+    log_unavailable: "(log file not found)"
+    logs_included: "included (last 30 lines, redacted)"
 
   # Model switching
   model_usage: "Usage: /model [model-name]"

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -149,7 +149,23 @@ shell:
     plan: "Control del modo plan"
     token: "Mostrar uso de tokens"
     resume: "Reanudar sesión anterior"
-    feedback: "Abrir GitHub Issues"
+    feedback: "Enviar comentarios"
+
+  feedback:
+    select_type: "Seleccionar tipo de comentario"
+    type_bug: "Informe de error"
+    type_feature: "Solicitud de función"
+    type_question: "Pregunta"
+    confirm_title: "Revisar información recopilada"
+    confirm_question: "La siguiente información se adjuntará al issue. Los registros pueden contener información sensible."
+    confirm: "Confirmar y abrir"
+    without_logs: "Abrir sin registros"
+    cancel: "Cancelar"
+    opening: "Abriendo GitHub Issue..."
+    failed: "No se pudo abrir el navegador: {error}"
+    visit: "Visitar: {url}"
+    log_unavailable: "(archivo de registro no encontrado)"
+    logs_included: "incluidos (últimas 30 líneas, redactados)"
 
   security:
     panel_title:

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -149,7 +149,23 @@ shell:
     plan: "Contrôle du mode plan"
     token: "Afficher l'utilisation des tokens"
     resume: "Reprendre la session précédente"
-    feedback: "Ouvrir les Issues GitHub"
+    feedback: "Envoyer un commentaire"
+
+  feedback:
+    select_type: "Sélectionner le type de commentaire"
+    type_bug: "Rapport de bug"
+    type_feature: "Demande de fonctionnalité"
+    type_question: "Question"
+    confirm_title: "Vérifier les informations collectées"
+    confirm_question: "Les informations suivantes seront jointes à l'issue. Les journaux peuvent contenir des informations sensibles."
+    confirm: "Confirmer et ouvrir"
+    without_logs: "Ouvrir sans les journaux"
+    cancel: "Annuler"
+    opening: "Ouverture du GitHub Issue..."
+    failed: "Impossible d'ouvrir le navigateur : {error}"
+    visit: "Visiter : {url}"
+    log_unavailable: "(fichier journal introuvable)"
+    logs_included: "inclus (30 dernières lignes, expurgés)"
 
   security:
     panel_title:

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -149,7 +149,23 @@ shell:
     plan: "プランモードの制御"
     token: "トークン使用量を表示"
     resume: "前回のセッションを再開"
-    feedback: "GitHub Issues を開く"
+    feedback: "フィードバックを送信"
+
+  feedback:
+    select_type: "フィードバックの種類を選択"
+    type_bug: "バグ報告"
+    type_feature: "機能リクエスト"
+    type_question: "質問"
+    confirm_title: "収集した情報を確認"
+    confirm_question: "以下の情報が Issue に添付されます。ログには機密情報が含まれる場合があります。"
+    confirm: "確認して開く"
+    without_logs: "ログなしで開く"
+    cancel: "キャンセル"
+    opening: "GitHub Issue を開いています..."
+    failed: "ブラウザを開けませんでした: {error}"
+    visit: "アクセス: {url}"
+    log_unavailable: "（ログファイルが見つかりません）"
+    logs_included: "含まれる（最後の30行、秘匿済み）"
 
   security:
     panel_title:

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -329,7 +329,23 @@ shell:
     plan: "计划模式控制"
     token: "显示令牌用量"
     resume: "恢复之前的会话"
-    feedback: "打开 GitHub Issues"
+    feedback: "提交反馈"
+
+  feedback:
+    select_type: "选择反馈类型"
+    type_bug: "Bug 报告"
+    type_feature: "功能建议"
+    type_question: "问题咨询"
+    confirm_title: "确认收集的信息"
+    confirm_question: "以下信息将附加到 Issue 中。日志可能包含敏感信息。"
+    confirm: "确认并打开"
+    without_logs: "不包含日志直接打开"
+    cancel: "取消"
+    opening: "正在打开 GitHub Issue..."
+    failed: "无法打开浏览器: {error}"
+    visit: "访问: {url}"
+    log_unavailable: "（未找到日志文件）"
+    logs_included: "已包含（最近 30 行，已脱敏）"
 
   # 模型切换
   model_usage: "用法: /model [模型名称]"

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -2038,12 +2038,7 @@ impl AishShell {
                 return false;
             }
             Some("/feedback") => {
-                let url = "https://github.com/AI-Shell-Team/aish/issues";
-                println!("Opening GitHub Issues...");
-                if let Err(e) = open::that(url) {
-                    eprintln!("Failed to open browser: {e}");
-                    println!("Visit: {url}");
-                }
+                crate::feedback::run_feedback(&self.config.model, &self.config.api_base);
             }
             _ => {
                 eprintln!("{}", {

--- a/crates/aish-shell/src/feedback.rs
+++ b/crates/aish-shell/src/feedback.rs
@@ -1,0 +1,430 @@
+//! Interactive feedback command: collect system info and open a pre-filled GitHub issue.
+
+use std::path::PathBuf;
+
+use aish_i18n::{t, t_with_args};
+use aish_llm::provider::detect_provider_from_model;
+use inquire::Select;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Feedback category selected by the user.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FeedbackType {
+    Bug,
+    Feature,
+    Question,
+}
+
+impl FeedbackType {
+    fn title_prefix(&self) -> &'static str {
+        match self {
+            Self::Bug => "[Bug]: ",
+            Self::Feature => "[Feature]: ",
+            Self::Question => "[Question]: ",
+        }
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Bug => "bug",
+            Self::Feature => "enhancement",
+            Self::Question => "",
+        }
+    }
+}
+
+/// Collected system environment information for the GitHub issue body.
+struct SystemInfo {
+    version: String,
+    os: String,
+    model: String,
+    provider: String,
+    logs: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// System info collection
+// ---------------------------------------------------------------------------
+
+/// Gather aish version, OS info, AI model/provider, and recent log lines.
+fn collect_system_info(model: &str, api_base: &str) -> SystemInfo {
+    let version = env!("CARGO_PKG_VERSION").to_string();
+
+    let os = {
+        use sysinfo::System;
+        let name = System::name().unwrap_or_else(|| "Unknown".into());
+        let kernel = System::kernel_version().unwrap_or_else(|| "unknown".into());
+        format!("{} {}", name, kernel)
+    };
+
+    let provider_info = detect_provider_from_model(model);
+    let provider = if api_base.is_empty() {
+        provider_info.display_name
+    } else {
+        aish_llm::provider::detect_provider(model, api_base).display_name
+    };
+
+    let logs = read_recent_logs(30);
+
+    SystemInfo {
+        version,
+        os,
+        model: model.to_string(),
+        provider,
+        logs,
+    }
+}
+
+/// Read the last `max_lines` lines from the log file without loading the
+/// entire file into memory. Uses seek-to-end + backward byte scan.
+/// Read the last `max_lines` lines from the aish log file, with sensitive data redacted.
+fn read_recent_logs(max_lines: usize) -> Option<String> {
+    let log_path = log_file_path()?;
+    let content = std::fs::read_to_string(&log_path).ok()?;
+    let lines: Vec<&str> = content.lines().collect();
+    if lines.is_empty() {
+        return None;
+    }
+    let start = lines.len().saturating_sub(max_lines);
+    let mut selected: Vec<String> = lines[start..].iter().map(|s| s.to_string()).collect();
+    redact_sensitive_lines_owned(&mut selected);
+    Some(selected.join("\n"))
+}
+
+/// Resolve the aish log file path under the user's config directory.
+fn log_file_path() -> Option<PathBuf> {
+    let config_dir = dirs::config_dir()?;
+    let path = config_dir.join("aish").join("logs").join("aish.log");
+    if path.exists() {
+        return Some(path);
+    }
+    None
+}
+
+/// Replace any line containing sensitive keywords with `[REDACTED]`.
+fn redact_sensitive_lines_owned(lines: &mut [String]) {
+    let sensitive_patterns = [
+        "api_key",
+        "apikey",
+        "token",
+        "secret",
+        "password",
+        "authorization",
+        "bearer",
+    ];
+    for line in lines.iter_mut() {
+        let lower = line.to_lowercase();
+        for pattern in &sensitive_patterns {
+            if lower.contains(pattern) {
+                *line = "[REDACTED]".to_string();
+                break;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// URL generation
+// ---------------------------------------------------------------------------
+
+/// Maximum URL length to stay within browser/GitHub limits.
+const MAX_URL_LEN: usize = 7168;
+
+/// Build a GitHub issue URL with template, title, labels, and pre-filled body.
+/// Automatically strips logs if the URL exceeds `MAX_URL_LEN`.
+fn generate_issue_url(
+    feedback_type: FeedbackType,
+    info: &SystemInfo,
+    include_logs: bool,
+) -> String {
+    let mut params = Vec::new();
+
+    params.push("template=feedback_auto.md".to_string());
+    params.push(format!(
+        "title={}{}",
+        feedback_type.title_prefix(),
+        percent_encode_str("<describe your issue>")
+    ));
+
+    let label = feedback_type.label();
+    if !label.is_empty() {
+        params.push(format!("labels={}", label));
+    }
+
+    // Try with logs first, strip if URL too long
+    let body = build_body(info, include_logs);
+    params.push(format!("body={}", percent_encode_str(&body)));
+
+    let url = format!(
+        "https://github.com/AI-Shell-Team/aish/issues/new?{}",
+        params.join("&")
+    );
+
+    if url.len() > MAX_URL_LEN && include_logs {
+        return generate_issue_url(feedback_type, info, false);
+    }
+
+    url
+}
+
+/// Compose the Markdown body for the GitHub issue with environment info and optional logs.
+fn build_body(info: &SystemInfo, include_logs: bool) -> String {
+    let mut body = String::from("## Summary\n\n");
+    body.push_str("## Environment\n");
+    body.push_str(&format!("- AISH version: {}\n", info.version));
+    body.push_str(&format!("- Operating system: {}\n", info.os));
+    body.push_str(&format!(
+        "- AI Model / Provider: {} / {}\n",
+        info.model, info.provider
+    ));
+
+    if include_logs {
+        if let Some(ref logs) = info.logs {
+            body.push_str("\n## Logs\n```shell\n");
+            body.push_str(logs);
+            body.push_str("\n```\n");
+        }
+    }
+
+    body
+}
+
+/// Percent-encode a string for use in a URL query parameter.
+fn percent_encode_str(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    for byte in s.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                result.push(byte as char);
+            }
+            b' ' => result.push('+'),
+            _ => {
+                result.push('%');
+                result.push_str(&format!("{:02X}", byte));
+            }
+        }
+    }
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/// Run the interactive feedback wizard.
+pub fn run_feedback(model: &str, api_base: &str) {
+    let feedback_type = match select_feedback_type() {
+        Some(ft) => ft,
+        None => return,
+    };
+
+    let info = collect_system_info(model, api_base);
+
+    let include_logs = match confirm_and_review(&info) {
+        ConfirmAction::Confirm => true,
+        ConfirmAction::WithoutLogs => false,
+        ConfirmAction::Cancel => return,
+    };
+
+    let url = generate_issue_url(feedback_type, &info, include_logs);
+    println!("{}", t("shell.feedback.opening"));
+    if let Err(e) = open::that(&url) {
+        let mut args = std::collections::HashMap::new();
+        args.insert("error".to_string(), e.to_string());
+        eprintln!("{}", t_with_args("shell.feedback.failed", &args));
+        let mut visit_args = std::collections::HashMap::new();
+        visit_args.insert("url".to_string(), url);
+        println!("{}", t_with_args("shell.feedback.visit", &visit_args));
+    }
+}
+
+/// User's choice after reviewing collected system info.
+enum ConfirmAction {
+    Confirm,
+    WithoutLogs,
+    Cancel,
+}
+
+/// Prompt the user to select a feedback type (Bug / Feature / Question).
+fn select_feedback_type() -> Option<FeedbackType> {
+    let bug = t("shell.feedback.type_bug");
+    let feature = t("shell.feedback.type_feature");
+    let question = t("shell.feedback.type_question");
+
+    let items = vec![bug.clone(), feature.clone(), question.clone()];
+
+    let result = Select::new(&t("shell.feedback.select_type"), items).prompt_skippable();
+
+    match result {
+        Ok(Some(sel)) => {
+            if sel == bug {
+                Some(FeedbackType::Bug)
+            } else if sel == feature {
+                Some(FeedbackType::Feature)
+            } else if sel == question {
+                Some(FeedbackType::Question)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Show collected system info and ask the user to confirm, exclude logs, or cancel.
+fn confirm_and_review(info: &SystemInfo) -> ConfirmAction {
+    let confirm_label = t("shell.feedback.confirm");
+    let without_logs_label = t("shell.feedback.without_logs");
+    let cancel_label = t("shell.feedback.cancel");
+
+    let logs_status = if info.logs.is_some() {
+        t("shell.feedback.logs_included")
+    } else {
+        t("shell.feedback.log_unavailable")
+    };
+
+    let review = format!(
+        "aish version: {}\nOS: {}\nAI Model: {}\nProvider: {}\nLogs: {}",
+        info.version, info.os, info.model, info.provider, logs_status
+    );
+
+    let prompt_text = format!("{}\n{}", t("shell.feedback.confirm_question"), review);
+
+    let items = vec![
+        confirm_label.clone(),
+        without_logs_label.clone(),
+        cancel_label,
+    ];
+
+    let result = Select::new(&prompt_text, items).prompt_skippable();
+
+    match result {
+        Ok(Some(sel)) => {
+            if sel == confirm_label {
+                ConfirmAction::Confirm
+            } else if sel == without_logs_label {
+                ConfirmAction::WithoutLogs
+            } else {
+                ConfirmAction::Cancel
+            }
+        }
+        _ => ConfirmAction::Cancel,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_percent_encode_basic() {
+        assert_eq!(percent_encode_str("hello"), "hello");
+        assert_eq!(percent_encode_str("hello world"), "hello+world");
+        assert_eq!(percent_encode_str("a=b&c=d"), "a%3Db%26c%3Dd");
+    }
+
+    #[test]
+    fn test_percent_encode_special_chars() {
+        assert_eq!(percent_encode_str("!@#$%"), "%21%40%23%24%25");
+        assert_eq!(percent_encode_str("newline\n"), "newline%0A");
+    }
+
+    #[test]
+    fn test_redact_sensitive_lines() {
+        let mut lines = vec![
+            "normal log line".to_string(),
+            "setting api_key=sk-abc123".to_string(),
+            "another normal line".to_string(),
+            "Authorization: Bearer token123".to_string(),
+            "my secret value".to_string(),
+        ];
+        redact_sensitive_lines_owned(&mut lines);
+        assert_eq!(lines[0], "normal log line");
+        assert_eq!(lines[1], "[REDACTED]");
+        assert_eq!(lines[2], "another normal line");
+        assert_eq!(lines[3], "[REDACTED]");
+        assert_eq!(lines[4], "[REDACTED]");
+    }
+
+    #[test]
+    fn test_generate_issue_url_structure() {
+        let info = SystemInfo {
+            version: "0.3.3".to_string(),
+            os: "Linux 6.12".to_string(),
+            model: "test-model".to_string(),
+            provider: "TestProvider".to_string(),
+            logs: None,
+        };
+
+        let url = generate_issue_url(FeedbackType::Bug, &info, false);
+        assert!(url.starts_with("https://github.com/AI-Shell-Team/aish/issues/new?"));
+        assert!(url.contains("template=feedback_auto.md"));
+        assert!(url.contains("labels=bug"));
+        assert!(url.contains("title="));
+        assert!(url.contains("body="));
+        assert!(url.contains("AISH+version%3A+0.3.3"));
+
+        let url = generate_issue_url(FeedbackType::Feature, &info, false);
+        assert!(url.contains("labels=enhancement"));
+
+        let url = generate_issue_url(FeedbackType::Question, &info, false);
+        assert!(!url.contains("labels="));
+    }
+
+    #[test]
+    fn test_url_length_limit_strips_logs() {
+        let big_logs = "x".repeat(10000);
+        let info = SystemInfo {
+            version: "0.3.3".to_string(),
+            os: "Linux".to_string(),
+            model: "test".to_string(),
+            provider: "Test".to_string(),
+            logs: Some(big_logs),
+        };
+
+        let url = generate_issue_url(FeedbackType::Bug, &info, true);
+        assert!(url.len() <= MAX_URL_LEN);
+        assert!(!url.contains(&"x".repeat(100)));
+    }
+
+    #[test]
+    fn test_build_body_contains_env_info() {
+        let info = SystemInfo {
+            version: "0.3.3".to_string(),
+            os: "Linux 6.12".to_string(),
+            model: "claude-sonnet".to_string(),
+            provider: "Anthropic".to_string(),
+            logs: Some("line1\nline2".to_string()),
+        };
+
+        let body = build_body(&info, true);
+        assert!(body.contains("AISH version: 0.3.3"));
+        assert!(body.contains("Operating system: Linux 6.12"));
+        assert!(body.contains("AI Model / Provider: claude-sonnet / Anthropic"));
+        assert!(body.contains("## Logs"));
+        assert!(body.contains("line1\nline2"));
+        // No excessive blank lines
+        assert!(!body.contains("\n\n\n"));
+    }
+
+    #[test]
+    fn test_build_body_without_logs() {
+        let info = SystemInfo {
+            version: "0.3.3".to_string(),
+            os: "Linux".to_string(),
+            model: "test".to_string(),
+            provider: "Test".to_string(),
+            logs: Some("secret stuff".to_string()),
+        };
+
+        let body = build_body(&info, false);
+        assert!(!body.contains("## Logs"));
+    }
+}

--- a/crates/aish-shell/src/feedback.rs
+++ b/crates/aish-shell/src/feedback.rs
@@ -173,6 +173,9 @@ fn generate_issue_url(
 /// Compose the Markdown body for the GitHub issue with environment info and optional logs.
 fn build_body(info: &SystemInfo, include_logs: bool) -> String {
     let mut body = String::from("## Summary\n\n");
+    body.push_str("## Steps to reproduce\n\n1.\n2.\n3.\n\n");
+    body.push_str("## Expected behavior\n\n");
+    body.push_str("## Actual behavior\n\n");
     body.push_str("## Environment\n");
     body.push_str(&format!("- AISH version: {}\n", info.version));
     body.push_str(&format!("- Operating system: {}\n", info.os));
@@ -405,6 +408,10 @@ mod tests {
         };
 
         let body = build_body(&info, true);
+        assert!(body.contains("## Summary"));
+        assert!(body.contains("## Steps to reproduce"));
+        assert!(body.contains("## Expected behavior"));
+        assert!(body.contains("## Actual behavior"));
         assert!(body.contains("AISH version: 0.3.3"));
         assert!(body.contains("Operating system: Linux 6.12"));
         assert!(body.contains("AI Model / Provider: claude-sonnet / Anthropic"));

--- a/crates/aish-shell/src/lib.rs
+++ b/crates/aish-shell/src/lib.rs
@@ -22,6 +22,7 @@ pub mod commands;
 pub mod environment;
 pub mod esc_watcher;
 pub mod expand_history;
+pub mod feedback;
 pub mod image;
 pub mod input;
 pub mod keyboard;

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -29,7 +29,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/plan", "Plan mode control"),
     ("/token", "Show token usage"),
     ("/resume", "Resume previous session"),
-    ("/feedback", "Open GitHub Issues"),
+    ("/feedback", "Submit feedback"),
 ];
 
 /// Timeout for PTY completion queries.


### PR DESCRIPTION
## Summary

- Enrich `feedback_auto.md` template with structured sections matching `bug_report.yml`: Steps to reproduce, Expected behavior, Actual behavior
- Update `build_body()` in `feedback.rs` to auto-generate body with these placeholder sections
- Environment info (version, OS, model/provider) and logs are still auto-filled; user fills in the bug details

## User-visible Changes

- `/feedback` auto-generated GitHub issue now contains placeholder sections for Steps to reproduce, Expected behavior, and Actual behavior, matching the structure of the manual bug report form

## Compatibility

- No breaking changes. Only extends the existing template and auto-generated body.

## Testing

- [x] `cargo test -p aish-shell --lib -- feedback` — 7/7 passed
- [x] `cargo clippy -p aish-shell --all-targets -- -D warnings` — clean

## Change Type

- [x] Enhancement

## Scope

- `.github/ISSUE_TEMPLATE/feedback_auto.md`
- `crates/aish-shell/src/feedback.rs` (build_body + test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `/feedback` command now provides an interactive feedback submission wizard.
  * Users can select feedback type (bug, feature request, or question).
  * Optional automatic log inclusion with sensitive information redacted.
  * Pre-filled GitHub issues are created and opened directly in your browser.
  * Expanded localization support with detailed messages across all languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->