### PR TITLE
feat: add /status command for system environment display

### DIFF
--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -152,6 +152,9 @@ shell:
     resume: "Vorherige Sitzung fortsetzen"
     feedback: "Feedback geben"
     quit: "AI Shell beenden"
+    record: "Terminalsitzung aufzeichnen (start/stop)"
+    doctor: "Systemdiagnose ausführen"
+    status: "Systemumgebungsstatus anzeigen"
 
   feedback:
     select_type: "Feedback-Typ auswählen"

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -333,7 +333,8 @@ shell:
     feedback: "Submit feedback"
     quit: "Exit AI Shell"
     record: "Record terminal session (start/stop)"
-    doctor: "Basic config diagnostics"
+    doctor: "Run system diagnostics"
+    status: "Show system environment status"
 
   record:
     started: "⏺ Recording started: {path}"

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -152,6 +152,9 @@ shell:
     resume: "Reanudar sesión anterior"
     feedback: "Enviar comentarios"
     quit: "Salir de AI Shell"
+    record: "Grabar sesión de terminal (start/stop)"
+    doctor: "Ejecutar diagnósticos del sistema"
+    status: "Mostrar estado del entorno del sistema"
 
   feedback:
     select_type: "Seleccionar tipo de comentario"

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -152,6 +152,9 @@ shell:
     resume: "Reprendre la session précédente"
     feedback: "Envoyer un commentaire"
     quit: "Quitter AI Shell"
+    record: "Enregistrer la session terminal (start/stop)"
+    doctor: "Exécuter les diagnostics système"
+    status: "Afficher l'état de l'environnement système"
 
   feedback:
     select_type: "Sélectionner le type de commentaire"

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -152,6 +152,9 @@ shell:
     resume: "前回のセッションを再開"
     feedback: "フィードバックを送信"
     quit: "AI Shell を終了"
+    record: "ターミナルセッションを録画 (start/stop)"
+    doctor: "システム診断を実行"
+    status: "システム環境の状態を表示"
 
   feedback:
     select_type: "フィードバックの種類を選択"

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -333,7 +333,8 @@ shell:
     feedback: "提交反馈"
     quit: "退出 AI Shell"
     record: "录制终端会话 (start/stop)"
-    doctor: "基本配置诊断"
+    doctor: "运行系统诊断"
+    status: "显示系统环境状态"
 
   record:
     started: "⏺ 录制已开始: {path}"

--- a/crates/aish-pty/src/lib.rs
+++ b/crates/aish-pty/src/lib.rs
@@ -50,7 +50,7 @@ pub use readline_tab::ReadlineTabResult;
 pub use session_interceptor::{
     pop_last_utf8_char, AiCallback, AiEvent, AiQuery, AiResponse, AskUserAnswer, AskUserChannel,
     AskUserOption, AskUserRequest, BashExecResult, FollowupCallback, InterceptorState,
-    SessionInterceptor, StdinAction,
+    RemoteExecFn, SessionInterceptor, StatusCallback, StdinAction,
 };
 pub use state_capture::StateChanges;
 pub use types::CancelToken;

--- a/crates/aish-pty/src/persistent.rs
+++ b/crates/aish-pty/src/persistent.rs
@@ -439,6 +439,7 @@ impl PersistentPty {
         &mut self,
         command: &str,
         ai_callback: Option<Box<crate::AiCallback>>,
+        status_callback: Option<Box<crate::StatusCallback>>,
         shared_host: Option<std::sync::Arc<std::sync::Mutex<Option<String>>>>,
         secret_check: Option<
             std::sync::Arc<dyn Fn(&str) -> Option<crate::SshSecretCheckResult> + Send + Sync>,
@@ -448,9 +449,9 @@ impl PersistentPty {
     ) -> aish_core::Result<(i32, String, String)> {
         let is_session = is_session_command(command);
         let mut interceptor = if is_session {
-            crate::SessionInterceptor::new(ai_callback)
+            crate::SessionInterceptor::new(ai_callback, status_callback)
         } else {
-            crate::SessionInterceptor::new(None)
+            crate::SessionInterceptor::new(None, None)
         };
 
         // Drain stale data from both the PTY master fd and the control
@@ -1495,6 +1496,101 @@ impl PersistentPty {
                                         }
                                     }
                                 }
