### PR TITLE
feat: tab completion with native bash and readline forwarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Development files
 .env
 *.log
+.completion_test_tmp/
 .vscode/
 .idea/
 .claude/

--- a/crates/aish-pty/src/aish_completion.rs
+++ b/crates/aish-pty/src/aish_completion.rs
@@ -1,0 +1,301 @@
+//! PTY-side tab completion: JSON queries and readline Tab forwarding.
+
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+
+use nix::sys::termios::{tcgetattr, tcsetattr, LocalFlags, SetArg};
+
+use super::PersistentPty;
+use crate::control::{decode_control_chunk, BackendControlEvent, CompletionResponse};
+use crate::readline_tab::{
+    build_readline_tab_payload, clamp_pos, parse_readline_tab_output, ReadlineTabResult,
+};
+
+const MASTER_READ_SIZE: usize = 8192;
+const CONTROL_READ_SIZE: usize = 4096;
+const TAB_IDLE_QUIET: Duration = Duration::from_millis(60);
+
+impl PersistentPty {
+    /// Query tab completions via bash `__aish_complete` (control pipe JSON).
+    pub fn query_completions(
+        &mut self,
+        line: &str,
+        pos: usize,
+        timeout: Duration,
+    ) -> aish_core::Result<CompletionResponse> {
+        if !self.is_running() {
+            return Ok(CompletionResponse::empty());
+        }
+
+        let request_id = self
+            .next_completion_request_id
+            .fetch_add(1, Ordering::SeqCst)
+            .saturating_add(1);
+        let seq = self.allocate_backend_seq();
+        let cmd = format!(
+            "__aish_complete {request_id} {} {pos}",
+            super::shell_quote_escape(line)
+        );
+
+        self.exec_buffer.lock().unwrap().clear();
+        self.exec_mode.store(true, Ordering::SeqCst);
+        self.send_command(&cmd, Some(seq))?;
+
+        let deadline = Instant::now() + timeout;
+        let mut completion = None;
+
+        'wait: while Instant::now() < deadline {
+            let mut fds = zero_fd_set();
+            set_fd(&mut fds, self.master_fd);
+            set_fd(&mut fds, self.control_fd);
+            let max_fd = self.master_fd.max(self.control_fd) + 1;
+
+            if select_fds(max_fd, &mut fds, select_tv(deadline, Duration::from_secs(1))) <= 0 {
+                continue;
+            }
+
+            if fd_isset(self.master_fd, &fds) {
+                match self.read_master_into_exec() {
+                    ReadMaster::Data => {}
+                    ReadMaster::Eof => break,
+                    ReadMaster::Ignored => {}
+                }
+            }
+
+            if fd_isset(self.control_fd, &fds) {
+                let events = self.read_control_chunk();
+                for event in &events {
+                    if matches!(event, BackendControlEvent::ShellExiting { .. }) {
+                        self.running.store(false, Ordering::SeqCst);
+                    }
+                    if let BackendControlEvent::CompletionResult {
+                        request_id: rid,
+                        word_start,
+                        candidates,
+                    } = event
+                    {
+                        if *rid == request_id {
+                            completion = Some(CompletionResponse {
+                                word_start: *word_start,
+                                candidates: candidates.clone(),
+                            });
+                            break 'wait;
+                        }
+                    }
+                    if let Some(r) = self.command_state.handle_event(event) {
+                        if r.command_seq == Some(seq) {
+                            break 'wait;
+                        }
+                    }
+                }
+                if events.is_empty() && !self.is_running() {
+                    break;
+                }
+            }
+        }
+
+        self.drain_master_to_exec_buffer();
+        self.exec_mode.store(false, Ordering::SeqCst);
+        Ok(completion.unwrap_or_else(CompletionResponse::empty))
+    }
+
+    /// Forward Tab to bash readline; capture PTY output without writing to stdout.
+    pub fn forward_readline_tab(
+        &mut self,
+        line: &str,
+        pos: usize,
+        timeout: Duration,
+    ) -> Option<ReadlineTabResult> {
+        if !self.is_running() || line.is_empty() {
+            return None;
+        }
+
+        let pos = clamp_pos(line, pos);
+        self.run_hidden_bash_line("set -o emacs");
+        self.set_pty_echo(true);
+        self.drain_master_silent();
+
+        let half = timeout / 2;
+        let cap1 = self.capture_readline_probe(
+            &build_readline_tab_payload(line, pos, 1, false),
+            half,
+        );
+        let mut result = parse_readline_tab_output(&cap1, line, pos);
+        if !result.is_useful(line) {
+            let mut combined = cap1;
+            combined.extend_from_slice(&self.capture_readline_probe(b"\t", half));
+            result = parse_readline_tab_output(&combined, line, pos);
+        }
+
+        self.set_pty_echo(false);
+        let _ = self.write_master(b"\x15");
+        self.drain_master_silent();
+        self.run_hidden_bash_line("set +o emacs; set +o vi");
+        result.is_useful(line).then_some(result)
+    }
+
+    fn capture_readline_probe(&mut self, payload: &[u8], timeout: Duration) -> Vec<u8> {
+        self.drain_master_silent();
+        self.exec_buffer.lock().unwrap().clear();
+        self.exec_mode.store(true, Ordering::SeqCst);
+        if self.write_master(payload).is_err() {
+            self.exec_mode.store(false, Ordering::SeqCst);
+            return Vec::new();
+        }
+
+        let deadline = Instant::now() + timeout;
+        let mut last_read = Instant::now();
+        while Instant::now() < deadline {
+            let mut fds = zero_fd_set();
+            set_fd(&mut fds, self.master_fd);
+            let tick = deadline.saturating_duration_since(Instant::now()).min(TAB_IDLE_QUIET);
+            if select_fds(self.master_fd + 1, &mut fds, timeval_from_duration(tick)) <= 0 {
+                if last_read.elapsed() >= TAB_IDLE_QUIET
+                    && !self.exec_buffer.lock().unwrap().is_empty()
+                {
+                    break;
+                }
+                continue;
+            }
+            match self.read_master_into_exec() {
+                ReadMaster::Data => last_read = Instant::now(),
+                ReadMaster::Eof | ReadMaster::Ignored => break,
+            }
+        }
+
+        self.exec_mode.store(false, Ordering::SeqCst);
+        self.exec_buffer.lock().unwrap().clone()
+    }
+
+    fn run_hidden_bash_line(&mut self, command: &str) {
+        self.drain_master_silent();
+        self.drain_control_pipe_raw();
+        self.exec_buffer.lock().unwrap().clear();
+        self.exec_mode.store(true, Ordering::SeqCst);
+        if self.write_master(format!(" {command}\n").as_bytes()).is_err() {
+            self.exec_mode.store(false, Ordering::SeqCst);
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(30));
+        self.drain_control_pipe_raw();
+        self.exec_mode.store(false, Ordering::SeqCst);
+        self.drain_master_silent();
+    }
+
+    fn set_pty_echo(&self, enabled: bool) {
+        let fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(self.master_fd) };
+        if let Ok(mut term) = tcgetattr(fd) {
+            if enabled {
+                term.local_flags.insert(LocalFlags::ECHO | LocalFlags::ECHONL);
+            } else {
+                term.local_flags.remove(LocalFlags::ECHO | LocalFlags::ECHONL);
+            }
+            let _ = tcsetattr(fd, SetArg::TCSANOW, &term);
+        }
+    }
+
+    fn read_control_chunk(&mut self) -> Vec<BackendControlEvent> {
+        let mut tmp = [0u8; CONTROL_READ_SIZE];
+        match unsafe {
+            libc::read(
+                self.control_fd,
+                tmp.as_mut_ptr() as *mut libc::c_void,
+                tmp.len(),
+            )
+        } {
+            n if n > 0 => decode_control_chunk(&mut self.control_buffer, &tmp[..n as usize]),
+            0 => {
+                self.running.store(false, Ordering::SeqCst);
+                vec![]
+            }
+            _ => vec![],
+        }
+    }
+
+    fn read_master_into_exec(&self) -> ReadMaster {
+        if !self.exec_mode.load(Ordering::SeqCst) {
+            return ReadMaster::Ignored;
+        }
+        let mut tmp = [0u8; MASTER_READ_SIZE];
+        match unsafe {
+            libc::read(
+                self.master_fd,
+                tmp.as_mut_ptr() as *mut libc::c_void,
+                tmp.len(),
+            )
+        } {
+            n if n > 0 => {
+                self.exec_buffer
+                    .lock()
+                    .unwrap()
+                    .extend_from_slice(&tmp[..n as usize]);
+                ReadMaster::Data
+            }
+            0 => {
+                self.running.store(false, Ordering::SeqCst);
+                ReadMaster::Eof
+            }
+            _ => ReadMaster::Ignored,
+        }
+    }
+}
+
+enum ReadMaster {
+    Data,
+    Eof,
+    Ignored,
+}
+
+impl CompletionResponse {
+    fn empty() -> Self {
+        Self {
+            word_start: 0,
+            candidates: Vec::new(),
+        }
+    }
+}
+
+fn zero_fd_set() -> libc::fd_set {
+    unsafe { std::mem::zeroed() }
+}
+
+fn set_fd(set: &mut libc::fd_set, fd: i32) {
+    unsafe { libc::FD_SET(fd, set) };
+}
+
+fn fd_isset(fd: i32, set: &libc::fd_set) -> bool {
+    unsafe { libc::FD_ISSET(fd, set) }
+}
+
+fn select_tv(deadline: Instant, max: Duration) -> libc::timeval {
+    timeval_from_duration(deadline.saturating_duration_since(Instant::now()).min(max))
+}
+
+fn timeval_from_duration(d: Duration) -> libc::timeval {
+    libc::timeval {
+        tv_sec: d.as_secs().min(1) as libc::c_long,
+        tv_usec: (d.subsec_micros() % 1_000_000) as libc::c_long,
+    }
+}
+
+fn select_fds(max_fd: i32, fds: &mut libc::fd_set, tv: libc::timeval) -> i32 {
+    let mut tv = tv;
+    loop {
+        let sel = unsafe {
+            libc::select(
+                max_fd,
+                fds,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut tv,
+            )
+        };
+        if sel >= 0 {
+            return sel;
+        }
+        let errno = unsafe { *libc::__errno_location() };
+        if errno != libc::EINTR {
+            return sel;
+        }
+    }
+}

