### PR TITLE
fix: preserve \r in cast recording and record Ctrl+C events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ dependencies = [
  "regex",
  "reqwest",
  "richrs",
+ "rusqlite",
  "rustyline",
  "serde",
  "serde_json",

--- a/crates/aish-cli/src/main.rs
+++ b/crates/aish-cli/src/main.rs
@@ -141,6 +141,13 @@ enum Commands {
         #[arg(long)]
         config: Option<String>,
     },
+
+    /// Run system diagnostics
+    Doctor {
+        /// Attempt to auto-fix issues
+        #[arg(long)]
+        fix: bool,
+    },
 }
 
 fn main() {
@@ -215,6 +222,13 @@ fn main() {
         }
         Commands::Uninstall { purge } => {
             uninstall::run_uninstall(purge);
+        }
+        Commands::Doctor { fix } => {
+            let doctor = aish_shell::doctor::Doctor::new();
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(async {
+                doctor.run(fix).await;
+            });
         }
         Commands::ModelsAuth {
             provider,

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -333,6 +333,7 @@ shell:
     feedback: "Submit feedback"
     quit: "Exit AI Shell"
     record: "Record terminal session (start/stop)"
+    doctor: "Basic config diagnostics"
 
   record:
     started: "⏺ Recording started: {path}"

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -333,6 +333,7 @@ shell:
     feedback: "提交反馈"
     quit: "退出 AI Shell"
     record: "录制终端会话 (start/stop)"
+    doctor: "基本配置诊断"
 
   record:
     started: "⏺ 录制已开始: {path}"

--- a/crates/aish-shell/Cargo.toml
+++ b/crates/aish-shell/Cargo.toml
@@ -13,6 +13,7 @@ aish-pty.workspace = true
 aish-scripts.workspace = true
 aish-llm.workspace = true
 aish-session.workspace = true
+rusqlite.workspace = true
 aish-context.workspace = true
 aish-skills.workspace = true
 aish-memory.workspace = true

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -1410,7 +1410,11 @@ impl AishShell {
                 aish_core::PlanPhase::Planning => "plan",
                 aish_core::PlanPhase::Normal => "aish",
             };
-            let recording = self.shared_recorder.lock().unwrap().is_some();
+            let recording = self
+                .shared_recorder
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .is_some();
             let prompt_str = prompt::render_prompt(
                 &self.state.cwd,
                 &self.config.model,
@@ -1569,8 +1573,14 @@ impl AishShell {
                                                 }
                                                 aish_ui::SlashInputOutcome::Cancelled => {}
                                             }
-                                        } else if self.handle_ctrl_c() {
-                                            break;
+                                        } else {
+                                            crate::recorder::shared_record_output(
+                                                &self.shared_recorder,
+                                                "\r\n",
+                                            );
+                                            if self.handle_ctrl_c() {
+                                                break;
+                                            }
                                         }
                                     }
                                     Err(_) => {}
