### PR TITLE
feat: ESC key support, slash popup, /help & /quit commands

### DIFF
--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -144,12 +144,14 @@ shell:
     skills_loaded_suffix: " geladen"
 
   slash:
+    help: "Hilfeinformationen anzeigen"
     model: "KI-Modell anzeigen oder wechseln"
     setup: "Setup-Assistenten öffnen"
     plan: "Planmodus steuern"
     token: "Token-Nutzung anzeigen"
     resume: "Vorherige Sitzung fortsetzen"
     feedback: "Feedback geben"
+    quit: "AI Shell beenden"
 
   feedback:
     select_type: "Feedback-Typ auswählen"
@@ -353,9 +355,25 @@ security:
 
 tools:
   ask_user:
+    description: "Stellt dem Benutzer eine gezielte Rückfrage. Nur mit prompt wird Texteingabe verwendet; mit options werden Auswahlmöglichkeiten angeboten."
     unknown_kind: "Unbekannter Typ: {kind}"
     runtime_not_configured: "ask_user-Laufzeit ist nicht konfiguriert"
     execute_failed: "ask_user fehlgeschlagen: {error}"
+    param:
+      kind: "Interaktionstyp: text_input für freie Eingabe, choice_or_text für Auswahl mit eigener Eingabe"
+      prompt: "Die Frage, die dem Benutzer gestellt wird."
+      options: "Optionale Auswahlmöglichkeiten. Wenn sie fehlen oder leer sind, verwendet ask_user Texteingabe."
+      option_value: "Stabiler Optionswert in den Tool-Metadaten."
+      option_label: "Für den Benutzer sichtbare Bezeichnung in der Auswahlliste."
+      option_description: "Optionale Zusatzbeschreibung unterhalb der Option."
+      option_recommended: "Markiert diese Option sichtbar als empfohlene Vorgabe."
+      title: "Optionaler Titel für die Frage"
+      default: "Standardwert"
+      placeholder: "Platzhaltertext"
+      allow_freeform_input: "Erlaubt bei vorhandenen Optionen eine benutzerdefinierte Antwort. Standard ist true."
+      required: "Ob der Benutzer eine Antwort geben muss (Standard: true)"
+      allow_cancel: "Ob der Benutzer abbrechen/überspringen darf (Standard: true)"
+      min_length: "Minimale Länge für Texteingabe (Standard: 0)"
     validation:
       prompt_empty: "prompt darf nicht leer sein"
       option_value_empty: "option value darf nicht leer sein"
@@ -390,54 +408,269 @@ help:
     notes: "Hinweise"
     brief_usage: "Verwendung: {usage}"
   general:
-    title: "📖 AI Shell Hilfe"
+    title: "AI Shell Hilfe"
     markdown: |-
-      ## Verfügbare Befehle:
+      ## Schnellstart
+      - **Shell-Befehle** — direkt eingeben: `ls`, `cd`, `vim`, `ssh`, `top` …
+      - **KI fragen** — mit `;` beginnen: `;wie finde ich große Dateien`
+      - **Slash-Befehle** — `/` in leerer Zeile drückt für interaktive Auswahl
 
-      ### Verzeichnisnavigation
-      - `cd [-L|[-P [-e]]] [directory]` - Verzeichnis mit vollständiger Parameterunterstützung wechseln
-      - `pushd [directory]` - Verzeichnis auf den Stapel legen
-      - `popd` - Verzeichnis vom Stapel nehmen
-      - `dirs [-c]` - Verzeichnisstapel anzeigen
+      ## Slash-Befehle
+      | Befehl | Beschreibung |
+      |--------|--------------|
+      | `/help [page]` | Hilfe anzeigen (`/help` für Seiten) |
+      | `/quit` | AI Shell beenden |
+      | `/model [Name]` | KI-Modell anzeigen oder wechseln |
+      | `/setup` | API-Einstellungen neu konfigurieren |
+      | `/plan [start\|status\|exit]` | Planmodus steuern |
+      | `/token` | Token-Nutzung anzeigen (letzte 7 Tage) |
+      | `/resume [id]` | Vorherige Sitzung fortsetzen |
+      | `/feedback` | Feedback geben oder Fehler melden |
 
-      ### Verlauf
-      - `history [options] [n]` - Befehlsverlauf anzeigen
-      - `history -c` - Verlauf löschen
-      - `history -d offset` - Verlaufseintrag löschen
+      ## Konfiguration
+      - Konfigurationsdatei: `~/.config/aish/config.yaml`
+      - Priorität: CLI-Argumente > Umgebungsvariablen (`AISH_MODEL`, `AISH_API_KEY`, `AISH_API_BASE`) > Konfigurationsdatei
+      - `/setup` oder `aish setup` für interaktive Konfiguration
 
-      ### Umgebungsvariablen
-      - `export [-fn] [name[=value] ...]` - Umgebungsvariablen setzen oder exportieren
-      - `export -p` - Exportierte Variablen anzeigen
-      - `unset [-fv] [name ...]` - Umgebungsvariablen entfernen
-      - `pwd [-L|-P]` - Aktuelles Arbeitsverzeichnis ausgeben
+      ## Tastenkombinationen
+      | Taste | Aktion |
+      |-------|--------|
+      | `Ctrl+C` | Aktuellen Vorgang abbrechen (zweimal zum Beenden) |
+      | `Ctrl+D` | Shell beenden |
+      | `Shift+Tab` / `F2` | Planmodus umschalten |
+      | `Ctrl+O` | Ausgabeverlauf durchsuchen |
+      | `/` in leerer Zeile | Slash-Befehlsauswahl |
 
-      ### Allgemeine Befehle
-      - `help` - Diese Hilfe anzeigen
-      - `clear` - Bildschirm löschen
-      - `exit` - Shell beenden
-      - `/model [model]` - Modell anzeigen oder wechseln
-      - `/setup` - API-Einstellungen neu konfigurieren
+      ## Hilfeseiten
+      `/help <page>` für Details zu aish-spezifischen Funktionen:
 
-      ### KI-Befehle
-      - `; <question>` - Den KI-Assistenten fragen
+      | Seite | Inhalt |
+      |-------|--------|
+      | `ai` | KI-Assistent (`;`-Präfix, Kontext, Gespräch) |
+      | `model` | Modellverwaltung (anzeigen, wechseln, Anbieter) |
+      | `plan` | Planmodus (Workflow, Genehmigung, vs. Normalmodus) |
+      | `config` | Konfiguration (Dateien, Umgebungsvariablen, Priorität) |
+      | `shortcuts` | Tastenkombinationen (Bearbeitung, Steuerung, Moduswechsel) |
+      | `security` | Sicherheitsrichtlinie (Risikostufen, Regeln, Erkennung) |
 
-      ### Funktionen
-      - ✅ Vollständige PTY-Unterstützung für alle Befehle
-      - ✅ Befehlsverlauf und KI-Kontextintegration
-      - ✅ Umfangreiche Terminalausgabe für KI-Antworten
-      - ✅ Signalbehandlung und sauberes Aufräumen
+      ## Mehr
+      - Sicherheitsrichtlinie: `~/.config/aish/security_policy.yaml`
+      - Sitzungsdaten: `~/.local/share/aish/sessions.db`
+      - Protokolle: `~/.config/aish/logs/aish.log`
+      - Dokumentation: https://github.com/AI-Shell-Team/aish
 
-      ### Weitere Hilfe
-      Verwenden Sie `<command> --help` oder `<command> -h`, um die detaillierte Hilfe für einen beliebigen Befehl anzuzeigen.
+  topics:
+    unknown: "Unbekannte Hilfeseite '{topic}'. Verfügbare Seiten: ai, model, plan, config, shortcuts, security"
 