--- a/crates/aish-pty/src/aish_completion.rs
+++ b/crates/aish-pty/src/aish_completion.rs
@@ -50,7 +50,12 @@ impl PersistentPty {
             set_fd(&mut fds, self.control_fd);
             let max_fd = self.master_fd.max(self.control_fd) + 1;
 
-            if select_fds(max_fd, &mut fds, select_tv(deadline, Duration::from_secs(1))) <= 0 {
+            if select_fds(
+                max_fd,
+                &mut fds,
+                select_tv(deadline, Duration::from_secs(1)),
+            ) <= 0
+            {
                 continue;
             }
 
@@ -116,10 +121,8 @@ impl PersistentPty {
         self.drain_master_silent();
 
         let half = timeout / 2;
-        let cap1 = self.capture_readline_probe(
-            &build_readline_tab_payload(line, pos, 1, false),
-            half,
-        );
+        let cap1 =
+            self.capture_readline_probe(&build_readline_tab_payload(line, pos, 1, false), half);
         let mut result = parse_readline_tab_output(&cap1, line, pos);
         if !result.is_useful(line) {
             let mut combined = cap1;
@@ -148,7 +151,9 @@ impl PersistentPty {
         while Instant::now() < deadline {
             let mut fds = zero_fd_set();
             set_fd(&mut fds, self.master_fd);
-            let tick = deadline.saturating_duration_since(Instant::now()).min(TAB_IDLE_QUIET);
+            let tick = deadline
+                .saturating_duration_since(Instant::now())
+                .min(TAB_IDLE_QUIET);
             if select_fds(self.master_fd + 1, &mut fds, timeval_from_duration(tick)) <= 0 {
                 if last_read.elapsed() >= TAB_IDLE_QUIET
                     && !self.exec_buffer.lock().unwrap().is_empty()
@@ -172,7 +177,10 @@ impl PersistentPty {
         self.drain_control_pipe_raw();
         self.exec_buffer.lock().unwrap().clear();
         self.exec_mode.store(true, Ordering::SeqCst);
-        if self.write_master(format!(" {command}\n").as_bytes()).is_err() {
+        if self
+            .write_master(format!(" {command}\n").as_bytes())
+            .is_err()
+        {
             self.exec_mode.store(false, Ordering::SeqCst);
             return;
         }
@@ -186,9 +194,11 @@ impl PersistentPty {
         let fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(self.master_fd) };
         if let Ok(mut term) = tcgetattr(fd) {
             if enabled {
-                term.local_flags.insert(LocalFlags::ECHO | LocalFlags::ECHONL);
+                term.local_flags
+                    .insert(LocalFlags::ECHO | LocalFlags::ECHONL);
             } else {
-                term.local_flags.remove(LocalFlags::ECHO | LocalFlags::ECHONL);
+                term.local_flags
+                    .remove(LocalFlags::ECHO | LocalFlags::ECHONL);
             }
             let _ = tcsetattr(fd, SetArg::TCSANOW, &term);
         }

--- a/crates/aish-pty/src/bash_rc_wrapper.sh
+++ b/crates/aish-pty/src/bash_rc_wrapper.sh
@@ -4,6 +4,7 @@
 # Disable readline — the frontend (aish) handles all display and editing.
 # Without readline, bash uses the simple line reader which does not emit
 # extra newlines on Enter, preventing spurious blank lines in PTY output.
+# Tab forwarding temporarily re-enables readline via `set -o emacs` in the PTY layer.
 set +o emacs
 set +o vi
 
@@ -160,7 +161,7 @@ __aish_on_debug() {
     fi
 
     case "$BASH_COMMAND" in
-        __aish_prompt_command*|__aish_on_debug*|__aish_emit_*|__aish_json_escape*|trap* )
+        __aish_prompt_command*|__aish_on_debug*|__aish_emit_*|__aish_json_escape*|__aish_complete*|_aish_*|trap* )
             return 0
             ;;
         __AISH_ACTIVE_COMMAND_SEQ=* )
@@ -240,96 +241,295 @@ __aish_mark_dirs() {
 }
 
 # ---------------------------------------------------------------------------
-# Completion query function for aish frontend.
-# Usage: __aish_query_completions "command line" cursor_position
-# Outputs one completion candidate per line.
+# Tab completion for aish frontend (bash is the single source of truth).
+# Usage: __aish_complete REQUEST_ID "command line" CURSOR_POINT
+# Emits completion_result JSON on the control pipe.
 # ---------------------------------------------------------------------------
-__aish_query_completions() {
-    local cmd_line="${1:-}"
-    local cursor="${2:-0}"
-    local -a words=()
-    local word=""
-    local i ch
 
-    # Parse command line into words (simple whitespace split).
-    for (( i=0; i<${#cmd_line}; i++ )); do
-        ch="${cmd_line:$i:1}"
+__AISH_COMP_DISPLAY=()
+__AISH_COMP_REPLACEMENT=()
+
+_aish_reset_candidates() {
+    __AISH_COMP_DISPLAY=()
+    __AISH_COMP_REPLACEMENT=()
+}
+
+_aish_add_candidate() {
+    local raw="$1"
+    local cur="${2:-}"
+    local as_command="${3:-0}"
+    local display="" replacement="" base="" existing
+
+    [[ -z "$raw" ]] && return 0
+
+    if [[ "$raw" == */ ]]; then
+        replacement="$raw"
+    elif [[ -d "$raw" ]]; then
+        replacement="${raw}/"
+    else
+        replacement="$raw"
+        [[ "$replacement" != *' ' ]] && replacement+=" "
+    fi
+
+    if [[ -n "$cur" && "$replacement" == "$cur" ]]; then
+        return 0
+    fi
+    for existing in "${__AISH_COMP_REPLACEMENT[@]}"; do
+        if [[ "$existing" == "$replacement" ]]; then
+            return 0
+        fi
+    done
+
+    if [[ "$as_command" == 1 ]]; then
+        display="${raw% }"
+    else
+        base="${raw%/}"
+        base="${base##*/}"
+        [[ -z "$base" ]] && base="${raw%/}"
+        if [[ "$raw" == */ || -d "$raw" ]]; then
+            display="${base}/"
+        else
+            display="$base"
+        fi
+    fi
+
+    __AISH_COMP_DISPLAY+=("$display")
+    __AISH_COMP_REPLACEMENT+=("$replacement")
+}
+
+__aish_emit_completion_result() {
+    local request_id="$1"
+    local word_start="$2"
+    local parts=() i payload candidates_json
+
+    for (( i=0; i<${#__AISH_COMP_DISPLAY[@]}; i++ )); do
+        parts+=("{\"display\":\"$(__aish_json_escape "${__AISH_COMP_DISPLAY[$i]}")\",\"replacement\":\"$(__aish_json_escape "${__AISH_COMP_REPLACEMENT[$i]}")\"}")
+    done
+
+    if ((${#parts[@]} > 0)); then
+        local IFS=,
+        candidates_json="[${parts[*]}]"
+    else
+        candidates_json="[]"
+    fi
+
+    printf -v payload \
+        '{"version":%s,"type":"completion_result","request_id":%s,"word_start":%s,"candidates":%s}' \
+        "$__AISH_PROTOCOL_VERSION" "$request_id" "$word_start" "$candidates_json"
+    __aish_emit_control_line "$payload"
+}
+
+_aish_is_path_like() {
+    local token="$1"
+    [[ -z "$token" ]] && return 1
+    [[ "$token" == /* || "$token" == ./* || "$token" == ../* || "$token" == ~* || "$token" == */ ]] && return 0
+    return 1
+}
+
+_aish_parse_line() {
+    local comp_line="$1"
+    local cursor="$2"
+    local -n _pl_words="$3"
+    local -n _pl_starts="$4"
+
+    _pl_words=()
+    _pl_starts=()
+    local i=0 word="" start=0 ch=""
+
+    for (( i=0; i<${#comp_line}; i++ )); do
+        ch="${comp_line:$i:1}"
         if [[ "$ch" == " " || "$ch" == $'\t' ]]; then
             if [[ -n "$word" ]]; then
-                words+=("$word")
+                _pl_words+=("$word")
+                _pl_starts+=("$start")
                 word=""
             fi
         else
+            if [[ -z "$word" ]]; then
+                start=$i
+            fi
             word+="$ch"
         fi
     done
     if [[ -n "$word" ]]; then
-        words+=("$word")
+        _pl_words+=("$word")
+        _pl_starts+=("$start")
     fi
 
-    # If cursor is after a trailing space, append an empty word so that
-    # argument completion (not command-name completion) is triggered.
-    if (( cursor > 0 )) && [[ "${cmd_line:$((cursor-1)):1}" == " " ]]; then
-        words+=("")
+    if (( cursor > 0 )) && [[ "${comp_line:$((cursor-1)):1}" == " " ]]; then
+        _pl_words+=("")
+        _pl_starts+=("$cursor")
+    fi
+}
+
+# Maximum candidates emitted per completion (large dirs like /usr/bin/).
+__AISH_COMPLETION_LIMIT=100
+
+# readline sorts matches before display; COMPREPLY/compgen keep readdir order.
+_aish_sort_compreply() {
+    ((${#COMPREPLY[@]} < 2)) && return 0
+    mapfile -t COMPREPLY < <(
+        printf '%s\n' "${COMPREPLY[@]}" \
+            | LC_COLLATE="${LC_COLLATE:-${LC_ALL:-C}}" sort
+    )
+}
+
+__aish_load_bash_completion() {
+    [[ -n "${__AISH_BASH_COMP_LOADED:-}" ]] && return 0
+    if [[ -f /usr/share/bash-completion/bash_completion ]]; then
+        # shellcheck source=/dev/null
+        source /usr/share/bash-completion/bash_completion
+    elif [[ -f /etc/bash_completion ]]; then
+        # shellcheck source=/dev/null
+        source /etc/bash_completion
+    fi
+    __AISH_BASH_COMP_LOADED=1
+}
+
+_aish_resolve_compreply() {
+    local item="$1" cur="$2" dir=""
+
+    [[ -z "$item" ]] && return 0
+    if [[ "$item" == /* || "$item" == ~* || "$item" == ./* || "$item" == ../* ]]; then
+        printf '%s' "$item"
+        return 0
     fi
 
-    # Determine COMP_CWORD: index of the word under the cursor.
-    local cword=0
-    local pos=0
-    for (( i=0; i<${#words[@]}; i++ )); do
-        pos=$(( pos + ${#words[$i]} + 1 ))
+    if [[ "$cur" == */ ]]; then
+        dir="$cur"
+    elif [[ "$cur" == */* ]]; then
+        dir="${cur%/*}/"
+    elif [[ -n "$cur" && -d "$cur" ]]; then
+        dir="${cur}/"
+    else
+        dir="./"
+    fi
+    printf '%s' "${dir}${item}"
+}
+
+_aish_set_comp_context() {
+    local comp_line="$1"
+    local cursor="$2"
+    local -n _sc_words="$3"
+    local -n _sc_starts="$4"
+    local -n _sc_cword="$5"
+
+    _aish_parse_line "$comp_line" "$cursor" _sc_words _sc_starts
+
+    COMP_LINE="$comp_line"
+    COMP_POINT="$cursor"
+    COMP_WORDS=("${_sc_words[@]}")
+
+    local pos=0 i=0
+    _sc_cword=0
+    for (( i=0; i<${#_sc_words[@]}; i++ )); do
+        pos=$(( pos + ${#_sc_words[i]} + 1 ))
         if (( pos > cursor )); then
-            cword=$i
+            _sc_cword=$i
             break
         fi
-        cword=$i
+        _sc_cword=$i
     done
+    COMP_CWORD=$_sc_cword
+}
 
-    local cmd="${words[0]:-}"
-    local cur="${words[$cword]:-}"
-    local prev="${words[$((cword-1))]:-}"
+_aish_invoke_native_completion() {
+    local cmd="$1"
+    local cword="$2"
+    local cur="$3"
+    local comp_spec="" func_name=""
 
-    # --- Empty line: list all commands ---
-    if [[ ${#words[@]} -eq 0 ]]; then
-        compgen -c 2>/dev/null
-        return 0
-    fi
+    COMPREPLY=()
 
-    # --- First word (command name) ---
     if (( cword == 0 )); then
-        compgen -c -- "$cur" 2>/dev/null
+        local entry
+        if _aish_is_path_like "$cur"; then
+            while IFS= read -r entry; do
+                [[ -z "$entry" ]] && continue
+                COMPREPLY+=("$entry")
+            done < <(compgen -f -- "$cur" 2>/dev/null | __aish_mark_dirs)
+        else
+            while IFS= read -r entry; do
+                [[ -z "$entry" ]] && continue
+                COMPREPLY+=("$entry")
+            done < <(compgen -c -- "$cur" 2>/dev/null)
+        fi
         return 0
     fi
 
-    # --- Argument completion: use bash-completion if available ---
-    # Attempt to load the completion function for this command.
-    _completion_loader "$cmd" 2>/dev/null || true
+    if declare -F _comp_load &>/dev/null; then
+        _comp_load -- "$cmd" 2>/dev/null || true
+    fi
+    if ! complete -p "$cmd" &>/dev/null && declare -F _completion_loader &>/dev/null; then
+        _completion_loader "$cmd" 2>/dev/null || true
+    fi
+    comp_spec=$(complete -p "$cmd" 2>/dev/null || true)
 
-    local comp_spec func_name=""
-    comp_spec=$(complete -p "$cmd" 2>/dev/null) || true
     if [[ "$comp_spec" =~ -F[[:space:]]+([^[:space:]]+) ]]; then
         func_name="${BASH_REMATCH[1]}"
+        "$func_name" "$cmd" 2>/dev/null || true
+    elif [[ "$comp_spec" =~ -C[[:space:]]+([^[:space:]]+) ]]; then
+        func_name="${BASH_REMATCH[1]}"
+        COMPREPLY=( $(compgen -W "$(eval "$func_name")" -- "$cur") )
+    elif declare -F _comp_compgen_filedir &>/dev/null; then
+        local wcur="" wprev="" wwords=() wcword=0
+        _comp_get_words -n "<>&" wcur wprev wwords wcword 2>/dev/null || true
+        _comp_compgen_filedir 2>/dev/null || true
+    else
+        local entry
+        while IFS= read -r entry; do
+            [[ -z "$entry" ]] && continue
+            COMPREPLY+=("$entry")
+        done < <(compgen -f -- "$cur" 2>/dev/null | __aish_mark_dirs)
     fi
+}
 
-    if [[ -n "$func_name" ]]; then
-        # Call the registered completion function with the standard
-        # bash signature: func COMMAND CURRENT_WORD PREVIOUS_WORD
-        COMPREPLY=()
-        COMP_WORDS=("${words[@]}")
-        COMP_CWORD=$cword
-        COMP_LINE="$cmd_line"
-        COMP_POINT=$cursor
-        "$func_name" "$cmd" "$cur" "$prev" 2>/dev/null || true
+_aish_compreply_to_candidates() {
+    local cur="$1"
+    local item resolved count=0
 
-        # Deduplicate and output, marking directories with /.
-        if [[ ${#COMPREPLY[@]} -gt 0 ]]; then
-            printf '%s\n' "${COMPREPLY[@]}" 2>/dev/null | __aish_mark_dirs
-            return 0
+    for item in "${COMPREPLY[@]}"; do
+        if _aish_is_path_like "$cur" || _aish_is_path_like "$item" || \
+           [[ "$item" == */* || "$item" == /* ]]; then
+            resolved=$(_aish_resolve_compreply "$item" "$cur")
+            _aish_add_candidate "$resolved" "$cur"
+        else
+            _aish_add_candidate "$item" "$cur" 1
         fi
+        count=$(( count + 1 ))
+        if (( count >= __AISH_COMPLETION_LIMIT )); then
+            break
+        fi
+    done
+}
+
+__aish_complete() {
+    local request_id="${1:-0}"
+    local comp_line="${2:-}"
+    local cursor="${3:-0}"
+    local -a words=()
+    local -a word_starts=()
+    local cword=0 cmd="" cur="" word_start=0
+
+    _aish_reset_candidates
+    __aish_load_bash_completion
+
+    _aish_set_comp_context "$comp_line" "$cursor" words word_starts cword
+
+    if ((${#words[@]} == 0)); then
+        __aish_emit_completion_result "$request_id" 0
+        return 0
     fi
 
-    # --- Fallback: file/directory completion ---
-    compgen -f -- "$cur" 2>/dev/null | __aish_mark_dirs
+    word_start=${word_starts[$cword]:-0}
+    cmd="${words[0]:-}"
+    cur="${words[$cword]:-}"
+
+    _aish_invoke_native_completion "$cmd" "$cword" "$cur"
+    _aish_sort_compreply
+    _aish_compreply_to_candidates "$cur"
+
+    __aish_emit_completion_result "$request_id" "$word_start"
 }
 
 __aish_emit_session_ready

--- a/crates/aish-pty/src/command_state.rs
+++ b/crates/aish-pty/src/command_state.rs
@@ -92,6 +92,7 @@ impl CommandState {
             BackendControlEvent::SessionReady { .. } => None,
             BackendControlEvent::ShellExiting { .. } => None,
             BackendControlEvent::CommandOutput { .. } => None,
+            BackendControlEvent::CompletionResult { .. } => None,
         }
     }
 

--- a/crates/aish-pty/src/control.rs
+++ b/crates/aish-pty/src/control.rs
@@ -1,6 +1,24 @@
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
+// Completion types (Tab completion)
+// ---------------------------------------------------------------------------
+
+/// One completion candidate with separate display and replacement text.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompletionCandidate {
+    pub display: String,
+    pub replacement: String,
+}
+
+/// Response from bash `__aish_complete` delivered over the control pipe.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompletionResponse {
+    pub word_start: usize,
+    pub candidates: Vec<CompletionCandidate>,
+}
+
+// ---------------------------------------------------------------------------
 // BackendControlEvent
 // ---------------------------------------------------------------------------
 
@@ -35,6 +53,13 @@ pub enum BackendControlEvent {
 
     #[serde(rename = "command_output")]
     CommandOutput { data: String },
+
+    #[serde(rename = "completion_result")]
+    CompletionResult {
+        request_id: u64,
+        word_start: usize,
+        candidates: Vec<CompletionCandidate>,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -245,6 +270,67 @@ mod tests {
                 assert_eq!(*command_seq, None);
             }
             other => panic!("expected PromptReady, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn roundtrip_completion_result() {
+        let evt = BackendControlEvent::CompletionResult {
+            request_id: 42,
+            word_start: 3,
+            candidates: vec![
+                CompletionCandidate {
+                    display: "lixin/".to_string(),
+                    replacement: "/home/lixin/".to_string(),
+                },
+                CompletionCandidate {
+                    display: "crates/".to_string(),
+                    replacement: "crates/".to_string(),
+                },
+            ],
+        };
+        let encoded = encode_control_event(&evt);
+        assert!(encoded.contains("\"type\":\"completion_result\""));
+        assert!(encoded.contains("\"request_id\":42"));
+        let mut buf = String::new();
+        let decoded = decode_control_chunk(&mut buf, encoded.as_bytes());
+        match decoded.first() {
+            Some(BackendControlEvent::CompletionResult {
+                request_id,
+                word_start,
+                candidates,
+            }) => {
+                assert_eq!(*request_id, 42);
+                assert_eq!(*word_start, 3);
+                assert_eq!(candidates.len(), 2);
+                assert_eq!(candidates[0].display, "lixin/");
+                assert_eq!(candidates[0].replacement, "/home/lixin/");
+            }
+            other => panic!("expected CompletionResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_completion_result_with_escaped_json() {
+        let json = concat!(
+            "{\"version\":1,\"type\":\"completion_result\",\"request_id\":7,",
+            "\"word_start\":0,\"candidates\":[",
+            "{\"display\":\"git\",\"replacement\":\"git \"}",
+            "]}\n"
+        );
+        let mut buf = String::new();
+        let decoded = decode_control_chunk(&mut buf, json.as_bytes());
+        match &decoded[0] {
+            BackendControlEvent::CompletionResult {
+                request_id,
+                word_start,
+                candidates,
+            } => {
+                assert_eq!(*request_id, 7);
+                assert_eq!(*word_start, 0);
+                assert_eq!(candidates[0].replacement, "git ");
+            }
+            other => panic!("expected CompletionResult, got {other:?}"),
         }
     }
 }

--- a/crates/aish-pty/src/lib.rs
+++ b/crates/aish-pty/src/lib.rs
@@ -21,6 +21,7 @@ pub mod nl_detect;
 pub mod offload;
 pub mod output_buffer;
 pub mod persistent;
+pub mod readline_tab;
 pub mod session_interceptor;
 pub mod state_capture;
 pub mod types;
@@ -34,7 +35,10 @@ pub struct SshSecretCheckResult {
 }
 
 pub use command_state::CommandState;
-pub use control::{decode_control_chunk, encode_control_event, BackendControlEvent};
+pub use control::{
+    decode_control_chunk, encode_control_event, BackendControlEvent, CompletionCandidate,
+    CompletionResponse,
+};
 pub use executor::PtyExecutor;
 pub use offload::{
     truncate_utf8_safe, BashOffloadResult, BashOffloadSettings, BashOutputOffload, OffloadResult,
@@ -42,6 +46,7 @@ pub use offload::{
 };
 pub use output_buffer::OutputBuffer;
 pub use persistent::{is_interactive_command, shell_quote_escape, PersistentPty};
+pub use readline_tab::ReadlineTabResult;
 pub use session_interceptor::{
     pop_last_utf8_char, AiCallback, AiEvent, AiQuery, AiResponse, AskUserAnswer, AskUserChannel,
     AskUserOption, AskUserRequest, BashExecResult, FollowupCallback, InterceptorState,

--- a/crates/aish-pty/src/persistent.rs
+++ b/crates/aish-pty/src/persistent.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 use std::os::fd::{AsRawFd, IntoRawFd, OwnedFd, RawFd};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -85,7 +85,12 @@ pub struct PersistentPty {
     exec_buffer: Arc<Mutex<Vec<u8>>>,
     /// Whether we are in exec mode (buffer output instead of forwarding).
     exec_mode: Arc<AtomicBool>,
+    /// Monotonic id for tab-completion requests.
+    next_completion_request_id: AtomicU64,
 }
+
+#[path = "aish_completion.rs"]
+mod aish_completion;
 
 impl PersistentPty {
     /// Start a new persistent bash session.
@@ -153,6 +158,7 @@ impl PersistentPty {
             next_backend_seq: -1,
             exec_buffer: Arc::new(Mutex::new(Vec::new())),
             exec_mode: Arc::new(AtomicBool::new(false)),
+            next_completion_request_id: AtomicU64::new(0),
         };
 
         // Wait for session_ready event.  Also returns whether the

--- a/crates/aish-pty/src/readline_tab.rs
+++ b/crates/aish-pty/src/readline_tab.rs
@@ -1,0 +1,243 @@
+//! Parse bash/readline Tab completion output captured from the PTY master fd.
+
+use std::time::Duration;
+
+use crate::offload::strip_ansi_escapes;
+
+pub const TAB_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadlineTabResult {
+    pub word_start: usize,
+    pub line_after: Option<String>,
+    pub candidates: Vec<String>,
+}
+
+impl ReadlineTabResult {
+    pub fn is_useful(&self, input_line: &str) -> bool {
+        let extended = self.line_after.as_ref().is_some_and(|line| {
+            !line.contains("^U")
+                && line != input_line
+                && (line.len() > input_line.len() || line.starts_with(input_line.trim_end()))
+        });
+        extended || !self.candidates.is_empty()
+    }
+}
+
+pub fn clamp_pos(line: &str, pos: usize) -> usize {
+    if line.is_char_boundary(pos) {
+        pos
+    } else {
+        (0..=pos)
+            .rev()
+            .find(|&p| line.is_char_boundary(p))
+            .unwrap_or(0)
+    }
+}
+
+pub fn word_start_at(line: &str, pos: usize) -> usize {
+    let before = line.get(..pos).unwrap_or(line);
+    before
+        .char_indices()
+        .rev()
+        .find(|(_, c)| c.is_whitespace())
+        .map(|(i, c)| i + c.len_utf8())
+        .unwrap_or(0)
+}
+
+pub fn is_path_like_token(token: &str) -> bool {
+    !token.is_empty()
+        && (token.starts_with('/')
+            || token.starts_with("./")
+            || token.starts_with("../")
+            || token.starts_with('~')
+            || token.contains('/'))
+}
+
+/// Build keystrokes for PTY readline: optional Ctrl-U, line text, cursor, Tab×n.
+pub fn build_readline_tab_payload(line: &str, pos: usize, tabs: u8, clear_line: bool) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(line.len() + 8);
+    if clear_line {
+        buf.push(0x15);
+    }
+    buf.extend_from_slice(line.as_bytes());
+    if pos < line.len() {
+        buf.push(0x01);
+        for _ in 0..line[..pos].chars().count() {
+            buf.push(0x06);
+        }
+    }
+    for _ in 0..tabs {
+        buf.push(0x09);
+    }
+    buf
+}
+
+pub fn parse_readline_tab_output(raw: &[u8], input_line: &str, cursor: usize) -> ReadlineTabResult {
+    let word_start = word_start_at(input_line, cursor);
+    let current_word = input_line.get(word_start..cursor).unwrap_or("");
+    let text = normalize_tab_text(raw);
+
+    let mut candidates = parse_column_candidates(&text, current_word);
+    let line_after = parse_inline_line(&text, input_line);
+
+    if candidates.is_empty() {
+        if let Some(extended) = &line_after {
+            if extended != input_line {
+                if let Some(suffix) = extended.get(word_start..) {
+                    if !suffix.is_empty() && suffix != current_word {
+                        candidates.push(suffix.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    ReadlineTabResult {
+        word_start,
+        line_after,
+        candidates,
+    }
+}
+
+pub fn to_replacement_pairs(
+    result: &ReadlineTabResult,
+    line: &str,
+    pos: usize,
+) -> (usize, Vec<(String, String)>) {
+    let word_start = result.word_start;
+    let current = line.get(word_start..pos).unwrap_or("");
+
+    if let Some(new_line) = &result.line_after {
+        if new_line != line {
+            if let Some(suffix) = new_line.get(word_start..) {
+                if !suffix.is_empty() && suffix != current {
+                    let s = suffix.to_string();
+                    return (word_start, vec![(s.clone(), s)]);
+                }
+            }
+        }
+    }
+
+    let pairs = result
+        .candidates
+        .iter()
+        .filter(|c| !c.is_empty())
+        .map(|c| {
+            let rep = word_replacement(c);
+            (c.trim_end_matches(' ').to_string(), rep)
+        })
+        .collect();
+    (word_start, pairs)
+}
+
+fn word_replacement(word: &str) -> String {
+    if word.ends_with('/') || word.contains('/') {
+        word.to_string()
+    } else if word.ends_with(' ') {
+        word.to_string()
+    } else {
+        format!("{word} ")
+    }
+}
+
+fn normalize_tab_text(raw: &[u8]) -> String {
+    String::from_utf8_lossy(&strip_ansi_escapes(raw))
+        .into_owned()
+        .replace('\x07', "")
+}
+
+fn strip_ps1_line(line: &str) -> &str {
+    if let Some(pos) = line.rfind("$ ").or_else(|| line.rfind("# ")) {
+        line[pos + 2..].trim()
+    } else {
+        line.trim()
+    }
+}
+
+fn parse_column_candidates(text: &str, current_word: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in text.split(['\r', '\n']) {
+        let trimmed = line.trim();
+        if trimmed.is_empty()
+            || trimmed.contains("Display all ")
+            || trimmed.contains(" possibilities?")
+            || !trimmed.contains("  ")
+        {
+            continue;
+        }
+        for token in trimmed.split("  ") {
+            let token = token.trim();
+            if token.is_empty() {
+                continue;
+            }
+            if !current_word.is_empty() && !token.starts_with(current_word) {
+                continue;
+            }
+            if !out.iter().any(|existing| existing == token) {
+                out.push(token.to_string());
+            }
+        }
+    }
+    out
+}
+
+fn parse_inline_line(text: &str, input_line: &str) -> Option<String> {
+    if text.contains("Display all ") {
+        return None;
+    }
+    if text.split(['\r', '\n']).any(|l| l.contains("  ") && l.matches(' ').count() >= 2) {
+        return None;
+    }
+
+    for segment in text.replace('\r', "").split('\n').rev() {
+        let seg = strip_ps1_line(segment);
+        if seg.is_empty() || seg.contains("Display all") {
+            continue;
+        }
+        if input_line.starts_with(seg)
+            || seg.starts_with(input_line.trim_end())
+            || seg.len() >= input_line.len()
+        {
+            return Some(seg.to_string());
+        }
+    }
+
+    let flat = strip_ps1_line(text.replace('\r', "").as_str()).to_string();
+    if !flat.is_empty()
+        && flat != input_line
+        && (flat.starts_with(input_line.trim_end()) || input_line.starts_with(&flat))
+    {
+        return Some(flat);
+    }
+
+    text.rsplit('\r').next().and_then(|last| {
+        let last = strip_ps1_line(last.trim_matches('\n'));
+        (!last.is_empty() && !last.contains("  ")).then(|| last.to_string())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_gi_list_and_inline_extend() {
+        let list = b"\x07gi\x07\r\ngit                 git-receive-pack    \r\ngi";
+        let list_result = parse_readline_tab_output(list, "gi", 2);
+        assert!(list_result.candidates.iter().any(|c| c.starts_with("git")));
+
+        let inline = b"\x07ls /home/";
+        assert_eq!(
+            parse_readline_tab_output(inline, "ls /ho", 6).line_after.as_deref(),
+            Some("ls /home/")
+        );
+    }
+
+    #[test]
+    fn word_replacement_respects_trailing_space() {
+        assert_eq!(word_replacement("status"), "status ");
+        assert_eq!(word_replacement("status "), "status ");
+        assert_eq!(word_replacement("/home/"), "/home/");
+    }
+}

--- a/crates/aish-pty/src/readline_tab.rs
+++ b/crates/aish-pty/src/readline_tab.rs
@@ -63,13 +63,9 @@ pub fn build_readline_tab_payload(line: &str, pos: usize, tabs: u8, clear_line: 
     buf.extend_from_slice(line.as_bytes());
     if pos < line.len() {
         buf.push(0x01);
-        for _ in 0..line[..pos].chars().count() {
-            buf.push(0x06);
-        }
+        buf.extend(std::iter::repeat_n(0x06, line[..pos].chars().count()));
     }
-    for _ in 0..tabs {
-        buf.push(0x09);
-    }
+    buf.extend(std::iter::repeat_n(0x09, tabs as usize));
     buf
 }
 
@@ -132,9 +128,7 @@ pub fn to_replacement_pairs(
 }
 
 fn word_replacement(word: &str) -> String {
-    if word.ends_with('/') || word.contains('/') {
-        word.to_string()
-    } else if word.ends_with(' ') {
+    if word.ends_with('/') || word.contains('/') || word.ends_with(' ') {
         word.to_string()
     } else {
         format!("{word} ")
@@ -186,7 +180,10 @@ fn parse_inline_line(text: &str, input_line: &str) -> Option<String> {
     if text.contains("Display all ") {
         return None;
     }
-    if text.split(['\r', '\n']).any(|l| l.contains("  ") && l.matches(' ').count() >= 2) {
+    if text
+        .split(['\r', '\n'])
+        .any(|l| l.contains("  ") && l.matches(' ').count() >= 2)
+    {
         return None;
     }
 
@@ -229,7 +226,9 @@ mod tests {
 
         let inline = b"\x07ls /home/";
         assert_eq!(
-            parse_readline_tab_output(inline, "ls /ho", 6).line_after.as_deref(),
+            parse_readline_tab_output(inline, "ls /ho", 6)
+                .line_after
+                .as_deref(),
             Some("ls /home/")
         );
     }

--- a/crates/aish-pty/tests/completion_query.rs
+++ b/crates/aish-pty/tests/completion_query.rs
@@ -1,0 +1,142 @@
+//! Integration tests for PTY tab completion (control-pipe JSON).
+
+use std::time::Duration;
+
+use aish_pty::PersistentPty;
+
+fn with_pty<F, R>(f: F) -> R
+where
+    F: FnOnce(&mut PersistentPty) -> R,
+{
+    let cwd = std::env::current_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "/tmp".to_string());
+    let mut pty = PersistentPty::start(&cwd, 24, 80).expect("start");
+    let out = f(&mut pty);
+    pty.stop();
+    out
+}
+
+#[test]
+fn query_completions_command_prefix() {
+    with_pty(|pty| {
+        let resp = pty
+            .query_completions("gi", 2, Duration::from_secs(5))
+            .expect("query");
+        assert!(
+            resp.candidates.iter().any(|c| c.replacement.starts_with("git")),
+            "expected git, got {:?}",
+            resp.candidates
+        );
+    });
+}
+
+#[test]
+fn query_completions_path_prefix() {
+    with_pty(|pty| {
+        let line = "ls /ho";
+        let resp = pty
+            .query_completions(line, line.len(), Duration::from_secs(5))
+            .expect("query");
+        assert!(
+            resp.candidates
+                .iter()
+                .any(|c| c.replacement.starts_with("/home")),
+            "expected /home, got {:?}",
+            resp.candidates
+        );
+    });
+}
+
+#[test]
+fn query_completions_ls_home_lists_children() {
+    if !std::path::Path::new("/home").is_dir() {
+        return;
+    }
+    with_pty(|pty| {
+        let line = "ls /home/";
+        let resp = pty
+            .query_completions(line, line.len(), Duration::from_secs(5))
+            .expect("query");
+        assert!(resp.candidates.len() >= 2, "got {:?}", resp.candidates);
+        assert!(resp.candidates.iter().all(|c| !c.display.starts_with("/home/")));
+    });
+}
+
+#[test]
+fn query_completions_empty_line() {
+    with_pty(|pty| {
+        let resp = pty
+            .query_completions("", 0, Duration::from_secs(5))
+            .expect("query");
+        assert!(resp.candidates.is_empty());
+    });
+}
+
+#[test]
+fn query_completions_absolute_path_at_word_zero() {
+    if !std::path::Path::new("/home").is_dir() {
+        return;
+    }
+    with_pty(|pty| {
+        let resp = pty
+            .query_completions("/ho", 3, Duration::from_secs(5))
+            .expect("query");
+        assert!(
+            resp.candidates
+                .iter()
+                .any(|c| c.replacement.starts_with("/home"))
+        );
+
+        let resp2 = pty
+            .query_completions("/home/", 7, Duration::from_secs(5))
+            .expect("query");
+        assert!(resp2.candidates.len() >= 2);
+    });
+}
+
+#[test]
+fn query_completions_usr_path_at_word_zero() {
+    if !std::path::Path::new("/usr").is_dir() {
+        return;
+    }
+    with_pty(|pty| {
+        let resp = pty
+            .query_completions("/us", 3, Duration::from_secs(5))
+            .expect("query");
+        assert!(
+            resp.candidates
+                .iter()
+                .any(|c| c.replacement.starts_with("/usr"))
+        );
+
+        let resp2 = pty
+            .query_completions("/usr/", 5, Duration::from_secs(5))
+            .expect("query");
+        assert!(resp2.candidates.len() >= 2);
+        assert!(!resp2.candidates.iter().any(|c| c.replacement == "/usr/"));
+    });
+}
+
+#[test]
+fn query_completions_ls_usr_bin_directory() {
+    if !std::path::Path::new("/usr/bin").is_dir() {
+        return;
+    }
+    with_pty(|pty| {
+        let start = std::time::Instant::now();
+        let resp = pty
+            .query_completions("ls /usr/bin", 11, Duration::from_secs(5))
+            .expect("query");
+        assert!(start.elapsed() < Duration::from_millis(800));
+        assert!(!resp.candidates.is_empty());
+        assert!(resp.candidates.len() <= 100);
+
+        let start2 = std::time::Instant::now();
+        let resp2 = pty
+            .query_completions("ls /usr/bin/", 12, Duration::from_secs(5))
+            .expect("query");
+        assert!(start2.elapsed() < Duration::from_millis(1200));
+        assert!(resp2.candidates.len() >= 2);
+    });
+}

--- a/crates/aish-pty/tests/completion_query.rs
+++ b/crates/aish-pty/tests/completion_query.rs
@@ -24,7 +24,9 @@ fn query_completions_command_prefix() {
             .query_completions("gi", 2, Duration::from_secs(5))
             .expect("query");
         assert!(
-            resp.candidates.iter().any(|c| c.replacement.starts_with("git")),
+            resp.candidates
+                .iter()
+                .any(|c| c.replacement.starts_with("git")),
             "expected git, got {:?}",
             resp.candidates
         );
@@ -59,7 +61,10 @@ fn query_completions_ls_home_lists_children() {
             .query_completions(line, line.len(), Duration::from_secs(5))
             .expect("query");
         assert!(resp.candidates.len() >= 2, "got {:?}", resp.candidates);
-        assert!(resp.candidates.iter().all(|c| !c.display.starts_with("/home/")));
+        assert!(resp
+            .candidates
+            .iter()
+            .all(|c| !c.display.starts_with("/home/")));
     });
 }
 
@@ -82,11 +87,10 @@ fn query_completions_absolute_path_at_word_zero() {
         let resp = pty
             .query_completions("/ho", 3, Duration::from_secs(5))
             .expect("query");
-        assert!(
-            resp.candidates
-                .iter()
-                .any(|c| c.replacement.starts_with("/home"))
-        );
+        assert!(resp
+            .candidates
+            .iter()
+            .any(|c| c.replacement.starts_with("/home")));
 
         let resp2 = pty
             .query_completions("/home/", 7, Duration::from_secs(5))
@@ -104,11 +108,10 @@ fn query_completions_usr_path_at_word_zero() {
         let resp = pty
             .query_completions("/us", 3, Duration::from_secs(5))
             .expect("query");
-        assert!(
-            resp.candidates
-                .iter()
-                .any(|c| c.replacement.starts_with("/usr"))
-        );
+        assert!(resp
+            .candidates
+            .iter()
+            .any(|c| c.replacement.starts_with("/usr")));
 
         let resp2 = pty
             .query_completions("/usr/", 5, Duration::from_secs(5))

--- a/crates/aish-pty/tests/completion_test.sh
+++ b/crates/aish-pty/tests/completion_test.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Shell tests for __aish_complete control-pipe protocol.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="${ROOT}/src/bash_rc_wrapper.sh"
+TEST_TMP="${ROOT}/.completion_test_tmp"
+mkdir -p "$TEST_TMP"
+export TMPDIR="$TEST_TMP"
+
+if [[ ! -f "$WRAPPER" ]]; then
+  echo "missing wrapper: $WRAPPER" >&2
+  exit 1
+fi
+
+# Capture control-pipe JSON lines.
+CONTROL_OUT=""
+setup_control_fd() {
+  local ctl
+  ctl="$(mktemp -u)"
+  exec {AISH_TEST_CTL}<>"$ctl"
+  rm -f "$ctl"
+  export AISH_CONTROL_FD=$AISH_TEST_CTL
+  CONTROL_OUT="$(mktemp)"
+  tail -f /dev/null &
+  local tailpid=$!
+  kill "$tailpid" 2>/dev/null || true
+}
+
+run_complete() {
+  local line="$1"
+  local cursor="$2"
+  local request_id="${3:-1}"
+  : >"$CONTROL_OUT"
+  (
+    source "$WRAPPER" 2>/dev/null
+    __aish_complete "$request_id" "$line" "$cursor"
+  ) &
+  local pid=$!
+  wait "$pid" || true
+}
+
+last_completion_json() {
+  # In test mode without real control fd wired, invoke directly:
+  true
+}
+
+# Direct invocation with mocked control fd writer.
+source_wrapper_and_complete() {
+  local line="$1"
+  local cursor="$2"
+  local request_id="${3:-1}"
+  local fifo
+  fifo="$(mktemp -u)"
+  mkfifo "$fifo"
+  exec {CTL_FD}<> "$fifo"
+  rm -f "$fifo"
+
+  export AISH_CONTROL_FD=$CTL_FD
+  bash --norc --noprofile -c "source '$WRAPPER'; __aish_complete $request_id $(printf '%q' "$line") $cursor" \
+    >/dev/null 2>/dev/null &
+  local pid=$!
+
+  local json="" buf=""
+  while IFS= read -r -t 3 buf <&$CTL_FD; do
+    if [[ "$buf" == *'"type":"completion_result"'* ]]; then
+      json="$buf"
+      break
+    fi
+  done
+  wait "$pid" 2>/dev/null || true
+  exec {CTL_FD}<&-
+  printf '%s' "$json"
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local msg="${3:-}"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "ASSERT FAIL: ${msg:-expected '$needle' in output}" >&2
+    echo "  got: $haystack" >&2
+    exit 1
+  fi
+}
+
+echo "=== completion shell tests ==="
+
+json=$(source_wrapper_and_complete "gi" 2)
+assert_contains "$json" '"type":"completion_result"' "gi emits completion_result"
+assert_contains "$json" '"replacement":"git "' "gi includes git candidate"
+
+json=$(source_wrapper_and_complete "ls /ho" 6)
+assert_contains "$json" '/home/' "ls /ho completes /home/"
+
+json=$(source_wrapper_and_complete "/ho" 3)
+assert_contains "$json" '/home/' "/ho at word 0 completes /home/"
+
+json=$(source_wrapper_and_complete "/home/" 7)
+assert_contains "$json" '"display":"' "/home/ lists directory children"
+
+json=$(source_wrapper_and_complete "/us" 3)
+assert_contains "$json" '/usr/' "/us at word 0 completes /usr/"
+
+json=$(source_wrapper_and_complete "/usr/" 5)
+assert_contains "$json" '"display":"' "/usr/ lists directory children"
+assert_contains "$json" '/usr/' "/usr/ has child replacement paths"
+
+json=$(source_wrapper_and_complete "/usr/" 5)
+if [[ "$json" == *'"replacement":"/usr/"'* ]]; then
+  echo "ASSERT FAIL: /usr/ should not offer itself as candidate" >&2
+  exit 1
+fi
+
+if [[ -d /home ]]; then
+  json=$(source_wrapper_and_complete "ls /home/" 9)
+  assert_contains "$json" '"display":"' "ls /home/ has display fields"
+  assert_contains "$json" '/home/' "ls /home/ has replacement paths"
+  if [[ "$json" == *'"/home/"'* && "$json" != *'lixin'* && "$json" != *'test'* ]]; then
+    echo "WARN: ls /home/ may only list self — check path-like bypass" >&2
+  fi
+fi
+
+json=$(source_wrapper_and_complete "cd /home/" 9)
+assert_contains "$json" '/home/' "cd /home/ completes children"
+
+json=$(source_wrapper_and_complete "" 0)
+assert_contains "$json" '"candidates":[]' "empty line returns no candidates"
+
+if [[ -d /usr/bin ]]; then
+  json=$(source_wrapper_and_complete "ls /usr/bin" 11)
+  assert_contains "$json" '/usr/bin' "ls /usr/bin uses native bash completion"
+  n=$(echo "$json" | grep -o '"display"' | wc -l)
+  if (( n > 100 )); then
+    echo "ASSERT FAIL: ls /usr/bin exceeded completion limit ($n)" >&2
+    exit 1
+  fi
+
+  json=$(source_wrapper_and_complete "ls /usr/bin/" 12)
+  assert_contains "$json" '"display":"' "ls /usr/bin/ lists children"
+fi
+
+SORT_DIR="${ROOT}/.completion_test_tmp/sorttest"
+mkdir -p "$SORT_DIR"/{zebra,alpha,beta}
+json=$(source_wrapper_and_complete "ls ${SORT_DIR}/" $(( ${#SORT_DIR} + 4 )) )
+if [[ "$json" == *'"display":"alpha/'* ]] && [[ "$json" == *'"display":"beta/'* ]] && [[ "$json" == *'"display":"zebra/'* ]]; then
+  alpha_pos=${json%%\"display\":\"alpha/\"*}
+  beta_pos=${json%%\"display\":\"beta/\"*}
+  zebra_pos=${json%%\"display\":\"zebra/\"*}
+  if (( ${#alpha_pos} >= ${#beta_pos} || ${#beta_pos} >= ${#zebra_pos} )); then
+    echo "ASSERT FAIL: directory children should be sorted like bash (alpha beta zebra), got $json" >&2
+    exit 1
+  fi
+else
+  echo "ASSERT FAIL: expected alpha/beta/zebra candidates, got $json" >&2
+  exit 1
+fi
+
+echo "All completion shell tests passed."

--- a/crates/aish-pty/tests/completion_test.sh
+++ b/crates/aish-pty/tests/completion_test.sh
@@ -13,38 +13,6 @@ if [[ ! -f "$WRAPPER" ]]; then
   exit 1
 fi
 
-# Capture control-pipe JSON lines.
-CONTROL_OUT=""
-setup_control_fd() {
-  local ctl
-  ctl="$(mktemp -u)"
-  exec {AISH_TEST_CTL}<>"$ctl"
-  rm -f "$ctl"
-  export AISH_CONTROL_FD=$AISH_TEST_CTL
-  CONTROL_OUT="$(mktemp)"
-  tail -f /dev/null &
-  local tailpid=$!
-  kill "$tailpid" 2>/dev/null || true
-}
-
-run_complete() {
-  local line="$1"
-  local cursor="$2"
-  local request_id="${3:-1}"
-  : >"$CONTROL_OUT"
-  (
-    source "$WRAPPER" 2>/dev/null
-    __aish_complete "$request_id" "$line" "$cursor"
-  ) &
-  local pid=$!
-  wait "$pid" || true
-}
-
-last_completion_json() {
-  # In test mode without real control fd wired, invoke directly:
-  true
-}
-
 # Direct invocation with mocked control fd writer.
 source_wrapper_and_complete() {
   local line="$1"

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use rustyline::completion::{Completer, FilenameCompleter, Pair};
+use rustyline::completion::{Completer, Pair};
 use rustyline::config::Configurer;
 use rustyline::highlight::Highlighter;
 use rustyline::hint::Hinter;
@@ -14,13 +14,11 @@ use rustyline::{
     EventContext, EventHandler, KeyCode, KeyEvent, Modifiers, RepeatCount,
 };
 
-use crate::autosuggest::AutoSuggest;
+use aish_pty::readline_tab::{
+    clamp_pos, is_path_like_token, to_replacement_pairs, word_start_at, TAB_PROBE_TIMEOUT,
+};
 
-/// Built-in command names for completion.
-const BUILTINS: &[&str] = &[
-    "cd", "pwd", "export", "unset", "pushd", "popd", "dirs", "history", "help", "clear", "exit",
-    "quit",
-];
+use crate::autosuggest::AutoSuggest;
 
 /// Slash commands with descriptions for popup completion.
 pub const SLASH_COMMANDS: &[(&str, &str)] = &[
@@ -35,7 +33,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
 ];
 
 /// Timeout for PTY completion queries.
-const COMPLETION_TIMEOUT: Duration = Duration::from_millis(500);
+const COMPLETION_TIMEOUT: Duration = Duration::from_millis(1200);
 
 // ---------------------------------------------------------------------------
 // Mode toggle key binding handler
@@ -111,10 +109,8 @@ impl ConditionalEventHandler for SlashHandler {
     }
 }
 
-/// Shell command completer that delegates to the persistent PTY bash process
-/// for full bash-completion support (git add, systemctl status, etc.).
+/// Shell readline helper: tab completion delegates to PTY bash.
 struct ShellHelper {
-    file_completer: FilenameCompleter,
     /// Shared reference to the persistent PTY session.
     pty: Arc<Mutex<aish_pty::PersistentPty>>,
     /// Shared autosuggest engine.
@@ -123,39 +119,62 @@ struct ShellHelper {
 
 impl ShellHelper {
     fn new(pty: Arc<Mutex<aish_pty::PersistentPty>>, autosuggest: Arc<Mutex<AutoSuggest>>) -> Self {
-        Self {
-            file_completer: FilenameCompleter::new(),
-            pty,
-            autosuggest,
-        }
+        Self { pty, autosuggest }
     }
 
-    /// Query the PTY bash for completions using `__aish_query_completions`.
-    /// Returns a list of completion candidates on success, or an empty vec on
-    /// any error (timeout, PTY not running, etc.).
-    fn query_pty_completions(&self, line: &str, pos: usize) -> Vec<String> {
-        let mut pty = match self.pty.lock() {
-            Ok(guard) => guard,
-            Err(_) => return Vec::new(),
-        };
+    /// Drop candidates that would not change the current word (rustyline re-applies
+    /// single-candidate replacements even when the word is already complete).
+    fn filter_extending_candidates(
+        line: &str,
+        pos: usize,
+        word_start: usize,
+        candidates: Vec<aish_pty::CompletionCandidate>,
+    ) -> Vec<Pair> {
+        let current = line.get(word_start..pos).unwrap_or("");
+        candidates
+            .into_iter()
+            .filter(|c| c.replacement != current)
+            .map(|c| Pair {
+                display: c.display,
+                replacement: c.replacement,
+            })
+            .collect()
+    }
 
-        // Skip if PTY is not running.
+    fn complete_via_pty(&self, line: &str, pos: usize) -> Option<(usize, Vec<Pair>)> {
+        let pos = clamp_pos(line, pos);
+        let mut pty = self.pty.lock().ok()?;
         if !pty.is_running() {
-            return Vec::new();
+            return None;
         }
 
-        // Build the completion query command.
-        let escaped_line = aish_pty::shell_quote_escape(line);
-        let cmd = format!("__aish_query_completions {} {}", escaped_line, pos);
-
-        match pty.execute_command(&cmd, COMPLETION_TIMEOUT, None, false) {
-            Ok((output, _exit_code, _cwd)) => output
-                .lines()
-                .filter(|l| !l.is_empty())
-                .map(|l| l.to_string())
-                .collect(),
-            Err(_) => Vec::new(),
+        if !is_path_like_token(line.get(word_start_at(line, pos)..pos).unwrap_or("")) {
+            if let Some(tab) = pty.forward_readline_tab(line, pos, TAB_PROBE_TIMEOUT) {
+                let (word_start, raw_pairs) = to_replacement_pairs(&tab, line, pos);
+                if !raw_pairs.is_empty() {
+                    return Some((
+                        word_start,
+                        raw_pairs
+                            .into_iter()
+                            .map(|(display, replacement)| Pair {
+                                display,
+                                replacement,
+                            })
+                            .collect(),
+                    ));
+                }
+            }
         }
+
+        pty.query_completions(line, pos, COMPLETION_TIMEOUT)
+            .ok()
+            .filter(|resp| !resp.candidates.is_empty())
+            .map(|resp| {
+                (
+                    resp.word_start,
+                    Self::filter_extending_candidates(line, pos, resp.word_start, resp.candidates),
+                )
+            })
     }
 }
 
@@ -197,115 +216,27 @@ impl Completer for ShellHelper {
         &self,
         line: &str,
         pos: usize,
-        ctx: &Context<'_>,
+        _ctx: &Context<'_>,
     ) -> rustyline::Result<(usize, Vec<Pair>)> {
-        // Clamp pos to nearest valid char boundary (guards against CJK misalignment)
-        let pos = if line.is_char_boundary(pos) {
-            pos
-        } else {
-            (0..=pos)
-                .rev()
-                .find(|&p| line.is_char_boundary(p))
-                .unwrap_or(0)
-        };
+        let pos = clamp_pos(line, pos);
         let before = &line[..pos];
-        let word_start = before.rfind(' ').map(|i| i + 1).unwrap_or(0);
-        let word = &before[word_start..];
 
         // Skip completion for AI queries
         if before.starts_with(';') || before.starts_with('\u{ff1b}') {
             return Ok((0, Vec::new()));
         }
 
-        // At the start of the line: mix builtins/specials with PTY results
-        if !before.contains(' ') {
-            let mut candidates: Vec<Pair> = Vec::new();
-
-            // Builtin commands (handled by Rust shell, not PTY)
-            for cmd in BUILTINS {
-                if cmd.starts_with(word) {
-                    candidates.push(Pair {
-                        display: cmd.to_string(),
-                        replacement: format!("{} ", cmd),
-                    });
-                }
-            }
-
-            // Slash commands
-            for (cmd, _desc) in SLASH_COMMANDS {
-                if cmd.starts_with(word) {
-                    candidates.push(Pair {
-                        display: cmd.to_string(),
-                        replacement: format!("{} ", cmd),
-                    });
-                }
-            }
-
-            // AI prefix
-            if ";".starts_with(word) || "\u{ff1b}".starts_with(word) {
-                candidates.push(Pair {
-                    display: "; <question>".to_string(),
-                    replacement: "; ".to_string(),
-                });
-            }
-
-            // Query PTY for all other command completions
-            if !word.is_empty() {
-                let pty_results = self.query_pty_completions(line, pos);
-                let builtin_set: Vec<&str> = BUILTINS.to_vec();
-                let slash_set: Vec<&str> = SLASH_COMMANDS.iter().map(|(c, _)| *c).collect();
-                for candidate in &pty_results {
-                    // Skip duplicates already covered by BUILTINS/SLASH_COMMANDS
-                    if builtin_set.contains(&candidate.as_str())
-                        || slash_set.contains(&candidate.as_str())
-                    {
-                        continue;
-                    }
-                    candidates.push(Pair {
-                        display: candidate.clone(),
-                        replacement: format!("{} ", candidate),
-                    });
-                }
-            }
-
-            // Merge file completions for path-like tokens so slash commands
-            // don't shadow absolute paths like /usr, /tmp, /proc, etc.
-            if word.starts_with("./")
-                || word.starts_with("../")
-                || word.starts_with("/")
-                || word.starts_with("~/")
-            {
-                if let Ok((_, file_candidates)) = self.file_completer.complete(line, pos, ctx) {
-                    candidates.extend(file_candidates);
-                }
-            }
-
-            return Ok((word_start, candidates));
+        // Empty input: no completion (bash semantics)
+        if before.trim().is_empty() {
+            return Ok((0, Vec::new()));
         }
 
-        // After a command: delegate entirely to PTY for context-aware completion
-        let pty_results = self.query_pty_completions(line, pos);
-        if !pty_results.is_empty() {
-            let candidates: Vec<Pair> = pty_results
-                .into_iter()
-                .map(|c| {
-                    // Append space for non-directory completions
-                    let replacement = if c.ends_with('/') {
-                        c.clone()
-                    } else {
-                        format!("{} ", c)
-                    };
-                    Pair {
-                        display: c,
-                        replacement,
-                    }
-                })
-                .collect();
-            return Ok((word_start, candidates));
+        if let Some((word_start, pairs)) = self.complete_via_pty(line, pos) {
+            return Ok((word_start, pairs));
         }
 
-        // Fallback: file completion
-        self.file_completer.complete(line, pos, ctx)
+        // PTY unavailable — no fallback (bash is the single source of truth).
+        Ok((0, Vec::new()))
     }
 }
 
@@ -477,9 +408,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_builtins_contains_cd() {
-        assert!(BUILTINS.contains(&"cd"));
-        assert!(BUILTINS.contains(&"exit"));
+    fn test_filter_extending_candidates_drops_unchanged() {
+        let candidates = vec![aish_pty::CompletionCandidate {
+            display: "usr/".into(),
+            replacement: "/usr/".into(),
+        }];
+        let pairs = ShellHelper::filter_extending_candidates("/usr/", 5, 0, candidates);
+        assert!(pairs.is_empty(), "unchanged replacement should be filtered");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Delegate Tab completion to bash via control-pipe JSON (`__aish_complete`), using bash/bash-completion as the single source of truth for candidates.
- Add readline Tab forwarding through the PTY for command-prefix completion, with JSON fallback when readline does not produce a result.
- Skip readline forwarding for path-like tokens to reduce latency; fix trailing-space duplication for bash-completion results (e.g. `git stat`).

## Test plan
- [x] `cargo test -p aish-pty`
- [x] `bash crates/aish-pty/tests/completion_test.sh`
- [ ] Manual: Tab on `gi`, `ls /ho`, `git stat`, path completion under `/usr/bin/`
- [ ] Manual: verify no extra blank lines after `ls` (emacs mode toggled only during Tab probe)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PTY-backed tab-completion using bash-native completions, returning formatted candidates with correct word boundaries.
  * Integrated readline tab-capture/parsing and candidate filtering; completion path now prefers PTY results only and timeout increased for more reliable responses.

* **Tests**
  * Added Rust integration tests for completion queries.
  * Added a Bash test script validating the completion control-protocol and candidate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->