### PR TITLE
Release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2026-06-08
+
+### Added
+
+- Added multimodal image support so user messages can attach local image files and send them as structured content blocks to compatible models.
+- Added an interactive `/feedback` command that collects system context, redacts sensitive log lines, and opens a pre-filled GitHub issue in the browser.
+- Added `/help` with topic-based help pages and markdown rendering, plus `/quit` as an exit alias for the interactive shell.
+- Added a `web_fetch` tool so the agent can retrieve and summarize web page content during a session.
+- Added ESC handling in readline to cancel the current input line without leaving the shell.
+
+### Changed
+
+- Changed the feedback issue template to include bug-report sections such as steps to reproduce, expected behavior, and actual behavior.
+- Changed the project license metadata from MIT to Apache-2.0 so packaging files match the shipped `LICENSE`.
+
+### Fixed
+
+- Fixed confirmation panel rendering so the right border draws correctly in the terminal UI.
+- Fixed feedback log attachment so oversized bodies keep as many recent log lines as possible instead of dropping logs entirely when the GitHub issue URL would exceed the length limit.
+
+## [Unreleased]
+
+### Added
+
+- No unreleased changes yet.
+
 ## [0.3.3] - 2026-06-03
 
 ### Added
@@ -25,11 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `ask_user` default matching and validation reporting so trimmed defaults and structured errors behave consistently.
 - Fixed slash popup anchoring so the menu stays attached to the active prompt line.
 
-## [Unreleased]
-
-### Added
-
-- No unreleased changes yet.
 
 ## [0.3.2] - 2026-05-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "aish-cli"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "aish-config"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "aish-context"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aish-core",
  "serde",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "aish-core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "aish-hosts"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "aish-i18n"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "aish-llm"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aish-context",
  "aish-core",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "aish-memory"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aish-core",
  "chrono",
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "aish-prompts"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "aish-pty"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aish-core",
  "aish-hosts",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "aish-scripts"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "aish-security"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "libc",
  "regex",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aish-session"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aish-core",
  "chrono",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "aish-shell"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aish-config",
  "aish-context",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "aish-skills"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "aish-tools"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aish-core",
  "aish-i18n",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "aish-ui"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "crossterm 0.28.1",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"


### PR DESCRIPTION
## Summary

- Bump workspace version to **0.3.4** and add the release changelog section.
- Highlights since v0.3.3: multimodal image input, interactive `/feedback`, `/help` and `/quit`, `web_fetch` tool, Apache-2.0 license metadata alignment, and UI/feedback fixes.

## Test plan

- [ ] CI passes on this release PR (version/metadata, tests, bundle build, install smoke)
- [ ] Run **Release Preparation** with `version=0.3.4` and `ref=release/v0.3.4-prep`
- [ ] Verify release notes extracted from `CHANGELOG.md` match the `0.3.4` section
- [ ] Merge to `main`, then run **Release Final Check** and tag `v0.3.4`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multimodal image support
  * New `/feedback` and `/help` commands with `/quit` alias
  * `web_fetch` tool
  * Improved readline ESC handling

* **Bug Fixes**
  * Terminal confirmation panel border rendering
  * Feedback log attachment truncation behavior

* **Chores**
  * Version bumped to 0.3.4
  * License metadata updated to Apache-2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->