-      ### Beispiele
-      ```bash
-      history --help       # Detaillierte Hilfe zu history anzeigen
-      cd --help            # Detaillierte Hilfe zu cd anzeigen
-      export JAVA_HOME="/usr/lib/jvm/java-11"  # Umgebungsvariable setzen
-      unset TEMP_VAR       # Umgebungsvariable entfernen
-      ; erkläre ls -la     # KI um Erklärung eines Befehls bitten
-      ```
+    ai:
+      title: "KI-Assistent"
+      markdown: |-
+        ## KI fragen
+
+        Stellen Sie Ihre Frage mit `;` (Semikolon) oder `；` (vollbreites Semikolon) als Präfix:
+
+        ```
+        ; Wie finde ich große Dateien?
+        ; Erkläre diesen Befehl: ls -la
+        ; Schlage eine bessere Komprimierungsmethode vor
+        ```
+
+        Die KI sieht Ihren Gesprächskontext, einschließlich vorheriger Shell-Befehle und KI-Antworten.
+
+        ## Funktionsweise
+
+        - Ihre Frage wird an das konfigurierte LLM-Modell gesendet
+        - Die KI erhält den Gesprächsverlauf als Kontext
+        - Antworten werden mit Syntaxhervorhebung und Tabellenformatierung angezeigt
+
+        ## Kontextverwaltung
+
+        - Der Gesprächsverlauf wird automatisch verwaltet
+        - Bei Überschreitung des Token-Budgets wird der Kontext automatisch komprimiert
+        - Ältere Nachrichten werden zusammengefasst, um den aktuellen Kontext zu erhalten
+
+    model:
+      title: "Modellverwaltung"
+      markdown: |-
+        ## Modell anzeigen & wechseln
+
+        ```
+        /model                    # Aktuelles Modell anzeigen
+        /model gpt-4o             # Zu GPT-4o wechseln
+        /model claude-sonnet-4-6  # Zu Claude wechseln
+        ```
+
+        ## Unterstützte Anbieter
+
+        | Anbieter | Modellpräfix |
+        |----------|-------------|
+        | OpenAI | `gpt-*`, `o1-*`, `o3-*`, `o4-*` |
+        | Anthropic | `claude-*` |
+        | Google | `gemini-*`, `gemma-*` |
+        | DeepSeek | `deepseek-*` |
+        | Qwen | `qwen-*`, `qwq-*` |
+        | Mistral | `mistral-*`, `mixtral-*`, `codestral-*` |
+        | xAI | `grok-*` |
+        | Moonshot | `kimi-*`, `moonshot-*` |
+        | Zhipu | `glm-*` |
+        | Lokal | Ollama, vLLM, lokale API |
+
+        ## Wechselverhalten
+
+        - Anbieter wird automatisch anhand des Modellnamens erkannt
+        - Konnektivität wird vor dem Wechsel überprüft
+        - Bei Fehler bleibt das aktuelle Modell bestehen
+        - Konfiguration wird automatisch in `~/.config/aish/config.yaml` gespeichert
+
+    plan:
+      title: "Planmodus"
+      markdown: |-
+        ## Was ist der Planmodus?
+
+        Im Planmodus analysiert die KI Ihre Codebasis und erstellt einen detaillierten Implementierungsplan, bevor Code geschrieben wird. Änderungen werden erst nach Ihrer Genehmigung angewendet.
+
+        ## Befehle
+
+        ```
+        /plan start     # Planmodus starten
+        /plan status    # Aktuellen Planstatus anzeigen
+        /plan exit      # Planmodus beenden
+        ```
+
+        Sie können den Planmodus auch mit `Shift+Tab` oder `F2` umschalten.
+
+        ## Verwendung
+
+        1. Planmodus starten: `/plan start`
+        2. KI um Plan bitten: `; Auth-Modul auf JWT umstellen`
+        3. KI erstellt einen Plan mit Schritten und Dateiänderungen
+        4. Plan prüfen und jeden Schritt genehmigen oder ablehnen
+        5. Nach Genehmigung werden Änderungen angewendet
+        6. Planmodus beenden: `/plan exit`
+
+        ## Planmodus vs. Normalmodus
+
+        | | Normalmodus | Planmodus |
+        |---|---|---|
+        | KI-Tools | Voller Zugriff | Schreibgeschützt + Plan erstellen |
+        | Codeänderungen | Sofort | Nach Genehmigung |
+        | Geeignet für | Schnelle Fixes, Fragen | Refactoring, neue Funktionen |
+
+    config:
+      title: "Konfiguration"
+      markdown: |-
+        ## Konfigurationsdatei
+
+        Speicherort: `~/.config/aish/config.yaml`
+
+        Kann mit `$AISH_CONFIG_DIR` oder `$XDG_CONFIG_HOME` überschrieben werden.
+
+        ## Priorität
+
+        Kommandozeilenargumente > Umgebungsvariablen > Konfigurationsdatei
+
+        ## Umgebungsvariablen
+
+        | Variable | Zweck |
+        |----------|-------|
+        | `AISH_MODEL` | Standardmodell überschreiben |
+        | `AISH_API_KEY` | API-Schlüssel überschreiben |
+        | `AISH_API_BASE` | API-Basis-URL überschreiben |
+        | `AISH_CONFIG_DIR` | Konfigurationsverzeichnis überschreiben |
+
+        ## Wichtige Einstellungen
+
+        ```
+        model: gpt-4o                    # Standard-KI-Modell
+        api_key: sk-xxx                  # API-Schlüssel
+        api_base: https://api.openai.com/v1  # API-Endpunkt
+        temperature: 0.3                 # Antwort-Zufälligkeit
+        theme: dark                      # UI-Theme (dark/light)
+        output_language: de              # Ausgabesprache erzwingen
+        ```
+
+        ## Einrichtungsassistent
+
+        `/setup` oder `aish setup` für interaktive Konfiguration. Einstellungen werden sofort ohne Neustart wirksam.
+
+        ## Weitere Dateien
+
+        - Sicherheitsrichtlinie: `~/.config/aish/security_policy.yaml`
+        - Sitzungsdatenbank: `~/.local/share/aish/sessions.db`
+        - Protokolle: `~/.config/aish/logs/aish.log`
+
+    shortcuts:
+      title: "Tastenkombinationen"
+      markdown: |-
+        ## Bearbeitung
+
+        | Taste | Aktion |
+        |-------|--------|
+        | `Tab` | Autovervollständigung |
+        | `↑` / `↓` | Verlauf navigieren |
+        | `Ctrl+R` | Verlauf durchsuchen |
+        | `Ctrl+L` | Bildschirm löschen |
+        | `Backspace` / `Delete` | Zeichen löschen |
+
+        ## Shell-Steuerung
+
+        | Taste | Aktion |
+        |-------|--------|
+        | `Ctrl+C` | Aktuelle Operation abbrechen (zweimal drücken zum Beenden) |
+        | `Ctrl+D` | Shell beenden |
+        | `Ctrl+O` | Ausgabeverlauf durchsuchen |
+        | `Esc` | Aktuelle Eingabe abbrechen |
+
+        ## Moduswechsel
+
+        | Taste | Aktion |
+        |-------|--------|
+        | `Shift+Tab` / `F2` | Planmodus umschalten |
+        | `/` in leerer Zeile | Slash-Befehlsauswahl öffnen |
+
+    security:
+      title: "Sicherheitsrichtlinie"
+      markdown: |-
+        ## Übersicht
+
+        aish verwendet eine Sicherheitsrichtlinie, um zu steuern, welche Befehle und Dateioperationen eine Bestätigung erfordern oder blockiert werden.
+
+        ## Speicherort
+
+        Priorität:
+        1. Explizit angegebener Pfad
+        2. `/etc/aish/security_policy.yaml`
+        3. `~/.config/aish/security_policy.yaml`
+
+        ## Risikostufen
+
+        | Stufe | Verhalten |
+        |-------|-----------|
+        | `LOW` | Erlaubt, protokolliert |
+        | `MEDIUM` | Bestätigung erforderlich |
+        | `HIGH` | Blockiert oder erfordert explizite Bestätigung |
+
+        ## Regelstruktur
+
+        ```yaml
+        rules:
+          - id: protect-system
+            name: Systemverzeichnisse schützen
+            path: ["/boot/**", "/etc/passwd"]
+            operations: [WRITE, DELETE]
+            risk: HIGH
+            reason: "Systemdateien sollten nicht geändert werden"
+        ```
+
+        ## Pfadmuster
+
+        - `*` passt auf ein einzelnes Pfadsegment
+        - `**` passt auf null oder mehr Pfadsegmente
+        - Variablen: `$HOME`, `$PWD`
+
+        ## Geheimnisserkennung
+
+        Eingebaute Erkennungsmuster für API-Schlüssel (OpenAI, Anthropic, AWS, Google, GitHub, Stripe, Slack), JWT-Token und URLs mit eingebetteten Passwörtern. Benutzerdefinierte Muster über `secret_patterns` möglich.
 
   command:
     history:

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -324,12 +324,14 @@ shell:
 
   # Slash command descriptions (for popup)
   slash:
+    help: "Show help information"
     model: "Show or switch AI model"
     setup: "Open setup wizard"
     plan: "Plan mode control"
     token: "Show token usage"
     resume: "Resume previous session"
     feedback: "Submit feedback"
+    quit: "Exit AI Shell"
 
   feedback:
     select_type: "Select feedback type"
@@ -674,8 +676,24 @@ tools:
       edit_write_failed: "Failed to write {path}: {error}"
 
   ask_user:
+    description: "Ask the user a focused clarifying question. Use prompt for text input, and add options when you can offer choices."
     runtime_not_configured: "ask_user runtime is not configured"
     execute_failed: "ask_user failed: {error}"
+    param:
+      kind: "Interaction type: text_input for free-form, choice_or_text for options with custom input"
+      prompt: "The question to ask the user."
+      options: "Optional choices to offer the user. If omitted or empty, ask_user uses text input."
+      option_value: "Stable option value returned in tool metadata."
+      option_label: "User-facing label shown in the choice list."
+      option_description: "Optional extra detail shown below the option."
+      option_recommended: "Mark this option visibly as the recommended default."
+      title: "Optional title for the question"
+      default: "Default value"
+      placeholder: "Placeholder text"
+      allow_freeform_input: "When options are present, allow the user to choose Other and type a custom answer. Defaults to true."
+      required: "Whether the user must provide an answer (default: true)"
+      allow_cancel: "Whether the user can cancel/skip (default: true)"
+      min_length: "Minimum length for text input (default: 0)"
     validation:
       prompt_empty: "prompt cannot be empty"
       option_value_empty: "option value cannot be empty"
@@ -761,54 +779,270 @@ help:
     brief_usage: "Usage: {usage}"
 
   general:
-    title: "📖 AI Shell Help"
+    title: "AI Shell Help"
     markdown: |-
-      ## Available Commands:
+      ## Quick Start
+      - **Shell commands** — type directly: `ls`, `cd`, `vim`, `ssh`, `top` ...
+      - **Ask AI** — prefix with `;` or `；`: `;how to find large files`
+      - **Slash commands** — type `/` on empty line for interactive picker
 
-      ### Directory Navigation
-      - `cd [-L|[-P [-e]]] [directory]` - Change directory with full parameter support
-      - `pushd [directory]` - Push directory onto stack
-      - `popd` - Pop directory from stack
-      - `dirs [-c]` - Show directory stack
+      ## Slash Commands
+      | Command | Description |
+      |---------|-------------|
+      | `/help [page]` | Show help (`/help` for pages) |
+      | `/quit` | Exit AI Shell |
+      | `/model [name]` | Show or switch AI model |
+      | `/setup` | Reconfigure API settings |
+      | `/plan [start\|status\|exit]` | Plan mode control |
+      | `/token` | Show token usage (last 7 days) |
+      | `/resume [id]` | Resume a previous session |
+      | `/feedback` | Submit feedback or report a bug |
 
-      ### History Management
-      - `history [options] [n]` - Show command history
-      - `history -c` - Clear history
-      - `history -d offset` - Delete history entry
+      ## Configuration
+      - Config file: `~/.config/aish/config.yaml`
+      - CLI args > env vars (`AISH_MODEL`, `AISH_API_KEY`, `AISH_API_BASE`) > config file
+      - Run `/setup` or `aish setup` for interactive configuration
 
-      ### Environment Variables
-      - `export [-fn] [name[=value] ...]` - Set/export environment variables
-      - `export -p` - Display exported variables
-      - `unset [-fv] [name ...]` - Unset environment variables
-      - `pwd [-L|-P]` - Print working directory
+      ## Keyboard Shortcuts
+      | Key | Action |
+      |-----|--------|
+      | `Ctrl+C` | Cancel current operation (press twice to exit) |
+      | `Ctrl+D` | Exit shell |
+      | `Shift+Tab` / `F2` | Toggle plan mode |
+      | `Ctrl+O` | Browse output history |
+      | `/` on empty line | Slash command picker |
 
-      ### General Commands
-      - `help` - Show this help message
-      - `clear` - Clear the screen
-      - `exit` - Exit the shell
-      - `/model [model]` - Show or switch model
-      - `/setup` - Reconfigure API settings
+      ## Help Pages
+      Use `/help <page>` for details on aish-specific features:
 
-      ### AI Commands
-      - `; <question>` - Ask the AI assistant
+      | Page | Content |
+      |------|---------|
+      | `ai` | AI assistant usage (`;` prefix, context, conversation) |
+      | `model` | Model management (view, switch, supported providers) |
+      | `plan` | Plan mode (workflow, approval, vs normal mode) |
+      | `config` | Configuration (files, env vars, priority) |
+      | `shortcuts` | Keyboard shortcuts (editing, control, mode switching) |
+      | `security` | Security policy (risk levels, rules, secret detection) |
 
-      ### Features
-      - ✅ Full PTY support for all commands
-      - ✅ Command history and AI context integration
-      - ✅ Rich terminal output for AI responses
-      - ✅ Signal handling and graceful cleanup
+      ## More
+      - Security policy: `~/.config/aish/security_policy.yaml`
+      - Session data: `~/.local/share/aish/sessions.db`
+      - Logs: `~/.config/aish/logs/aish.log`
+      - Docs: https://github.com/AI-Shell-Team/aish
 
-      ### Getting Help
-      Use `<command> --help` or `<command> -h` for detailed help on any command.
+  topics:
+    unknown: "Unknown help page '{topic}'. Available pages: ai, model, plan, config, shortcuts, security"
 
