### PR TITLE
feat: real-time cast recording for session commands and error correction

### DIFF
--- a/crates/aish-pty/src/persistent.rs
+++ b/crates/aish-pty/src/persistent.rs
@@ -444,6 +444,7 @@ impl PersistentPty {
             std::sync::Arc<dyn Fn(&str) -> Option<crate::SshSecretCheckResult> + Send + Sync>,
         >,
         secret_vault: Option<std::sync::Arc<std::sync::Mutex<aish_security::secret::SecretVault>>>,
+        on_output: Option<Box<dyn Fn(&str) + Send>>,
     ) -> aish_core::Result<(i32, String, String)> {
         let is_session = is_session_command(command);
         let mut interceptor = if is_session {
@@ -591,6 +592,14 @@ impl PersistentPty {
                                                 // preventing further followup/tool chaining until the next AI trigger.
         let mut ai_cancelled: bool = false;
 
+        // Helper: write to stdout and optionally record via on_output callback.
+        let show = |text: &str| {
+            write_stdout_all(text.as_bytes());
+            if let Some(ref cb) = on_output {
+                cb(text);
+            }
+        };
+
         while !done {
             // Build fd sets.
             let mut read_fds: libc::fd_set = unsafe { std::mem::zeroed() };
@@ -689,13 +698,7 @@ impl PersistentPty {
                                             "\x1b[33m{}\x1b[0m\r\n",
                                             aish_i18n::t("shell.session.ai_cancelled"),
                                         );
-                                        unsafe {
-                                            libc::write(
-                                                libc::STDOUT_FILENO,
-                                                cancel_msg.as_ptr() as *const libc::c_void,
-                                                cancel_msg.len(),
-                                            );
-                                        }
+                                        show(&cancel_msg);
                                     }
                                 }
                             }
@@ -894,13 +897,7 @@ impl PersistentPty {
                             1 => {
                                 // Ctrl+C: hard abort — skip followup entirely
                                 if ans[0] == 0x03 {
-                                    unsafe {
-                                        libc::write(
-                                            libc::STDOUT_FILENO,
-                                            b"^C\r\n".as_ptr() as *const libc::c_void,
-                                            4,
-                                        );
-                                    }
+                                    show("^C\r\n");
                                     drain_stdin_trailing(stdin_fd);
                                     ai_cancelled = true;
                                     false
@@ -914,13 +911,7 @@ impl PersistentPty {
                                     } else {
                                         b"n\r\n"
                                     };
-                                    unsafe {
-                                        libc::write(
-                                            libc::STDOUT_FILENO,
-                                            echo.as_ptr() as *const libc::c_void,
-                                            echo.len(),
-                                        );
-                                    }
+                                    show(std::str::from_utf8(echo).unwrap_or("y\r\n"));
                                     // Drain trailing newline/CR so it doesn't leak
                                     // into the next read cycle.
                                     drain_stdin_trailing(stdin_fd);
@@ -961,13 +952,7 @@ impl PersistentPty {
                                 "\x1b[90m{}\x1b[0m\r\n",
                                 aish_i18n::t("shell.session.running")
                             );
-                            unsafe {
-                                libc::write(
-                                    libc::STDOUT_FILENO,
-                                    running_msg.as_ptr() as *const libc::c_void,
-                                    running_msg.len(),
-                                );
-                            }
+                            show(&running_msg);
                             let safe_cmd = close_unclosed_heredoc(&cmd_restored);
                             skip_echo_cmd = Some(safe_cmd.clone());
                             let mut inject = safe_cmd.as_bytes().to_vec();
@@ -1009,12 +994,8 @@ impl PersistentPty {
                                 "\x1b[33m{}\x1b[0m\r\n",
                                 aish_i18n::t("shell.command_cancelled")
                             );
+                            show(&cancel_msg);
                             unsafe {
-                                libc::write(
-                                    libc::STDOUT_FILENO,
-                                    cancel_msg.as_ptr() as *const libc::c_void,
-                                    cancel_msg.len(),
-                                );
                                 libc::write(
                                     self.master_fd,
                                     b"\r".as_ptr() as *const libc::c_void,
@@ -1032,12 +1013,8 @@ impl PersistentPty {
                                 "\x1b[33m{}\x1b[0m\r\n",
                                 aish_i18n::t("shell.command_cancelled")
                             );
+                            show(&cancel_msg);
                             unsafe {
-                                libc::write(
-                                    libc::STDOUT_FILENO,
-                                    cancel_msg.as_ptr() as *const libc::c_void,
-                                    cancel_msg.len(),
-                                );
                                 libc::write(
                                     self.master_fd,
                                     b"\r".as_ptr() as *const libc::c_void,
@@ -1060,13 +1037,7 @@ impl PersistentPty {
                         if !response.display_text.is_empty() {
                             let mut msg = response.display_text.clone();
                             msg.push_str("\r\n");
-                            unsafe {
-                                libc::write(
-                                    libc::STDOUT_FILENO,
-                                    msg.as_ptr() as *const libc::c_void,
-                                    msg.len(),
-                                );
-                            }
+                            show(&msg);
                         }
                         unsafe {
                             libc::write(self.master_fd, b"\r".as_ptr() as *const libc::c_void, 1);
@@ -1139,13 +1110,7 @@ impl PersistentPty {
                                             "\r\n\x1b[33m{}\x1b[0m\r\n",
                                             aish_i18n::t("shell.command_cancelled"),
                                         );
-                                        unsafe {
-                                            libc::write(
-                                                libc::STDOUT_FILENO,
-                                                cancel_msg.as_ptr() as *const libc::c_void,
-                                                cancel_msg.len(),
-                                            );
-                                        }
+                                        show(&cancel_msg);
                                         skip_leading_newline = true;
                                     } else if followup_capturing && byte == 0x1b {
                                         // ESC during followup capturing —
@@ -1187,13 +1152,7 @@ impl PersistentPty {
                                                 "\r\n\x1b[33m{}\x1b[0m\r\n",
                                                 aish_i18n::t("shell.command_cancelled"),
                                             );
-                                            unsafe {
-                                                libc::write(
-                                                    libc::STDOUT_FILENO,
-                                                    cancel_msg.as_ptr() as *const libc::c_void,
-                                                    cancel_msg.len(),
-                                                );
-                                            }
+                                            show(&cancel_msg);
                                             skip_leading_newline = true;
                                         } else {
                                             // Follow-up bytes exist (arrow/function
@@ -1483,12 +1442,8 @@ impl PersistentPty {
                                                 "\r\x1b[90m{}\x1b[0m\r\n",
                                                 aish_i18n::t("shell.session.probing"),
                                             );
+                                            show(&status);
                                             unsafe {
-                                                libc::write(
-                                                    libc::STDOUT_FILENO,
-                                                    status.as_ptr() as *const libc::c_void,
-                                                    status.len(),
-                                                );
                                                 libc::write(
                                                     self.master_fd,
                                                     probe_cmd.as_ptr() as *const libc::c_void,
@@ -1521,12 +1476,8 @@ impl PersistentPty {
                                             "\x1b[33m{}\x1b[0m\r\n",
                                             aish_i18n::t("shell.session.ai_cancelled")
                                         );
+                                        show(&cancel_msg);
                                         unsafe {
-                                            libc::write(
-                                                libc::STDOUT_FILENO,
-                                                cancel_msg.as_ptr() as *const libc::c_void,
-                                                cancel_msg.len(),
-                                            );
                                             libc::write(
                                                 self.master_fd,
                                                 b"\r".as_ptr() as *const libc::c_void,
@@ -1688,13 +1639,7 @@ impl PersistentPty {
                                                     "\x1b[33m{}\x1b[0m\r\n",
                                                     aish_i18n::t("shell.session.ai_cancelled"),
                                                 );
-                                                unsafe {
-                                                    libc::write(
-                                                        libc::STDOUT_FILENO,
-                                                        cancel_msg.as_ptr() as *const libc::c_void,
-                                                        cancel_msg.len(),
-                                                    );
-                                                }
+                                                show(&cancel_msg);
                                             }
                                         }
                                     }
@@ -1874,13 +1819,11 @@ impl PersistentPty {
                             // probe completes (probe_active changes to false mid-parse).
                             if !interceptor.is_ai_processing() && !probe_active && !was_probe_active
                             {
-                                let _ = unsafe {
-                                    libc::write(
-                                        libc::STDOUT_FILENO,
-                                        data.as_ptr() as *const libc::c_void,
-                                        data.len(),
-                                    )
-                                };
+                                write_stdout_all(data);
+                                if let Some(ref cb) = on_output {
+                                    let text = String::from_utf8_lossy(data);
+                                    cb(&text);
+                                }
                             }
                         }
                     }
@@ -1937,12 +1880,18 @@ impl PersistentPty {
                         m
                     });
                     let tool_line = format!("\x1b[36m{}\x1b[0m\r\n", tool_text);
-                    unsafe {
+                    // Display directly (terminal cursor is already on a new line
+                    // after user input).  Record with leading \r\n so the cast
+                    // replay starts the indicator on a fresh line.
+                    let _ = unsafe {
                         libc::write(
                             libc::STDOUT_FILENO,
                             tool_line.as_ptr() as *const libc::c_void,
                             tool_line.len(),
-                        );
+                        )
+                    };
+                    if let Some(ref cb) = on_output {
+                        cb(&format!("\r\n{}", tool_line));
                     }
 
                     // Confirmation prompt before execution
@@ -1950,13 +1899,7 @@ impl PersistentPty {
                         "\x1b[33m{}\x1b[0m ",
                         aish_i18n::t("shell.session.confirm_execute")
                     );
-                    unsafe {
-                        libc::write(
-                            libc::STDOUT_FILENO,
-                            confirm.as_ptr() as *const libc::c_void,
-                            confirm.len(),
-                        );
-                    }
+                    show(&confirm);
 
                     // Read one byte for confirmation (raw mode)
                     let mut ans = [0u8; 1];
@@ -1966,13 +1909,7 @@ impl PersistentPty {
                         1 => {
                             // Ctrl+C: hard abort — skip followup entirely
                             if ans[0] == 0x03 {
-                                unsafe {
-                                    libc::write(
-                                        libc::STDOUT_FILENO,
-                                        b"^C\r\n".as_ptr() as *const libc::c_void,
-                                        4,
-                                    );
-                                }
+                                show("^C\r\n");
                                 drain_stdin_trailing(stdin_fd);
                                 ai_cancelled = true;
                                 false
@@ -1982,17 +1919,11 @@ impl PersistentPty {
                                     || ans[0] == b'\r'
                                     || ans[0] == b'\n'
                                 {
-                                    b"y\r\n"
+                                    "y\r\n"
                                 } else {
-                                    b"n\r\n"
+                                    "n\r\n"
                                 };
-                                unsafe {
-                                    libc::write(
-                                        libc::STDOUT_FILENO,
-                                        echo.as_ptr() as *const libc::c_void,
-                                        echo.len(),
-                                    );
-                                }
+                                show(echo);
                                 drain_stdin_trailing(stdin_fd);
                                 ans[0] == b'y'
                                     || ans[0] == b'Y'
@@ -2009,13 +1940,7 @@ impl PersistentPty {
                             "\x1b[90m{}\x1b[0m\r\n",
                             aish_i18n::t("shell.session.running")
                         );
-                        unsafe {
-                            libc::write(
-                                libc::STDOUT_FILENO,
-                                running_msg.as_ptr() as *const libc::c_void,
-                                running_msg.len(),
-                            );
-                        }
+                        show(&running_msg);
                         // Restore secret placeholders before execution.
                         let mut cmd_restored = cmd.clone();
                         if let Some(ref vault) = secret_vault {
@@ -2028,13 +1953,7 @@ impl PersistentPty {
                                     &rargs,
                                 );
                                 let info = format!("\x1b[2m{}\x1b[0m\r\n", msg);
-                                unsafe {
-                                    libc::write(
-                                        libc::STDOUT_FILENO,
-                                        info.as_ptr() as *const libc::c_void,
-                                        info.len(),
-                                    );
-                                }
+                                show(&info);
                                 cmd_restored = restored;
                             }
                         }
@@ -2077,12 +1996,8 @@ impl PersistentPty {
                             "\x1b[33m{}\x1b[0m\r\n",
                             aish_i18n::t("shell.command_cancelled")
                         );
+                        show(&cancel_msg);
                         unsafe {
-                            libc::write(
-                                libc::STDOUT_FILENO,
-                                cancel_msg.as_ptr() as *const libc::c_void,
-                                cancel_msg.len(),
-                            );
                             libc::write(self.master_fd, b"\r".as_ptr() as *const libc::c_void, 1);
                         }
                         if let Some(followup) = response.followup {
@@ -2096,12 +2011,8 @@ impl PersistentPty {
                             "\x1b[33m{}\x1b[0m\r\n",
                             aish_i18n::t("shell.command_cancelled")
                         );
+                        show(&cancel_msg);
                         unsafe {
-                            libc::write(
-                                libc::STDOUT_FILENO,
-                                cancel_msg.as_ptr() as *const libc::c_void,
-                                cancel_msg.len(),
-                            );
                             libc::write(self.master_fd, b"\r".as_ptr() as *const libc::c_void, 1);
                         }
                         // User rejected the command — terminate the

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -1629,6 +1629,7 @@ impl AishShell {
                     // If just ";" with no question and there's a pending error,
                     // trigger error correction instead of a normal AI query.
                     if question.is_empty() && self.state.can_correct_error {
+                        crate::recorder::shared_record_input(&self.shared_recorder, ";\n");
                         if let Some(ref cmd) = self.state.last_command.clone() {
                             let old_sigint = self.install_ai_sigint_handler();
                             let mut esc_watcher = CrosstermEscWatcher::start(
@@ -1656,14 +1657,23 @@ impl AishShell {
                                     match &correction.command {
                                         Some(corrected) => {
                                             // Display corrected command and description
-                                            println!(
+                                            let corrected_line = format!(
                                                 "{} \x1b[1;36m{}\x1b[0m",
                                                 t("shell.error_correction.corrected_command_title"),
                                                 corrected
                                             );
+                                            println!("{}", corrected_line);
+                                            crate::recorder::shared_record_output(
+                                                &self.shared_recorder,
+                                                &format!("{}\r\n", corrected_line),
+                                            );
                                             if let Some(ref desc) = correction.description {
                                                 if !desc.is_empty() {
                                                     println!("   {}", desc);
+                                                    crate::recorder::shared_record_output(
+                                                        &self.shared_recorder,
+                                                        &format!("   {}\r\n", desc),
+                                                    );
                                                 }
                                             }
                                             // Ask user confirmation: Y/n
@@ -1674,11 +1684,19 @@ impl AishShell {
                                                 t("shell.error_correction.confirm_execute_suffix")
                                             );
                                             print!("{}", prompt);
+                                            crate::recorder::shared_record_output(
+                                                &self.shared_recorder,
+                                                &prompt,
+                                            );
                                             let _ = std::io::stdout().flush();
                                             let mut answer = String::new();
                                             if std::io::stdin().read_line(&mut answer).is_err() {
                                                 continue;
                                             }
+                                            crate::recorder::shared_record_input(
+                                                &self.shared_recorder,
+                                                &answer,
+                                            );
                                             let answer = answer.trim().to_lowercase();
                                             if answer == "y" || answer == "yes" || answer.is_empty()
                                             {
@@ -1690,9 +1708,14 @@ impl AishShell {
                                         }
                                         None => {
                                             // No valid command, show description if available
-                                            println!(
+                                            let warn_line = format!(
                                                 "\x1b[33m\u{26a0} {}\x1b[0m",
                                                 t("shell.error_correction.no_valid_command")
+                                            );
+                                            println!("{}", warn_line);
+                                            crate::recorder::shared_record_output(
+                                                &self.shared_recorder,
+                                                &format!("{}\r\n", warn_line),
                                             );
                                             if let Some(ref desc) = correction.description {
                                                 let clean = desc
@@ -1702,17 +1725,30 @@ impl AishShell {
                                                     .trim();
                                                 if !clean.is_empty() {
                                                     println!("   {}", clean);
+                                                    crate::recorder::shared_record_output(
+                                                        &self.shared_recorder,
+                                                        &format!("   {}\r\n", clean),
+                                                    );
                                                 }
                                             }
-                                            println!(
+                                            let hint_line = format!(
                                                 "   \x1b[36m{}\x1b[0m",
                                                 t("shell.error_correction.retry_hint")
+                                            );
+                                            println!("{}", hint_line);
+                                            crate::recorder::shared_record_output(
+                                                &self.shared_recorder,
+                                                &format!("{}\r\n", hint_line),
                                             );
                                         }
                                     }
                                 }
                                 Err(aish_core::AishError::Cancelled) => {
                                     self.animation.stop();
+                                    crate::recorder::shared_record_output(
+                                        &self.shared_recorder,
+                                        "\x1b[33mInterrupted\x1b[0m\r\n",
+                                    );
                                     println!("\x1b[33mInterrupted\x1b[0m");
                                 }
                                 Err(e) => {
@@ -1736,10 +1772,17 @@ impl AishShell {
                         continue;
                     }
 
-                    // Record sanitized user input after security check passes
+                    // Record sanitized user input after security check passes.
+                    // Use the original prefix (; or ；) so the cast replay shows
+                    // the AI trigger character.
+                    let ai_prefix = if input.starts_with('\u{ff1b}') {
+                        "\u{ff1b}"
+                    } else {
+                        ";"
+                    };
                     crate::recorder::shared_record_input(
                         &self.shared_recorder,
-                        &format!("{}\n", question),
+                        &format!("{}{}\n", ai_prefix, question),
                     );
 
                     let old_sigint = self.install_ai_sigint_handler();
@@ -2676,6 +2719,14 @@ impl AishShell {
 
         // Send command via PTY (release the lock inside the block so the
         // MutexGuard is dropped before any potential restart_pty() call).
+        //
+        // For session commands (ssh, telnet) the PTY output must be recorded
+        // in real-time so that the cast file reflects the correct timing and
+        // order.  For normal (short-lived) commands, real-time recording would
+        // suppress output during the AI processing window inside
+        // send_command_interactive, so we fall back to post-return recording
+        // instead.
+        let is_session = aish_pty::is_interactive_command(command);
         let result = {
             let mut pty = self.lock_pty();
             let remote_host = extract_remote_host(command);
@@ -2686,12 +2737,21 @@ impl AishShell {
                 shared_host.clone(),
                 self.shared_recorder.clone(),
             );
+            let on_output: Option<Box<dyn Fn(&str) + Send>> = if is_session {
+                let recorder = self.shared_recorder.clone();
+                Some(Box::new(move |data: &str| {
+                    crate::recorder::shared_record_output(&recorder, data);
+                }))
+            } else {
+                None
+            };
             pty.send_command_interactive(
                 command,
                 ai_cb,
                 Some(shared_host),
                 Some(self.secret_check_closure.clone()),
                 Some(self.secret_vault.clone()),
+                on_output,
             )
         };
         let (exit_code, cwd, output) = match result {
@@ -2711,8 +2771,9 @@ impl AishShell {
         // Store captured output for error correction and LLM context
         self.state.last_output = output.clone();
 
-        // Record command output if recording is active
-        if !output.is_empty() {
+        // For normal (non-session) commands, record output after the PTY call
+        // returns.  Session commands are recorded in real-time via on_output.
+        if !is_session && !output.is_empty() {
             crate::recorder::shared_record_output(&self.shared_recorder, &output);
         }
 
@@ -3038,7 +3099,7 @@ impl AishShell {
             .pty
             .lock()
             .unwrap()
-            .send_command_interactive(segment, None, None, None, None)
+            .send_command_interactive(segment, None, None, None, None, None)
             .unwrap_or((-1, self.state.cwd.clone(), String::new()));
 
         if !output.is_empty() {

--- a/crates/aish-shell/src/renderer.rs
+++ b/crates/aish-shell/src/renderer.rs
@@ -450,7 +450,8 @@ impl ShellRenderer {
         let width = self.terminal_width.max(20);
         let sep = "─".repeat(width);
         self.record_output("\x1b[32m─────\x1b[0m\r\n");
-        println!("\x1b[32m{}\x1b[0m", sep);
+        print!("\r\x1b[32m{}\x1b[0m\r\n", sep);
+        let _ = std::io::stdout().flush();
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `on_output` callback to `send_command_interactive` for streaming PTY output recording during session commands (ssh/telnet)
- Consolidate 20+ duplicate `unsafe libc::write` calls into a reusable `show()` closure using `write_stdout_all` with retry logic
- Record error correction flow (corrected command, confirmation prompt, user input) in cast files
- Preserve AI trigger prefix (`;` or fullwidth `；`) in recorded input
- Fix separator rendering to include `\r` for proper cast replay

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes
- [ ] Manual test: run aish, execute commands, verify cast recording captures all output correctly
- [ ] Manual test: error correction flow (`;` with failed command) records properly
- [ ] Manual test: session command (ssh) records output in real-time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved recording of interactive shell workflows, now capturing confirmation prompts and error corrections for accurate replay.
  * Enhanced output capture for interactive command sessions with real-time feedback recording.
  * Better handling of interactive versus standard command execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->