### PR TITLE
feat: enrich feedback template with bug report sections

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback_auto.md
+++ b/.github/ISSUE_TEMPLATE/feedback_auto.md
@@ -9,6 +9,20 @@ labels: []
 
 
 
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+
+
+## Actual behavior
+
+
+
 ## Environment
 
 - AISH version:

--- a/crates/aish-shell/src/feedback.rs
+++ b/crates/aish-shell/src/feedback.rs
@@ -173,6 +173,9 @@ fn generate_issue_url(
 /// Compose the Markdown body for the GitHub issue with environment info and optional logs.
 fn build_body(info: &SystemInfo, include_logs: bool) -> String {
     let mut body = String::from("## Summary\n\n");
+    body.push_str("## Steps to reproduce\n\n1.\n2.\n3.\n\n");
+    body.push_str("## Expected behavior\n\n");
+    body.push_str("## Actual behavior\n\n");
     body.push_str("## Environment\n");
     body.push_str(&format!("- AISH version: {}\n", info.version));
     body.push_str(&format!("- Operating system: {}\n", info.os));
@@ -405,6 +408,10 @@ mod tests {
         };
 
         let body = build_body(&info, true);
+        assert!(body.contains("## Summary"));
+        assert!(body.contains("## Steps to reproduce"));
+        assert!(body.contains("## Expected behavior"));
+        assert!(body.contains("## Actual behavior"));
         assert!(body.contains("AISH version: 0.3.3"));
         assert!(body.contains("Operating system: Linux 6.12"));
         assert!(body.contains("AI Model / Provider: claude-sonnet / Anthropic"));


### PR DESCRIPTION
## Summary

- Enrich `feedback_auto.md` template with structured sections matching `bug_report.yml`: Steps to reproduce, Expected behavior, Actual behavior
- Update `build_body()` in `feedback.rs` to auto-generate body with these placeholder sections
- Environment info (version, OS, model/provider) and logs are still auto-filled; user fills in the bug details

## User-visible Changes

- `/feedback` auto-generated GitHub issue now contains placeholder sections for Steps to reproduce, Expected behavior, and Actual behavior, matching the structure of the manual bug report form

## Compatibility

- No breaking changes. Only extends the existing template and auto-generated body.

## Testing

- [x] `cargo test -p aish-shell --lib -- feedback` — 7/7 passed
- [x] `cargo clippy -p aish-shell --all-targets -- -D warnings` — clean

## Change Type

- [x] Enhancement

## Scope

- `.github/ISSUE_TEMPLATE/feedback_auto.md`
- `crates/aish-shell/src/feedback.rs` (build_body + test)