-      ### Examples
-      ```bash
-      history --help       # Show detailed history help
-      cd --help            # Show detailed cd help
-      export JAVA_HOME="/usr/lib/jvm/java-11"  # Set environment variable
-      unset TEMP_VAR       # Remove environment variable
-      ; explain ls -la     # Ask AI to explain a command
-      ```
+    ai:
+      title: "AI Assistant"
+      markdown: |-
+        ## Asking AI
+
+        Prefix your question with `;` (semicolon) or `；` (full-width):
+
+        ```
+        ; how do I find large files?
+        ; explain this command: ls -la
+        ; suggest a better way to compress files
+        ```
+
+        The AI sees your conversation context, including previous shell commands and AI responses.
+
+        ## How It Works
+
+        - Your question is sent to the configured LLM model
+        - The AI receives conversation history for context
+        - Responses are rendered with syntax highlighting and table formatting
+
+        ## Context Management
+
+        - Conversation history is maintained automatically
+        - Context auto-compaction triggers when token budget is exceeded
+        - Older messages are summarized to keep recent context fresh
+
+    model:
+      title: "Model Management"
+      markdown: |-
+        ## Viewing & Switching Models
+
+        ```
+        /model                # Show current model
+        /model gpt-4o         # Switch to GPT-4o
+        /model claude-sonnet-4-6  # Switch to Claude
+        ```
+
+        ## Supported Providers
+
+        | Provider | Model Prefix |
+        |----------|-------------|
+        | OpenAI | `gpt-*`, `o1-*`, `o3-*`, `o4-*` |
+        | Anthropic | `claude-*` |
+        | Google | `gemini-*`, `gemma-*` |
+        | DeepSeek | `deepseek-*` |
+        | Qwen | `qwen-*`, `qwq-*` |
+        | Mistral | `mistral-*`, `mixtral-*`, `codestral-*` |
+        | xAI | `grok-*` |
+        | Moonshot | `kimi-*`, `moonshot-*` |
+        | Zhipu | `glm-*` |
+        | Local | Ollama, vLLM, local API endpoints |
+
+        ## Switching Behavior
+
+        - Provider is auto-detected from model name
+        - Connectivity is validated before switching
+        - On failure, the current model is kept
+        - Config is persisted automatically to `~/.config/aish/config.yaml`
+
+    plan:
+      title: "Plan Mode"
+      markdown: |-
+        ## What Is Plan Mode?
+
+        Plan mode lets the AI analyze your codebase and create a detailed implementation plan before writing any code. Changes are only applied after you approve the plan.
+
+        ## Commands
+
+        ```
+        /plan start     # Enter plan mode
+        /plan status    # Show current plan status
+        /plan exit      # Exit plan mode
+        ```
+
+        You can also toggle plan mode with `Shift+Tab` or `F2`.
+
+        ## Usage
+
+        1. Enter plan mode: `/plan start`
+        2. Ask the AI to plan: `; refactor the auth module to use JWT`
+        3. The AI generates a plan with steps and file changes
+        4. Review the plan and approve or reject each step
+        5. Once approved, changes are applied
+        6. Exit plan mode: `/plan exit`
+
+        ## Plan Mode vs Normal Mode
+
+        | | Normal Mode | Plan Mode |
+        |---|---|---|
+        | AI tools | Full access | Read-only + plan writing |
+        | Code changes | Immediate | After approval |
+        | Best for | Quick fixes, questions | Refactors, new features |
+
+    config:
+      title: "Configuration"
+      markdown: |-
+        ## Config File
+
+        Location: `~/.config/aish/config.yaml`
+
+        Override with `$AISH_CONFIG_DIR` or `$XDG_CONFIG_HOME`.
+
+        ## Priority
+
+        CLI arguments > environment variables > config file
+
+        ## Environment Variables
+
+        | Variable | Purpose |
+        |----------|---------|
+        | `AISH_MODEL` | Override default model |
+        | `AISH_API_KEY` | Override API key |
+        | `AISH_API_BASE` | Override API base URL |
+        | `AISH_CONFIG_DIR` | Override config directory |
+
+        ## Key Settings
+
+        ```
+        model: gpt-4o                    # Default LLM model
+        api_key: sk-xxx                  # API key
+        api_base: https://api.openai.com/v1  # API endpoint
+        temperature: 0.3                 # Response randomness
+        theme: dark                      # UI theme (dark/light)
+        output_language: en              # Force output language
+        ```
+
+        ## Setup Wizard
+
+        Run `/setup` or `aish setup` for interactive configuration.
+        Settings take effect immediately without restart.
+
+        ## Other Files
+
+        - Security policy: `~/.config/aish/security_policy.yaml`
+        - Session database: `~/.local/share/aish/sessions.db`
+        - Logs: `~/.config/aish/logs/aish.log`
+
+    shortcuts:
+      title: "Keyboard Shortcuts"
+      markdown: |-
+        ## Editing
+
+        | Key | Action |
+        |-----|--------|
+        | `Tab` | Autocomplete |
+        | `Up` / `Down` | Navigate history |
+        | `Ctrl+R` | Search history |
+        | `Ctrl+L` | Clear screen |
+        | `Backspace` / `Delete` | Delete character |
+
+        ## Shell Control
+
+        | Key | Action |
+        |-----|--------|
+        | `Ctrl+C` | Cancel current operation (press twice to exit) |
+        | `Ctrl+D` | Exit shell |
+        | `Ctrl+O` | Browse output history |
+        | `Esc` | Cancel current input |
+
+        ## Mode Switching
+
+        | Key | Action |
+        |-----|--------|
+        | `Shift+Tab` / `F2` | Toggle plan mode |
+        | `/` on empty line | Open slash command picker |
+
+    security:
+      title: "Security Policy"
+      markdown: |-
+        ## Overview
+
+        aish uses a security policy file to control which commands and file operations require confirmation or are blocked.
+
+        ## Config Location
+
+        Priority:
+        1. Explicit path (if configured)
+        2. `/etc/aish/security_policy.yaml`
+        3. `~/.config/aish/security_policy.yaml`
+
+        ## Risk Levels
+
+        | Level | Behavior |
+        |-------|----------|
+        | `LOW` | Allowed, logged |
+        | `MEDIUM` | Confirmation prompt |
+        | `HIGH` | Blocked or requires explicit confirmation |
+
+        ## Rule Structure
+
+        ```yaml
+        rules:
+          - id: protect-system
+            name: Protect system directories
+            path: ["/boot/**", "/etc/passwd"]
+            operations: [WRITE, DELETE]
+            risk: HIGH
+            reason: "System files should not be modified"
+        ```
+
+        ## Path Patterns
+
+        - `*` matches any single path segment
+        - `**` matches zero or more path segments
+        - Variables: `$HOME`, `$PWD`
+
+        ## Secret Detection
+
+        Built-in patterns for detecting API keys (OpenAI, Anthropic, AWS, Google, GitHub, Stripe, Slack), JWT tokens, and URLs with embedded passwords. Custom patterns supported via `secret_patterns`.
 
   command:
     history:

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -144,12 +144,14 @@ shell:
     skills_loaded_suffix: " cargadas"
 
   slash:
+    help: "Mostrar información de ayuda"
     model: "Mostrar o cambiar modelo de IA"
     setup: "Abrir asistente de configuración"
     plan: "Control del modo plan"
     token: "Mostrar uso de tokens"
     resume: "Reanudar sesión anterior"
     feedback: "Enviar comentarios"
+    quit: "Salir de AI Shell"
 
   feedback:
     select_type: "Seleccionar tipo de comentario"
@@ -353,9 +355,25 @@ security:
 
 tools:
   ask_user:
+    description: "Haz al usuario una pregunta de aclaración enfocada. Con solo prompt se usa texto libre; con options se ofrecen elecciones."
     unknown_kind: "Tipo desconocido: {kind}"
     runtime_not_configured: "el runtime de ask_user no está configurado"
     execute_failed: "ask_user falló: {error}"
+    param:
+      kind: "Tipo de interacción: text_input para texto libre, choice_or_text para opciones con entrada personalizada"
+      prompt: "La pregunta que se le hará al usuario."
+      options: "Opciones que se pueden ofrecer al usuario. Si faltan o están vacías, ask_user usa entrada de texto."
+      option_value: "Valor estable de la opción que se devuelve en los metadatos de la herramienta."
+      option_label: "Etiqueta visible para el usuario en la lista de opciones."
+      option_description: "Detalle opcional que se muestra debajo de la opción."
+      option_recommended: "Marca esta opción visiblemente como la recomendada."
+      title: "Título opcional para la pregunta"
+      default: "Valor predeterminado"
+      placeholder: "Texto de marcador"
+      allow_freeform_input: "Cuando hay opciones, permite elegir otra respuesta y escribirla. El valor predeterminado es true."
+      required: "Si el usuario debe proporcionar una respuesta (predeterminado: true)"
+      allow_cancel: "Si el usuario puede cancelar/omitir (predeterminado: true)"
+      min_length: "Longitud mínima para entrada de texto (predeterminado: 0)"
     validation:
       prompt_empty: "prompt no puede estar vacío"
       option_value_empty: "option value no puede estar vacío"
@@ -390,54 +408,269 @@ help:
     notes: "Notas"
     brief_usage: "Uso: {usage}"
   general:
-    title: "📖 Ayuda de AI Shell"
+    title: "Ayuda de AI Shell"
     markdown: |-
-      ## Comandos disponibles:
+      ## Inicio rápido
+      - **Comandos Shell** — escribe directamente: `ls`, `cd`, `vim`, `ssh`, `top` …
+      - **Pregunta a la IA** — comienza con `;`: `;cómo encontrar archivos grandes`
+      - **Comandos slash** — pulsa `/` en línea vacía para el selector interactivo
 
-      ### Navegación por directorios
-      - `cd [-L|[-P [-e]]] [directory]` - Cambiar de directorio con soporte completo de parámetros
-      - `pushd [directory]` - Apilar un directorio
-      - `popd` - Sacar un directorio de la pila
-      - `dirs [-c]` - Mostrar la pila de directorios
+      ## Comandos Slash
+      | Comando | Descripción |
+      |---------|-------------|
+      | `/help [page]` | Mostrar ayuda (`/help` para páginas) |
+      | `/quit` | Salir de AI Shell |
+      | `/model [nombre]` | Mostrar o cambiar el modelo de IA |
+      | `/setup` | Reconfigurar ajustes de API |
+      | `/plan [start\|status\|exit]` | Control del modo plan |
+      | `/token` | Mostrar uso de tokens (últimos 7 días) |
+      | `/resume [id]` | Reanudar sesión anterior |
+      | `/feedback` | Enviar comentarios o reportar un bug |
 
-      ### Historial
-      - `history [options] [n]` - Mostrar el historial de comandos
-      - `history -c` - Borrar el historial
-      - `history -d offset` - Eliminar una entrada del historial
+      ## Configuración
+      - Archivo de configuración: `~/.config/aish/config.yaml`
+      - Prioridad: argumentos CLI > variables de entorno (`AISH_MODEL`, `AISH_API_KEY`, `AISH_API_BASE`) > archivo de config
+      - Ejecuta `/setup` o `aish setup` para configuración interactiva
 
-      ### Variables de entorno
-      - `export [-fn] [name[=value] ...]` - Establecer o exportar variables de entorno
-      - `export -p` - Mostrar variables exportadas
-      - `unset [-fv] [name ...]` - Eliminar variables de entorno
-      - `pwd [-L|-P]` - Mostrar el directorio de trabajo actual
+      ## Atajos de teclado
+      | Tecla | Acción |
+      |-------|--------|
+      | `Ctrl+C` | Cancelar operación actual (dos veces para salir) |
+      | `Ctrl+D` | Salir del shell |
+      | `Shift+Tab` / `F2` | Alternar modo plan |
+      | `Ctrl+O` | Navegar historial de salida |
+      | `/` en línea vacía | Selector de comandos slash |
 
-      ### Comandos generales
-      - `help` - Mostrar esta ayuda
-      - `clear` - Limpiar la pantalla
-      - `exit` - Salir del shell
-      - `/model [model]` - Mostrar o cambiar el modelo
-      - `/setup` - Reconfigurar la API
+      ## Páginas de ayuda
+      Use `/help <page>` para detalles sobre funciones específicas de aish:
 
-      ### Comandos de IA
-      - `; <question>` - Preguntar al asistente de IA
+      | Página | Contenido |
+      |---------|-----------|
+      | `ai` | Asistente de IA (prefijo `;`, contexto, conversación) |
+      | `model` | Gestión de modelos (ver, cambiar, proveedores) |
+      | `plan` | Modo plan (flujo, aprobación, vs modo normal) |
+      | `config` | Configuración (archivos, variables, prioridad) |
+      | `shortcuts` | Atajos de teclado (edición, control, cambio de modo) |
+      | `security` | Política de seguridad (niveles, reglas, detección) |
 