@@ -1582,6 +1592,9 @@ impl AishShell {
                     }
                     // Interrupt (Ctrl-C) — handle double-press exit
                     if matches!(e, rustyline::error::ReadlineError::Interrupted) {
+                        // Record newline so cast replay moves cursor to next line
+                        // instead of filling the current line with spaces via \x1b[2K.
+                        crate::recorder::shared_record_output(&self.shared_recorder, "\r\n");
                         if self.handle_ctrl_c() {
                             break;
                         }
@@ -1977,6 +1990,12 @@ impl AishShell {
                                 // Route to AI
                                 let mut question = input.trim().to_string();
 
+                                // Record user input for cast file
+                                crate::recorder::shared_record_input(
+                                    &self.shared_recorder,
+                                    &format!("{}\n", question),
+                                );
+
                                 // Security gate: same secret check as the normal AI path
                                 if !self.check_security_gate(&mut question) {
                                     continue;
@@ -2066,7 +2085,10 @@ impl AishShell {
 
         // Auto-stop recording if active
         {
-            let mut guard = self.shared_recorder.lock().unwrap();
+            let mut guard = self
+                .shared_recorder
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             if let Some(ref mut rec) = *guard {
                 let path = rec.file_path().to_path_buf();
                 let _ = rec.flush();
@@ -2167,6 +2189,7 @@ impl AishShell {
                 crate::feedback::run_feedback(&self.config.model, &self.config.api_base);
             }
             Some("/record") => self.handle_record_command(&parts),
+            Some("/doctor") => self.handle_doctor_command(&parts),
             _ => {
                 eprintln!("{}", {
                     let mut args = std::collections::HashMap::new();
@@ -2184,6 +2207,15 @@ impl AishShell {
             2 => self.resume_session(parts[1]),
             _ => eprintln!("{}", t("shell.resume.usage")),
         }
+    }
+
+    fn handle_doctor_command(&mut self, parts: &[&str]) {
+        let doctor = crate::doctor::Doctor::new();
+        let fix = parts.iter().skip(1).any(|arg| *arg == "--fix");
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            doctor.run(fix).await;
+        });
     }
 
     fn select_recent_session(&mut self) {
@@ -2367,7 +2399,10 @@ impl AishShell {
 
     fn handle_record_command(&mut self, parts: &[&str]) {
         let subcmd = parts.get(1).copied().unwrap_or("");
-        let mut guard = self.shared_recorder.lock().unwrap();
+        let mut guard = self
+            .shared_recorder
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
 
         match subcmd {
             "start" => {
@@ -2626,6 +2661,9 @@ impl AishShell {
 
     /// Execute an external command via the persistent PTY session.
     fn execute_external_command(&mut self, command: &str) -> i32 {
+        // Record user command input before execution
+        crate::recorder::shared_record_input(&self.shared_recorder, &format!("{}\n", command));
+
         // Sync terminal size before each command
         if let Ok((cols, rows)) = crossterm::terminal::size() {
             self.lock_pty().resize(rows, cols);
@@ -2819,6 +2857,11 @@ impl AishShell {
             InterruptionState::Normal | InterruptionState::Inputting => {
                 self.interruption = InterruptionState::ClearPending;
                 self.last_ctrl_c = Some(now);
+                let msg = format!(
+                    "\x1b[33m({})\x1b[0m\r\n",
+                    aish_i18n::t("shell.ctrl_c_again")
+                );
+                crate::recorder::shared_record_output(&self.shared_recorder, &msg);
                 println!("\x1b[33m({})\x1b[0m", aish_i18n::t("shell.ctrl_c_again"));
                 false
             }
@@ -2826,12 +2869,19 @@ impl AishShell {
                 if let Some(last) = self.last_ctrl_c {
                     if now.duration_since(last).as_secs() < 1 {
                         self.interruption = InterruptionState::ExitPending;
+                        let msg = format!("\x1b[33m{}\x1b[0m\r\n", aish_i18n::t("shell.exiting"));
+                        crate::recorder::shared_record_output(&self.shared_recorder, &msg);
                         println!("\x1b[33m{}\x1b[0m", aish_i18n::t("shell.exiting"));
                         return true;
                     }
                 }
                 self.interruption = InterruptionState::ClearPending;
                 self.last_ctrl_c = Some(now);
+                let msg = format!(
+                    "\x1b[33m({})\x1b[0m\r\n",
+                    aish_i18n::t("shell.ctrl_c_again")
+                );
+                crate::recorder::shared_record_output(&self.shared_recorder, &msg);
                 println!("\x1b[33m({})\x1b[0m", aish_i18n::t("shell.ctrl_c_again"));
                 false
             }

--- a/crates/aish-shell/src/doctor/api.rs
+++ b/crates/aish-shell/src/doctor/api.rs
@@ -1,0 +1,131 @@
+use crate::doctor::checker::{CheckItem, CheckResult, Checker, FixResult};
+use std::time::{Duration, Instant};
+
+pub struct ApiConnectivityChecker;
+
+impl ApiConnectivityChecker {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn resolve_config(&self) -> (Option<String>, String) {
+        let config = aish_config::ConfigLoader::load(None).unwrap_or_default();
+        let api_key = if let Ok(key) = std::env::var("AISH_API_KEY") {
+            Some(key)
+        } else if !config.api_key.is_empty() {
+            Some(config.api_key)
+        } else {
+            None
+        };
+        let api_base = if config.api_base.is_empty() {
+            "https://api.openai.com/v1".to_string()
+        } else {
+            config.api_base
+        };
+        (api_key, api_base)
+    }
+
+    fn check_connectivity(&self) -> CheckItem {
+        let (api_key, api_base) = self.resolve_config();
+        let api_key = match api_key {
+            Some(k) => k,
+            None => {
+                return CheckItem::warn("api", "No API key configured")
+                    .hint("Run 'aish setup' to configure");
+            }
+        };
+
+        let url = format!("{}/models", api_base.trim_end_matches('/'));
+
+        let client = match reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+        {
+            Ok(c) => c,
+            Err(e) => {
+                return CheckItem::fail("api", format!("Failed to create HTTP client: {}", e));
+            }
+        };
+
+        let req = client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", api_key));
+
+        let start = Instant::now();
+        match req.send() {
+            Ok(resp) => {
+                let latency = start.elapsed().as_millis();
+                let status = resp.status();
+                if status.is_success() {
+                    CheckItem::pass(
+                        "api",
+                        format!("API connectivity: OK ({}ms, {})", latency, api_base),
+                    )
+                } else if status.as_u16() == 401 {
+                    CheckItem::fail("api", "API connectivity: invalid API key (HTTP 401)")
+                        .hint("Check your API key in config or AISH_API_KEY env var")
+                } else if status.is_server_error() {
+                    CheckItem::fail(
+                        "api",
+                        format!("API connectivity: server error (HTTP {})", status),
+                    )
+                    .hint("The API server may be temporarily unavailable")
+                } else if status.is_client_error() {
+                    CheckItem::fail(
+                        "api",
+                        format!(
+                            "API connectivity: client error (HTTP {}, {})",
+                            status, api_base
+                        ),
+                    )
+                    .hint("Check your API base URL and endpoint configuration")
+                } else {
+                    CheckItem::warn(
+                        "api",
+                        format!(
+                            "API connectivity: unexpected status (HTTP {}, {}ms)",
+                            status, latency
+                        ),
+                    )
+                }
+            }
+            Err(e) => {
+                let hint = if e.is_timeout() {
+                    "Request timed out — check network connectivity"
+                } else if e.is_connect() {
+                    "Connection refused — check API base URL and network"
+                } else {
+                    "Check network connectivity and API base URL"
+                };
+                CheckItem::fail("api", format!("API connectivity: {} ({})", e, api_base)).hint(hint)
+            }
+        }
+    }
+}
+
+impl Checker for ApiConnectivityChecker {
+    fn name(&self) -> &str {
+        "API Connectivity"
+    }
+
+    fn check(&self) -> Vec<CheckResult> {
+        let item = self.check_connectivity();
+        let status = item.status.clone();
+        vec![CheckResult {
+            checker: self.name().to_string(),
+            items: vec![item],
+            status,
+        }]
+    }
+
+    fn fix(&self, _item: &CheckItem) -> FixResult {
+        FixResult {
+            success: false,
+            message: "Cannot auto-fix connectivity issues".to_string(),
+        }
+    }
+
+    fn box_clone(&self) -> Box<dyn Checker> {
+        Box::new(Self::new())
+    }
+}

--- a/crates/aish-shell/src/doctor/apikey.rs
+++ b/crates/aish-shell/src/doctor/apikey.rs
@@ -1,0 +1,70 @@
+use crate::doctor::checker::{CheckItem, CheckResult, Checker, FixResult};
+use std::env;
+
+pub struct ApiKeyChecker;
+
+impl ApiKeyChecker {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn mask_key(key: &str) -> String {
+        if key.len() > 4 {
+            format!("{}...", &key[..4])
+        } else if !key.is_empty() {
+            "***".to_string()
+        } else {
+            "(empty)".to_string()
+        }
+    }
+}
+
+impl Checker for ApiKeyChecker {
+    fn name(&self) -> &str {
+        "API Keys"
+    }
+
+    fn check(&self) -> Vec<CheckResult> {
+        let mut items = Vec::new();
+
+        let config = aish_config::ConfigLoader::load(None).unwrap_or_default();
+
+        if !config.api_key.is_empty() {
+            items.push(CheckItem::pass(
+                "config.api_key",
+                format!(
+                    "Config API key: {} (configured)",
+                    Self::mask_key(&config.api_key)
+                ),
+            ));
+        } else {
+            items.push(
+                CheckItem::warn("config.api_key", "API key not set in config")
+                    .hint("Run 'aish setup' to configure"),
+            );
+        }
+
+        if let Ok(key) = env::var("AISH_API_KEY") {
+            items.push(CheckItem::pass(
+                "AISH_API_KEY",
+                format!(
+                    "AISH_API_KEY: {} (env override, active)",
+                    Self::mask_key(&key)
+                ),
+            ));
+        }
+
+        vec![CheckResult::from_items(self.name(), items)]
+    }
+
+    fn fix(&self, _item: &CheckItem) -> FixResult {
+        FixResult {
+            success: false,
+            message: "Run 'aish setup' to configure API key".to_string(),
+        }
+    }
+
+    fn box_clone(&self) -> Box<dyn Checker> {
+        Box::new(Self::new())
+    }
+}

--- a/crates/aish-shell/src/doctor/checker.rs
+++ b/crates/aish-shell/src/doctor/checker.rs
@@ -1,0 +1,97 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub enum CheckStatus {
+    Pass,
+    Warn,
+    Fail,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CheckResult {
+    pub checker: String,
+    pub items: Vec<CheckItem>,
+    pub status: CheckStatus,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CheckItem {
+    pub name: String,
+    pub status: CheckStatus,
+    pub message: String,
+    pub fixable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hint: Option<String>,
+}
+
+impl CheckItem {
+    pub fn pass(name: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: CheckStatus::Pass,
+            message: message.into(),
+            fixable: false,
+            hint: None,
+        }
+    }
+
+    pub fn warn(name: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: CheckStatus::Warn,
+            message: message.into(),
+            fixable: false,
+            hint: None,
+        }
+    }
+
+    pub fn fail(name: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: CheckStatus::Fail,
+            message: message.into(),
+            fixable: false,
+            hint: None,
+        }
+    }
+
+    pub fn fixable(mut self) -> Self {
+        self.fixable = true;
+        self
+    }
+
+    pub fn hint(mut self, hint: impl Into<String>) -> Self {
+        self.hint = Some(hint.into());
+        self
+    }
+}
+
+impl CheckResult {
+    pub fn from_items(checker: impl Into<String>, items: Vec<CheckItem>) -> Self {
+        let status = if items.iter().any(|i| i.status == CheckStatus::Fail) {
+            CheckStatus::Fail
+        } else if items.iter().any(|i| i.status == CheckStatus::Warn) {
+            CheckStatus::Warn
+        } else {
+            CheckStatus::Pass
+        };
+        Self {
+            checker: checker.into(),
+            items,
+            status,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FixResult {
+    pub success: bool,
+    pub message: String,
+}
+
+pub trait Checker: Send + Sync {
+    fn name(&self) -> &str;
+    fn check(&self) -> Vec<CheckResult>;
+    fn fix(&self, result: &CheckItem) -> FixResult;
+    fn box_clone(&self) -> Box<dyn Checker>;
+}

--- a/crates/aish-shell/src/doctor/config.rs
+++ b/crates/aish-shell/src/doctor/config.rs
@@ -1,0 +1,177 @@
+use crate::doctor::checker::{CheckItem, CheckResult, Checker, FixResult};
+use aish_config::ConfigModel;
+use std::path::PathBuf;
+
+pub struct ConfigChecker {
+    config_path: PathBuf,
+}
+
+impl ConfigChecker {
+    pub fn new() -> Self {
+        Self {
+            config_path: dirs::config_dir()
+                .unwrap_or_else(|| std::env::temp_dir().join("aish-fallback"))
+                .join("aish/config.yaml"),
+        }
+    }
+
+    fn validate_structure(&self, config: &ConfigModel) -> Vec<CheckItem> {
+        let mut items = Vec::new();
+
+        if !config.api_base.is_empty() {
+            if config.api_base.starts_with("http://") || config.api_base.starts_with("https://") {
+                items.push(CheckItem::pass(
+                    "api_base_valid",
+                    format!("API base URL: {}", config.api_base),
+                ));
+            } else {
+                items.push(
+                    CheckItem::fail(
+                        "api_base_valid",
+                        format!(
+                            "Invalid api_base: {} (must start with http:// or https://)",
+                            config.api_base
+                        ),
+                    )
+                    .hint("Fix api_base in config.yaml"),
+                );
+            }
+        }
+
+        if !config.model.is_empty() {
+            items.push(CheckItem::pass(
+                "model_set",
+                format!("Model: {}", config.model),
+            ));
+        } else {
+            items.push(
+                CheckItem::warn("model_set", "No model configured")
+                    .hint("Run 'aish setup' to select a model"),
+            );
+        }
+
+        if !config.enable_sandbox && config.sandbox_off_action != "allow" {
+            items.push(CheckItem::warn(
+                "sandbox_config",
+                format!(
+                    "Sandbox disabled but sandbox_off_action is '{}' (expected 'allow')",
+                    config.sandbox_off_action
+                ),
+            ));
+        }
+
+        items
+    }
+}
+
+impl Checker for ConfigChecker {
+    fn name(&self) -> &str {
+        "Configuration"
+    }
+
+    fn check(&self) -> Vec<CheckResult> {
+        let mut items = Vec::new();
+
+        if self.config_path.exists() {
+            items.push(CheckItem::pass(
+                "exists",
+                format!("Config file: {}", self.config_path.display()),
+            ));
+
+            match std::fs::read_to_string(&self.config_path) {
+                Ok(content) => match serde_yaml::from_str::<ConfigModel>(&content) {
+                    Ok(config) => {
+                        items.push(CheckItem::pass("yaml", "YAML format valid"));
+                        items.extend(self.validate_structure(&config));
+                    }
+                    Err(e) => {
+                        items.push(
+                            CheckItem::fail("yaml", format!("YAML parse error: {}", e)).fixable(),
+                        );
+                    }
+                },
+                Err(e) => {
+                    items.push(CheckItem::fail(
+                        "read",
+                        format!("Cannot read config: {}", e),
+                    ));
+                }
+            }
+        } else {
+            items.push(
+                CheckItem::fail("exists", "Config file not found")
+                    .fixable()
+                    .hint("Run 'aish setup' to create one"),
+            );
+        }
+
+        vec![CheckResult::from_items(self.name(), items)]
+    }
+
+    fn fix(&self, item: &CheckItem) -> FixResult {
+        match item.name.as_str() {
+            "exists" => {
+                if let Some(parent) = self.config_path.parent() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
+                let default_config = ConfigModel::default();
+                match serde_yaml::to_string(&default_config) {
+                    Ok(yaml) => match std::fs::write(&self.config_path, yaml) {
+                        Ok(_) => FixResult {
+                            success: true,
+                            message: format!(
+                                "Created default config at {}",
+                                self.config_path.display()
+                            ),
+                        },
+                        Err(e) => FixResult {
+                            success: false,
+                            message: format!("Failed to write config: {}", e),
+                        },
+                    },
+                    Err(e) => FixResult {
+                        success: false,
+                        message: format!("Failed to serialize default config: {}", e),
+                    },
+                }
+            }
+            "yaml" => {
+                let backup_path = self.config_path.with_extension("yaml.bak");
+                if let Err(e) = std::fs::rename(&self.config_path, &backup_path) {
+                    return FixResult {
+                        success: false,
+                        message: format!("Failed to backup broken config: {}", e),
+                    };
+                }
+                let default_config = ConfigModel::default();
+                match serde_yaml::to_string(&default_config) {
+                    Ok(yaml) => match std::fs::write(&self.config_path, yaml) {
+                        Ok(_) => FixResult {
+                            success: true,
+                            message: format!(
+                                "Reset to default config (backup: {})",
+                                backup_path.display()
+                            ),
+                        },
+                        Err(e) => FixResult {
+                            success: false,
+                            message: format!("Failed to write config: {}", e),
+                        },
+                    },
+                    Err(e) => FixResult {
+                        success: false,
+                        message: format!("Failed to serialize default config: {}", e),
+                    },
+                }
+            }
+            _ => FixResult {
+                success: false,
+                message: "Cannot fix this item".to_string(),
+            },
+        }
+    }
+
+    fn box_clone(&self) -> Box<dyn Checker> {
+        Box::new(Self::new())
+    }
+}

--- a/crates/aish-shell/src/doctor/dirs.rs
+++ b/crates/aish-shell/src/doctor/dirs.rs
@@ -1,0 +1,101 @@
+use crate::doctor::checker::{CheckItem, CheckResult, Checker, FixResult};
+use std::path::PathBuf;
+
+pub struct DirsChecker {
+    config_dir: PathBuf,
+    data_dir: PathBuf,
+}
+
+impl DirsChecker {
+    pub fn new() -> Self {
+        Self {
+            config_dir: dirs::config_dir()
+                .unwrap_or_else(|| std::env::temp_dir().join("aish-fallback"))
+                .join("aish"),
+            data_dir: dirs::data_local_dir()
+                .unwrap_or_else(|| std::env::temp_dir().join("aish-fallback"))
+                .join("aish"),
+        }
+    }
+}
+
+impl Checker for DirsChecker {
+    fn name(&self) -> &str {
+        "Directory Structure"
+    }
+
+    fn check(&self) -> Vec<CheckResult> {
+        let mut items = Vec::new();
+
+        if self.config_dir.exists() {
+            items.push(CheckItem::pass(
+                "config_dir",
+                format!("Config directory: {}", self.config_dir.display()),
+            ));
+
+            let skills_dir = self.config_dir.join("skills");
+            if skills_dir.exists() {
+                items.push(CheckItem::pass(
+                    "skills",
+                    format!("Skills directory: {}", skills_dir.display()),
+                ));
+            } else {
+                items.push(CheckItem::warn("skills", "Skills directory not found").fixable());
+            }
+
+            let logs_dir = self.config_dir.join("logs");
+            if logs_dir.exists() {
+                items.push(CheckItem::pass(
+                    "logs",
+                    format!("Logs directory: {}", logs_dir.display()),
+                ));
+            } else {
+                items.push(CheckItem::warn("logs", "Logs directory not found").fixable());
+            }
+        } else {
+            items.push(CheckItem::fail("config_dir", "Config directory not found").fixable());
+        }
+
+        if self.data_dir.exists() {
+            items.push(CheckItem::pass(
+                "data_dir",
+                format!("Data directory: {}", self.data_dir.display()),
+            ));
+        } else {
+            items.push(CheckItem::warn("data_dir", "Data directory not found").fixable());
+        }
+
+        vec![CheckResult::from_items(self.name(), items)]
+    }
+
+    fn fix(&self, item: &CheckItem) -> FixResult {
+        let path = match item.name.as_str() {
+            "config_dir" => Some(self.config_dir.clone()),
+            "skills" => Some(self.config_dir.join("skills")),
+            "logs" => Some(self.config_dir.join("logs")),
+            "data_dir" => Some(self.data_dir.clone()),
+            _ => None,
+        };
+
+        match path {
+            Some(p) => match std::fs::create_dir_all(&p) {
+                Ok(_) => FixResult {
+                    success: true,
+                    message: format!("Created directory: {}", p.display()),
+                },
+                Err(e) => FixResult {
+                    success: false,
+                    message: format!("Failed to create directory: {}", e),
+                },
+            },
+            None => FixResult {
+                success: false,
+                message: "Cannot fix this item".to_string(),
+            },
+        }
+    }
+
+    fn box_clone(&self) -> Box<dyn Checker> {
+        Box::new(Self::new())
+    }
+}

--- a/crates/aish-shell/src/doctor/memory.rs
+++ b/crates/aish-shell/src/doctor/memory.rs
@@ -1,0 +1,82 @@
+use crate::doctor::checker::{CheckItem, CheckResult, Checker, FixResult};
+use std::path::PathBuf;
+
+pub struct MemoryChecker {
+    memory_path: PathBuf,
+    config_dir: PathBuf,
+}
+
+impl MemoryChecker {
+    pub fn new() -> Self {
+        let config_dir =
+            dirs::config_dir().unwrap_or_else(|| std::env::temp_dir().join("aish-fallback"));
+        Self {
+            memory_path: config_dir.join("aish/MEMORY.md"),
+            config_dir: config_dir.join("aish"),
+        }
+    }
+}
+
+impl Checker for MemoryChecker {
+    fn name(&self) -> &str {
+        "Memory"
+    }
+
+    fn check(&self) -> Vec<CheckResult> {
+        let mut items = Vec::new();
+
+        if !self.config_dir.exists() {
+            items.push(CheckItem::warn("config_dir", "Config directory does not exist").fixable());
+            return vec![CheckResult::from_items(self.name(), items)];
+        }
+
+        items.push(CheckItem::pass(
+            "config_dir",
+            format!("Config directory: {}", self.config_dir.display()),
+        ));
+
+        if self.memory_path.exists() {
+            items.push(CheckItem::pass(
+                "memory_md",
+                format!("MEMORY.md: {}", self.memory_path.display()),
+            ));
+        } else {
+            items.push(CheckItem::warn("memory_md", "MEMORY.md not found").fixable());
+        }
+
+        vec![CheckResult::from_items(self.name(), items)]
+    }
+
+    fn fix(&self, item: &CheckItem) -> FixResult {
+        match item.name.as_str() {
+            "config_dir" => match std::fs::create_dir_all(&self.config_dir) {
+                Ok(_) => FixResult {
+                    success: true,
+                    message: format!("Created config directory: {}", self.config_dir.display()),
+                },
+                Err(e) => FixResult {
+                    success: false,
+                    message: format!("Failed to create config directory: {}", e),
+                },
+            },
+            "memory_md" => match std::fs::write(&self.memory_path, "# Memory\n\n") {
+                Ok(_) => FixResult {
+                    success: true,
+                    message: format!("Created MEMORY.md at {}", self.memory_path.display()),
+                },
+                Err(e) => FixResult {
+                    success: false,
+                    message: format!("Failed to create MEMORY.md: {}", e),
+                },
+            },
+            _ => FixResult {
+                success: false,
+                message: "Cannot fix this item".to_string(),
+            },
+        }
+    }
+
+    fn box_clone(&self) -> Box<dyn Checker> {
+        Box::new(Self::new())
+    }
+}

--- a/crates/aish-shell/src/doctor/mod.rs
+++ b/crates/aish-shell/src/doctor/mod.rs
@@ -1,0 +1,150 @@
+use crossterm::style::Stylize;
+
+pub mod api;
+pub mod apikey;
+pub mod checker;
+pub mod config;
+pub mod dirs;
+pub mod memory;
+pub mod output;
+pub mod session;
+pub mod skills;
+pub mod tools;
+
+pub use api::ApiConnectivityChecker;
+pub use apikey::ApiKeyChecker;
+pub use checker::{CheckResult, CheckStatus, Checker};
+pub use config::ConfigChecker;
+pub use dirs::DirsChecker;
+pub use memory::MemoryChecker;
+pub use output::Output;
+pub use session::SessionChecker;
+pub use skills::SkillsChecker;
+pub use tools::ExternalToolsChecker;
+
+pub struct Doctor {
+    checkers: Vec<Box<dyn Checker>>,
+}
+
+impl Doctor {
+    pub fn new() -> Self {
+        let checkers: Vec<Box<dyn Checker>> = vec![
+            Box::new(ConfigChecker::new()),
+            Box::new(ApiKeyChecker::new()),
+            Box::new(DirsChecker::new()),
+            Box::new(SessionChecker::new()),
+            Box::new(ExternalToolsChecker::new()),
+            Box::new(SkillsChecker::new()),
+            Box::new(MemoryChecker::new()),
+            Box::new(ApiConnectivityChecker::new()),
+        ];
+        Self { checkers }
+    }
+
+    pub async fn run(&self, fix: bool) {
+        Output::print_header();
+
+        let handles: Vec<_> = self
+            .checkers
+            .iter()
+            .map(|checker| {
+                let checker: Box<dyn Checker> = checker.box_clone();
+                tokio::task::spawn_blocking(move || checker.check())
+            })
+            .collect();
+
+        let mut all_results = Vec::new();
+        for handle in handles {
+            match handle.await {
+                Ok(results) => all_results.extend(results),
+                Err(e) => {
+                    eprintln!("Warning: A checker task failed: {}", e);
+                }
+            }
+        }
+
+        for result in &all_results {
+            Output::print_result(result);
+        }
+
+        // Collect issues and count stats
+        let mut fail_count = 0usize;
+        let mut warn_count = 0usize;
+        let mut fixable_count = 0usize;
+        let mut issues: Vec<String> = Vec::new();
+
+        for result in &all_results {
+            for item in &result.items {
+                match item.status {
+                    CheckStatus::Fail => {
+                        fail_count += 1;
+                        let msg = format!("[{}] {}", result.checker, item.message);
+                        issues.push(msg);
+                        if item.fixable {
+                            fixable_count += 1;
+                        }
+                    }
+                    CheckStatus::Warn => {
+                        warn_count += 1;
+                        if item.fixable {
+                            fixable_count += 1;
+                            let msg = format!("[{}] {}", result.checker, item.message);
+                            issues.push(msg);
+                        }
+                    }
+                    CheckStatus::Pass => {}
+                }
+            }
+        }
+
+        Output::print_summary(fail_count, warn_count, fixable_count, &issues);
+
+        if fix && fixable_count > 0 {
+            let remaining = Self::run_fixes(&self.checkers, &all_results);
+            let fixed = fixable_count - remaining.len();
+            Output::print_fix_summary(fixed, &remaining);
+        }
+    }
+
+    fn run_fixes(checkers: &[Box<dyn Checker>], results: &[CheckResult]) -> Vec<String> {
+        println!("\nRunning auto-fix...\n");
+        let mut remaining = Vec::new();
+
+        for checker in checkers {
+            for result in results {
+                if result.checker == checker.name() {
+                    for item in &result.items {
+                        if item.fixable
+                            && (item.status == CheckStatus::Fail
+                                || item.status == CheckStatus::Warn)
+                        {
+                            let fix_result = checker.fix(item);
+                            if fix_result.success {
+                                println!(
+                                    "  {} {}",
+                                    crossterm::style::style("✓")
+                                        .with(crossterm::style::Color::Green),
+                                    fix_result.message
+                                );
+                            } else {
+                                println!(
+                                    "  {} {}",
+                                    crossterm::style::style("✗").with(crossterm::style::Color::Red),
+                                    fix_result.message
+                                );
+                                remaining.push(format!("[{}] {}", result.checker, item.message));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        remaining
+    }
+}
+
+impl Default for Doctor {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/aish-shell/src/doctor/output.rs
+++ b/crates/aish-shell/src/doctor/output.rs
@@ -1,0 +1,109 @@
+use crate::doctor::checker::{CheckItem, CheckResult, CheckStatus};
+use crossterm::style::{Color, Stylize};
+
+pub struct Output;
+
+impl Output {
+    pub fn print_header() {
+        println!();
+        println!("{}", Self::header("       AISH Basic Config Diagnostics"));
+        println!();
+    }
+
+    pub fn print_result(result: &CheckResult) {
+        let icon = match result.status {
+            CheckStatus::Pass => Self::colored("✓", Color::Green),
+            CheckStatus::Warn => Self::colored("⚠", Color::Yellow),
+            CheckStatus::Fail => Self::colored("✗", Color::Red),
+        };
+        println!("[{}] {}", icon, result.checker);
+        for item in &result.items {
+            Self::print_item(item);
+        }
+    }
+
+    fn print_item(item: &CheckItem) {
+        let icon = match item.status {
+            CheckStatus::Pass => Self::colored("✓", Color::Green),
+            CheckStatus::Warn => Self::colored("⚠", Color::Yellow),
+            CheckStatus::Fail => Self::colored("✗", Color::Red),
+        };
+        let indent = "    ";
+        println!("{}{} {}", indent, icon, item.message);
+        if let Some(hint) = &item.hint {
+            println!("{}{} {}", indent, Self::colored("→", Color::Cyan), hint);
+        }
+    }
+
+    pub fn print_summary(
+        fail_count: usize,
+        warn_count: usize,
+        fixable_count: usize,
+        issues: &[String],
+    ) {
+        println!();
+        println!("{}", Self::separator());
+        if fail_count == 0 && warn_count == 0 {
+            println!("{}", Self::colored("  All checks passed!", Color::Green));
+        } else {
+            println!("  Found {} issue(s)", fail_count + warn_count);
+            if !issues.is_empty() {
+                for (i, issue) in issues.iter().enumerate() {
+                    println!("  {}. {}", i + 1, issue);
+                }
+            }
+            if fixable_count > 0 {
+                println!();
+                println!(
+                    "  {}",
+                    Self::colored(
+                        &format!(
+                            "Tip: run 'aish doctor --fix' to auto-fix ({} fixable)",
+                            fixable_count
+                        ),
+                        Color::DarkGrey
+                    )
+                );
+            }
+        }
+        println!("{}", Self::separator());
+    }
+
+    pub fn print_fix_summary(fixed_count: usize, remaining: &[String]) {
+        println!();
+        println!("{}", Self::separator());
+        if fixed_count > 0 {
+            println!(
+                "  {}",
+                Self::colored(&format!("Fixed {} issue(s).", fixed_count), Color::Green)
+            );
+            if !remaining.is_empty() {
+                println!(
+                    "  {}",
+                    Self::colored(
+                        &format!("{} issue(s) require manual intervention:", remaining.len()),
+                        Color::Yellow
+                    )
+                );
+                println!();
+                for (i, issue) in remaining.iter().enumerate() {
+                    println!("  {}. {}", i + 1, issue);
+                }
+            }
+        }
+        println!("{}", Self::separator());
+        println!();
+    }
+
+    fn header(s: &str) -> String {
+        Self::colored(s, Color::Cyan).to_string()
+    }
+
+    fn separator() -> String {
+        Self::colored(&"─".repeat(50), Color::DarkGrey).to_string()
+    }
+
+    fn colored(s: &str, color: Color) -> String {
+        format!("{}", crossterm::style::style(s).with(color))
+    }
+}

--- a/crates/aish-shell/src/doctor/session.rs
+++ b/crates/aish-shell/src/doctor/session.rs
@@ -1,0 +1,126 @@
+use crate::doctor::checker::{CheckItem, CheckResult, Checker, FixResult};
+use std::path::PathBuf;
+
+const WAL_SIZE_WARN_MB: f64 = 100.0;
+
+pub struct SessionChecker {
+    db_path: PathBuf,
+}
+
+impl SessionChecker {
+    pub fn new() -> Self {
+        Self {
+            db_path: dirs::data_local_dir()
+                .unwrap_or_else(|| std::env::temp_dir().join("aish-fallback"))
+                .join("aish/sessions.db"),
+        }
+    }
+
+    fn wal_path(&self) -> PathBuf {
+        let mut p = self.db_path.as_os_str().to_owned();
+        p.push("-wal");
+        PathBuf::from(p)
+    }
+
+    fn check_db(&self) -> Option<CheckItem> {
+        match aish_session::SessionStore::open(Some(&self.db_path)) {
+            Ok(store) => {
+                let count = store.list_sessions(1).map(|s| s.len()).ok();
+                match count {
+                    Some(n) => Some(CheckItem::pass(
+                        "db_readable",
+                        format!(
+                            "SQLite database: {} ({} sessions)",
+                            self.db_path.display(),
+                            n
+                        ),
+                    )),
+                    None => Some(CheckItem::pass(
+                        "db_readable",
+                        format!("SQLite database: {} (opened OK)", self.db_path.display()),
+                    )),
+                }
+            }
+            Err(e) => Some(
+                CheckItem::warn(
+                    "db_readable",
+                    format!("Database exists but unreadable: {}", e),
+                )
+                .hint("Consider backing up and removing the database file"),
+            ),
+        }
+    }
+}
+
+impl Checker for SessionChecker {
+    fn name(&self) -> &str {
+        "Session Store"
+    }
+
+    fn check(&self) -> Vec<CheckResult> {
+        let mut items = Vec::new();
+
+        if self.db_path.exists() {
+            if let Some(item) = self.check_db() {
+                items.push(item);
+            }
+
+            let wal_path = self.wal_path();
+            if wal_path.exists() {
+                if let Ok(metadata) = std::fs::metadata(&wal_path) {
+                    let size_mb = metadata.len() as f64 / 1_048_576.0;
+                    let is_large = size_mb > WAL_SIZE_WARN_MB;
+                    let mut item =
+                        CheckItem::pass("wal_size", format!("WAL file size: {:.1}MB", size_mb));
+                    if is_large {
+                        item.status = crate::doctor::CheckStatus::Warn;
+                        item.fixable = true;
+                        item.hint = Some("Large WAL may indicate missed checkpoints".to_string());
+                    }
+                    items.push(item);
+                }
+            }
+        } else {
+            items.push(
+                CheckItem::warn("exists", "No session database found")
+                    .hint("Will be created on first session"),
+            );
+        }
+
+        vec![CheckResult::from_items(self.name(), items)]
+    }
+
+    fn fix(&self, item: &CheckItem) -> FixResult {
+        if item.name == "wal_size" {
+            // Use SQLite checkpoint instead of deleting the WAL file.
+            // Deleting the WAL directly can cause data loss if there are
+            // uncommitted transactions. A checkpoint safely flushes the WAL
+            // contents back into the main database file.
+            match rusqlite::Connection::open(&self.db_path) {
+                Ok(conn) => match conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
+                    Ok(()) => FixResult {
+                        success: true,
+                        message: "WAL checkpoint completed (database flushed)".to_string(),
+                    },
+                    Err(e) => FixResult {
+                        success: false,
+                        message: format!("Checkpoint failed: {}", e),
+                    },
+                },
+                Err(e) => FixResult {
+                    success: false,
+                    message: format!("Failed to open database for checkpoint: {}", e),
+                },
+            }
+        } else {
+            FixResult {
+                success: false,
+                message: "Cannot fix this item".to_string(),
+            }
+        }
+    }
+
+    fn box_clone(&self) -> Box<dyn Checker> {
+        Box::new(Self::new())
+    }
+}

--- a/crates/aish-shell/src/doctor/skills.rs
+++ b/crates/aish-shell/src/doctor/skills.rs
@@ -1,0 +1,108 @@
+use crate::doctor::checker::{CheckItem, CheckResult, Checker, FixResult};
+use std::path::PathBuf;
+
+pub struct SkillsChecker {
+    user_skills_dir: PathBuf,
+    claude_skills_dir: PathBuf,
+}
+
+impl SkillsChecker {
+    pub fn new() -> Self {
+        Self {
+            user_skills_dir: dirs::config_dir()
+                .unwrap_or_else(|| std::env::temp_dir().join("aish-fallback"))
+                .join("aish/skills"),
+            claude_skills_dir: dirs::home_dir()
+                .unwrap_or_else(|| std::env::temp_dir().join("aish-fallback"))
+                .join(".claude/skills"),
+        }
+    }
+
+    fn check_skill_dir(&self, dir: &PathBuf, name: &str) -> Vec<CheckItem> {
+        let mut items = Vec::new();
+
+        if !dir.exists() {
+            items.push(CheckItem::warn(name, format!("{} not found", dir.display())).fixable());
+            return items;
+        }
+
+        match std::fs::read_dir(dir) {
+            Ok(entries) => {
+                let skill_dirs: Vec<_> = entries
+                    .filter_map(|e| e.ok())
+                    .filter(|e| e.path().is_dir())
+                    .collect();
+                if !skill_dirs.is_empty() {
+                    items.push(CheckItem::pass(
+                        name,
+                        format!("{}: {} skills", name, skill_dirs.len()),
+                    ));
+
+                    for dir_entry in skill_dirs {
+                        let skill_name = dir_entry.file_name().to_string_lossy().to_string();
+                        if !dir_entry.path().join("SKILL.md").exists() {
+                            items.push(CheckItem::warn(
+                                &skill_name,
+                                format!("{}: missing SKILL.md", skill_name),
+                            ));
+                        }
+                    }
+                } else {
+                    items.push(CheckItem::pass(name, format!("{}: empty", name)));
+                }
+            }
+            Err(e) => {
+                items.push(CheckItem::fail(
+                    name,
+                    format!("Cannot read {}: {}", name, e),
+                ));
+            }
+        }
+
+        items
+    }
+}
+
+impl Checker for SkillsChecker {
+    fn name(&self) -> &str {
+        "Skills"
+    }
+
+    fn check(&self) -> Vec<CheckResult> {
+        let mut items = Vec::new();
+        items.extend(self.check_skill_dir(&self.user_skills_dir, "User Skills"));
+        items.extend(self.check_skill_dir(&self.claude_skills_dir, "Claude Skills"));
+        vec![CheckResult::from_items(self.name(), items)]
+    }
+
+    fn fix(&self, item: &CheckItem) -> FixResult {
+        let path = if item.name == "User Skills" {
+            Some(self.user_skills_dir.clone())
+        } else if item.name == "Claude Skills" {
+            Some(self.claude_skills_dir.clone())
+        } else {
+            None
+        };
+
+        match path {
+            Some(p) => match std::fs::create_dir_all(&p) {
+                Ok(_) => FixResult {
+                    success: true,
+                    message: format!("Created skills directory: {}", p.display()),
+                },
+                Err(e) => FixResult {
+                    success: false,
+                    message: format!("Failed to create skills directory: {}", e),
+                },
+            },
+            None => FixResult {
+                success: false,
+                message: "Cannot auto-fix skill configuration".to_string(),
+            },
+        }
+    }
+
+    fn box_clone(&self) -> Box<dyn Checker> {
+        Box::new(Self::new())
+    }
+}

--- a/crates/aish-shell/src/doctor/tools.rs
+++ b/crates/aish-shell/src/doctor/tools.rs
@@ -1,0 +1,65 @@
+use crate::doctor::checker::{CheckItem, CheckResult, Checker, FixResult};
+
+struct ToolInfo {
+    name: &'static str,
+    binary: &'static str,
+    install_hint: &'static str,
+}
+
+pub struct ExternalToolsChecker;
+
+impl ExternalToolsChecker {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn tools() -> Vec<ToolInfo> {
+        vec![
+            ToolInfo {
+                name: "git",
+                binary: "git",
+                install_hint: "Install git for version control support",
+            },
+            ToolInfo {
+                name: "ripgrep (rg)",
+                binary: "rg",
+                install_hint:
+                    "Install ripgrep for faster file search: https://github.com/BurntSushi/ripgrep",
+            },
+        ]
+    }
+}
+
+impl Checker for ExternalToolsChecker {
+    fn name(&self) -> &str {
+        "External Tools"
+    }
+
+    fn check(&self) -> Vec<CheckResult> {
+        let mut items = Vec::new();
+
+        for tool in Self::tools() {
+            if which::which(tool.binary).is_ok() {
+                items.push(CheckItem::pass(tool.name, tool.name));
+            } else {
+                items.push(
+                    CheckItem::warn(tool.name, format!("{} not found", tool.name))
+                        .hint(tool.install_hint),
+                );
+            }
+        }
+
+        vec![CheckResult::from_items(self.name(), items)]
+    }
+
+    fn fix(&self, _item: &CheckItem) -> FixResult {
+        FixResult {
+            success: false,
+            message: "Install external tools manually".to_string(),
+        }
+    }
+
+    fn box_clone(&self) -> Box<dyn Checker> {
+        Box::new(Self::new())
+    }
+}

--- a/crates/aish-shell/src/lib.rs
+++ b/crates/aish-shell/src/lib.rs
@@ -19,6 +19,7 @@ pub mod animation;
 pub mod app;
 pub mod autosuggest;
 pub mod commands;
+pub mod doctor;
 pub mod environment;
 pub mod esc_watcher;
 pub mod expand_history;

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -31,6 +31,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/feedback", "Submit feedback"),
     ("/record", "Record terminal session (start/stop)"),
     ("/quit", "Exit AI Shell"),
+    ("/doctor", "Run system diagnostics"),
 ];
 
 /// Timeout for PTY completion queries.

--- a/crates/aish-shell/src/recorder.rs
+++ b/crates/aish-shell/src/recorder.rs
@@ -10,7 +10,10 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use chrono::Local;
-use serde_json::{json, Value};
+use serde_json::json;
+
+#[cfg(test)]
+use serde_json::Value;
 
 /// Thread-safe shared recorder handle.
 ///
@@ -142,11 +145,10 @@ impl Recorder {
 
     fn write_event(&mut self, event_type: &str, data: &str) {
         let ts = self.start_time.elapsed().as_secs_f64();
-        let payload = Value::String(data.to_string());
-        let line = format!("[{ts:.6},\"{event_type}\",{payload}]");
+        let event = json!([ts, event_type, data]);
         // Best-effort write — recording should not crash the shell on I/O errors,
         // but we log failures so users know if recording is corrupted.
-        if let Err(e) = writeln!(self.writer, "{line}") {
+        if let Err(e) = writeln!(self.writer, "{event}") {
             eprintln!("Recording write failed: {}", e);
         }
     }
@@ -154,16 +156,26 @@ impl Recorder {
 
 /// Normalize standalone `\n` to `\r\n` so virtual terminals (agg, asciinema)
 /// correctly return the cursor to column 0 on each line break.
+/// Preserves standalone `\r` used for cursor positioning in ANSI sequences.
 fn normalize_newlines(s: &str) -> String {
     let mut result = String::with_capacity(s.len() + s.len() / 8);
-    let chars = s.chars().peekable();
-    for c in chars {
-        if c == '\n' {
-            result.push_str("\r\n");
-        } else if c == '\r' {
-            continue;
-        } else {
-            result.push(c);
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\r' => {
+                if chars.peek() == Some(&'\n') {
+                    result.push_str("\r\n");
+                    chars.next();
+                } else {
+                    result.push('\r');
+                }
+            }
+            '\n' => {
+                result.push_str("\r\n");
+            }
+            _ => {
+                result.push(c);
+            }
         }
     }
     result
@@ -371,7 +383,7 @@ mod tests {
         assert_eq!(evt2[2].as_str().unwrap(), "\x1b[2mdim\r\nline2\x1b[0m");
     }
 
-    // 10. normalize_newlines converts \n to \r\n and skips bare \r
+    // 10. normalize_newlines converts \n to \r\n, preserves standalone \r
     #[test]
     fn test_normalize_newlines() {
         use super::normalize_newlines;
@@ -383,5 +395,7 @@ mod tests {
         );
         assert_eq!(normalize_newlines("no newline"), "no newline");
         assert_eq!(normalize_newlines(""), "");
+        // Standalone \r is preserved (used in ANSI cursor sequences)
+        assert_eq!(normalize_newlines("\r\x1b[2Kprompt"), "\r\x1b[2Kprompt");
     }
 }

--- a/crates/aish-shell/src/renderer.rs
+++ b/crates/aish-shell/src/renderer.rs
@@ -277,6 +277,13 @@ fn parse_pipe_row(line: &str) -> Option<Vec<String>> {
 // Code block rendering
 // ---------------------------------------------------------------------------
 
+/// Record output data to a shared recorder if one is present.
+fn record_to_shared(recorder: &Option<SharedRecorder>, data: &str) {
+    if let Some(ref sr) = recorder {
+        crate::recorder::shared_record_output(sr, data);
+    }
+}
+
 /// Render a fenced code block with syntax highlighting.
 /// Minimal style: dim bold language tag, then syntax-highlighted code, no borders.
 fn render_code_block(
@@ -294,18 +301,14 @@ fn render_code_block(
     // Dim bold language label
     if !lang.is_empty() {
         let lang_ansi = format!("\x1b[1;2m{}\x1b[0m\n", lang);
-        if let Some(ref sr) = shared_recorder {
-            crate::recorder::shared_record_output(sr, &lang_ansi);
-        }
+        record_to_shared(shared_recorder, &lang_ansi);
         println!("\x1b[1;2m{}\x1b[0m", lang);
     }
 
     // Syntax-highlighted code
     let syntax = Syntax::new(code_trimmed, lang).theme("base16-ocean.dark");
     let segments = syntax.render(width);
-    if let Some(ref sr) = shared_recorder {
-        crate::recorder::shared_record_output(sr, &segments.to_ansi());
-    }
+    record_to_shared(shared_recorder, &segments.to_ansi());
     let _ = console.write_segments(&segments);
     let _ = console.flush();
 }
@@ -363,9 +366,7 @@ impl ShellRenderer {
                 ContentSegment::Table(content) => {
                     let lines: Vec<&str> = content.lines().collect();
                     if let Some(segs) = render_table_to_segments(&lines, self.terminal_width) {
-                        if let Some(ref sr) = self.shared_recorder {
-                            crate::recorder::shared_record_output(sr, &segs.to_ansi());
-                        }
+                        self.record_output(&segs.to_ansi());
                         let _ = self.console.write_segments(&segs);
                     }
                     last_was_markdown = false;
@@ -380,12 +381,12 @@ impl ShellRenderer {
                     // richrs adds two trailing newlines per paragraph; the terminal
                     // removes one with \x1b[1A\x1b[M. Remove one trailing newline
                     // from the recording to match the terminal display.
-                    if let Some(ref sr) = self.shared_recorder {
+                    {
                         let mut ansi = segs.to_ansi();
                         if ansi.ends_with("\n\n") {
                             ansi.truncate(ansi.len() - 1);
                         }
-                        crate::recorder::shared_record_output(sr, &ansi);
+                        self.record_output(&ansi);
                     }
                     let _ = self.console.write_segments(&segs);
                     last_was_markdown = true;
@@ -409,9 +410,7 @@ impl ShellRenderer {
         if delta.is_empty() {
             return;
         }
-        if let Some(ref sr) = self.shared_recorder {
-            crate::recorder::shared_record_output(sr, &format!("\x1b[1;90m{}\x1b[0m", delta));
-        }
+        self.record_output(&format!("\x1b[1;90m{}\x1b[0m", delta));
         self.streaming_active = true;
         print!("\x1b[1;90m{}\x1b[0m", delta);
         let _ = io::stdout().flush();
@@ -437,14 +436,20 @@ impl ShellRenderer {
         self.shared_recorder = Some(recorder);
     }
 
+    /// Helper: record output data to the shared recorder if one is attached.
+    fn record_output(&self, data: &str) {
+        if let Some(ref sr) = self.shared_recorder {
+            crate::recorder::shared_record_output(sr, data);
+        }
+    }
+
     /// Render a green horizontal separator line spanning the terminal.
-    /// Records a fixed 5-char separator with trailing newline for clean cast/GIF output.
+    /// Records a fixed 5-char separator for GIF output (terminal width is
+    /// unknown in asciinema→GIF conversion).
     pub fn render_separator(&mut self) {
         let width = self.terminal_width.max(20);
         let sep = "─".repeat(width);
-        if let Some(ref sr) = self.shared_recorder {
-            crate::recorder::shared_record_output(sr, "─────\r\n");
-        }
+        self.record_output("\x1b[32m─────\x1b[0m\r\n");
         println!("\x1b[32m{}\x1b[0m", sep);
     }
 }

--- a/crates/aish-shell/tests/doctor_test.rs
+++ b/crates/aish-shell/tests/doctor_test.rs
@@ -1,0 +1,61 @@
+#[cfg(test)]
+mod tests {
+    use aish_shell::doctor::{
+        ApiKeyChecker, Checker, ConfigChecker, DirsChecker, ExternalToolsChecker,
+    };
+
+    #[test]
+    fn test_dirs_checker_creates_expected_items() {
+        let checker = DirsChecker::new();
+        let results = checker.check();
+        assert!(!results.is_empty());
+        let result = &results[0];
+        assert_eq!(result.checker, "Directory Structure");
+        assert!(!result.items.is_empty());
+    }
+
+    #[test]
+    fn test_apikey_checker_checks_env_vars() {
+        let checker = ApiKeyChecker::new();
+        let results = checker.check();
+        assert!(!results.is_empty());
+        let result = &results[0];
+        assert_eq!(result.checker, "API Keys");
+    }
+
+    #[test]
+    fn test_config_checker_returns_result() {
+        let checker = ConfigChecker::new();
+        let results = checker.check();
+        assert!(!results.is_empty());
+        let result = &results[0];
+        assert_eq!(result.checker, "Configuration");
+    }
+
+    #[test]
+    fn test_external_tools_checker_returns_result() {
+        let checker = ExternalToolsChecker::new();
+        let results = checker.check();
+        assert!(!results.is_empty());
+        let result = &results[0];
+        assert_eq!(result.checker, "External Tools");
+        assert!(!result.items.is_empty());
+    }
+
+    #[test]
+    fn test_pass_items_are_not_fixable() {
+        let checker = DirsChecker::new();
+        let results = checker.check();
+        for result in results {
+            for item in result.items {
+                if item.status == aish_shell::doctor::CheckStatus::Pass {
+                    assert!(
+                        !item.fixable,
+                        "Pass items should not be fixable: {}",
+                        item.message
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Fix `normalize_newlines` stripping `\r`**: The function unconditionally removed all `\r` characters, including those used for ANSI cursor positioning (`\r\x1b[2K`). This caused asciinema replay to fill lines with spaces instead of showing proper line breaks. Now standalone `\r` is preserved while `\r\n` pairs and `\n→\r\n` normalization still work correctly.
- **Record Ctrl+C events in cast file**: When Ctrl+C is pressed, the interruption message and newline are now recorded to the cast file, so replay shows the complete interaction.
- **Add `/doctor` command**: System diagnostics for checking API connectivity, config, sessions, memory, skills, and tools.

## Test plan

- [ ] `cargo test -p aish-shell` passes (all 20 tests)
- [ ] Start recording with `/record start`, press Ctrl+C, verify cast file shows `\r\n` and the interruption message instead of spaces
- [ ] Press Ctrl+C twice rapidly, verify the "exiting" message is also recorded
- [ ] Replay the cast file with `asciinema play` and verify no blank space artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/doctor` command with `--fix` to run diagnostics and optionally auto-repair config, dirs, sessions, tools, memory, and API connectivity.
* **Improvements**
  * More reliable session/recording behavior on interrupts; recorder now normalizes newlines for consistent captures.
* **Localization**
  * English and Chinese strings added for the doctor command.
* **Tests**
  * Added test coverage for multiple doctor checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->