### PR TITLE
feat: add session recorder for shell interaction recording

### DIFF
--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -332,6 +332,17 @@ shell:
     resume: "Resume previous session"
     feedback: "Submit feedback"
     quit: "Exit AI Shell"
+    record: "Record terminal session (start/stop)"
+
+  record:
+    started: "⏺ Recording started: {path}"
+    stopped: "⏹ Recording saved: {path} ({duration}s, {size})"
+    already_recording: "Recording already in progress. Use /record stop first."
+    not_recording: "No recording in progress."
+    recording_status: "⏺ Recording in progress: {path} ({duration}s)"
+    usage: "Usage: /record start | /record stop"
+    auto_saved: "⏹ Recording auto-saved: {path}"
+    start_failed: "Failed to start recording: {error}"
 
   feedback:
     select_type: "Select feedback type"
@@ -797,6 +808,12 @@ help:
       | `/token` | Show token usage (last 7 days) |
       | `/resume [id]` | Resume a previous session |
       | `/feedback` | Submit feedback or report a bug |
+      | `/record start\|stop` | Record terminal session as asciinema cast |
+
+      ```
+      /record start         # Start recording
+      /record stop          # Stop and save recording
+      ```
 
       ## Configuration
       - Config file: `~/.config/aish/config.yaml`

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -332,6 +332,17 @@ shell:
     resume: "恢复之前的会话"
     feedback: "提交反馈"
     quit: "退出 AI Shell"
+    record: "录制终端会话 (start/stop)"
+
+  record:
+    started: "⏺ 录制已开始: {path}"
+    stopped: "⏹ 录制已保存: {path} ({duration}s, {size})"
+    already_recording: "录制正在进行中。请先使用 /record stop 停止。"
+    not_recording: "当前没有进行中的录制。"
+    recording_status: "⏺ 正在录制: {path} ({duration}s)"
+    usage: "用法: /record start | /record stop"
+    auto_saved: "⏹ 录制已自动保存: {path}"
+    start_failed: "录制启动失败: {error}"
 
   feedback:
     select_type: "选择反馈类型"
@@ -796,6 +807,12 @@ help:
       | `/token` | 显示令牌用量（近 7 天） |
       | `/resume [id]` | 恢复之前的会话 |
       | `/feedback` | 提交反馈或报告问题 |
+      | `/record start\|stop` | 录制终端会话 (asciinema 格式) |
+
+      ```
+      /record start         # 开始录制
+      /record stop          # 停止并保存录制
+      ```
 
       ## 配置
       - 配置文件：`~/.config/aish/config.yaml`

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -265,6 +265,8 @@ pub struct AishShell {
     animation: Arc<SharedAnimation>,
     /// Session history of collapsed outputs for Ctrl+O browsing.
     expand_history: Arc<Mutex<crate::expand_history::ExpandHistory>>,
+    /// Shared terminal session recorder for asciinema v2 recording.
+    shared_recorder: crate::recorder::SharedRecorder,
 }
 
 impl AishShell {
@@ -655,8 +657,14 @@ impl AishShell {
 
         // Shared animation controlled by event callback
         let animation: Arc<SharedAnimation> = Arc::new(SharedAnimation::new());
+        // Shared recorder for terminal session recording
+        let shared_recorder = crate::recorder::new_shared_recorder();
         // Shared renderer for streaming markdown re-rendering
-        let renderer = Arc::new(std::sync::Mutex::new(ShellRenderer::new()));
+        let renderer = Arc::new(Mutex::new(ShellRenderer::new()));
+        renderer
+            .lock()
+            .unwrap()
+            .set_shared_recorder(shared_recorder.clone());
         let renderer_ref = renderer.clone();
 
         // Set up LLM event callback for real-time streaming display
@@ -746,6 +754,7 @@ impl AishShell {
             }));
         }
 