-      ### Funciones
-      - ✅ Soporte PTY completo para todos los comandos
-      - ✅ Integración del historial de comandos con el contexto de IA
-      - ✅ Salida enriquecida para respuestas de IA
-      - ✅ Manejo de señales y limpieza ordenada
+      ## Más
+      - Política de seguridad: `~/.config/aish/security_policy.yaml`
+      - Datos de sesión: `~/.local/share/aish/sessions.db`
+      - Registros: `~/.config/aish/logs/aish.log`
+      - Documentación: https://github.com/AI-Shell-Team/aish
 
-      ### Más ayuda
-      Usa `<command> --help` o `<command> -h` para ver la ayuda detallada de cualquier comando.
+  topics:
+    unknown: "Página de ayuda desconocida '{topic}'. Páginas disponibles: ai, model, plan, config, shortcuts, security"
 
-      ### Ejemplos
-      ```bash
-      history --help       # Mostrar ayuda detallada de history
-      cd --help            # Mostrar ayuda detallada de cd
-      export JAVA_HOME="/usr/lib/jvm/java-11"  # Establecer una variable de entorno
-      unset TEMP_VAR       # Eliminar una variable de entorno
-      ; explica ls -la     # Pedir a la IA que explique un comando
-      ```
+    ai:
+      title: "Asistente de IA"
+      markdown: |-
+        ## Preguntar a la IA
+
+        Prefije su pregunta con `;` (punto y coma) o `；` (punto y coma ancho):
+
+        ```
+        ; ¿cómo encontrar archivos grandes?
+        ; explica este comando: ls -la
+        ; sugiere una mejor forma de comprimir archivos
+        ```
+
+        La IA ve el contexto de su conversación, incluidos los comandos de shell y respuestas anteriores.
+
+        ## Cómo funciona
+
+        - Su pregunta se envía al modelo LLM configurado
+        - La IA recibe el historial de conversación como contexto
+        - Las respuestas se muestran con resaltado de sintaxis y formato de tablas
+
+        ## Gestión de contexto
+
+        - El historial de conversación se mantiene automáticamente
+        - La compactación automática se activa cuando se excede el presupuesto de tokens
+        - Los mensajes antiguos se resumen para mantener el contexto reciente
+
+    model:
+      title: "Gestión de modelos"
+      markdown: |-
+        ## Ver y cambiar modelos
+
+        ```
+        /model                    # Mostrar modelo actual
+        /model gpt-4o             # Cambiar a GPT-4o
+        /model claude-sonnet-4-6  # Cambiar a Claude
+        ```
+
+        ## Proveedores compatibles
+
+        | Proveedor | Prefijo del modelo |
+        |-----------|-------------------|
+        | OpenAI | `gpt-*`, `o1-*`, `o3-*`, `o4-*` |
+        | Anthropic | `claude-*` |
+        | Google | `gemini-*`, `gemma-*` |
+        | DeepSeek | `deepseek-*` |
+        | Qwen | `qwen-*`, `qwq-*` |
+        | Mistral | `mistral-*`, `mixtral-*`, `codestral-*` |
+        | xAI | `grok-*` |
+        | Moonshot | `kimi-*`, `moonshot-*` |
+        | Zhipu | `glm-*` |
+        | Local | Ollama, vLLM, API local |
+
+        ## Comportamiento al cambiar
+
+        - El proveedor se detecta automáticamente por el nombre del modelo
+        - Se valida la conectividad antes de cambiar
+        - En caso de fallo, se mantiene el modelo actual
+        - La configuración se guarda automáticamente en `~/.config/aish/config.yaml`
+
+    plan:
+      title: "Modo Plan"
+      markdown: |-
+        ## ¿Qué es el modo Plan?
+
+        El modo Plan permite que la IA analice su base de código y cree un plan de implementación detallado antes de escribir código. Los cambios solo se aplican después de su aprobación.
+
+        ## Comandos
+
+        ```
+        /plan start     # Entrar en modo plan
+        /plan status    # Mostrar estado del plan actual
+        /plan exit      # Salir del modo plan
+        ```
+
+        También puede alternar el modo plan con `Shift+Tab` o `F2`.
+
+        ## Uso
+
+        1. Entrar en modo plan：`/plan start`
+        2. Pedir a la IA que planifique：`; refactorizar el módulo auth para usar JWT`
+        3. La IA genera un plan con pasos y cambios de archivos
+        4. Revisar el plan y aprobar o rechazar cada paso
+        5. Una vez aprobado, se aplican los cambios
+        6. Salir del modo plan：`/plan exit`
+
+        ## Modo Plan vs Modo Normal
+
+        | | Modo Normal | Modo Plan |
+        |---|---|---|
+        | Herramientas IA | Acceso completo | Solo lectura + escritura de plan |
+        | Cambios de código | Inmediatos | Tras aprobación |
+        | Ideal para | Correcciones rápidas, preguntas | Refactorizaciones, nuevas funciones |
+
+    config:
+      title: "Configuración"
+      markdown: |-
+        ## Archivo de configuración
+
+        Ubicación：`~/.config/aish/config.yaml`
+
+        Se puede sobrescribir con `$AISH_CONFIG_DIR` o `$XDG_CONFIG_HOME`.
+
+        ## Prioridad
+
+        Argumentos CLI > variables de entorno > archivo de configuración
+
+        ## Variables de entorno
+
+        | Variable | Propósito |
+        |----------|-----------|
+        | `AISH_MODEL` | Sobrescribir modelo predeterminado |
+        | `AISH_API_KEY` | Sobrescribir clave API |
+        | `AISH_API_BASE` | Sobrescribir URL base de API |
+        | `AISH_CONFIG_DIR` | Sobrescribir directorio de configuración |
+
+        ## Configuraciones principales
+
+        ```
+        model: gpt-4o                    # Modelo LLM predeterminado
+        api_key: sk-xxx                  # Clave API
+        api_base: https://api.openai.com/v1  # Endpoint de API
+        temperature: 0.3                 # Aleatoriedad de respuestas
+        theme: dark                      # Tema de UI (dark/light)
+        output_language: es              # Forzar idioma de salida
+        ```
+
+        ## Asistente de configuración
+
+        Ejecute `/setup` o `aish setup` para configuración interactiva. Los cambios se aplican inmediatamente sin reiniciar.
+
+        ## Otros archivos
+
+        - Política de seguridad：`~/.config/aish/security_policy.yaml`
+        - Base de datos de sesiones：`~/.local/share/aish/sessions.db`
+        - Registros：`~/.config/aish/logs/aish.log`
+
+    shortcuts:
+      title: "Atajos de teclado"
+      markdown: |-
+        ## Edición
+
+        | Tecla | Acción |
+        |-------|--------|
+        | `Tab` | Autocompletar |
+        | `↑` / `↓` | Navegar historial |
+        | `Ctrl+R` | Buscar en historial |
+        | `Ctrl+L` | Limpiar pantalla |
+        | `Backspace` / `Delete` | Eliminar carácter |
+
+        ## Control de Shell
+
+        | Tecla | Acción |
+        |-------|--------|
+        | `Ctrl+C` | Cancelar operación actual (presionar dos veces para salir) |
+        | `Ctrl+D` | Salir del shell |
+        | `Ctrl+O` | Explorar historial de salida |
+        | `Esc` | Cancelar entrada actual |
+
+        ## Cambio de modo
+
+        | Tecla | Acción |
+        |-------|--------|
+        | `Shift+Tab` / `F2` | Alternar modo plan |
+        | `/` en línea vacía | Abrir selector de comandos |
+
+    security:
+      title: "Política de seguridad"
+      markdown: |-
+        ## Resumen
+
+        aish usa un archivo de política de seguridad para controlar qué comandos y operaciones de archivos requieren confirmación o son bloqueados.
+
+        ## Ubicación de configuración
+
+        Prioridad：
+        1. Ruta explícita especificada
+        2. `/etc/aish/security_policy.yaml`
+        3. `~/.config/aish/security_policy.yaml`
+
+        ## Niveles de riesgo
+
+        | Nivel | Comportamiento |
+        |-------|---------------|
+        | `LOW` | Permitido, registrado |
+        | `MEDIUM` | Solicitar confirmación |
+        | `HIGH` | Bloqueado o requiere confirmación explícita |
+
+        ## Estructura de reglas
+
+        ```yaml
+        rules:
+          - id: protect-system
+            name: Proteger directorios del sistema
+            path: ["/boot/**", "/etc/passwd"]
+            operations: [WRITE, DELETE]
+            risk: HIGH
+            reason: "Los archivos del sistema no deben modificarse"
+        ```
+
+        ## Patrones de ruta
+
+        - `*` coincide con un solo segmento de ruta
+        - `**` coincide con cero o más segmentos de ruta
+        - Variables：`$HOME`, `$PWD`
+
+        ## Detección de secretos
+
+        Patrones integrados para detectar claves API (OpenAI, Anthropic, AWS, Google, GitHub, Stripe, Slack), tokens JWT y URLs con contraseñas incrustadas. Patrones personalizados vía `secret_patterns`.
 
   command:
     history:

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -144,12 +144,14 @@ shell:
     skills_loaded_suffix: " charges"
 
   slash:
+    help: "Afficher les informations d'aide"
     model: "Afficher ou changer le modèle IA"
     setup: "Ouvrir l'assistant de configuration"
     plan: "Contrôle du mode plan"
     token: "Afficher l'utilisation des tokens"
     resume: "Reprendre la session précédente"
     feedback: "Envoyer un commentaire"
+    quit: "Quitter AI Shell"
 
   feedback:
     select_type: "Sélectionner le type de commentaire"
@@ -353,9 +355,25 @@ security:
 
 tools:
   ask_user:
+    description: "Poser a l'utilisateur une question de clarification ciblee. Avec seulement prompt, ask_user utilise la saisie texte ; avec options, il propose des choix."
     unknown_kind: "Type inconnu : {kind}"
     runtime_not_configured: "le runtime ask_user n'est pas configure"
     execute_failed: "echec de ask_user : {error}"
+    param:
+      kind: "Type d'interaction : text_input pour saisie libre, choice_or_text pour options avec saisie personnalisee"
+      prompt: "La question a poser a l'utilisateur."
+      options: "Choix optionnels a proposer a l'utilisateur. S'ils sont absents ou vides, ask_user utilise la saisie texte."
+      option_value: "Valeur stable de l'option retournee dans les metadonnees de l'outil."
+      option_label: "Libelle affiche a l'utilisateur dans la liste."
+      option_description: "Detail optionnel affiche sous l'option."
+      option_recommended: "Marque visiblement cette option comme recommandee."
+      title: "Titre optionnel pour la question"
+      default: "Valeur par defaut"
+      placeholder: "Texte indicatif"
+      allow_freeform_input: "Quand des options sont presentes, autorise une reponse personnalisee. La valeur par defaut est true."
+      required: "Indique si l'utilisateur doit fournir une reponse (par defaut : true)"
+      allow_cancel: "Indique si l'utilisateur peut annuler/ignorer (par defaut : true)"
+      min_length: "Longueur minimale pour la saisie texte (par defaut : 0)"
     validation:
       prompt_empty: "prompt ne peut pas etre vide"
       option_value_empty: "option value ne peut pas etre vide"
@@ -390,54 +408,269 @@ help:
     notes: "Notes"
     brief_usage: "Utilisation : {usage}"
   general:
-    title: "📖 Aide AI Shell"
+    title: "Aide AI Shell"
     markdown: |-
-      ## Commandes disponibles :
+      ## Démarrage rapide
+      - **Commandes Shell** — saisissez directement : `ls`, `cd`, `vim`, `ssh`, `top` …
+      - **Demander à l'IA** — préfixez par `;` : `;comment trouver les gros fichiers`
+      - **Commandes slash** — appuyez sur `/` sur une ligne vide pour le sélecteur interactif
 
