### PR TITLE
fix: correct license from MIT to Apache-2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 [workspace.package]
 version = "0.3.3"
 edition = "2021"
-license = "MIT"
+license = "Apache-2.0"
 rust-version = "1.80"
 
 [workspace.dependencies]

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "AI Shell command-line interface"
 readme = "README_PYPI.md"
 requires-python = ">=3.9"
-license = { text = "MIT" }
+license = { text = "Apache-2.0" }
 authors = [
     { name = "AI Shell Team" }
 ]


### PR DESCRIPTION
## Summary
- Fix `Cargo.toml` license field: MIT → Apache-2.0
- Fix `packaging/pypi/pyproject.toml` license field: MIT → Apache-2.0

The project LICENSE file is Apache License 2.0, but these two files incorrectly declared MIT.

## Test plan
- [ ] Verify `Cargo.toml` license field reads `Apache-2.0`
- [ ] Verify `packaging/pypi/pyproject.toml` license field reads `Apache-2.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project license from MIT to Apache-2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->