+        let shared_recorder_cb = shared_recorder.clone();
         let event_callback: Arc<dyn Fn(LlmEvent) -> Option<LlmCallbackResult> + Send + Sync> =
             Arc::new(move |event: LlmEvent| {
                 // Helper: clear multi-line reasoning overlay and reset state.
@@ -844,6 +853,10 @@ impl AishShell {
                                 if !content_started_flag.load(Ordering::SeqCst) {
                                     content_started_flag.store(true, Ordering::SeqCst);
                                     renderer_ref.lock().unwrap().render_separator();
+                                    crate::recorder::shared_record_output(
+                                        &shared_recorder_cb,
+                                        "\x1b[1;90m🤖 ",
+                                    );
                                     print!("\x1b[1;90m🤖 ");
                                 }
                                 // Accumulate delta and print raw text
@@ -968,12 +981,17 @@ impl AishShell {
                             if content_started_flag.load(Ordering::SeqCst) {
                                 println!();
                             }
-                            println!(
+                            let tool_line = format!(
                                 "\x1b[36m{}: {} ({})\x1b[0m",
                                 t("shell.tool.prefix"),
                                 name,
                                 args_preview
                             );
+                            crate::recorder::shared_record_output(
+                                &shared_recorder_cb,
+                                &format!("{}\n", tool_line),
+                            );
+                            println!("{}", tool_line);
                             let _ = io::stdout().flush();
                         }
                     }
@@ -1008,15 +1026,20 @@ impl AishShell {
                                         .unwrap_or_else(|| content.lines().count() as u64)
                                         as usize;
                                     let collapsed = collapse_display_lines(&content, 2);
-                                    print!("\x1b[2m{}\x1b[0m", collapsed);
+                                    let mut preview_ansi = format!("\x1b[2m{}\x1b[0m", collapsed);
                                     if total_lines > 2 {
                                         let hidden = total_lines - 2;
-                                        print!(
+                                        preview_ansi.push_str(&format!(
                                             "\x1b[2m\n  ... {} lines hidden ─── \x1b[1;36mCtrl+O\x1b[0m\x1b[2m to expand ...\x1b[0m",
                                             hidden
-                                        );
+                                        ));
                                     }
-                                    println!();
+                                    preview_ansi.push('\n');
+                                    crate::recorder::shared_record_output(
+                                        &shared_recorder_cb,
+                                        &preview_ansi,
+                                    );
+                                    print!("{}", preview_ansi);
                                     let _ = io::stdout().flush();
                                     // Only record to expand history when output is
                                     // actually collapsed (total_lines > 2).
@@ -1264,6 +1287,7 @@ impl AishShell {
             last_ctrl_c: None,
             animation,
             expand_history,
+            shared_recorder,
         })
     }
 
@@ -1386,12 +1410,23 @@ impl AishShell {
                 aish_core::PlanPhase::Planning => "plan",
                 aish_core::PlanPhase::Normal => "aish",
             };
+            let recording = self.shared_recorder.lock().unwrap().is_some();
             let prompt_str = prompt::render_prompt(
                 &self.state.cwd,
                 &self.config.model,
                 self.state.last_exit_code,
                 mode,
+                recording,
             );
+            // Record prompt output if recording is active.
+            // \r\x1b[2K clears the current line so re-rendered prompts
+            // overwrite the previous one instead of appending after it.
+            {
+                crate::recorder::shared_record_output(
+                    &self.shared_recorder,
+                    &format!("\r\x1b[2K{}", prompt_str),
+                );
+            }
             let input = match rl.read_line(&prompt_str) {
                 Ok(Some(line)) => line,
                 Ok(None) => break, // EOF (Ctrl-D)
@@ -1427,6 +1462,11 @@ impl AishShell {
                     {
                         match self.run_slash_input_session(&prompt_str) {
                             aish_ui::SlashInputOutcome::Command(cmd) => {
+                                // Record user input if recording is active
+                                crate::recorder::shared_record_input(
+                                    &self.shared_recorder,
+                                    &format!("{}\n", cmd.trim()),
+                                );
                                 // Execute the selected command directly (avoids raw mode
                                 // conflict between crossterm and rustyline).
                                 let input = cmd.trim();
@@ -1508,6 +1548,11 @@ impl AishShell {
                                             // the slash popup.
                                             match self.run_slash_input_session(&prompt_str) {
                                                 aish_ui::SlashInputOutcome::Command(cmd) => {
+                                                    // Record user input if recording is active
+                                                    crate::recorder::shared_record_input(
+                                                        &self.shared_recorder,
+                                                        &format!("{}\n", cmd.trim()),
+                                                    );
                                                     let input = cmd.trim();
                                                     if !input.is_empty() {
                                                         self.state.history.push(input.to_string());
@@ -1678,6 +1723,12 @@ impl AishShell {
                         continue;
                     }
 
+                    // Record sanitized user input after security check passes
+                    crate::recorder::shared_record_input(
+                        &self.shared_recorder,
+                        &format!("{}\n", question),
+                    );
+
                     let old_sigint = self.install_ai_sigint_handler();
                     let mut esc_watcher =
                         CrosstermEscWatcher::start(self.ai_handler.cancellation_token_arc());
@@ -1702,8 +1753,9 @@ impl AishShell {
                             if !did_stream && !response.trim().is_empty() {
                                 // Non-streaming fallback: print full response with formatting
                                 let mut sep_renderer = ShellRenderer::new();
+                                sep_renderer.set_shared_recorder(self.shared_recorder.clone());
                                 sep_renderer.render_separator();
-                                print_md(&response);
+                                print_md_with_recording(&response, &self.shared_recorder);
                                 sep_renderer.render_separator();
                             } else if did_stream {
                                 // Streaming display already handled by event callback
@@ -1839,6 +1891,12 @@ impl AishShell {
                     let result = self.state.handle_builtin("help", &[]);
                     if let Some(output) = result.output {
                         println!("{}", output);
+                        if !output.is_empty() {
+                            crate::recorder::shared_record_output(
+                                &self.shared_recorder,
+                                &format!("{}\n", output),
+                            );
+                        }
                     }
                     self.record_history(input, 0);
                 }
@@ -1848,6 +1906,12 @@ impl AishShell {
                         let result = self.state.handle_builtin(cmd, &parts[1..]);
                         if let Some(ref output) = result.output {
                             println!("{}", output);
+                            if !output.is_empty() {
+                                crate::recorder::shared_record_output(
+                                    &self.shared_recorder,
+                                    &format!("{}\n", output),
+                                );
+                            }
                         }
                         if result.should_exit {
                             self.record_history(input, 0);
@@ -1941,8 +2005,13 @@ impl AishShell {
                                     Ok(response) => {
                                         if !did_stream && !response.trim().is_empty() {
                                             let mut sep_renderer = ShellRenderer::new();
+                                            sep_renderer
+                                                .set_shared_recorder(self.shared_recorder.clone());
                                             sep_renderer.render_separator();
-                                            print_md(&response);
+                                            print_md_with_recording(
+                                                &response,
+                                                &self.shared_recorder,
+                                            );
                                             sep_renderer.render_separator();
                                         }
                                         self.persist_session_snapshot();
@@ -1979,6 +2048,8 @@ impl AishShell {
                     // Show error correction hint
                     if exit_code != 0 && exit_code != 130 {
                         let hint = t("shell.error_correction.press_semicolon_hint");
+                        let hint_str = format!("\x1b[2m\x1b[37m<{}>\x1b[0m\n", hint);
+                        crate::recorder::shared_record_output(&self.shared_recorder, &hint_str);
                         eprintln!("\x1b[2m\x1b[37m<{}>\x1b[0m", hint);
                     }
                 }
@@ -1992,6 +2063,24 @@ impl AishShell {
         // Save history on exit
         rl.save_history(&history_path);
         self.persist_session_snapshot();
+
+        // Auto-stop recording if active
+        {
+            let mut guard = self.shared_recorder.lock().unwrap();
+            if let Some(ref mut rec) = *guard {
+                let path = rec.file_path().to_path_buf();
+                let _ = rec.flush();
+                *guard = None;
+                println!(
+                    "\x1b[33m{}\x1b[0m",
+                    t_with_args("shell.record.auto_saved", &{
+                        let mut args = std::collections::HashMap::new();
+                        args.insert("path".to_string(), path.display().to_string());
+                        args
+                    })
+                );
+            }
+        }
 
         println!(
             "{}",
@@ -2077,6 +2166,7 @@ impl AishShell {
             Some("/feedback") => {
                 crate::feedback::run_feedback(&self.config.model, &self.config.api_base);
             }
+            Some("/record") => self.handle_record_command(&parts),
             _ => {
                 eprintln!("{}", {
                     let mut args = std::collections::HashMap::new();
@@ -2275,6 +2365,90 @@ impl AishShell {
             )));
     }
 
+    fn handle_record_command(&mut self, parts: &[&str]) {
+        let subcmd = parts.get(1).copied().unwrap_or("");
+        let mut guard = self.shared_recorder.lock().unwrap();
+
+        match subcmd {
+            "start" => {
+                if guard.is_some() {
+                    eprintln!("\x1b[33m{}\x1b[0m", t("shell.record.already_recording"));
+                    return;
+                }
+                let term_size = crossterm::terminal::size().unwrap_or((80, 24));
+                let file_path = crate::recorder::Recorder::generate_file_path();
+                match crate::recorder::Recorder::new(file_path.clone(), term_size) {
+                    Ok(recorder) => {
+                        *guard = Some(recorder);
+                        println!(
+                            "\x1b[32m{}\x1b[0m",
+                            t_with_args("shell.record.started", &{
+                                let mut args = std::collections::HashMap::new();
+                                args.insert("path".to_string(), file_path.display().to_string());
+                                args
+                            })
+                        );
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "\x1b[31m{}\x1b[0m",
+                            t_with_args("shell.record.start_failed", &{
+                                let mut args = std::collections::HashMap::new();
+                                args.insert("error".to_string(), e.to_string());
+                                args
+                            })
+                        );
+                    }
+                }
+            }
+            "stop" => {
+                let elapsed = guard.as_ref().map(|r| r.elapsed()).unwrap_or_default();
+                if let Some(mut rec) = guard.take() {
+                    let path = rec.file_path().to_path_buf();
+                    let _ = rec.flush();
+                    let metadata = std::fs::metadata(&path).ok();
+                    let size = metadata.map(|m| m.len()).unwrap_or(0);
+                    let secs = elapsed.as_secs();
+                    let size_str = if size < 1024 {
+                        format!("{} B", size)
+                    } else {
+                        format!("{:.1} KB", size as f64 / 1024.0)
+                    };
+                    println!(
+                        "\x1b[32m{}\x1b[0m",
+                        t_with_args("shell.record.stopped", &{
+                            let mut args = std::collections::HashMap::new();
+                            args.insert("path".to_string(), path.display().to_string());
+                            args.insert("duration".to_string(), secs.to_string());
+                            args.insert("size".to_string(), size_str);
+                            args
+                        })
+                    );
+                } else {
+                    eprintln!("\x1b[33m{}\x1b[0m", t("shell.record.not_recording"));
+                }
+            }
+            _ => {
+                if let Some(ref rec) = *guard {
+                    let elapsed = rec.elapsed();
+                    let path = rec.file_path().display().to_string();
+                    let secs = elapsed.as_secs();
+                    println!(
+                        "\x1b[33m{}\x1b[0m",
+                        t_with_args("shell.record.recording_status", &{
+                            let mut args = std::collections::HashMap::new();
+                            args.insert("path".to_string(), path);
+                            args.insert("duration".to_string(), secs.to_string());
+                            args
+                        })
+                    );
+                } else {
+                    println!("{}", t("shell.record.usage"));
+                }
+            }
+        }
+    }
+
     fn handle_model_command(&mut self, parts: &[&str]) {
         if parts.len() == 1 {
             let mut args = std::collections::HashMap::new();
@@ -2468,8 +2642,12 @@ impl AishShell {
             let mut pty = self.lock_pty();
             let remote_host = extract_remote_host(command);
             let shared_host = Arc::new(Mutex::new(remote_host.clone()));
-            let ai_cb =
-                Self::build_session_ai_callback(&self.config, &self.animation, shared_host.clone());
+            let ai_cb = Self::build_session_ai_callback(
+                &self.config,
+                &self.animation,
+                shared_host.clone(),
+                self.shared_recorder.clone(),
+            );
             pty.send_command_interactive(
                 command,
                 ai_cb,
@@ -2494,6 +2672,11 @@ impl AishShell {
 
         // Store captured output for error correction and LLM context
         self.state.last_output = output.clone();
+
+        // Record command output if recording is active
+        if !output.is_empty() {
+            crate::recorder::shared_record_output(&self.shared_recorder, &output);
+        }
 
         // Track whether CWD changed so we can include it in the context entry
         let mut cwd_changed_to: Option<String> = None;
@@ -2773,7 +2956,7 @@ impl AishShell {
                     match rt.block_on(self.ai_handler.handle_question(prompt_str)) {
                         Ok(response) => {
                             self.sync_state_from_pty_cwd();
-                            print_md(&response);
+                            print_md_with_recording(&response, &self.shared_recorder);
                             self.persist_session_snapshot();
                             script_env.insert("AISH_LAST_OUTPUT".to_string(), response);
                         }
@@ -2928,6 +3111,7 @@ impl AishShell {
         animation: &Arc<crate::animation::SharedAnimation>,
         history: &Arc<Mutex<Vec<ChatMessage>>>,
         shared_host: Arc<Mutex<Option<String>>>,
+        shared_recorder: crate::recorder::SharedRecorder,
     ) -> Box<aish_pty::FollowupCallback> {
         let api_base_f = api_base.to_string();
         let api_key_f = api_key.to_string();
@@ -2937,6 +3121,7 @@ impl AishShell {
         let anim_f = animation.clone();
         let history_f = history.clone();
         let shared_host_f = shared_host.clone();
+        let shared_recorder = shared_recorder.clone();
 
         Box::new(
             move |output: &str, _offload_path: Option<&str>| -> Option<aish_pty::AiResponse> {
@@ -2987,6 +3172,7 @@ impl AishShell {
                 let question_th = question_f.clone();
                 let conversation_history_th = history_f.clone();
                 let shared_host_th_f = shared_host_f.clone();
+                let shared_recorder_th = shared_recorder.clone();
 
                 std::thread::spawn(move || {
                     let rt = match tokio::runtime::Runtime::new() {
@@ -3255,6 +3441,7 @@ impl AishShell {
                         if !t.trim().is_empty() {
                             let _ = std::io::stdout().flush();
                             let mut renderer = crate::renderer::ShellRenderer::new();
+                            renderer.set_shared_recorder(shared_recorder_th.clone());
                             renderer.render_separator();
                             renderer.render_markdown(t);
                             let _ = std::io::stdout().flush();
@@ -3275,6 +3462,7 @@ impl AishShell {
                             &anim_th,
                             &conversation_history_th,
                             shared_host_th_f.clone(),
+                            shared_recorder_th.clone(),
                         );
                         Some(aish_pty::AiResponse {
                             command: next_cmd,
@@ -3661,6 +3849,7 @@ impl AishShell {
         config: &aish_config::ConfigModel,
         animation: &Arc<crate::animation::SharedAnimation>,
         shared_host: Arc<Mutex<Option<String>>>,
+        shared_recorder: crate::recorder::SharedRecorder,
     ) -> Option<Box<aish_pty::AiCallback>> {
         let api_base = config.api_base.clone();
         let api_key = config.api_key.clone();
@@ -3668,6 +3857,7 @@ impl AishShell {
         let temperature = config.temperature;
         let max_tokens = config.max_tokens;
         let animation = animation.clone();
+        let shared_recorder = shared_recorder.clone();
 
         // Load skills snapshot for SSH sessions (same as local session).
         // Stored in Arc so each AI query closure can create a fresh SkillTool.
@@ -3888,6 +4078,7 @@ impl AishShell {
             let shared_host_th = dossier_host.clone();
             let skills_snapshot_th = ssh_skills_snapshot.clone();
             let skill_names_th = ssh_skill_names.clone();
+            let shared_recorder_th = shared_recorder.clone();
 
             std::thread::spawn(move || {
                 let rt = tokio::runtime::Runtime::new().unwrap();
@@ -4201,6 +4392,7 @@ impl AishShell {
                             if !desc.trim().is_empty() {
                                 let _ = std::io::stdout().flush();
                                 let mut renderer = crate::renderer::ShellRenderer::new();
+                                renderer.set_shared_recorder(shared_recorder_th.clone());
                                 renderer.render_separator();
                                 renderer.render_markdown(desc);
                                 let _ = std::io::stdout().flush();
@@ -4218,6 +4410,7 @@ impl AishShell {
                         if !t.trim().is_empty() {
                             let _ = std::io::stdout().flush();
                             let mut renderer = crate::renderer::ShellRenderer::new();
+                            renderer.set_shared_recorder(shared_recorder_th.clone());
                             renderer.render_separator();
                             renderer.render_markdown(t.trim());
                             let elapsed = thinking_start_thread
@@ -4249,6 +4442,7 @@ impl AishShell {
                                 &animation_th,
                                 &conversation_history_th,
                                 shared_host_th.clone(),
+                                shared_recorder_th.clone(),
                             )
                         });
                         Some(aish_pty::AiResponse {
@@ -5257,9 +5451,11 @@ fn read_raw_confirmation() -> bool {
 }
 
 /// Render markdown-formatted text to the terminal using richrs.
-fn print_md(text: &str) {
+/// Print markdown with recording support.
+fn print_md_with_recording(text: &str, shared_recorder: &crate::recorder::SharedRecorder) {
     use crate::renderer::ShellRenderer;
     let mut renderer = ShellRenderer::new();
+    renderer.set_shared_recorder(shared_recorder.clone());
     renderer.render_markdown(text);
 }
 

--- a/crates/aish-shell/src/lib.rs
+++ b/crates/aish-shell/src/lib.rs
@@ -29,6 +29,7 @@ pub mod keyboard;
 pub mod nl_detect;
 pub mod prompt;
 pub mod readline;
+pub mod recorder;
 pub mod renderer;
 pub mod resume_selector;
 pub mod security_panel;

--- a/crates/aish-shell/src/prompt.rs
+++ b/crates/aish-shell/src/prompt.rs
@@ -100,14 +100,26 @@ fn strip_ansi_len(s: &str) -> usize {
 /// - Path is abbreviated and colored blue
 /// - Git branch in magenta with clean (green ●) or dirty (red ●) indicator
 /// - Prompt symbol: green ➜ on success, red ➜➜ on error
-pub fn render_prompt(cwd: &str, _model: &str, last_exit_code: i32, mode: &str) -> String {
+pub fn render_prompt(
+    cwd: &str,
+    _model: &str,
+    last_exit_code: i32,
+    mode: &str,
+    recording: bool,
+) -> String {
     let home = dirs::home_dir()
         .map(|h| h.to_string_lossy().to_string())
         .unwrap_or_default();
 
+    // Recording indicator
+    let mut prompt = String::new();
+    if recording {
+        prompt.push_str("\x1b[31m⏺\x1b[0m ");
+    }
+
     // Mode badge (magenta for aish, yellow for plan)
     let mode_color = if mode == "plan" { "33" } else { "35" };
-    let mut prompt = format!("\x1b[{}m<{}>\x1b[0m ", mode_color, mode);
+    prompt.push_str(&format!("\x1b[{}m<{}>\x1b[0m ", mode_color, mode));
 
     // Abbreviated path in blue
     let abbreviated = abbreviate_path(cwd, &home);
@@ -368,7 +380,7 @@ mod tests {
     fn test_render_prompt_with_home_substitution() {
         let home = dirs::home_dir().expect("home dir should exist");
         let cwd = home.join("projects").to_string_lossy().to_string();
-        let result = render_prompt(&cwd, "test-model", 0, "aish");
+        let result = render_prompt(&cwd, "test-model", 0, "aish", false);
         assert!(
             result.contains("~"),
             "should substitute home with ~: {}",
@@ -381,7 +393,7 @@ mod tests {
     #[test]
     fn test_render_prompt_without_git() {
         // /tmp is very unlikely to be inside a git repo
-        let result = render_prompt("/tmp", "test-model", 0, "aish");
+        let result = render_prompt("/tmp", "test-model", 0, "aish", false);
         // Should NOT contain git branch separator '|'
         assert!(
             !result.contains("|"),
@@ -392,7 +404,7 @@ mod tests {
 
     #[test]
     fn test_render_prompt_success_symbol() {
-        let result = render_prompt("/tmp", "test-model", 0, "aish");
+        let result = render_prompt("/tmp", "test-model", 0, "aish", false);
         assert!(
             result.contains("\x1b[32m➜\x1b[0m"),
             "should have green single arrow on success"
@@ -405,7 +417,7 @@ mod tests {
 
     #[test]
     fn test_render_prompt_error_symbol() {
-        let result = render_prompt("/tmp", "test-model", 1, "aish");
+        let result = render_prompt("/tmp", "test-model", 1, "aish", false);
         assert!(
             result.contains("\x1b[31m➜➜\x1b[0m"),
             "should have red double arrow on error"
@@ -414,7 +426,7 @@ mod tests {
 
     #[test]
     fn test_render_prompt_aish_mode_badge() {
-        let result = render_prompt("/tmp", "test-model", 0, "aish");
+        let result = render_prompt("/tmp", "test-model", 0, "aish", false);
         assert!(result.contains("<aish>"), "should show aish mode badge");
         assert!(
             result.contains("\x1b[35m<aish>"),
@@ -424,11 +436,31 @@ mod tests {
 
     #[test]
     fn test_render_prompt_plan_mode_badge() {
-        let result = render_prompt("/tmp", "test-model", 0, "plan");
+        let result = render_prompt("/tmp", "test-model", 0, "plan", false);
         assert!(result.contains("<plan>"), "should show plan mode badge");
         assert!(
             result.contains("\x1b[33m<plan>"),
             "plan badge should be yellow"
+        );
+    }
+
+    #[test]
+    fn test_render_prompt_recording_indicator() {
+        let result = render_prompt("/tmp", "test-model", 0, "aish", true);
+        assert!(
+            result.contains("⏺"),
+            "should contain recording indicator: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_render_prompt_no_recording_indicator() {
+        let result = render_prompt("/tmp", "test-model", 0, "aish", false);
+        assert!(
+            !result.contains("⏺"),
+            "should not contain recording indicator when not recording: {}",
+            result
         );
     }
 

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -31,6 +31,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/token", "Show token usage"),
     ("/resume", "Resume previous session"),
     ("/feedback", "Submit feedback"),
+    ("/record", "Record terminal session (start/stop)"),
     ("/quit", "Exit AI Shell"),
 ];
 

--- a/crates/aish-shell/src/recorder.rs
+++ b/crates/aish-shell/src/recorder.rs
@@ -1,0 +1,387 @@
+//! Terminal session recorder using asciinema v2 format.
+//!
+//! Produces `.cast` files that can be replayed with `asciinema play`
+//! or any asciinema-compatible player.
+
+use std::fs::{self, File};
+use std::io::{self, LineWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use chrono::Local;
+use serde_json::{json, Value};
+
+/// Thread-safe shared recorder handle.
+///
+/// All `ShellRenderer` instances (shared or temporary) can hold a clone of this
+/// Arc and write events through the same Mutex-protected Recorder. This ensures
+/// that recording captures output from every code path, not just the main renderer.
+pub type SharedRecorder = Arc<Mutex<Option<Recorder>>>;
+
+/// Create a new SharedRecorder (initially inactive, contains None).
+pub fn new_shared_recorder() -> SharedRecorder {
+    Arc::new(Mutex::new(None))
+}
+
+/// Record an output event if a shared recorder is active.
+pub fn shared_record_output(recorder: &SharedRecorder, data: &str) {
+    if let Ok(mut guard) = recorder.lock() {
+        if let Some(ref mut rec) = *guard {
+            rec.record_output(data);
+        }
+    }
+}
+
+/// Record an input event if a shared recorder is active.
+pub fn shared_record_input(recorder: &SharedRecorder, data: &str) {
+    if let Ok(mut guard) = recorder.lock() {
+        if let Some(ref mut rec) = *guard {
+            rec.record_input(data);
+        }
+    }
+}
+
+/// Records terminal input/output events in asciinema v2 format.
+///
+/// # Asciinema v2 format
+///
+/// Line 1 (header): JSON object with `version`, `width`, `height`, `timestamp`, `env`.
+/// Line 2+ (events): JSON array `[timestamp, type, payload]` where:
+/// - timestamp: float seconds since recording started
+/// - type: `"o"` for output, `"i"` for input
+/// - payload: raw text, JSON-string escaped
+pub struct Recorder {
+    start_time: Instant,
+    writer: LineWriter<File>,
+    file_path: PathBuf,
+}
+
+impl Recorder {
+    /// Create a new recorder that writes asciinema v2 events to `file_path`.
+    ///
+    /// Creates parent directories if they do not exist, opens the file, and
+    /// writes the v2 header line.
+    pub fn new(file_path: PathBuf, term_size: (u16, u16)) -> io::Result<Self> {
+        // Ensure parent directory exists
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let file = File::create(&file_path)?;
+        let mut writer = LineWriter::new(file);
+
+        let unix_ts = Local::now().timestamp();
+        let header = json!({
+            "version": 2,
+            "width": term_size.0,
+            "height": term_size.1,
+            "timestamp": unix_ts,
+            "env": {
+                "SHELL": "/bin/bash",
+                "TERM": "xterm-256color",
+            }
+        });
+        writeln!(writer, "{header}")?;
+
+        Ok(Self {
+            start_time: Instant::now(),
+            writer,
+            file_path,
+        })
+    }
+
+    /// Record an output event (newlines normalized to \r\n, ANSI colors preserved).
+    pub fn record_output(&mut self, data: &str) {
+        let normalized = normalize_newlines(data);
+        self.write_event("o", &normalized);
+    }
+
+    /// Record an input event, echoing non-empty text as output for replay.
+    /// Empty input (bare Enter / Ctrl+C) is not echoed — the prompt
+    /// re-display already handles line positioning via `\r\x1b[2K`,
+    /// avoiding spurious blank lines in GIF output.
+    pub fn record_input(&mut self, data: &str) {
+        self.write_event("i", data);
+        if !data.trim().is_empty() {
+            let echoed = normalize_newlines(data);
+            self.write_event("o", &echoed);
+        }
+    }
+
+    /// Return the file path this recorder writes to.
+    pub fn file_path(&self) -> &Path {
+        &self.file_path
+    }
+
+    /// Return the time elapsed since this recorder was created.
+    pub fn elapsed(&self) -> Duration {
+        self.start_time.elapsed()
+    }
+
+    /// Return the default recordings directory: `~/.local/share/aish/recordings/`
+    pub fn recordings_dir() -> PathBuf {
+        dirs::data_local_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("aish")
+            .join("recordings")
+    }
+
+    /// Generate a timestamped file path under the recordings directory.
+    ///
+    /// Format: `~/.local/share/aish/recordings/2024-01-15_14-30-00.cast`
+    pub fn generate_file_path() -> PathBuf {
+        let filename = format!("{}.cast", Local::now().format("%Y-%m-%d_%H-%M-%S"));
+        Self::recordings_dir().join(filename)
+    }
+
+    /// Flush buffered events to disk.
+    pub fn flush(&mut self) -> io::Result<()> {
+        self.writer.flush()
+    }
+
+    fn write_event(&mut self, event_type: &str, data: &str) {
+        let ts = self.start_time.elapsed().as_secs_f64();
+        let payload = Value::String(data.to_string());
+        let line = format!("[{ts:.6},\"{event_type}\",{payload}]");
+        // Best-effort write — recording should not crash the shell on I/O errors,
+        // but we log failures so users know if recording is corrupted.
+        if let Err(e) = writeln!(self.writer, "{line}") {
+            eprintln!("Recording write failed: {}", e);
+        }
+    }
+}
+
+/// Normalize standalone `\n` to `\r\n` so virtual terminals (agg, asciinema)
+/// correctly return the cursor to column 0 on each line break.
+fn normalize_newlines(s: &str) -> String {
+    let mut result = String::with_capacity(s.len() + s.len() / 8);
+    let chars = s.chars().peekable();
+    for c in chars {
+        if c == '\n' {
+            result.push_str("\r\n");
+        } else if c == '\r' {
+            continue;
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::thread;
+    use tempfile::TempDir;
+
+    /// Helper: create a Recorder writing into a temp directory.
+    fn make_recorder(dir: &TempDir) -> Recorder {
+        let path = dir.path().join("test.cast");
+        Recorder::new(path, (80, 24)).expect("failed to create recorder")
+    }
+
+    /// Helper: read all lines from the recorder's output file.
+    fn read_lines(recorder: &Recorder) -> Vec<String> {
+        let content = fs::read_to_string(recorder.file_path()).expect("read file");
+        content.lines().map(|l| l.to_string()).collect()
+    }
+
+    // 1. Header is valid JSON with expected fields
+    #[test]
+    fn test_recorder_creates_file_with_valid_header() {
+        let dir = TempDir::new().unwrap();
+        let rec = make_recorder(&dir);
+        let lines = read_lines(&rec);
+
+        assert!(lines.len() >= 1, "should have at least a header line");
+
+        let header: Value = serde_json::from_str(&lines[0]).expect("header should be valid JSON");
+        assert_eq!(header["version"], 2);
+        assert_eq!(header["width"], 80);
+        assert_eq!(header["height"], 24);
+        assert!(header["timestamp"].is_number());
+        assert_eq!(header["env"]["SHELL"], "/bin/bash");
+        assert_eq!(header["env"]["TERM"], "xterm-256color");
+    }
+
+    // 2. Output events are written correctly
+    #[test]
+    fn test_recorder_records_output_events() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.cast");
+        {
+            let mut rec = Recorder::new(path.clone(), (80, 24)).unwrap();
+            rec.record_output("Hello");
+            rec.record_output("World");
+        } // drop flushes
+
+        let content = fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 3); // header + 2 events
+
+        let evt1: Vec<Value> = serde_json::from_str(lines[1]).unwrap();
+        assert!(evt1[0].is_number());
+        assert_eq!(evt1[1], "o");
+        assert_eq!(evt1[2].as_str().unwrap(), "Hello");
+
+        let evt2: Vec<Value> = serde_json::from_str(lines[2]).unwrap();
+        assert_eq!(evt2[1], "o");
+        assert_eq!(evt2[2].as_str().unwrap(), "World");
+    }
+
+    // 3. Input events are written with echo (input + output pair)
+    #[test]
+    fn test_recorder_records_input_events() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.cast");
+        {
+            let mut rec = Recorder::new(path.clone(), (80, 24)).unwrap();
+            rec.record_input("ls\n");
+        }
+
+        let content = fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 3); // header + input event + echo output event
+
+        let evt_i: Vec<Value> = serde_json::from_str(lines[1]).unwrap();
+        assert!(evt_i[0].is_number());
+        assert_eq!(evt_i[1], "i");
+        assert_eq!(evt_i[2].as_str().unwrap(), "ls\n");
+
+        let evt_o: Vec<Value> = serde_json::from_str(lines[2]).unwrap();
+        assert!(evt_o[0].is_number());
+        assert_eq!(evt_o[1], "o");
+        assert_eq!(evt_o[2].as_str().unwrap(), "ls\r\n");
+    }
+
+    // 4. Timestamps increase across events
+    #[test]
+    fn test_recorder_timestamps_increase() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.cast");
+        {
+            let mut rec = Recorder::new(path.clone(), (80, 24)).unwrap();
+            rec.record_output("first");
+            thread::sleep(Duration::from_millis(50));
+            rec.record_output("second");
+        }
+
+        let content = fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+
+        let evt1: Vec<Value> = serde_json::from_str(lines[1]).unwrap();
+        let evt2: Vec<Value> = serde_json::from_str(lines[2]).unwrap();
+
+        let t1 = evt1[0].as_f64().unwrap();
+        let t2 = evt2[0].as_f64().unwrap();
+        assert!(
+            t2 > t1,
+            "second event timestamp {t2} should be > first {t1}"
+        );
+    }
+
+    // 5. Special characters are properly JSON-escaped, \n normalized to \r\n
+    #[test]
+    fn test_recorder_escapes_special_characters() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.cast");
+        {
+            let mut rec = Recorder::new(path.clone(), (80, 24)).unwrap();
+            rec.record_output("line1\nline2\ttab\"quote");
+        }
+
+        let content = fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+
+        let evt: Vec<Value> = serde_json::from_str(lines[1]).unwrap();
+        let payload = evt[2].as_str().unwrap();
+        assert_eq!(payload, "line1\r\nline2\ttab\"quote");
+    }
+
+    // 6. Parent directories are created automatically
+    #[test]
+    fn test_recorder_creates_parent_directory() {
+        let dir = TempDir::new().unwrap();
+        let nested = dir.path().join("a").join("b").join("c").join("test.cast");
+        {
+            let _rec = Recorder::new(nested.clone(), (80, 24)).unwrap();
+        }
+        assert!(nested.exists(), "file should exist at nested path");
+    }
+
+    // 7. generate_file_path contains "recordings" and ends with ".cast"
+    #[test]
+    fn test_generate_file_path() {
+        let path = Recorder::generate_file_path();
+        let path_str = path.to_string_lossy();
+        assert!(
+            path_str.contains("recordings"),
+            "path should contain 'recordings': {path_str}"
+        );
+        assert!(
+            path_str.ends_with(".cast"),
+            "path should end with '.cast': {path_str}"
+        );
+    }
+
+    // 8. A recorder that is immediately dropped produces only the header
+    #[test]
+    fn test_empty_recording() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.cast");
+        {
+            let _rec = Recorder::new(path.clone(), (80, 24)).unwrap();
+        } // drop immediately
+
+        let content = fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(
+            lines.len(),
+            1,
+            "empty recording should have only the header"
+        );
+
+        let header: Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(header["version"], 2);
+    }
+
+    // 9. ANSI colors preserved, \n normalized to \r\n
+    #[test]
+    fn test_recorder_preserves_ansi_and_normalizes_newlines() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.cast");
+        {
+            let mut rec = Recorder::new(path.clone(), (80, 24)).unwrap();
+            rec.record_output("\x1b[31mred\x1b[0m plain \x1b[1;32mbold green\x1b[0m");
+            rec.record_output("\x1b[2mdim\nline2\x1b[0m");
+        }
+
+        let content = fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+
+        let evt1: Vec<Value> = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(
+            evt1[2].as_str().unwrap(),
+            "\x1b[31mred\x1b[0m plain \x1b[1;32mbold green\x1b[0m"
+        );
+
+        let evt2: Vec<Value> = serde_json::from_str(lines[2]).unwrap();
+        assert_eq!(evt2[2].as_str().unwrap(), "\x1b[2mdim\r\nline2\x1b[0m");
+    }
+
+    // 10. normalize_newlines converts \n to \r\n and skips bare \r
+    #[test]
+    fn test_normalize_newlines() {
+        use super::normalize_newlines;
+
+        assert_eq!(normalize_newlines("line1\nline2\n"), "line1\r\nline2\r\n");
+        assert_eq!(
+            normalize_newlines("line1\r\nline2\r\n"),
+            "line1\r\nline2\r\n"
+        );
+        assert_eq!(normalize_newlines("no newline"), "no newline");
+        assert_eq!(normalize_newlines(""), "");
+    }
+}

--- a/crates/aish-shell/src/renderer.rs
+++ b/crates/aish-shell/src/renderer.rs
@@ -1,5 +1,6 @@
 use std::io::{self, Write};
 
+use crate::recorder::SharedRecorder;
 use richrs::color::{Color, StandardColor};
 use richrs::console::Console;
 use richrs::markdown::Markdown;
@@ -278,7 +279,13 @@ fn parse_pipe_row(line: &str) -> Option<Vec<String>> {
 
 /// Render a fenced code block with syntax highlighting.
 /// Minimal style: dim bold language tag, then syntax-highlighted code, no borders.
-fn render_code_block(console: &mut Console, lang: &str, code: &str, width: usize) {
+fn render_code_block(
+    console: &mut Console,
+    lang: &str,
+    code: &str,
+    width: usize,
+    shared_recorder: &Option<SharedRecorder>,
+) {
     let code_trimmed = code.trim_end();
     if code_trimmed.is_empty() {
         return;
@@ -286,12 +293,19 @@ fn render_code_block(console: &mut Console, lang: &str, code: &str, width: usize
 
     // Dim bold language label
     if !lang.is_empty() {
+        let lang_ansi = format!("\x1b[1;2m{}\x1b[0m\n", lang);
+        if let Some(ref sr) = shared_recorder {
+            crate::recorder::shared_record_output(sr, &lang_ansi);
+        }
         println!("\x1b[1;2m{}\x1b[0m", lang);
     }
 
     // Syntax-highlighted code
     let syntax = Syntax::new(code_trimmed, lang).theme("base16-ocean.dark");
     let segments = syntax.render(width);
+    if let Some(ref sr) = shared_recorder {
+        crate::recorder::shared_record_output(sr, &segments.to_ansi());
+    }
     let _ = console.write_segments(&segments);
     let _ = console.flush();
 }
@@ -306,6 +320,8 @@ pub struct ShellRenderer {
     /// Tracks whether streaming content has been received.
     streaming_active: bool,
     terminal_width: usize,
+    /// Shared recorder — multiple renderer instances can write to the same file.
+    shared_recorder: Option<SharedRecorder>,
 }
 
 impl ShellRenderer {
@@ -316,6 +332,7 @@ impl ShellRenderer {
             console,
             streaming_active: false,
             terminal_width,
+            shared_recorder: None,
         }
     }
 
@@ -326,19 +343,30 @@ impl ShellRenderer {
 
     /// Render complete markdown text.
     /// Code blocks → syntax highlighting, tables → box drawing, rest → richrs Markdown.
+    /// Records output for cast file: raw text for markdown (preserving line breaks),
+    /// ANSI output for code blocks and tables (preserving formatting).
     pub fn render_markdown(&mut self, text: &str) {
         let segments = split_content(text);
         let mut last_was_markdown = false;
         for seg in segments {
             match seg {
                 ContentSegment::CodeBlock { lang, code } => {
-                    render_code_block(&mut self.console, &lang, &code, self.terminal_width);
+                    render_code_block(
+                        &mut self.console,
+                        &lang,
+                        &code,
+                        self.terminal_width,
+                        &self.shared_recorder,
+                    );
                     last_was_markdown = false;
                 }
                 ContentSegment::Table(content) => {
                     let lines: Vec<&str> = content.lines().collect();
-                    if let Some(segments) = render_table_to_segments(&lines, self.terminal_width) {
-                        let _ = self.console.write_segments(&segments);
+                    if let Some(segs) = render_table_to_segments(&lines, self.terminal_width) {
+                        if let Some(ref sr) = self.shared_recorder {
+                            crate::recorder::shared_record_output(sr, &segs.to_ansi());
+                        }
+                        let _ = self.console.write_segments(&segs);
                     }
                     last_was_markdown = false;
                 }
@@ -348,6 +376,17 @@ impl ShellRenderer {
                         .bold();
                     let md = Markdown::new(&content).inline_code_style(inline_style);
                     let segs = md.render(self.terminal_width);
+                    // Record ANSI-rendered output so agg/GIF shows proper formatting.
+                    // richrs adds two trailing newlines per paragraph; the terminal
+                    // removes one with \x1b[1A\x1b[M. Remove one trailing newline
+                    // from the recording to match the terminal display.
+                    if let Some(ref sr) = self.shared_recorder {
+                        let mut ansi = segs.to_ansi();
+                        if ansi.ends_with("\n\n") {
+                            ansi.truncate(ansi.len() - 1);
+                        }
+                        crate::recorder::shared_record_output(sr, &ansi);
+                    }
                     let _ = self.console.write_segments(&segs);
                     last_was_markdown = true;
                 }
@@ -364,10 +403,14 @@ impl ShellRenderer {
         }
     }
 
-    /// Append a streaming delta — prints raw text for real-time feedback.
+    /// Append a streaming delta — prints gray text for real-time feedback.
+    /// Records with ANSI color for accurate replay/GIF.
     pub fn append_delta(&mut self, delta: &str) {
         if delta.is_empty() {
             return;
+        }
+        if let Some(ref sr) = self.shared_recorder {
+            crate::recorder::shared_record_output(sr, &format!("\x1b[1;90m{}\x1b[0m", delta));
         }
         self.streaming_active = true;
         print!("\x1b[1;90m{}\x1b[0m", delta);
@@ -389,10 +432,20 @@ impl ShellRenderer {
         self.streaming_active = false;
     }
 
+    /// Attach a shared recorder for recording rendered output.
+    pub fn set_shared_recorder(&mut self, recorder: SharedRecorder) {
+        self.shared_recorder = Some(recorder);
+    }
+
     /// Render a green horizontal separator line spanning the terminal.
+    /// Records a fixed 5-char separator with trailing newline for clean cast/GIF output.
     pub fn render_separator(&mut self) {
         let width = self.terminal_width.max(20);
-        println!("\x1b[32m{}\x1b[0m", "─".repeat(width));
+        let sep = "─".repeat(width);
+        if let Some(ref sr) = self.shared_recorder {
+            crate::recorder::shared_record_output(sr, "─────\r\n");
+        }
+        println!("\x1b[32m{}\x1b[0m", sep);
     }
 }
 

--- a/crates/aish-shell/tests/recorder_integration_test.rs
+++ b/crates/aish-shell/tests/recorder_integration_test.rs
@@ -1,0 +1,246 @@
+// Integration tests for the asciinema v2 recording lifecycle.
+//
+// These tests verify the complete Recorder workflow: start -> write events ->
+// stop -> verify the .cast file structure is valid for asciinema-compatible
+// players.
+
+use std::fs;
+use std::io::{BufRead, BufReader};
+
+use aish_shell::recorder::Recorder;
+
+/// Test the full Recorder lifecycle: create -> record output -> record input ->
+/// flush -> drop -> verify the resulting .cast file.
+#[test]
+fn test_full_recording_lifecycle() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("lifecycle.cast");
+
+    // Create recorder
+    let mut recorder = Recorder::new(path.clone(), (80, 24)).unwrap();
+
+    // Record some output
+    recorder.record_output("$ ls\r\n");
+    recorder.record_output("file1.txt  file2.txt\r\n");
+
+    // Record user input (also creates echo output event)
+    recorder.record_input("echo hello\r\n");
+
+    // Record more output
+    recorder.record_output("hello\r\n");
+
+    // Flush and drop (simulates stop)
+    recorder.flush().unwrap();
+    drop(recorder);
+
+    // Verify the .cast file
+    let file = fs::File::open(&path).unwrap();
+    let reader = BufReader::new(file);
+    let lines: Vec<String> = reader.lines().map(|l| l.unwrap()).collect();
+
+    // Should have: 1 header + 5 events (3 output + 1 input + 1 echo output) = 6 lines
+    assert_eq!(lines.len(), 6);
+
+    // Verify header
+    let header: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+    assert_eq!(header["version"], 2);
+    assert_eq!(header["width"], 80);
+    assert_eq!(header["height"], 24);
+
+    // Verify event 1: output with "ls"
+    let e1: serde_json::Value = serde_json::from_str(&lines[1]).unwrap();
+    assert!(e1.is_array());
+    assert_eq!(e1[1], "o");
+    assert!(e1[2].as_str().unwrap().contains("ls"));
+
+    // Verify event 2: output with "file1"
+    let e2: serde_json::Value = serde_json::from_str(&lines[2]).unwrap();
+    assert!(e2.is_array());
+    assert_eq!(e2[1], "o");
+    assert!(e2[2].as_str().unwrap().contains("file1"));
+
+    // Verify event 3: input with "echo hello"
+    let e3: serde_json::Value = serde_json::from_str(&lines[3]).unwrap();
+    assert!(e3.is_array());
+    assert_eq!(e3[1], "i");
+    assert!(e3[2].as_str().unwrap().contains("echo hello"));
+
+    // Verify event 4: echo output from record_input
+    let e4: serde_json::Value = serde_json::from_str(&lines[4]).unwrap();
+    assert!(e4.is_array());
+    assert_eq!(e4[1], "o");
+    assert!(e4[2].as_str().unwrap().contains("echo hello"));
+
+    // Verify event 5: output with "hello"
+    let e5: serde_json::Value = serde_json::from_str(&lines[5]).unwrap();
+    assert!(e5.is_array());
+    assert_eq!(e5[1], "o");
+    assert!(e5[2].as_str().unwrap().contains("hello"));
+}
+
+/// Verify that the generated .cast file has a valid structure that
+/// asciinema-compatible players would accept.
+#[test]
+fn test_cast_file_playable_by_asciinema() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("playable.cast");
+
+    let mut recorder = Recorder::new(path.clone(), (120, 30)).unwrap();
+    recorder.record_output("Hello\r\n");
+    recorder.record_output("World\r\n");
+    recorder.flush().unwrap();
+    drop(recorder);
+
+    let content = fs::read_to_string(&path).unwrap();
+
+    // Each line should be valid JSON
+    for line in content.lines() {
+        let parsed: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("Invalid JSON in .cast file: {:?}\nLine: {:?}", e, line));
+        assert!(parsed.is_object() || parsed.is_array());
+    }
+
+    // First line should be the header object
+    let header: serde_json::Value = serde_json::from_str(content.lines().next().unwrap()).unwrap();
+    assert_eq!(header["version"], 2);
+    assert!(header.get("width").is_some());
+    assert!(header.get("height").is_some());
+    assert!(header.get("timestamp").is_some());
+    assert!(header.get("env").is_some());
+
+    // Event lines should be arrays of [timestamp, type, payload]
+    for line in content.lines().skip(1) {
+        let event: serde_json::Value = serde_json::from_str(line).unwrap();
+        assert!(event.is_array(), "Event should be a JSON array");
+        assert_eq!(
+            event.as_array().unwrap().len(),
+            3,
+            "Event should have 3 elements"
+        );
+        assert!(event[0].is_number(), "Timestamp should be a number");
+        assert!(event[1].is_string(), "Event type should be a string");
+        assert!(event[2].is_string(), "Payload should be a string");
+        let event_type = event[1].as_str().unwrap();
+        assert!(
+            event_type == "o" || event_type == "i",
+            "Event type should be 'o' or 'i', got: {:?}",
+            event_type
+        );
+    }
+}
+
+/// Test that timestamps in the .cast file are non-negative and events are
+/// ordered chronologically.
+#[test]
+fn test_recording_timestamps_are_ordered() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ordered.cast");
+
+    let mut recorder = Recorder::new(path.clone(), (100, 40)).unwrap();
+    recorder.record_output("first\n");
+    recorder.record_output("second\n");
+    recorder.record_output("third\n");
+    recorder.flush().unwrap();
+    drop(recorder);
+
+    let content = fs::read_to_string(&path).unwrap();
+    let mut prev_ts: f64 = -1.0;
+
+    for line in content.lines().skip(1) {
+        let event: serde_json::Value = serde_json::from_str(line).unwrap();
+        let ts = event[0].as_f64().unwrap();
+        assert!(ts >= 0.0, "Timestamp should be non-negative, got: {}", ts);
+        assert!(
+            ts >= prev_ts,
+            "Timestamps should be non-decreasing: {} < {}",
+            ts,
+            prev_ts
+        );
+        prev_ts = ts;
+    }
+}
+
+/// Test that the recorder correctly handles a mix of output and input events
+/// in an interleaved pattern, mimicking a real shell session.
+#[test]
+fn test_interleaved_input_output() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("interleaved.cast");
+
+    let mut recorder = Recorder::new(path.clone(), (80, 24)).unwrap();
+
+    // Simulate a brief interactive session
+    recorder.record_output("$ "); // prompt
+    recorder.record_input("date\n"); // user types (also creates echo output)
+    recorder.record_output("Mon Jan  1 00:00:00 UTC 2024\n"); // output
+    recorder.record_output("$ "); // next prompt
+    recorder.record_input("echo done\n"); // user types (also creates echo output)
+    recorder.record_output("done\n"); // output
+
+    recorder.flush().unwrap();
+    drop(recorder);
+
+    let content = fs::read_to_string(&path).unwrap();
+    let lines: Vec<&str> = content.lines().collect();
+
+    // 1 header + 8 events (prompt, input, echo, output, prompt, input, echo, output)
+    assert_eq!(lines.len(), 9);
+
+    // Verify event types: o, i, o(echo), o, o, i, o(echo), o
+    let expected_types = ["o", "i", "o", "o", "o", "i", "o", "o"];
+    for (i, expected) in expected_types.iter().enumerate() {
+        let event: serde_json::Value = serde_json::from_str(lines[i + 1]).unwrap();
+        assert_eq!(
+            event[1], *expected,
+            "Event {} should be type {:?}",
+            i, expected
+        );
+    }
+}
+
+/// Test that special characters (newlines, tabs, quotes, unicode) are properly
+/// preserved in the .cast file payload. Newlines in output are normalized to \r\n.
+#[test]
+fn test_special_characters_preserved() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("special.cast");
+
+    let special_output = "tab\there\nnewline\n\"quotes\"\nunicode: \u{1f600}";
+    let special_input = "input with \t tabs and \"quotes\"";
+
+    let mut recorder = Recorder::new(path.clone(), (80, 24)).unwrap();
+    recorder.record_output(special_output);
+    recorder.record_input(special_input);
+    recorder.flush().unwrap();
+    drop(recorder);
+
+    let content = fs::read_to_string(&path).unwrap();
+    let lines: Vec<&str> = content.lines().collect();
+
+    // Verify output payload has normalized newlines (\n → \r\n)
+    let out_event: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+    let expected_output = "tab\there\r\nnewline\r\n\"quotes\"\r\nunicode: \u{1f600}";
+    assert_eq!(out_event[2].as_str().unwrap(), expected_output);
+
+    // Verify input payload matches exactly (input is not transformed)
+    let in_event: serde_json::Value = serde_json::from_str(lines[2]).unwrap();
+    assert_eq!(in_event[2].as_str().unwrap(), special_input);
+
+    // Verify echo output from record_input
+    let echo_event: serde_json::Value = serde_json::from_str(lines[3]).unwrap();
+    assert_eq!(echo_event[1], "o");
+    assert!(echo_event[2].as_str().unwrap().contains("input with"));
+}
+
+/// Test that recorder metadata (file_path, term_size) is accessible.
+#[test]
+fn test_recorder_metadata() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("metadata.cast");
+
+    let recorder = Recorder::new(path.clone(), (200, 50)).unwrap();
+
+    assert_eq!(recorder.file_path(), path.as_path());
+    // Elapsed should be very small right after creation
+    assert!(recorder.elapsed().as_secs() < 1);
+}


### PR DESCRIPTION
Add recorder module for capturing and replaying shell sessions,
including integration tests. Update shell components to support
recording functionality and refresh i18n locale files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/record` slash command to start and stop terminal session recording
  * Added recording indicator to the shell prompt when recording is active

* **Internationalization**
  * Added English localization entries for the `/record` command and recording status messages
  * Added Chinese localization entries for the `/record` command and recording status messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->