-      ### Navigation dans les repertoires
-      - `cd [-L|[-P [-e]]] [directory]` - Changer de repertoire avec prise en charge complete des parametres
-      - `pushd [directory]` - Empiler un repertoire
-      - `popd` - Depiler un repertoire
-      - `dirs [-c]` - Afficher la pile de repertoires
+      ## Commandes Slash
+      | Commande | Description |
+      |----------|-------------|
+      | `/help [page]` | Afficher l'aide (`/help` pour les pages) |
+      | `/quit` | Quitter AI Shell |
+      | `/model [nom]` | Afficher ou changer le modèle IA |
+      | `/setup` | Reconfigurer les paramètres API |
+      | `/plan [start\|status\|exit]` | Contrôle du mode plan |
+      | `/token` | Afficher l'utilisation des tokens (7 derniers jours) |
+      | `/resume [id]` | Reprendre une session précédente |
+      | `/feedback` | Envoyer un commentaire ou signaler un bug |
 
-      ### Historique
-      - `history [options] [n]` - Afficher l'historique des commandes
-      - `history -c` - Effacer l'historique
-      - `history -d offset` - Supprimer une entree de l'historique
+      ## Configuration
+      - Fichier de configuration : `~/.config/aish/config.yaml`
+      - Priorité : arguments CLI > variables d'environnement (`AISH_MODEL`, `AISH_API_KEY`, `AISH_API_BASE`) > fichier de config
+      - Exécutez `/setup` ou `aish setup` pour la configuration interactive
 
-      ### Variables d'environnement
-      - `export [-fn] [name[=value] ...]` - Definir ou exporter des variables d'environnement
-      - `export -p` - Afficher les variables exportees
-      - `unset [-fv] [name ...]` - Supprimer des variables d'environnement
-      - `pwd [-L|-P]` - Afficher le repertoire courant
+      ## Raccourcis clavier
+      | Touche | Action |
+      |--------|--------|
+      | `Ctrl+C` | Annuler l'opération en cours (appuyer deux fois pour quitter) |
+      | `Ctrl+D` | Quitter le shell |
+      | `Shift+Tab` / `F2` | Basculer le mode plan |
+      | `Ctrl+O` | Parcourir l'historique de sortie |
+      | `/` sur ligne vide | Sélecteur de commandes slash |
 
-      ### Commandes generales
-      - `help` - Afficher cette aide
-      - `clear` - Effacer l'ecran
-      - `exit` - Quitter le shell
-      - `/model [model]` - Afficher ou changer le modele
-      - `/setup` - Reconfigurer les parametres API
+      ## Pages d'aide
+      `/help <page>` pour les détails sur les fonctions spécifiques d'aish :
 
-      ### Commandes IA
-      - `; <question>` - Interroger l'assistant IA
+      | Page | Contenu |
+      |------|---------|
+      | `ai` | Assistant IA (préfixe `;`, contexte, conversation) |
+      | `model` | Gestion des modèles (afficher, changer, fournisseurs) |
+      | `plan` | Mode plan (flux, approbation, vs mode normal) |
+      | `config` | Configuration (fichiers, variables, priorité) |
+      | `shortcuts` | Raccourcis clavier (édition, contrôle, changement de mode) |
+      | `security` | Politique de sécurité (niveaux, règles, détection) |
 
-      ### Fonctionnalites
-      - ✅ Prise en charge PTY complete pour toutes les commandes
-      - ✅ Integration de l'historique des commandes et du contexte IA
-      - ✅ Sortie terminal enrichie pour les reponses IA
-      - ✅ Gestion des signaux et nettoyage propre
+      ## Plus
+      - Politique de sécurité : `~/.config/aish/security_policy.yaml`
+      - Base de données de sessions : `~/.local/share/aish/sessions.db`
+      - Journaux : `~/.config/aish/logs/aish.log`
+      - Documentation : https://github.com/AI-Shell-Team/aish
 
-      ### Obtenir plus d'aide
-      Utilisez `<command> --help` ou `<command> -h` pour afficher l'aide detaillee de n'importe quelle commande.
+  topics:
+    unknown: "Page d'aide inconnue '{topic}'. Pages disponibles : ai, model, plan, config, shortcuts, security"
 
-      ### Exemples
-      ```bash
-      history --help       # Afficher l'aide detaillee de history
-      cd --help            # Afficher l'aide detaillee de cd
-      export JAVA_HOME="/usr/lib/jvm/java-11"  # Definir une variable d'environnement
-      unset TEMP_VAR       # Supprimer une variable d'environnement
-      ; explique ls -la    # Demander a l'IA d'expliquer une commande
-      ```
+    ai:
+      title: "Assistant IA"
+      markdown: |-
+        ## Poser une question à l'IA
+
+        Préfixez votre question avec `;` (point-virgule) ou `；` (point-virgule pleine chasse) :
+
+        ```
+        ; comment trouver les gros fichiers ?
+        ; explique cette commande : ls -la
+        ; suggère une meilleure méthode de compression
+        ```
+
+        L'IA voit le contexte de votre conversation, y compris les commandes shell précédentes et les réponses de l'IA.
+
+        ## Fonctionnement
+
+        - Votre question est envoyée au modèle LLM configuré
+        - L'IA reçoit l'historique de conversation comme contexte
+        - Les réponses sont affichées avec coloration syntaxique et formatage de tableaux
+
+        ## Gestion du contexte
+
+        - L'historique de conversation est maintenu automatiquement
+        - Le compactage automatique se déclenche quand le budget de tokens est dépassé
+        - Les anciens messages sont résumés pour garder le contexte récent
+
+    model:
+      title: "Gestion des modèles"
+      markdown: |-
+        ## Afficher et changer de modèle
+
+        ```
+        /model                    # Afficher le modèle actuel
+        /model gpt-4o             # Passer à GPT-4o
+        /model claude-sonnet-4-6  # Passer à Claude
+        ```
+
+        ## Fournisseurs pris en charge
+
+        | Fournisseur | Préfixe du modèle |
+        |-------------|------------------|
+        | OpenAI | `gpt-*`, `o1-*`, `o3-*`, `o4-*` |
+        | Anthropic | `claude-*` |
+        | Google | `gemini-*`, `gemma-*` |
+        | DeepSeek | `deepseek-*` |
+        | Qwen | `qwen-*`, `qwq-*` |
+        | Mistral | `mistral-*`, `mixtral-*`, `codestral-*` |
+        | xAI | `grok-*` |
+        | Moonshot | `kimi-*`, `moonshot-*` |
+        | Zhipu | `glm-*` |
+        | Local | Ollama, vLLM, API locale |
+
+        ## Comportement du changement
+
+        - Le fournisseur est détecté automatiquement selon le nom du modèle
+        - La connectivité est validée avant le changement
+        - En cas d'échec, le modèle actuel est conservé
+        - La config est sauvegardée automatiquement dans `~/.config/aish/config.yaml`
+
+    plan:
+      title: "Mode Plan"
+      markdown: |-
+        ## Qu'est-ce que le mode Plan ?
+
+        Le mode Plan permet à l'IA d'analyser votre base de code et de créer un plan d'implémentation détaillé avant d'écrire du code. Les modifications ne sont appliquées qu'après votre approbation.
+
+        ## Commandes
+
+        ```
+        /plan start     # Entrer en mode plan
+        /plan status    # Afficher l'état du plan actuel
+        /plan exit      # Quitter le mode plan
+        ```
+
+        Vous pouvez aussi basculer le mode plan avec `Shift+Tab` ou `F2`.
+
+        ## Utilisation
+
+        1. Entrer en mode plan : `/plan start`
+        2. Demander à l'IA de planifier : `; refactoriser le module auth pour utiliser JWT`
+        3. L'IA génère un plan avec des étapes et des modifications de fichiers
+        4. Examiner le plan et approuver ou rejeter chaque étape
+        5. Une fois approuvé, les modifications sont appliquées
+        6. Quitter le mode plan : `/plan exit`
+
+        ## Mode Plan vs Mode Normal
+
+        | | Mode Normal | Mode Plan |
+        |---|---|---|
+        | Outils IA | Accès complet | Lecture seule + écriture du plan |
+        | Modifications | Immédiates | Après approbation |
+        | Idéal pour | Corrections rapides, questions | Refactorisation, nouvelles fonctionnalités |
+
+    config:
+      title: "Configuration"
+      markdown: |-
+        ## Fichier de configuration
+
+        Emplacement : `~/.config/aish/config.yaml`
+
+        Remplaçable avec `$AISH_CONFIG_DIR` ou `$XDG_CONFIG_HOME`.
+
+        ## Priorité
+
+        Arguments CLI > variables d'environnement > fichier de configuration
+
+        ## Variables d'environnement
+
+        | Variable | Usage |
+        |----------|-------|
+        | `AISH_MODEL` | Remplacer le modèle par défaut |
+        | `AISH_API_KEY` | Remplacer la clé API |
+        | `AISH_API_BASE` | Remplacer l'URL de base de l'API |
+        | `AISH_CONFIG_DIR` | Remplacer le répertoire de configuration |
+
+        ## Paramètres principaux
+
+        ```
+        model: gpt-4o                    # Modèle LLM par défaut
+        api_key: sk-xxx                  # Clé API
+        api_base: https://api.openai.com/v1  # Point d'accès API
+        temperature: 0.3                 # Aléatoire des réponses
+        theme: dark                      # Thème UI (dark/light)
+        output_language: fr              # Forcer la langue de sortie
+        ```
+
+        ## Assistant de configuration
+
+        Exécutez `/setup` ou `aish setup` pour une configuration interactive. Les paramètres prennent effet immédiatement sans redémarrage.
+
+        ## Autres fichiers
+
+        - Politique de sécurité : `~/.config/aish/security_policy.yaml`
+        - Base de données de sessions : `~/.local/share/aish/sessions.db`
+        - Journaux : `~/.config/aish/logs/aish.log`
+
+    shortcuts:
+      title: "Raccourcis clavier"
+      markdown: |-
+        ## Édition
+
+        | Touche | Action |
+        |--------|--------|
+        | `Tab` | Auto-complétion |
+        | `↑` / `↓` | Naviguer dans l'historique |
+        | `Ctrl+R` | Rechercher dans l'historique |
+        | `Ctrl+L` | Effacer l'écran |
+        | `Backspace` / `Delete` | Supprimer un caractère |
+
+        ## Contrôle du shell
+
+        | Touche | Action |
+        |--------|--------|
+        | `Ctrl+C` | Annuler l'opération en cours (appuyer deux fois pour quitter) |
+        | `Ctrl+D` | Quitter le shell |
+        | `Ctrl+O` | Parcourir l'historique de sortie |
+        | `Échap` | Annuler la saisie en cours |
+
+        ## Changement de mode
+
+        | Touche | Action |
+        |--------|--------|
+        | `Shift+Tab` / `F2` | Basculer le mode plan |
+        | `/` sur ligne vide | Ouvrir le sélecteur de commandes |
+
+    security:
+      title: "Politique de sécurité"
+      markdown: |-
+        ## Aperçu
+
+        aish utilise un fichier de politique de sécurité pour contrôler quelles commandes et opérations de fichiers nécessitent une confirmation ou sont bloquées.
+
+        ## Emplacement de la configuration
+
+        Priorité :
+        1. Chemin explicitement spécifié
+        2. `/etc/aish/security_policy.yaml`
+        3. `~/.config/aish/security_policy.yaml`
+
+        ## Niveaux de risque
+
+        | Niveau | Comportement |
+        |--------|-------------|
+        | `LOW` | Autorisé, journalisé |
+        | `MEDIUM` | Demande de confirmation |
+        | `HIGH` | Bloqué ou nécessite une confirmation explicite |
+
+        ## Structure des règles
+
+        ```yaml
+        rules:
+          - id: protect-system
+            name: Protéger les répertoires système
+            path: ["/boot/**", "/etc/passwd"]
+            operations: [WRITE, DELETE]
+            risk: HIGH
+            reason: "Les fichiers système ne doivent pas être modifiés"
+        ```
+
+        ## Motifs de chemin
+
+        - `*` correspond à un seul segment de chemin
+        - `**` correspond à zéro ou plusieurs segments de chemin
+        - Variables : `$HOME`, `$PWD`
+
+        ## Détection de secrets
+
+        Motifs intégrés pour la détection de clés API (OpenAI, Anthropic, AWS, Google, GitHub, Stripe, Slack), de tokens JWT et d'URL avec mots de passe intégrés. Motifs personnalisés via `secret_patterns`.
 
   command:
     history:

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -144,12 +144,14 @@ shell:
     skills_loaded_suffix: " 件読み込み済み"
 
   slash:
