### PR TITLE
fix(readline): skip readline Tab probe for subcommand completion

### DIFF
--- a/crates/aish-pty/tests/completion_query.rs
+++ b/crates/aish-pty/tests/completion_query.rs
@@ -143,3 +143,35 @@ fn query_completions_ls_usr_bin_directory() {
         assert!(resp2.candidates.len() >= 2);
     });
 }
+
+/// Regression: subcommand completion must not run forward_readline_tab first.
+/// That probe injects the full line into interactive readline; slow systemctl
+/// completion leaves bash busy and query_completions times out (~1.4s, no candidates).
+#[test]
+fn query_completions_systemctl_rest_subcommand() {
+    if !std::path::Path::new("/usr/bin/systemctl").exists()
+        && !std::path::Path::new("/bin/systemctl").exists()
+    {
+        return;
+    }
+    with_pty(|pty| {
+        let line = "systemctl rest";
+        let pos = line.len();
+        let start = std::time::Instant::now();
+        let resp = pty
+            .query_completions(line, pos, Duration::from_millis(1200))
+            .expect("query");
+        assert!(
+            start.elapsed() < Duration::from_millis(800),
+            "subcommand completion took {:?}",
+            start.elapsed()
+        );
+        assert!(
+            resp.candidates
+                .iter()
+                .any(|c| c.replacement.starts_with("restart")),
+            "expected restart, got {:?}",
+            resp.candidates
+        );
+    });
+}

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -151,12 +151,19 @@ impl ShellHelper {
             return None;
         }
 
-        if !is_path_like_token(line.get(word_start_at(line, pos)..pos).unwrap_or("")) {
+        let word_start = word_start_at(line, pos);
+        let current_word = line.get(word_start..pos).unwrap_or("");
+
+        // Readline Tab probe only when completing the command name (cword == 0).
+        // Subcommands and arguments use __aish_complete directly: injecting the
+        // full line into interactive readline can leave bash busy on slow native
+        // completions (e.g. systemctl), causing query_completions to time out.
+        if word_start == 0 && !is_path_like_token(current_word) {
             if let Some(tab) = pty.forward_readline_tab(line, pos, TAB_PROBE_TIMEOUT) {
-                let (word_start, raw_pairs) = to_replacement_pairs(&tab, line, pos);
+                let (ws, raw_pairs) = to_replacement_pairs(&tab, line, pos);
                 if !raw_pairs.is_empty() {
                     return Some((
-                        word_start,
+                        ws,
                         raw_pairs
                             .into_iter()
                             .map(|(display, replacement)| Pair {


### PR DESCRIPTION
## Summary

- Only run `forward_readline_tab` when completing the command name (`word_start == 0`, bash `COMP_CWORD == 0`).
- Subcommands and later arguments go straight to `query_completions` (`__aish_complete`), avoiding the readline probe that injects the full line into interactive bash.
- Fixes Tab completion hanging ~1.4s with no results for slow completions such as `systemctl rest` → `restart`.

## Test plan

- [x] `cargo test -p aish-pty --test completion_query`
- [x] `make format-check` and `make lint`
- [ ] Manual: in aish REPL, type `systemctl rest` + Tab — should complete to `restart` within ~100ms
- [ ] Manual: `gi` + Tab still completes command names via readline probe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command completion reliability by preventing timeouts in specific scenarios and ensuring faster, more consistent completion results.

* **Tests**
  * Added regression test for command completion query handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->