+                                crate::StdinAction::TriggerStatus => {
+                                    ai_cancelled = false;
+                                    stdin_shadow.clear();
+
+                                    // Cancel the echoed /status line on the remote side
+                                    if interceptor.take_cancel_pty_line() {
+                                        unsafe {
+                                            libc::write(
+                                                self.master_fd,
+                                                b"\x03".as_ptr() as *const libc::c_void,
+                                                1,
+                                            );
+                                        }
+                                        let mut drain_buf = [0u8; 4096];
+                                        loop {
+                                            let mut rfds: libc::fd_set =
+                                                unsafe { std::mem::zeroed() };
+                                            unsafe {
+                                                libc::FD_ZERO(&mut rfds);
+                                                libc::FD_SET(self.master_fd, &mut rfds);
+                                            }
+                                            let mut tv = libc::timeval {
+                                                tv_sec: 0,
+                                                tv_usec: 100_000,
+                                            };
+                                            let sel = unsafe {
+                                                libc::select(
+                                                    self.master_fd + 1,
+                                                    &mut rfds,
+                                                    std::ptr::null_mut(),
+                                                    std::ptr::null_mut(),
+                                                    &mut tv,
+                                                )
+                                            };
+                                            if sel > 0
+                                                && unsafe { libc::FD_ISSET(self.master_fd, &rfds) }
+                                            {
+                                                let n = unsafe {
+                                                    libc::read(
+                                                        self.master_fd,
+                                                        drain_buf.as_mut_ptr() as *mut libc::c_void,
+                                                        drain_buf.len(),
+                                                    )
+                                                };
+                                                if n <= 0 {
+                                                    break;
+                                                }
+                                                interceptor
+                                                    .feed_pty_output(&drain_buf[..n as usize]);
+                                                continue;
+                                            }
+                                            break;
+                                        }
+                                    }
+
+                                    // Newline after user's input
+                                    unsafe {
+                                        libc::write(
+                                            libc::STDOUT_FILENO,
+                                            b"\r\n".as_ptr() as *const libc::c_void,
+                                            2,
+                                        );
+                                    }
+
+                                    // Execute remote status collection via callback
+                                    if interceptor.has_status_callback() {
+                                        let master_fd = self.master_fd;
+                                        let mut exec_fn: Box<crate::RemoteExecFn> =
+                                            Box::new(move |cmd: &str| {
+                                                execute_remote_command(master_fd, cmd)
+                                            });
+
+                                        let rendered =
+                                            interceptor.invoke_status_callback(&mut *exec_fn);
+
+                                        let msg = format!("{}\r\n", rendered);
+                                        unsafe {
+                                            libc::write(
+                                                libc::STDOUT_FILENO,
+                                                msg.as_ptr() as *const libc::c_void,
+                                                msg.len(),
+                                            );
+                                        }
+                                    }
+
+                                    interceptor.finish_ai();
+                                    skip_leading_newline = true;
+                                    unsafe {
+                                        libc::write(
+                                            self.master_fd,
+                                            b"\r".as_ptr() as *const libc::c_void,
+                                            1,
+                                        );
+                                    }
+                                }
                             }
                         }
                     }
@@ -2339,7 +2435,163 @@ impl PersistentPty {
         }
         Ok(())
     }
+}
 