+    help: "ヘルプ情報を表示"
     model: "AI モデルの表示・切替"
     setup: "セットアップウィザードを開く"
     plan: "プランモードの制御"
     token: "トークン使用量を表示"
     resume: "前回のセッションを再開"
     feedback: "フィードバックを送信"
+    quit: "AI Shell を終了"
 
   feedback:
     select_type: "フィードバックの種類を選択"
@@ -353,9 +355,25 @@ security:
 
 tools:
   ask_user:
+    description: "ユーザーに焦点を絞った確認質問をします。prompt のみならテキスト入力、options があれば選択肢を提示します。"
     unknown_kind: "不明な種類です: {kind}"
     runtime_not_configured: "ask_user ランタイムが構成されていません"
     execute_failed: "ask_user に失敗しました: {error}"
+    param:
+      kind: "操作タイプ: text_input は自由入力、choice_or_text は選択肢とカスタム入力"
+      prompt: "ユーザーに尋ねる質問です。"
+      options: "ユーザーに提示する任意の選択肢です。省略または空の場合、ask_user はテキスト入力を使います。"
+      option_value: "ツールメタデータに返される安定した選択肢の値です。"
+      option_label: "選択リストに表示されるユーザー向けラベルです。"
+      option_description: "選択肢の下に表示される任意の補足説明です。"
+      option_recommended: "この選択肢を推奨として明示表示します。"
+      title: "質問の任意タイトル"
+      default: "既定値"
+      placeholder: "プレースホルダーテキスト"
+      allow_freeform_input: "選択肢がある場合にカスタム回答を許可します。既定値は true です。"
+      required: "ユーザーが回答を入力する必要があるかどうか（既定値: true）"
+      allow_cancel: "ユーザーがキャンセル/スキップできるかどうか（既定値: true）"
+      min_length: "テキスト入力の最小文字数（既定値: 0）"
     validation:
       prompt_empty: "prompt は空にできません"
       option_value_empty: "option value は空にできません"
@@ -390,54 +408,269 @@ help:
     notes: "補足"
     brief_usage: "使い方: {usage}"
   general:
-    title: "📖 AI Shell ヘルプ"
+    title: "AI Shell ヘルプ"
     markdown: |-
-      ## 利用可能なコマンド:
+      ## クイックスタート
+      - **シェルコマンド** — そのまま入力：`ls`、`cd`、`vim`、`ssh`、`top` …
+      - **AI に質問** — `;` または `；` で始める：`;大きなファイルを見つける方法`
+      - **スラッシュコマンド** — 空行で `/` を押すとインタラクティブピッカーが開きます
 
-      ### ディレクトリ操作
-      - `cd [-L|[-P [-e]]] [directory]` - 完全なパラメーター対応でディレクトリを変更
-      - `pushd [directory]` - ディレクトリをスタックに積む
-      - `popd` - ディレクトリをスタックから取り出す
-      - `dirs [-c]` - ディレクトリスタックを表示
+      ## スラッシュコマンド
+      | コマンド | 説明 |
+      |----------|------|
+      | `/help [page]` | ヘルプを表示（`/help` でページ一覧） |
+      | `/quit` | AI Shell を終了 |
+      | `/model [名前]` | AI モデルを表示または切り替え |
+      | `/setup` | API 設定を再構成 |
+      | `/plan [start\|status\|exit]` | プランモードの制御 |
+      | `/token` | トークン使用量を表示（過去 7 日間） |
+      | `/resume [id]` | 前回のセッションを再開 |
+      | `/feedback` | フィードバックを送信またはバグを報告 |
 
-      ### 履歴管理
-      - `history [options] [n]` - コマンド履歴を表示
-      - `history -c` - 履歴を消去
-      - `history -d offset` - 履歴エントリーを削除
+      ## 設定
+      - 設定ファイル：`~/.config/aish/config.yaml`
+      - 優先度：コマンドライン引数 > 環境変数（`AISH_MODEL`、`AISH_API_KEY`、`AISH_API_BASE`） > 設定ファイル
+      - `/setup` または `aish setup` でインタラクティブに設定
 
-      ### 環境変数
-      - `export [-fn] [name[=value] ...]` - 環境変数を設定または export
-      - `export -p` - export 済み変数を表示
-      - `unset [-fv] [name ...]` - 環境変数を解除
-      - `pwd [-L|-P]` - 現在の作業ディレクトリを表示
+      ## キーボードショートカット
+      | キー | 操作 |
+      |------|------|
+      | `Ctrl+C` | 現在の操作をキャンセル（2 回押すと終了） |
+      | `Ctrl+D` | シェルを終了 |
+      | `Shift+Tab` / `F2` | プランモード切替 |
+      | `Ctrl+O` | 出力履歴を閲覧 |
+      | 空行で `/` | スラッシュコマンドピッカー |
 
-      ### 一般コマンド
-      - `help` - このヘルプを表示
-      - `clear` - 画面を消去
-      - `exit` - シェルを終了
-      - `/model [model]` - モデルを表示または切り替え
-      - `/setup` - API 設定を再構成
+      ## ヘルプページ
+      `/help <page>` で aish 固有機能の詳細を確認：
 
-      ### AI コマンド
-      - `; <question>` - AI アシスタントに質問
+      | ページ | 内容 |
+      |--------|------|
+      | `ai` | AIアシスタントの使い方（`;`プレフィックス、コンテキスト、会話） |
+      | `model` | モデル管理（表示、切替、対応プロバイダー） |
+      | `plan` | プランモード（ワークフロー、承認、通常モードとの比較） |
+      | `config` | 設定（ファイル、環境変数、優先順位） |
+      | `shortcuts` | キーボードショートカット（編集、制御、モード切替） |
+      | `security` | セキュリティポリシー（リスクレベル、ルール、シークレット検出） |
 
-      ### 機能
-      - ✅ すべてのコマンドで完全な PTY サポート
-      - ✅ コマンド履歴と AI コンテキストの統合
-      - ✅ AI 応答のリッチなターミナル表示
-      - ✅ シグナル処理と適切なクリーンアップ
+      ## その他
+      - セキュリティポリシー：`~/.config/aish/security_policy.yaml`
+      - セッションデータ：`~/.local/share/aish/sessions.db`
+      - ログ：`~/.config/aish/logs/aish.log`
+      - ドキュメント：https://github.com/AI-Shell-Team/aish
 
-      ### さらに詳しいヘルプ
-      任意のコマンドで `<command> --help` または `<command> -h` を使うと詳細ヘルプを表示できます。
+  topics:
+    unknown: "不明なヘルプページ '{topic}'。利用可能なページ：ai, model, plan, config, shortcuts, security"
 
-      ### 例
-      ```bash
-      history --help       # history の詳細ヘルプを表示
-      cd --help            # cd の詳細ヘルプを表示
-      export JAVA_HOME="/usr/lib/jvm/java-11"  # 環境変数を設定
-      unset TEMP_VAR       # 環境変数を削除
-      ; ls -la を説明して   # AI にコマンド説明を依頼
-      ```
+    ai:
+      title: "AI アシスタント"
+      markdown: |-
+        ## AI への質問
+
+        `;`（セミコロン）または `；`（全角セミコロン）を前に付けて質問します：
+
+        ```
+        ; 大きなファイルを見つける方法は？
+        ; このコマンドを説明して：ls -la
+        ; より良い圧縮方法を提案して
+        ```
+
+        AI は以前のシェルコマンドや AI 応答を含む会話コンテキストを参照します。
+
+        ## 仕組み
+
+        - 質問は設定された LLM モデルに送信されます
+        - AI は会話履歴をコンテキストとして受け取ります
+        - 応答はシンタックスハイライトとテーブル描画で表示されます
+
+        ## コンテキスト管理
+
+        - 会話履歴は自動的に維持されます
+        - トークン予算を超えると自動的にコンテキストを圧縮します
+        - 古いメッセージは要約され、最新のコンテキストが保持されます
+
+    model:
+      title: "モデル管理"
+      markdown: |-
+        ## モデルの確認と切り替え
+
+        ```
+        /model                    # 現在のモデルを表示
+        /model gpt-4o             # GPT-4o に切り替え
+        /model claude-sonnet-4-6  # Claude に切り替え
+        ```
+
+        ## 対応プロバイダー
+
+        | プロバイダー | モデルプレフィックス |
+        |-------------|-------------------|
+        | OpenAI | `gpt-*`, `o1-*`, `o3-*`, `o4-*` |
+        | Anthropic | `claude-*` |
+        | Google | `gemini-*`, `gemma-*` |
+        | DeepSeek | `deepseek-*` |
+        | Qwen | `qwen-*`, `qwq-*` |
+        | Mistral | `mistral-*`, `mixtral-*`, `codestral-*` |
+        | xAI | `grok-*` |
+        | Moonshot | `kimi-*`, `moonshot-*` |
+        | Zhipu | `glm-*` |
+        | ローカル | Ollama, vLLM, ローカル API |
+
+        ## 切り替え動作
+
+        - モデル名からプロバイダーを自動検出
+        - 切り替え前に接続性を検証
+        - 失敗時は現在のモデルを維持
+        - 設定は `~/.config/aish/config.yaml` に自動保存
+
+    plan:
+      title: "プランモード"
+      markdown: |-
+        ## プランモードとは？
+
+        プランモードでは、AI がコードを書く前にコードベースを分析し、詳細な実装計画を作成します。変更は承認後にのみ適用されます。
+
+        ## コマンド
+
+        ```
+        /plan start     # プランモードに入る
+        /plan status    # 現在のプラン状態を表示
+        /plan exit      # プランモードを終了
+        ```
+
+        `Shift+Tab` または `F2` でプランモードを切り替えることもできます。
+
+        ## 使い方
+
+        1. プランモードに入る：`/plan start`
+        2. AI に計画を依頼：`; auth モジュールを JWT にリファクタリングして`
+        3. AI がステップとファイル変更を含む計画を生成
+        4. 計画を確認し、各ステップを承認または拒否
+        5. 承認後、変更が適用される
+        6. プランモードを終了：`/plan exit`
+
+        ## プランモード vs 通常モード
+
+        | | 通常モード | プランモード |
+        |---|---|---|
+        | AI ツール | フルアクセス | 読み取り専用 + プラン書き込み |
+        | コード変更 | 即時実行 | 承認後実行 |
+        | 適した場面 | 簡単な修正、質問 | リファクタリング、新機能 |
+
+    config:
+      title: "設定"
+      markdown: |-
+        ## 設定ファイル
+
+        場所：`~/.config/aish/config.yaml`
+
+        `$AISH_CONFIG_DIR` または `$XDG_CONFIG_HOME` で上書き可能。
+
+        ## 優先順位
+
+        コマンドライン引数 > 環境変数 > 設定ファイル
+
+        ## 環境変数
+
+        | 変数 | 用途 |
+        |------|------|
+        | `AISH_MODEL` | デフォルトモデルを上書き |
+        | `AISH_API_KEY` | API キーを上書き |
+        | `AISH_API_BASE` | API ベース URL を上書き |
+        | `AISH_CONFIG_DIR` | 設定ディレクトリを上書き |
+
+        ## 主な設定項目
+
+        ```
+        model: gpt-4o                    # デフォルト LLM モデル
+        api_key: sk-xxx                  # API キー
+        api_base: https://api.openai.com/v1  # API エンドポイント
+        temperature: 0.3                 # 応答のランダム性
+        theme: dark                      # UI テーマ（dark/light）
+        output_language: ja              # 出力言語の強制
+        ```
+
+        ## セットアップウィザード
+
+        `/setup` または `aish setup` でインタラクティブに設定できます。設定は再起動なしで即座に反映されます。
+
+        ## その他のファイル
+
+        - セキュリティポリシー：`~/.config/aish/security_policy.yaml`
+        - セッションデータベース：`~/.local/share/aish/sessions.db`
+        - ログ：`~/.config/aish/logs/aish.log`
+
+    shortcuts:
+      title: "キーボードショートカット"
+      markdown: |-
+        ## 編集
+
+        | キー | 操作 |
+        |------|------|
+        | `Tab` | 自動補完 |
+        | `↑` / `↓` | 履歴を参照 |
+        | `Ctrl+R` | 履歴検索 |
+        | `Ctrl+L` | 画面クリア |
+        | `Backspace` / `Delete` | 文字削除 |
+
+        ## シェル制御
+
+        | キー | 操作 |
+        |------|------|
+        | `Ctrl+C` | 現在の操作をキャンセル（2 回押しで終了） |
+        | `Ctrl+D` | シェルを終了 |
+        | `Ctrl+O` | 出力履歴を参照 |
+        | `Esc` | 現在の入力をキャンセル |
+
+        ## モード切替
+
+        | キー | 操作 |
+        |------|------|
+        | `Shift+Tab` / `F2` | プランモード切替 |
+        | 空行で `/` | スラッシュコマンドピッカーを開く |
+
+    security:
+      title: "セキュリティポリシー"
+      markdown: |-
+        ## 概要
+
+        aish はセキュリティポリシーファイルを使用して、確認が必要またはブロックされるコマンドやファイル操作を制御します。
+
+        ## 設定場所
+
+        優先順位：
+        1. 明示的に指定されたパス
+        2. `/etc/aish/security_policy.yaml`
+        3. `~/.config/aish/security_policy.yaml`
+
+        ## リスクレベル
+
+        | レベル | 動作 |
+        |--------|------|
+        | `LOW` | 許可、ログ記録 |
+        | `MEDIUM` | 確認プロンプト |
+        | `HIGH` | ブロックまたは明示的な確認が必要 |
+
+        ## ルール構造
+
+        ```yaml
+        rules:
+          - id: protect-system
+            name: システムディレクトリの保護
+            path: ["/boot/**", "/etc/passwd"]
+            operations: [WRITE, DELETE]
+            risk: HIGH
+            reason: "システムファイルは変更すべきではありません"
+        ```
+
+        ## パスパターン
+
+        - `*` は単一のパスセグメントにマッチ
+        - `**` はゼロ以上のパスセグメントにマッチ
+        - 変数：`$HOME`、`$PWD`
+
+        ## シークレット検出
+
+        OpenAI、Anthropic、AWS、Google、GitHub、Stripe、Slack の API キー、JWT トークン、埋め込みパスワードを含む URL の検出パターンが組み込まれています。`secret_patterns` でカスタムパターンを追加できます。
 
   command:
     history:

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -324,12 +324,14 @@ shell:
 
   # 斜杠命令描述（弹窗用）
   slash:
