### PR TITLE
Release v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2026-06-24
+
+### Added
+
+- Added `/record start|stop` for asciinema v2 session recording, including real-time PTY output and error-correction flow capture.
+- Added native bash Tab completion via control-pipe JSON, with readline forwarding and Bash 4.2 compatibility.
+- Added InputGuard pre-execution screening for shell commands and AI prompts (Allow / Confirm / Block), including SSH/PTY sessions.
+- Added `/status` to display system environment (hostname, OS, CPU, memory, network, services, errors) in local and remote SSH modes.
+- Added `/doctor` for parallel environment diagnostics (config, API key, dirs, session, tools, skills, memory, connectivity).
+
+### Changed
+
+- Improved slash-command popup Enter/Tab UX, viewport stability, and arrow navigation.
+- Improved SSH error correction with exit codes, remote host context, and broader shell error-prefix support.
+- Added release profile size optimizations (LTO, strip).
+
+### Fixed
+
+- Fixed cast replay by preserving standalone `\r` and recording Ctrl+C events.
+- Fixed Tab completion timeout for slow native completions (e.g. systemctl).
+- Fixed Tab completion on Bash 4.2 (CentOS 7).
+
+### Removed
+
+- Removed deprecated dead code from the Rust runtime (LiteLLMClient, legacy diagnose agent, state_capture).
+
+## [Unreleased]
+
+### Added
+
+- No unreleased changes yet.
+
 ## [0.3.4] - 2026-06-08
 
 ### Added
@@ -26,12 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed confirmation panel rendering so the right border draws correctly in the terminal UI.
 - Fixed feedback log attachment so oversized bodies keep as many recent log lines as possible instead of dropping logs entirely when the GitHub issue URL would exceed the length limit.
-
-## [Unreleased]
-
-### Added
-
-- No unreleased changes yet.
 
 ## [0.3.3] - 2026-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed deprecated dead code from the Rust runtime (LiteLLMClient, legacy diagnose agent, state_capture).
 
-## [Unreleased]
-
-### Added
-
-- No unreleased changes yet.
-
 ## [0.3.4] - 2026-06-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "aish-cli"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "aish-config"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "aish-context"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aish-core",
  "serde",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "aish-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "aish-hosts"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "aish-i18n"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "aish-llm"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aish-context",
  "aish-core",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "aish-memory"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aish-core",
  "chrono",
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "aish-prompts"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "aish-pty"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aish-core",
  "aish-hosts",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "aish-scripts"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "aish-security"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "libc",
  "regex",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aish-session"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aish-core",
  "chrono",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "aish-shell"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aish-config",
  "aish-context",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "aish-skills"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "aish-tools"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aish-core",
  "aish-i18n",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "aish-ui"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "crossterm 0.28.1",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/packaging/scripts/update_release_files.py
+++ b/packaging/scripts/update_release_files.py
@@ -133,11 +133,9 @@ def _update_changelog(version: str, release_date: str) -> None:
     unreleased_bounds = _find_section_bounds(original, UNRELEASED_HEADING_RE)
     if unreleased_bounds is not None:
         unreleased_start, _, unreleased_end = unreleased_bounds
-        unreleased_section = f"## [Unreleased]\n\n{UNRELEASED_PLACEHOLDER}\n"
         updated = (
             f"{original[:unreleased_start]}"
             f"{new_section}"
-            f"{unreleased_section}"
             f"{original[unreleased_end:]}"
         )
     else:

--- a/packaging/tests/release_scripts_smoke.sh
+++ b/packaging/tests/release_scripts_smoke.sh
@@ -88,8 +88,10 @@ EOF
 
 grep -Fq '## [1.0.0] - 2026-05-10' "$SANDBOX/CHANGELOG.md"
 grep -Fq 'Beta release note' "$SANDBOX/CHANGELOG.md"
-grep -Fq '## [Unreleased]' "$SANDBOX/CHANGELOG.md"
-grep -Fq -- '- No unreleased changes yet.' "$SANDBOX/CHANGELOG.md"
+if grep -Fq '## [Unreleased]' "$SANDBOX/CHANGELOG.md"; then
+  echo "Expected stable release to drop the [Unreleased] section" >&2
+  exit 1
+fi
 
 cat > "$SANDBOX/Cargo.toml" <<'EOF'
 [workspace.package]


### PR DESCRIPTION
## Summary

Release v0.3.5 from current main (includes all changes since v0.3.4).

### Added
- `/record start|stop` for asciinema v2 session recording
- Native bash Tab completion with readline forwarding and Bash 4.2 support
- InputGuard pre-execution input screening (Allow / Confirm / Block)
- `/status` for local and remote SSH environment display
- `/doctor` for parallel environment diagnostics

### Changed
- Improved slash-command popup Enter/Tab UX
- Improved SSH error correction with exit codes and remote host context
- Release profile size optimizations (LTO, strip)

### Fixed
- Cast replay `\r` preservation and Ctrl+C recording
- Tab completion timeout for slow completions (e.g. systemctl)
- Tab completion on Bash 4.2 (CentOS 7)

### Removed
- Deprecated dead code from Rust runtime

## Test plan

- [x] `python3 packaging/scripts/release_metadata.py --expected-version 0.3.5`
- [x] `make test` (cargo test --workspace + release script smoke)

## Release checklist

- [ ] Run **Release Preparation** workflow with `version=0.3.5`, `ref=release/v0.3.5-prep`
- [ ] Merge this PR to `main`
- [ ] Run **Release Final Check** with `version=0.3.5`
- [ ] Tag and push `v0.3.5` to upstream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/record`, `/status`, and `/doctor` commands
  * Added bash tab completion with improved reliability
  * Added input screening to enhance security
  * Improved SSH error correction for smoother connections
* **Bug Fixes**
  * Fixed cast replay handling
  * Further improved tab completion reliability
* **Tests**
  * Updated release checks to ensure stable releases no longer include an `## [Unreleased]` section
<!-- end of auto-generated comment: release notes by coderabbit.ai -->