+// ---- Remote command execution helpers ----
+
+/// Execute a command on the remote host via PTY and capture its output.
+fn execute_remote_command(master_fd: i32, command: &str) -> String {
+    let mut cmd_bytes = command.as_bytes().to_vec();
+    cmd_bytes.push(b'\r');
+    unsafe {
+        libc::write(
+            master_fd,
+            cmd_bytes.as_ptr() as *const libc::c_void,
+            cmd_bytes.len(),
+        );
+    }
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let mut output = Vec::new();
+    let mut drain_buf = [0u8; 4096];
+    let mut idle_count: u32 = 0;
+    let mut timed_out = false;
+    loop {
+        if std::time::Instant::now() >= deadline {
+            timed_out = true;
+            break;
+        }
+        let mut rfds: libc::fd_set = unsafe { std::mem::zeroed() };
+        unsafe {
+            libc::FD_ZERO(&mut rfds);
+            libc::FD_SET(master_fd, &mut rfds);
+        }
+        let mut tv = libc::timeval {
+            tv_sec: 0,
+            tv_usec: 100_000,
+        };
+        let sel = unsafe {
+            libc::select(
+                master_fd + 1,
+                &mut rfds,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut tv,
+            )
+        };
+        if sel > 0 && unsafe { libc::FD_ISSET(master_fd, &rfds) } {
+            let n = unsafe {
+                libc::read(
+                    master_fd,
+                    drain_buf.as_mut_ptr() as *mut libc::c_void,
+                    drain_buf.len(),
+                )
+            };
+            if n > 0 {
+                output.extend_from_slice(&drain_buf[..n as usize]);
+                idle_count = 0;
+            } else {
+                break;
+            }
+        } else {
+            idle_count += 1;
+            // Only start counting idle after receiving first byte
+            if !output.is_empty() && idle_count >= 3 {
+                break;
+            }
+        }
+    }
+
+    // On timeout, cancel the remote command and drain remaining output
+    // to restore the shell to a clean prompt state.
+    if timed_out {
+        unsafe {
+            libc::write(master_fd, b"\x03".as_ptr() as *const libc::c_void, 1);
+        }
+        drain_pty(master_fd, Duration::from_millis(500));
+    }
+
+    let raw = String::from_utf8_lossy(&output).to_string();
+    strip_remote_output(&raw, command)
+}
+
+/// Drain any remaining bytes from the PTY master fd for up to `timeout`.
+fn drain_pty(master_fd: i32, timeout: Duration) {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut buf = [0u8; 4096];
+    loop {
+        if std::time::Instant::now() >= deadline {
+            break;
+        }
+        let mut rfds: libc::fd_set = unsafe { std::mem::zeroed() };
+        unsafe {
+            libc::FD_ZERO(&mut rfds);
+            libc::FD_SET(master_fd, &mut rfds);
+        }
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        let mut tv = libc::timeval {
+            tv_sec: remaining.as_secs() as libc::time_t,
+            tv_usec: remaining.subsec_micros() as libc::suseconds_t,
+        };
+        let sel = unsafe {
+            libc::select(
+                master_fd + 1,
+                &mut rfds,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut tv,
+            )
+        };
+        if sel > 0 && unsafe { libc::FD_ISSET(master_fd, &rfds) } {
+            let n =
+                unsafe { libc::read(master_fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+            if n <= 0 {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+}
+
+/// Strip command echo and ANSI codes from remote command output.
+fn strip_remote_output(raw: &str, command: &str) -> String {
+    let mut clean = String::with_capacity(raw.len());
+    let bytes = raw.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
+            i += 2;
+            while i < bytes.len() && !((0x40..=0x7E).contains(&bytes[i])) {
+                i += 1;
+            }
+            if i < bytes.len() {
+                i += 1;
+            }
+        } else if bytes[i] == b'\r' {
+            i += 1;
+        } else {
+            clean.push(bytes[i] as char);
+            i += 1;
+        }
+    }
+
+    let mut lines: Vec<&str> = clean.lines().collect();
+    let cmd_trimmed = command.trim();
+    if !lines.is_empty() && lines[0].contains(cmd_trimmed) {
+        lines.remove(0);
+    }
+    while let Some(last) = lines.last() {
+        if last.is_empty() || last.contains('$') || last.contains('#') || last.contains('~') {
+            lines.pop();
+        } else {
+            break;
+        }
+    }
+    lines.join("\n").trim().to_string()
+}
+
+impl PersistentPty {
     /// Returns Ok(true) if PromptReady was also seen in the same batch.
     fn wait_for_session_ready(&mut self, timeout: Duration) -> aish_core::Result<bool> {
         let deadline = std::time::Instant::now() + timeout;

--- a/crates/aish-pty/src/session_interceptor.rs
+++ b/crates/aish-pty/src/session_interceptor.rs
@@ -107,6 +107,14 @@ pub type FollowupCallback = dyn Fn(&str, Option<&str>) -> Option<AiResponse> + S
 /// AI callback type: receives an AiQuery and returns an optional AiResponse.
 pub type AiCallback = dyn Fn(AiQuery) -> Option<AiResponse> + Send + Sync;
 
+/// Callback for executing a command on the remote host and returning its output.
+pub type RemoteExecFn = dyn FnMut(&str) -> String;
+
+/// Callback invoked when `/status` is detected during an SSH/session.
+/// Receives a closure that can execute commands on the remote host.
+/// Returns the fully rendered status string to display.
+pub type StatusCallback = dyn Fn(&mut RemoteExecFn) -> String + Send + Sync;
+
 // ---------------------------------------------------------------------------
 // State machine
 // ---------------------------------------------------------------------------
@@ -128,6 +136,8 @@ pub enum StdinAction {
     EchoLocally,
     /// AI input line is complete. Caller should invoke AI callback.
     TriggerAi(String),
+    /// `/status` detected during session. Caller should run remote status scan.
+    TriggerStatus,
 }
 
 // ---------------------------------------------------------------------------
@@ -146,6 +156,7 @@ pub struct SessionInterceptor {
     cancel_pty_line: bool,
     output_buffer: OutputBuffer,
     ai_callback: Option<Box<AiCallback>>,
+    status_callback: Option<Box<StatusCallback>>,
     /// Escape sequence tracker: when Some, we're consuming bytes of a
     /// terminal escape sequence (arrow keys, function keys, etc.) so they
     /// don't corrupt line_shadow.
@@ -171,13 +182,18 @@ impl SessionInterceptor {
     /// Create a new interceptor.
     /// `ai_callback` is None -> interceptor is disabled (pure passthrough).
     /// `ai_callback` is Some -> interceptor will intercept `;` input.
-    pub fn new(ai_callback: Option<Box<AiCallback>>) -> Self {
+    /// `status_callback` is Some -> interceptor will intercept `/status` input.
+    pub fn new(
+        ai_callback: Option<Box<AiCallback>>,
+        status_callback: Option<Box<StatusCallback>>,
+    ) -> Self {
         Self {
             state: InterceptorState::Passthrough,
             line_shadow: Vec::with_capacity(4096),
             cancel_pty_line: false,
             output_buffer: OutputBuffer::new(8192),
             ai_callback,
+            status_callback,
             escape_seq: None,
             in_bracketed_paste: false,
             csi_params: Vec::with_capacity(16),
@@ -204,8 +220,15 @@ impl SessionInterceptor {
                         if self.in_bracketed_paste {
                             return StdinAction::Forward;
                         }
-                        // End of line — check whether the accumulated input
-                        // starts with `;` or `；` to trigger AI.
+                        // End of line — check for /status first, then AI prefix.
+                        if self.status_callback.is_some() && is_status_command(&self.line_shadow) {
+                            self.line_shadow.clear();
+                            self.cancel_pty_line = true;
+                            self.state = InterceptorState::AiProcessing;
+                            return StdinAction::TriggerStatus;
+                        }
+                        // Check whether the accumulated input starts with
+                        // `;` or `；` to trigger AI.
                         if self.ai_callback.is_some() && starts_with_ai_prefix(&self.line_shadow) {
                             let line = String::from_utf8_lossy(&self.line_shadow).to_string();
                             let question = extract_ai_question(&line);
@@ -353,6 +376,21 @@ impl SessionInterceptor {
         let bytes = self.output_buffer.recent(max_len);
         String::from_utf8_lossy(&bytes).to_string()
     }
+
+    /// Whether a status_callback is configured.
+    pub fn has_status_callback(&self) -> bool {
+        self.status_callback.is_some()
+    }
+
+    /// Invoke the status callback with the given remote-exec function.
+    /// Panics if no status_callback is set.
+    pub fn invoke_status_callback(&self, exec_fn: &mut RemoteExecFn) -> String {
+        let cb = self
+            .status_callback
+            .as_ref()
+            .expect("invoke_status_callback called without status_callback");
+        cb(exec_fn)
+    }
 }
 
 /// Extract the question text after `;` or `；` prefix.
@@ -371,6 +409,15 @@ fn extract_ai_question(line: &str) -> String {
 /// fullwidth semicolon `；` (UTF-8: 0xEF 0xBC 0x9B).
 fn starts_with_ai_prefix(line: &[u8]) -> bool {
     line.first() == Some(&b';') || line.starts_with(&[0xEF, 0xBC, 0x9B])
+}
+
+/// Check whether the line is exactly `/status` (ignoring leading/trailing whitespace).
+fn is_status_command(line: &[u8]) -> bool {
+    let s = match std::str::from_utf8(line) {
+        Ok(s) => s.trim(),
+        Err(_) => return false,
+    };
+    s == "/status"
 }
 
 /// Pop the last complete UTF-8 character from a byte buffer.
@@ -427,14 +474,14 @@ mod tests {
 
     #[test]
     fn test_passthrough_forward_normal_bytes() {
-        let mut ic = SessionInterceptor::new(Some(noop_callback()));
+        let mut ic = SessionInterceptor::new(Some(noop_callback()), None);
         assert_eq!(ic.feed_stdin(b'a'), StdinAction::Forward);
         assert_eq!(ic.feed_stdin(b'b'), StdinAction::Forward);
     }
 
     #[test]
     fn test_semicolon_triggers_ai_on_enter() {
-        let mut ic = SessionInterceptor::new(Some(noop_callback()));
+        let mut ic = SessionInterceptor::new(Some(noop_callback()), None);
         // `;` alone is Forward; AI triggers when Enter is pressed
         assert_eq!(ic.feed_stdin(b';'), StdinAction::Forward);
         let action = ic.feed_stdin(b'\r');
@@ -445,7 +492,7 @@ mod tests {
 
     #[test]
     fn test_semicolon_midline_does_not_trigger_ai() {
-        let mut ic = SessionInterceptor::new(Some(noop_callback()));
+        let mut ic = SessionInterceptor::new(Some(noop_callback()), None);
         // pwd; → starts with 'p', not ';' → Enter should be Forward
         ic.feed_stdin(b'p');
         ic.feed_stdin(b'w');
@@ -456,7 +503,7 @@ mod tests {
 
     #[test]
     fn test_ai_input_captures_question() {
-        let mut ic = SessionInterceptor::new(Some(noop_callback()));
+        let mut ic = SessionInterceptor::new(Some(noop_callback()), None);
         ic.feed_stdin(b';');
         ic.feed_stdin(b'i');
         ic.feed_stdin(b'p');
@@ -471,14 +518,14 @@ mod tests {
 
     #[test]
     fn test_no_callback_means_pure_passthrough() {
-        let mut ic = SessionInterceptor::new(None);
+        let mut ic = SessionInterceptor::new(None, None);
         assert_eq!(ic.feed_stdin(b';'), StdinAction::Forward);
         assert_eq!(ic.feed_stdin(b'\r'), StdinAction::Forward);
     }
 
     #[test]
     fn test_fullwidth_semicolon_triggers_ai() {
-        let mut ic = SessionInterceptor::new(Some(noop_callback()));
+        let mut ic = SessionInterceptor::new(Some(noop_callback()), None);
         // ； = 0xEF 0xBC 0x9B
         ic.feed_stdin(0xEF);
         ic.feed_stdin(0xBC);
@@ -494,7 +541,7 @@ mod tests {
 
     #[test]
     fn test_ctrl_c_clears_shadow() {
-        let mut ic = SessionInterceptor::new(Some(noop_callback()));
+        let mut ic = SessionInterceptor::new(Some(noop_callback()), None);
         ic.feed_stdin(b';');
         ic.feed_stdin(b'h');
         ic.feed_stdin(b'i');
@@ -506,7 +553,7 @@ mod tests {
 
     #[test]
     fn test_backspace_pops_from_shadow() {
-        let mut ic = SessionInterceptor::new(Some(noop_callback()));
+        let mut ic = SessionInterceptor::new(Some(noop_callback()), None);
         ic.feed_stdin(b'l');
         ic.feed_stdin(b's');
         ic.feed_stdin(0x7F); // backspace removes 's'
@@ -516,7 +563,7 @@ mod tests {
 
     #[test]
     fn test_ctrl_u_clears_shadow() {
-        let mut ic = SessionInterceptor::new(Some(noop_callback()));
+        let mut ic = SessionInterceptor::new(Some(noop_callback()), None);
         ic.feed_stdin(b'a');
         ic.feed_stdin(b'b');
         ic.feed_stdin(0x15); // Ctrl+U clears shadow
@@ -526,7 +573,7 @@ mod tests {
 
     #[test]
     fn test_escape_sequence_not_in_shadow() {
-        let mut ic = SessionInterceptor::new(Some(noop_callback()));
+        let mut ic = SessionInterceptor::new(Some(noop_callback()), None);
         // Simulate arrow key: ESC [ A
         ic.feed_stdin(b';');
         ic.feed_stdin(0x1B); // ESC
@@ -538,7 +585,7 @@ mod tests {
 
     #[test]
     fn test_cancel_pty_line_flag() {
-        let mut ic = SessionInterceptor::new(Some(noop_callback()));
+        let mut ic = SessionInterceptor::new(Some(noop_callback()), None);
         assert!(!ic.take_cancel_pty_line());
         ic.feed_stdin(b';');
         ic.feed_stdin(b'\r');
@@ -548,7 +595,7 @@ mod tests {
 
     #[test]
     fn test_finish_ai_resets_to_passthrough() {
-        let mut ic = SessionInterceptor::new(Some(noop_callback()));
+        let mut ic = SessionInterceptor::new(Some(noop_callback()), None);
         ic.feed_stdin(b';');
         ic.feed_stdin(b'\r');
         assert!(ic.is_ai_processing());
@@ -561,7 +608,7 @@ mod tests {
 
     #[test]
     fn test_recent_output_captures_pty_data() {
-        let mut ic = SessionInterceptor::new(Some(noop_callback()));
+        let mut ic = SessionInterceptor::new(Some(noop_callback()), None);
         ic.feed_pty_output(b"hello ");
         ic.feed_pty_output(b"world\n");
         assert!(ic.recent_output(100).contains("hello world"));
@@ -569,7 +616,7 @@ mod tests {
 
     #[test]
     fn test_call_ai_returns_command() {
-        let mut ic = SessionInterceptor::new(Some(noop_callback()));
+        let mut ic = SessionInterceptor::new(Some(noop_callback()), None);
         ic.feed_stdin(b';');
         ic.feed_stdin(b'\r');
         let resp = ic.call_ai("test".to_string(), None);
@@ -580,7 +627,7 @@ mod tests {
 
     #[test]
     fn test_call_ai_returns_none() {
-        let ic = SessionInterceptor::new(Some(noop_callback_no_cmd()));
+        let ic = SessionInterceptor::new(Some(noop_callback_no_cmd()), None);
         let cmd = ic.call_ai("test".to_string(), None);
         assert!(cmd.is_none());
     }

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -2233,6 +2233,7 @@ impl AishShell {
             }
             Some("/record") => self.handle_record_command(&parts),
             Some("/doctor") => self.handle_doctor_command(&parts),
+            Some("/status") => self.handle_status_command(),
             _ => {
                 eprintln!("{}", {
                     let mut args = std::collections::HashMap::new();
@@ -2259,6 +2260,15 @@ impl AishShell {
         rt.block_on(async {
             doctor.run(fix).await;
         });
+    }
+
+    fn handle_status_command(&mut self) {
+        crate::status::run_status(
+            &self.pty,
+            &self.version,
+            &self.session_uuid,
+            &self.config.model,
+        );
     }
 
     fn select_recent_session(&mut self) {
@@ -2745,9 +2755,25 @@ impl AishShell {
             } else {
                 None
             };
+            let version_for_status = self.version.clone();
+            let session_for_status = self.session_uuid.clone();
+            let model_for_status = self.config.model.clone();
+            let status_cb: Option<Box<aish_pty::StatusCallback>> = if is_session {
+                Some(Box::new(move |exec: &mut aish_pty::RemoteExecFn| {
+                    crate::status::run_status_remote(
+                        exec,
+                        &version_for_status,
+                        &session_for_status,
+                        &model_for_status,
+                    )
+                }))
+            } else {
+                None
+            };
             pty.send_command_interactive(
                 command,
                 ai_cb,
+                status_cb,
                 Some(shared_host),
                 Some(self.secret_check_closure.clone()),
                 Some(self.secret_vault.clone()),
@@ -3099,7 +3125,7 @@ impl AishShell {
             .pty
             .lock()
             .unwrap()
-            .send_command_interactive(segment, None, None, None, None, None)
+            .send_command_interactive(segment, None, None, None, None, None, None)
             .unwrap_or((-1, self.state.cwd.clone(), String::new()));
 
         if !output.is_empty() {

--- a/crates/aish-shell/src/lib.rs
+++ b/crates/aish-shell/src/lib.rs
@@ -34,6 +34,7 @@ pub mod recorder;
 pub mod renderer;
 pub mod resume_selector;
 pub mod security_panel;
+pub mod status;
 pub mod token_store;
 pub mod tui;
 pub mod types;

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -32,6 +32,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/record", "Record terminal session (start/stop)"),
     ("/quit", "Exit AI Shell"),
     ("/doctor", "Run system diagnostics"),
+    ("/status", "Show system environment status"),
 ];
 
 /// Timeout for PTY completion queries.

--- a/crates/aish-shell/src/status.rs
+++ b/crates/aish-shell/src/status.rs
@@ -1,0 +1,263 @@
+//! Environment status display for /status command.
+
+mod logs;
+mod network;
+mod remote;
+mod services;
+mod system_info;
+
+use std::sync::Mutex;
+
+/// System information collected via sysinfo crate.
+struct SystemInfo {
+    hostname: String,
+    os_version: String,
+    uptime_secs: u64,
+    cpu_percent: f32,
+    mem_used: u64,
+    mem_total: u64,
+    disk_used: u64,
+    disk_total: u64,
+}
+
+/// Status of a monitored service.
+struct ServiceStatus {
+    name: String,
+    active: bool,
+}
+
+const MONITORED_SERVICES: &[&str] = &[
+    "sshd",
+    "ssh",
+    "nginx",
+    "apache2",
+    "httpd",
+    "docker",
+    "containerd",
+    "mysql",
+    "mysqld",
+    "postgresql",
+    "redis",
+    "systemd-resolved",
+    "cron",
+];
+
+/// Run the environment status scan and display results.
+pub fn run_status(
+    pty: &Mutex<aish_pty::PersistentPty>,
+    version: &str,
+    session_id: &str,
+    model: &str,
+) {
+    let sys = system_info::collect();
+
+    let (ip, svcs, errors) = {
+        let mut pty_guard = pty.lock().unwrap();
+        let ip = network::collect_ip(&mut pty_guard);
+        let svcs = services::collect(&mut pty_guard);
+        let errors = logs::collect_error_count(&mut pty_guard);
+        (ip, svcs, errors)
+    };
+
+    render(version, session_id, model, &sys, &ip, &svcs, &errors);
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const GB: u64 = 1024 * 1024 * 1024;
+    const MB: u64 = 1024 * 1024;
+    if bytes >= GB {
+        format!("{:.1}G", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.0}M", bytes as f64 / MB as f64)
+    } else {
+        format!("{}K", bytes / 1024)
+    }
+}
+
+fn format_uptime(secs: u64) -> String {
+    let days = secs / 86400;
+    let hours = (secs % 86400) / 3600;
+    let minutes = (secs % 3600) / 60;
+    if days > 0 {
+        format!("{}d {}h", days, hours)
+    } else {
+        format!("{}h {}m", hours, minutes)
+    }
+}
+
+fn render(
+    version: &str,
+    session_id: &str,
+    model: &str,
+    sys: &SystemInfo,
+    ip: &Option<String>,
+    svcs: &Option<Vec<ServiceStatus>>,
+    errors: &Option<usize>,
+) {
+    let mut lines: Vec<String> = Vec::new();
+
+    // Line 1: aish info
+    let session_short = &session_id[..session_id.len().min(6)];
+    lines.push(format!(
+        "aish {} │ session: {} │ model: {}",
+        version, session_short, model
+    ));
+
+    // Line 2: host info
+    let ip_str = ip.as_deref().unwrap_or("N/A");
+    lines.push(format!(
+        "host: {} ({}) │ {} │ up {}",
+        sys.hostname,
+        ip_str,
+        sys.os_version,
+        format_uptime(sys.uptime_secs)
+    ));
+
+    // Line 3: resources
+    let mem_pct = (sys.mem_used * 100).checked_div(sys.mem_total).unwrap_or(0);
+    let disk_pct = (sys.disk_used * 100)
+        .checked_div(sys.disk_total)
+        .unwrap_or(0);
+    lines.push(format!(
+        "CPU: {:.0}% │ Mem: {}/{} ({}%) │ Disk: {}/{} ({}%)",
+        sys.cpu_percent,
+        format_bytes(sys.mem_used),
+        format_bytes(sys.mem_total),
+        mem_pct,
+        format_bytes(sys.disk_used),
+        format_bytes(sys.disk_total),
+        disk_pct
+    ));
+
+    // Line 4: services (optional)
+    if let Some(svc_list) = svcs {
+        if !svc_list.is_empty() {
+            let parts: Vec<String> = svc_list
+                .iter()
+                .map(|s| {
+                    if s.active {
+                        format!("\x1b[32m{}●\x1b[0m", s.name)
+                    } else {
+                        format!("\x1b[2m{}○\x1b[0m", s.name)
+                    }
+                })
+                .collect();
+            lines.push(format!("services: {}", parts.join(" ")));
+        }
+    }
+
+    // Line 5: errors (optional)
+    if let Some(count) = errors {
+        lines.push(format!("errors today: {}", count));
+    }
+
+    // Render with box drawing
+    let total = lines.len();
+    for (i, line) in lines.iter().enumerate() {
+        if i == 0 {
+            println!("┌─ {}", line);
+        } else if i == total - 1 {
+            println!("└─ {}", line);
+        } else {
+            println!("├─ {}", line);
+        }
+    }
+}
+
+/// Callback for remote /status. Returns rendered output string.
+pub fn run_status_remote(
+    exec: &mut dyn FnMut(&str) -> String,
+    version: &str,
+    session_id: &str,
+    model: &str,
+) -> String {
+    let rs = remote::collect_remote(exec);
+    render_to_string(version, session_id, model, &rs)
+}
+
+fn render_to_string(
+    version: &str,
+    session_id: &str,
+    model: &str,
+    rs: &remote::RemoteStatus,
+) -> String {
+    let mut lines: Vec<String> = Vec::new();
+
+    let session_short = &session_id[..session_id.len().min(6)];
+    lines.push(format!(
+        "aish {} │ session: {} │ model: {}",
+        version, session_short, model
+    ));
+
+    let ip_str = rs.ip.as_deref().unwrap_or("N/A");
+    let os_str = rs.os_info.as_deref().unwrap_or("?");
+    let up_str = rs
+        .uptime_secs
+        .map(|s| format_uptime(s))
+        .unwrap_or_else(|| "?".into());
+    lines.push(format!(
+        "host: {} ({}) │ {} │ up {}",
+        rs.hostname.as_deref().unwrap_or("?"),
+        ip_str,
+        os_str,
+        up_str
+    ));
+
+    let mem_pct = match (rs.mem_used, rs.mem_total) {
+        (Some(u), Some(t)) if t > 0 => (u * 100).checked_div(t).unwrap_or(0),
+        _ => 0,
+    };
+    let disk_pct = match (rs.disk_used, rs.disk_total) {
+        (Some(u), Some(t)) if t > 0 => (u * 100).checked_div(t).unwrap_or(0),
+        _ => 0,
+    };
+    let cpu_str = rs
+        .cpu_percent
+        .map(|p| format!("{:.0}%", p))
+        .unwrap_or_else(|| "?".into());
+    let mem_str = match (rs.mem_used, rs.mem_total) {
+        (Some(u), Some(t)) => format!("{}/{} ({}%)", format_bytes(u), format_bytes(t), mem_pct),
+        _ => "?/?".into(),
+    };
+    let disk_str = match (rs.disk_used, rs.disk_total) {
+        (Some(u), Some(t)) => format!("{}/{} ({}%)", format_bytes(u), format_bytes(t), disk_pct),
+        _ => "?/?".into(),
+    };
+    lines.push(format!(
+        "CPU: {} │ Mem: {} │ Disk: {}",
+        cpu_str, mem_str, disk_str
+    ));
+
+    if let Some(ref svcs) = rs.services {
+        if !svcs.is_empty() {
+            let parts: Vec<String> = svcs
+                .iter()
+                .map(|(name, active)| {
+                    if *active {
+                        format!("\x1b[32m{}●\x1b[0m", name)
+                    } else {
+                        format!("\x1b[2m{}○\x1b[0m", name)
+                    }
+                })
+                .collect();
+            lines.push(format!("services: {}", parts.join(" ")));
+        }
+    }
+
+    if let Some(count) = rs.error_count {
+        lines.push(format!("errors today: {}", count));
+    }
+
+    let total = lines.len();
+    let mut out = String::new();
+    for (i, line) in lines.iter().enumerate() {
+        if i == 0 {
+            out.push_str(&format!("┌─ {}\n", line));
+        } else if i == total - 1 {
+            out.push_str(&format!("└─ {}", line));
+        } else {
+            out.push_str(&format!("├─ {}\n", line));
+        }
+    }
+    out
+}

--- a/crates/aish-shell/src/status/logs.rs
+++ b/crates/aish-shell/src/status/logs.rs
@@ -1,0 +1,13 @@
+use aish_pty::PersistentPty;
+use std::time::Duration;
+
+pub fn collect_error_count(pty: &mut PersistentPty) -> Option<usize> {
+    let result = pty.execute_command(
+        "journalctl --no-pager -p err --since today -q 2>/dev/null | wc -l",
+        Duration::from_secs(5),
+        None,
+        false,
+    );
+    let output = result.ok()?.0;
+    output.trim().parse().ok()
+}

--- a/crates/aish-shell/src/status/network.rs
+++ b/crates/aish-shell/src/status/network.rs
@@ -1,0 +1,30 @@
+use aish_pty::PersistentPty;
+use std::time::Duration;
+
+pub fn collect_ip(pty: &mut PersistentPty) -> Option<String> {
+    let result = pty.execute_command(
+        "ip -4 addr show 2>/dev/null",
+        Duration::from_secs(3),
+        None,
+        false,
+    );
+    let output = result.ok()?.0;
+    parse_ip(&output)
+}
+
+fn parse_ip(output: &str) -> Option<String> {
+    for line in output.lines() {
+        let line = line.trim();
+        if line.contains("inet ") && !line.contains("127.0.0.1") {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 2 {
+                let cidr = parts[1];
+                let ip = cidr.split('/').next()?;
+                if !ip.is_empty() {
+                    return Some(ip.to_string());
+                }
+            }
+        }
+    }
+    None
+}

--- a/crates/aish-shell/src/status/remote.rs
+++ b/crates/aish-shell/src/status/remote.rs
@@ -1,0 +1,171 @@
+//! Remote status collection for SSH sessions.
+
+use super::MONITORED_SERVICES;
+
+pub struct RemoteStatus {
+    pub hostname: Option<String>,
+    pub os_info: Option<String>,
+    pub ip: Option<String>,
+    pub uptime_secs: Option<u64>,
+    pub cpu_percent: Option<f32>,
+    pub mem_used: Option<u64>,
+    pub mem_total: Option<u64>,
+    pub disk_used: Option<u64>,
+    pub disk_total: Option<u64>,
+    pub services: Option<Vec<(String, bool)>>,
+    pub error_count: Option<usize>,
+}
+
+pub fn collect_remote(exec: &mut dyn FnMut(&str) -> String) -> RemoteStatus {
+    let hostname = parse_hostname(&exec("command hostname 2>/dev/null"));
+    let os_info = parse_os_info(&exec("command cat /etc/os-release 2>/dev/null"));
+    let ip = parse_ip(&exec("command ip -4 addr show 2>/dev/null"));
+    let uptime_secs = parse_uptime(&exec("command cat /proc/uptime 2>/dev/null"));
+    let cpu_percent = collect_cpu(exec);
+    let (mem_used, mem_total) = parse_memory(&exec("LC_ALL=C command free -b 2>/dev/null"));
+    let (disk_used, disk_total) = parse_disk(&exec("LC_ALL=C command df -B1 / 2>/dev/null"));
+    let services = parse_services(
+        &exec("command systemctl list-units --type=service --all --no-pager --no-legend 2>/dev/null | awk '{print $1\":\"$3}'"),
+    );
+    let error_count = parse_error_count(&exec(
+        "command journalctl --no-pager -p err --since today -q 2>/dev/null | wc -l",
+    ));
+
+    RemoteStatus {
+        hostname,
+        os_info,
+        ip,
+        uptime_secs,
+        cpu_percent,
+        mem_used,
+        mem_total,
+        disk_used,
+        disk_total,
+        services,
+        error_count,
+    }
+}
+
+fn parse_hostname(output: &str) -> Option<String> {
+    let s = output.trim().to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
+fn strip_quotes(s: &str) -> &str {
+    s.trim_matches(|c| c == '"' || c == '\'')
+}
+
+fn parse_os_info(output: &str) -> Option<String> {
+    let mut name = None;
+    let mut version = None;
+    for line in output.lines() {
+        if let Some(val) = line.strip_prefix("PRETTY_NAME=") {
+            return Some(strip_quotes(val).to_string());
+        }
+        if let Some(val) = line.strip_prefix("NAME=") {
+            name = Some(strip_quotes(val).to_string());
+        }
+        if let Some(val) = line.strip_prefix("VERSION=") {
+            version = Some(strip_quotes(val).to_string());
+        }
+    }
+    match (name, version) {
+        (Some(n), Some(v)) => Some(format!("{} {}", n, v)),
+        (Some(n), None) => Some(n),
+        _ => None,
+    }
+}
+
+fn parse_ip(output: &str) -> Option<String> {
+    for line in output.lines() {
+        let line = line.trim();
+        if line.contains("inet ") && !line.contains("127.0.0.1") {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 2 {
+                let cidr = parts[1];
+                let ip = cidr.split('/').next()?;
+                if !ip.is_empty() {
+                    return Some(ip.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+fn parse_uptime(output: &str) -> Option<u64> {
+    let first = output.split_whitespace().next()?;
+    let secs: f64 = first.parse().ok()?;
+    Some(secs as u64)
+}
+
+fn collect_cpu(exec: &mut dyn FnMut(&str) -> String) -> Option<f32> {
+    let sample1 = exec("command cat /proc/stat 2>/dev/null");
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    let sample2 = exec("command cat /proc/stat 2>/dev/null");
+    let vals1 = parse_cpu_line(&sample1)?;
+    let vals2 = parse_cpu_line(&sample2)?;
+    // idle = column 3, iowait = column 4
+    let d_idle = (vals2[3] + vals2.get(4).copied().unwrap_or(0)) as f64
+        - (vals1[3] + vals1.get(4).copied().unwrap_or(0)) as f64;
+    let d_total: f64 = vals2
+        .iter()
+        .zip(vals1.iter())
+        .map(|(a, b)| *a as f64 - *b as f64)
+        .sum();
+    if d_total > 0.0 {
+        Some(((1.0 - d_idle / d_total) * 100.0) as f32)
+    } else {
+        None
+    }
+}
+
+fn parse_cpu_line(line: &str) -> Option<Vec<u64>> {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.len() < 5 {
+        return None;
+    }
+    parts[1..].iter().map(|s| s.parse().ok()).collect()
+}
+
+fn parse_memory(output: &str) -> (Option<u64>, Option<u64>) {
+    let parts: Vec<&str> = output.split_whitespace().collect();
+    if parts.len() < 3 {
+        return (None, None);
+    }
+    (parts[2].parse().ok(), parts[1].parse().ok())
+}
+
+fn parse_disk(output: &str) -> (Option<u64>, Option<u64>) {
+    let parts: Vec<&str> = output.split_whitespace().collect();
+    if parts.len() < 4 {
+        return (None, None);
+    }
+    (parts[2].parse().ok(), parts[1].parse().ok())
+}
+
+fn parse_services(output: &str) -> Option<Vec<(String, bool)>> {
+    if output.trim().is_empty() {
+        return None;
+    }
+    let mut services = Vec::new();
+    for line in output.lines() {
+        let line = line.trim();
+        if let Some((unit, status)) = line.split_once(':') {
+            if let Some(name) = unit.strip_suffix(".service") {
+                if MONITORED_SERVICES.contains(&name) {
+                    services.push((name.to_string(), status == "active"));
+                }
+            }
+        }
+    }
+    Some(services)
+}
+
+fn parse_error_count(output: &str) -> Option<usize> {
+    output.trim().parse().ok()
+}

--- a/crates/aish-shell/src/status/services.rs
+++ b/crates/aish-shell/src/status/services.rs
@@ -1,0 +1,37 @@
+use aish_pty::PersistentPty;
+use std::time::Duration;
+
+use super::{ServiceStatus, MONITORED_SERVICES};
+
+pub fn collect(pty: &mut PersistentPty) -> Option<Vec<ServiceStatus>> {
+    let result = pty.execute_command(
+        "systemctl list-units --type=service --all --no-pager --no-legend 2>/dev/null",
+        Duration::from_secs(5),
+        None,
+        false,
+    );
+    let output = result.ok()?.0;
+    if output.trim().is_empty() {
+        return None;
+    }
+
+    let mut services = Vec::new();
+    for line in output.lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() < 4 {
+            continue;
+        }
+        let unit = parts[0]; // e.g. "sshd.service"
+        let active = parts[2]; // "active" or "inactive" or "failed"
+
+        if let Some(name) = unit.strip_suffix(".service") {
+            if MONITORED_SERVICES.contains(&name) {
+                services.push(ServiceStatus {
+                    name: name.to_string(),
+                    active: active == "active",
+                });
+            }
+        }
+    }
+    Some(services)
+}

--- a/crates/aish-shell/src/status/system_info.rs
+++ b/crates/aish-shell/src/status/system_info.rs
@@ -1,0 +1,40 @@
+use sysinfo::{Disks, System};
+
+use super::SystemInfo;
+
+pub fn collect() -> SystemInfo {
+    let mut sys = System::new_all();
+    sys.refresh_all();
+
+    let hostname = System::host_name().unwrap_or_else(|| "?".into());
+    let os_version = System::long_os_version().unwrap_or_else(|| "?".into());
+    let uptime_secs = System::uptime();
+
+    // Refresh CPU usage twice with a short delay for meaningful measurement
+    sys.refresh_cpu_usage();
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    sys.refresh_cpu_usage();
+    let cpu_percent = sys.global_cpu_usage();
+
+    let mem_total = sys.total_memory();
+    let mem_used = sys.used_memory();
+
+    let disks = Disks::new_with_refreshed_list();
+    let mut disk_total = 0u64;
+    let mut disk_used = 0u64;
+    for disk in &disks {
+        disk_total += disk.total_space();
+        disk_used += disk.total_space() - disk.available_space();
+    }
+
+    SystemInfo {
+        hostname,
+        os_version,
+        uptime_secs,
+        cpu_percent,
+        mem_used,
+        mem_total,
+        disk_used,
+        disk_total,
+    }
+}

--- a/crates/aish-ui/src/slash_input.rs
+++ b/crates/aish-ui/src/slash_input.rs
@@ -214,11 +214,9 @@ impl SlashInputSession {
                 Some(SlashInputOutcome::Dismissed(self.input.clone()))
             }
             KeyCode::Tab => {
-                // Complete to selected item and submit immediately
-                if let Some(&cmd_idx) = self.filtered.get(self.selected) {
-                    let (name, _) = &self.commands[cmd_idx];
-                    return Some(SlashInputOutcome::Command(name.clone()));
-                }
+                // Sync input to selected item (like Up/Down arrows).
+                // User presses Enter to execute.
+                self.sync_input_to_selected();
                 None
             }
             KeyCode::Home => {


### PR DESCRIPTION
## Summary

- Add `/status` slash command that displays system environment info (hostname, OS, uptime, CPU, memory, disk, IP, monitored services, error count) with box-drawing UI
- Support both local mode (via sysinfo crate + PTY commands) and remote mode (SSH session via `RemoteExecFn`)
- Extend `SessionInterceptor` with `TriggerStatus` action and `StatusCallback` type for remote /status interception
- Fix Tab key behavior in slash input (`slash_input.rs`) — now syncs selection instead of immediately executing, preventing accidental command execution
- Add i18n translations for 6 languages (en, zh, ja, de, fr, es)

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes  
- [x] `cargo test` — all 421 tests pass (0 failed)
- [ ] Manual test: run `/status` in local mode
- [ ] Manual test: run `/status` during SSH session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/status` slash command to show system environment summary (host, IP, OS, uptime, CPU/memory/disk, monitored services, error counts); supports remote execution.

* **UI Changes**
  * Tab now syncs input to the selected slash suggestion without submitting.

* **Documentation**
  * Updated translations for slash commands (including `/record`, `/doctor`, `/status`) across multiple locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->