+    help: "显示帮助信息"
     model: "显示或切换 AI 模型"
     setup: "打开设置向导"
     plan: "计划模式控制"
     token: "显示令牌用量"
     resume: "恢复之前的会话"
     feedback: "提交反馈"
+    quit: "退出 AI Shell"
 
   feedback:
     select_type: "选择反馈类型"
@@ -673,8 +675,24 @@ tools:
       edit_write_failed: "写入 {path} 失败: {error}"
 
   ask_user:
-    runtime_not_configured: "ask_user runtime 未配置"
-    execute_failed: "ask_user 执行失败：{error}"
+    description: “向用户提出一个聚焦的澄清问题。只填 prompt 时为文本输入，提供 options 时为选项交互。”
+    runtime_not_configured: “ask_user runtime 未配置”
+    execute_failed: “ask_user 执行失败：{error}”
+    param:
+      kind: “交互类型：text_input 用于自由输入，choice_or_text 用于选项加自定义输入”
+      prompt: “要向用户提出的问题。”
+      options: “可选的候选项。为空或省略时，ask_user 使用文本输入。”
+      option_value: “返回到工具元数据中的稳定选项值。”
+      option_label: “展示给用户的选项标签。”
+      option_description: “显示在选项下方的附加说明。”
+      option_recommended: “显式标记该选项为推荐默认项。”
+      title: “问题的可选标题”
+      default: “默认值”
+      placeholder: “占位符文本”
+      allow_freeform_input: “当存在 options 时，允许用户选择”其他”并输入自定义答案，默认 true。”
+      required: “用户是否必须提供答案(默认：true)”
+      allow_cancel: “用户是否可以取消/跳过(默认：true)”
+      min_length: “文本输入的最小长度(默认：0)”
     validation:
       prompt_empty: "prompt 不能为空"
       option_value_empty: "option value 不能为空"
@@ -760,54 +778,269 @@ help:
     brief_usage: "用法：{usage}"
 
   general:
-    title: "📖 AI Shell 帮助"
+    title: "AI Shell 帮助"
     markdown: |-
-      ## 可用命令：
+      ## 快速开始
+      - **Shell 命令** — 直接输入：`ls`、`cd`、`vim`、`ssh`、`top` …
+      - **向 AI 提问** — 以 `;` 或 `；` 开头：`;如何查找大文件`
+      - **斜杠命令** — 在空行按 `/` 打开交互式选择器
 
-      ### 目录导航
-      - `cd [-L|[-P [-e]]] [directory]` - 切换目录(完整参数支持)
-      - `pushd [directory]` - 将目录压入栈并切换
-      - `popd` - 弹出目录栈并切换
-      - `dirs [-c]` - 显示目录栈
+      ## 斜杠命令
+      | 命令 | 说明 |
+      |------|------|
+      | `/help [page]` | 显示帮助（`/help` 查看可用页面） |
+      | `/quit` | 退出 AI Shell |
+      | `/model [名称]` | 查看或切换 AI 模型 |
+      | `/setup` | 重新配置 API 设置 |
+      | `/plan [start\|status\|exit]` | 计划模式控制 |
+      | `/token` | 显示令牌用量（近 7 天） |
+      | `/resume [id]` | 恢复之前的会话 |
+      | `/feedback` | 提交反馈或报告问题 |
 
-      ### 历史管理
-      - `history [options] [n]` - 查看命令历史
-      - `history -c` - 清空历史
-      - `history -d offset` - 删除指定位置的历史条目
+      ## 配置
+      - 配置文件：`~/.config/aish/config.yaml`
+      - 优先级：命令行参数 > 环境变量（`AISH_MODEL`、`AISH_API_KEY`、`AISH_API_BASE`） > 配置文件
+      - 运行 `/setup` 或 `aish setup` 进行交互式配置
 
-      ### 环境变量
-      - `export [-fn] [name[=value] ...]` - 设置/导出环境变量
-      - `export -p` - 显示所有已导出的变量
-      - `unset [-fv] [name ...]` - 取消设置环境变量
-      - `pwd [-L|-P]` - 显示当前工作目录
+      ## 快捷键
+      | 按键 | 功能 |
+      |------|------|
+      | `Ctrl+C` | 取消当前操作（连按两次退出） |
+      | `Ctrl+D` | 退出 Shell |
+      | `Shift+Tab` / `F2` | 切换计划模式 |
+      | `Ctrl+O` | 浏览输出历史 |
+      | 空行按 `/` | 斜杠命令选择器 |
 
-      ### 通用命令
-      - `help` - 显示本帮助
-      - `clear` - 清屏
-      - `exit` - 退出 shell
-      - `/model [模型名称]` - 查看或切换模型
-      - `/setup` - 重新配置 API 设置
+      ## 帮助页面
+      使用 `/help <page>` 查看 aish 特有功能的详细说明：
 
-      ### AI 命令
-      - `； <question>` - 向 AI 助手提问
+      | 页面 | 内容 |
+      |------|------|
+      | `ai` | AI 助手用法（`;` 前缀、上下文、对话） |
+      | `model` | 模型管理（查看、切换、支持供应商） |
+      | `plan` | 计划模式（工作流、审批、与普通模式对比） |
+      | `config` | 配置（文件、环境变量、优先级） |
+      | `shortcuts` | 快捷键（编辑、控制、模式切换） |
+      | `security` | 安全策略（风险等级、规则、密钥检测） |
 
-      ### 功能特性
-      - ✅ 所有命令完整 PTY 支持
-      - ✅ 命令历史与 AI 上下文融合
-      - ✅ AI 输出 Rich 美化
-      - ✅ 信号处理与优雅退出
+      ## 更多
+      - 安全策略：`~/.config/aish/security_policy.yaml`
+      - 会话数据：`~/.local/share/aish/sessions.db`
+      - 日志：`~/.config/aish/logs/aish.log`
+      - 文档：https://github.com/AI-Shell-Team/aish
 
-      ### 获取更多帮助
-      对任意命令使用 `<command> --help` 或 `<command> -h` 查看详细帮助。
+  topics:
+    unknown: "未知帮助页面 '{topic}'。可用页面：ai, model, plan, config, shortcuts, security"
 
-      ### 示例
-      ```bash
-      history --help       # 查看 history 的详细帮助
-      cd --help            # 查看 cd 的详细帮助
-      export JAVA_HOME="/usr/lib/jvm/java-11"  # 设置环境变量
-      unset TEMP_VAR       # 删除环境变量
-      ； explain ls -la     # 让 AI 解释命令
-      ```
+    ai:
+      title: "AI 助手"
+      markdown: |-
+        ## 向 AI 提问
+
+        在问题前加 `;`（半角分号）或 `；`（全角分号）：
+
+        ```
+        ; 如何查找大文件？
+        ; 解释这个命令：ls -la
+        ; 推荐一个更好的压缩方式
+        ```
+
+        AI 会看到你的对话上下文，包括之前的 shell 命令和 AI 回复。
+
+        ## 工作原理
+
+        - 你的问题会发送到配置的 LLM 模型
+        - AI 接收对话历史作为上下文
+        - 回复支持语法高亮和表格渲染
+
+        ## 上下文管理
+
+        - 对话历史自动维护
+        - 超出 token 预算时自动压缩上下文
+        - 旧消息被摘要化，保留近期上下文
+
+    model:
+      title: "模型管理"
+      markdown: |-
+        ## 查看 & 切换模型
+
+        ```
+        /model                    # 查看当前模型
+        /model gpt-4o             # 切换到 GPT-4o
+        /model claude-sonnet-4-6  # 切换到 Claude
+        ```
+
+        ## 支持的供应商
+
+        | 供应商 | 模型前缀 |
+        |--------|----------|
+        | OpenAI | `gpt-*`, `o1-*`, `o3-*`, `o4-*` |
+        | Anthropic | `claude-*` |
+        | Google | `gemini-*`, `gemma-*` |
+        | DeepSeek | `deepseek-*` |
+        | 通义千问 | `qwen-*`, `qwq-*` |
+        | Mistral | `mistral-*`, `mixtral-*`, `codestral-*` |
+        | xAI | `grok-*` |
+        | Moonshot | `kimi-*`, `moonshot-*` |
+        | 智谱 | `glm-*` |
+        | 本地 | Ollama、vLLM、本地 API |
+
+        ## 切换行为
+
+        - 根据模型名自动检测供应商
+        - 切换前验证连接性
+        - 失败时保留当前模型
+        - 配置自动保存到 `~/.config/aish/config.yaml`
+
+    plan:
+      title: "计划模式"
+      markdown: |-
+        ## 什么是计划模式？
+
+        计划模式让 AI 在写代码之前先分析代码库并创建详细的实施计划。只有在审批通过后才会应用更改。
+
+        ## 命令
+
+        ```
+        /plan start     # 进入计划模式
+        /plan status    # 查看当前计划状态
+        /plan exit      # 退出计划模式
+        ```
+
+        也可以用 `Shift+Tab` 或 `F2` 切换计划模式。
+
+        ## 使用流程
+
+        1. 进入计划模式：`/plan start`
+        2. 让 AI 规划：`; 重构 auth 模块使用 JWT`
+        3. AI 生成包含步骤和文件变更的计划
+        4. 审核计划，逐步批准或拒绝
+        5. 审批通过后应用更改
+        6. 退出计划模式：`/plan exit`
+
+        ## 计划模式 vs 普通模式
+
+        | | 普通模式 | 计划模式 |
+        |---|---|---|
+        | AI 工具 | 完整访问 | 只读 + 计划写入 |
+        | 代码变更 | 立即执行 | 审批后执行 |
+        | 适合场景 | 快速修复、提问 | 重构、新功能 |
+
+    config:
+      title: "配置"
+      markdown: |-
+        ## 配置文件
+
+        位置：`~/.config/aish/config.yaml`
+
+        可通过 `$AISH_CONFIG_DIR` 或 `$XDG_CONFIG_HOME` 覆盖。
+
+        ## 优先级
+
+        命令行参数 > 环境变量 > 配置文件
+
+        ## 环境变量
+
+        | 变量 | 用途 |
+        |------|------|
+        | `AISH_MODEL` | 覆盖默认模型 |
+        | `AISH_API_KEY` | 覆盖 API 密钥 |
+        | `AISH_API_BASE` | 覆盖 API 地址 |
+        | `AISH_CONFIG_DIR` | 覆盖配置目录 |
+
+        ## 主要设置
+
+        ```
+        model: gpt-4o                    # 默认 LLM 模型
+        api_key: sk-xxx                  # API 密钥
+        api_base: https://api.openai.com/v1  # API 端点
+        temperature: 0.3                 # 回复随机性
+        theme: dark                      # UI 主题（dark/light）
+        output_language: zh              # 强制输出语言
+        ```
+
+        ## 配置向导
+
+        运行 `/setup` 或 `aish setup` 进行交互式配置。设置立即生效，无需重启。
+
+        ## 其他文件
+
+        - 安全策略：`~/.config/aish/security_policy.yaml`
+        - 会话数据库：`~/.local/share/aish/sessions.db`
+        - 日志：`~/.config/aish/logs/aish.log`
+
+    shortcuts:
+      title: "快捷键"
+      markdown: |-
+        ## 编辑
+
+        | 按键 | 功能 |
+        |------|------|
+        | `Tab` | 自动补全 |
+        | `↑` / `↓` | 浏览历史 |
+        | `Ctrl+R` | 搜索历史 |
+        | `Ctrl+L` | 清屏 |
+        | `Backspace` / `Delete` | 删除字符 |
+
+        ## Shell 控制
+
+        | 按键 | 功能 |
+        |------|------|
+        | `Ctrl+C` | 取消当前操作（连按两次退出） |
+        | `Ctrl+D` | 退出 Shell |
+        | `Ctrl+O` | 浏览输出历史 |
+        | `Esc` | 取消当前输入 |
+
+        ## 模式切换
+
+        | 按键 | 功能 |
+        |------|------|
+        | `Shift+Tab` / `F2` | 切换计划模式 |
+        | 空行按 `/` | 打开斜杠命令选择器 |
+
+    security:
+      title: "安全策略"
+      markdown: |-
+        ## 概述
+
+        aish 使用安全策略文件来控制哪些命令和文件操作需要确认或被阻止。
+
+        ## 配置位置
+
+        优先级：
+        1. 显式指定的路径
+        2. `/etc/aish/security_policy.yaml`
+        3. `~/.config/aish/security_policy.yaml`
+
+        ## 风险等级
+
+        | 等级 | 行为 |
+        |------|------|
+        | `LOW` | 允许，记录日志 |
+        | `MEDIUM` | 需要确认 |
+        | `HIGH` | 阻止或需要明确确认 |
+
+        ## 规则结构
+
+        ```yaml
+        rules:
+          - id: protect-system
+            name: 保护系统目录
+            path: ["/boot/**", "/etc/passwd"]
+            operations: [WRITE, DELETE]
+            risk: HIGH
+            reason: "不应修改系统文件"
+        ```
+
+        ## 路径模式
+
+        - `*` 匹配单个路径段
+        - `**` 匹配零或多个路径段
+        - 变量：`$HOME`、`$PWD`
+
+        ## 密钥检测
+
+        内置 API 密钥检测模式（OpenAI、Anthropic、AWS、Google、GitHub、Stripe、Slack）、JWT 令牌和嵌入密码的 URL。支持通过 `secret_patterns` 添加自定义模式。
 
   command:
     history:

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -2051,6 +2051,21 @@ impl AishShell {
     fn handle_special_command(&mut self, input: &str) -> bool {
         let parts: Vec<&str> = input.split_whitespace().collect();
         match parts.first().copied() {
+            Some("/help") => {
+                let args: Vec<&str> = if parts.len() > 1 {
+                    parts[1..].to_vec()
+                } else {
+                    vec![]
+                };
+                let result = self.state.handle_builtin("help", &args);
+                if let Some(output) = result.output {
+                    println!("{}", output);
+                }
+            }
+            Some("/quit") => {
+                self.state.should_exit = true;
+                return false;
+            }
             Some("/model") => self.handle_model_command(&parts),
             Some("/setup") => self.run_setup_wizard(),
             Some("/plan") => self.handle_plan_command(&parts),

--- a/crates/aish-shell/src/commands.rs
+++ b/crates/aish-shell/src/commands.rs
@@ -1,6 +1,6 @@
 use crate::types::ShellState;
 use crate::wizard::SetupWizard;
-use aish_i18n::t;
+use aish_i18n::{t, t_with_args};
 
 /// Result of handling a built-in command.
 pub struct BuiltinResult {
@@ -89,7 +89,7 @@ impl ShellState {
             "pushd" => self.handle_pushd(args),
             "popd" => self.handle_popd(),
             "dirs" => self.handle_dirs(args),
-            "help" => self.handle_help(),
+            "help" => self.handle_help(args),
             "clear" => self.handle_clear(),
             "exit" | "quit" => self.handle_exit(),
             "su" | "sudo" => self.handle_pty_command(cmd, args),
@@ -469,27 +469,34 @@ impl ShellState {
 
     // -- help ----------------------------------------------------------------
 
-    fn handle_help(&self) -> BuiltinResult {
-        let help_text = r#"AI Shell - Built-in Commands
+    fn handle_help(&self, args: &[&str]) -> BuiltinResult {
+        match args.first() {
+            Some(topic) => self.render_topic_help(topic),
+            None => {
+                let title = t("help.general.title");
+                println!("\n\x1b[1;36m{}\x1b[0m\n", title);
+                let markdown = t("help.general.markdown");
+                crate::renderer::ShellRenderer::new().render_markdown(&markdown);
+                BuiltinResult::handled_no_output()
+            }
+        }
+    }
 
-  ; <question>       Ask the AI assistant a question
-  cd [-L|-P] [dir]   Change directory (~, - supported)
-  pwd [-L|-P]        Print working directory
-  export [-p|-n]     Set or list environment variables
-  unset [-v|-f]      Remove environment variables
-  pushd <dir>        Push directory onto stack and cd
-  popd               Pop directory from stack and cd
-  dirs [-c|-v|-l]    Show (or clear) directory stack
-  history [N]        Show last N commands
-  clear              Clear the terminal screen
-  help               Show this help text
-  exit / quit        Exit the shell
-  /model [name]      Show or switch the AI model
-  /setup             Open setup wizard
-  /token             Show token usage statistics (last 7 days)
-
-Any other input is executed as an external command via /bin/bash."#;
-        BuiltinResult::handled(help_text)
+    fn render_topic_help(&self, topic: &str) -> BuiltinResult {
+        let title_key = format!("help.topics.{}.title", topic);
+        let title = t(&title_key);
+        // If the returned value equals the key itself, the topic doesn't exist
+        if title == title_key {
+            let mut args = std::collections::HashMap::new();
+            args.insert("topic".to_string(), topic.to_string());
+            eprintln!("{}", t_with_args("help.topics.unknown", &args));
+            return BuiltinResult::handled_no_output();
+        }
+        println!("\n\x1b[1;36m{}\x1b[0m\n", title);
+        let md_key = format!("help.topics.{}.markdown", topic);
+        let markdown = t(&md_key);
+        crate::renderer::ShellRenderer::new().render_markdown(&markdown);
+        BuiltinResult::handled_no_output()
     }
 
     // -- clear ---------------------------------------------------------------

--- a/crates/aish-shell/src/input.rs
+++ b/crates/aish-shell/src/input.rs
@@ -97,6 +97,8 @@ mod tests {
         assert_eq!(classify_input("/resume"), InputIntent::SpecialCommand);
         assert_eq!(classify_input("/resume 1234"), InputIntent::SpecialCommand);
         assert_eq!(classify_input("/feedback"), InputIntent::SpecialCommand);
+        assert_eq!(classify_input("/help"), InputIntent::SpecialCommand);
+        assert_eq!(classify_input("/quit"), InputIntent::SpecialCommand);
     }
 
     #[test]

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -24,12 +24,14 @@ const BUILTINS: &[&str] = &[
 
 /// Slash commands with descriptions for popup completion.
 pub const SLASH_COMMANDS: &[(&str, &str)] = &[
+    ("/help", "Show help information"),
     ("/model", "Show or switch AI model"),
     ("/setup", "Open setup wizard"),
     ("/plan", "Plan mode control"),
     ("/token", "Show token usage"),
     ("/resume", "Resume previous session"),
     ("/feedback", "Submit feedback"),
+    ("/quit", "Exit AI Shell"),
 ];
 
 /// Timeout for PTY completion queries.


### PR DESCRIPTION
## Summary

- Add ESC key handling in readline to cancel/interrupt current input
- Add slash command popup with inline autocomplete (ratatui `Viewport::Inline`)
- Add `/help` command with topic-based help and markdown rendering
- Add `/quit` command as exit alias
- Refactor `ask_user` interaction flow with structured validation errors
- Rewrite i18n help documentation across all 6 locales (zh-CN, en-US, ja-JP, de-DE, fr-FR, es-ES)
- Add `/feedback` command with interactive issue template

## Test plan

- [ ] Press ESC during input to verify cancellation behavior
- [ ] Type `/` on empty line to trigger slash command popup
- [ ] Run `/help` to verify general help renders correctly
- [ ] Run `/help cd` to verify topic-specific help
- [ ] Run `/quit` to verify shell exits
- [ ] Verify all 6 locale translations are correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/quit` command to exit the AI Shell.
  * Enhanced `/help` command with topic-specific documentation covering AI, model management, planning, configuration, keyboard shortcuts, and security.
  * Restructured help system with Quick Start guide and organized reference pages.

* **Documentation**
  * Improved localization across German, Spanish, French, Japanese, and Chinese interfaces.
  * Expanded help text and parameter descriptions for better user guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->