### PR TITLE
feat(welcome): changelog panel + fix(pty): PRINTF_ERASE chunk-boundary leak

### DIFF
--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -314,6 +314,9 @@ shell:
       item3_suffix_2: " to see built-in help and usage."
     risk: "AI-generated content may be risky, please verify carefully."
     skills_loaded_suffix: " loaded"
+    changelog_title: "What's New in {version}"
+    changelog_hint_prefix: "{count} updates —"
+    changelog_hint_suffix: "to view all"
 
   # General error messages
   general_error: "error: {error}"

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -314,6 +314,9 @@ shell:
       item3_suffix_2: " 查看内置帮助与用法"
     risk: "AI 生成内容有风险，请仔细甄别！"
     skills_loaded_suffix: " 已加载"
+    changelog_title: "{version} 更新内容"
+    changelog_hint_prefix: "共 {count} 条更新 —"
+    changelog_hint_suffix: "查看全部"
 
   # 通用错误消息
   general_error: "错误: {error}"

--- a/crates/aish-i18n/src/changelog.rs
+++ b/crates/aish-i18n/src/changelog.rs
@@ -1,0 +1,214 @@
+/// A single changelog entry extracted from CHANGELOG.md.
+#[derive(Clone)]
+pub struct ChangelogEntry {
+    // Keep-a-Changelog categories: "Added", "Changed", "Fixed", "Removed",
+    // "Deprecated", "Security". Stored as a free-form String because the
+    // parser accepts whatever `### <word>` heading appears in the file.
+    pub category: String,
+    pub text: String, // description text (without leading "- ")
+}
+
+/// Embed the workspace root CHANGELOG.md at compile time.
+const CHANGELOG_CONTENT: &str = include_str!("../../../CHANGELOG.md");
+
+/// Parse the current version's changelog section from the embedded CHANGELOG.md.
+///
+/// Finds the `## [{version}]` heading and extracts list items under every
+/// `### <Category>` subsection (Added, Changed, Fixed, Removed, Deprecated,
+/// Security — the standard Keep-a-Changelog set). Categories the parser does
+/// not recognise are still emitted; the caller decides how to render them.
+pub fn parse_current_changelog(version: &str) -> Vec<ChangelogEntry> {
+    let section = match extract_version_section(CHANGELOG_CONTENT, version) {
+        Some(s) => s,
+        None => return Vec::new(),
+    };
+    parse_section_entries(&section)
+}
+
+/// Extract the text between `## [{version}]` and the next `## [` heading.
+fn extract_version_section(content: &str, version: &str) -> Option<String> {
+    let heading = format!("## [{}]", version);
+    let start = content.find(&heading)?;
+    let after_heading = &content[start + heading.len()..];
+
+    let end = after_heading
+        .find("\n## [")
+        .map(|i| start + heading.len() + i);
+    let section_text = match end {
+        Some(e) => &content[start..e],
+        None => &content[start..],
+    };
+
+    Some(section_text.to_string())
+}
+
+/// Parse `### Category` subsections into entries.
+fn parse_section_entries(section: &str) -> Vec<ChangelogEntry> {
+    let mut entries = Vec::new();
+    let mut current_category = String::new();
+
+    for line in section.lines() {
+        let trimmed = line.trim();
+
+        if let Some(cat) = trimmed.strip_prefix("### ") {
+            current_category = cat.trim().to_string();
+            continue;
+        }
+
+        if let Some(item) = trimmed.strip_prefix("- ") {
+            if !current_category.is_empty() {
+                entries.push(ChangelogEntry {
+                    category: current_category.clone(),
+                    text: item.to_string(),
+                });
+            }
+        }
+    }
+
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_CHANGELOG: &str = r#"## [0.3.4] - 2026-06-08
+
+### Added
+
+- Added multimodal image support.
+- Added interactive /feedback command.
+
+### Changed
+
+- Changed the feedback issue template.
+
+### Fixed
+
+- Fixed confirmation panel rendering.
+
+## [0.3.3] - 2026-06-03
+
+### Added
+
+- Added a slash-command suggestion popup.
+
+### Fixed
+
+- Fixed PTY cleanup on shell shutdown.
+"#;
+
+    #[test]
+    fn test_parse_returns_current_version_entries() {
+        let entries = parse_changelog_from(SAMPLE_CHANGELOG, "0.3.4");
+        assert_eq!(entries.len(), 4);
+        assert_eq!(entries[0].category, "Added");
+        assert_eq!(entries[0].text, "Added multimodal image support.");
+        assert_eq!(entries[1].category, "Added");
+        assert_eq!(entries[2].category, "Changed");
+        assert_eq!(entries[3].category, "Fixed");
+    }
+
+    #[test]
+    fn test_parse_skips_other_versions() {
+        let entries = parse_changelog_from(SAMPLE_CHANGELOG, "0.3.3");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].category, "Added");
+        assert_eq!(entries[1].category, "Fixed");
+    }
+
+    #[test]
+    fn test_parse_strips_leading_dash() {
+        let entries = parse_changelog_from(SAMPLE_CHANGELOG, "0.3.4");
+        assert!(!entries[0].text.starts_with('-'));
+    }
+
+    #[test]
+    fn test_parse_unknown_version_returns_empty() {
+        let entries = parse_changelog_from(SAMPLE_CHANGELOG, "99.0.0");
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_parse_empty_section_skipped() {
+        let changelog = r#"## [0.1.0] - 2025-01-01
+
+### Added
+
+- No unreleased changes yet.
+
+## [0.0.9] - 2024-01-01
+
+### Added
+
+- Something.
+"#;
+        let entries = parse_changelog_from(changelog, "0.1.0");
+        // "No unreleased changes yet." is still a valid entry, just informational
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].text, "No unreleased changes yet.");
+    }
+
+    #[test]
+    fn test_real_changelog_current_version_has_entries() {
+        // Guards against silent breakage when CHANGELOG.md format drifts or
+        // when the embedded version no longer matches any section. If this
+        // fires, either CHANGELOG.md needs a section for the current version
+        // or the parser needs to be updated for the new format.
+        let v = env!("CARGO_PKG_VERSION");
+        let entries = parse_current_changelog(v);
+        assert!(
+            !entries.is_empty(),
+            "current version {} has no changelog entries — check CHANGELOG.md format",
+            v,
+        );
+        for entry in &entries {
+            assert!(
+                matches!(
+                    entry.category.as_str(),
+                    "Added" | "Changed" | "Fixed" | "Removed" | "Deprecated" | "Security"
+                ),
+                "unexpected category {:?} for version {}",
+                entry.category,
+                v,
+            );
+            assert!(
+                !entry.text.is_empty(),
+                "empty changelog text for version {}",
+                v
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_unreleased_section() {
+        // "Unreleased" is a common Keep-a-Changelog section header that
+        // must round-trip through the parser just like a numbered version.
+        let changelog = r#"## [Unreleased]
+
+### Added
+
+- Sneak preview feature.
+
+## [0.1.0] - 2025-01-01
+
+### Added
+
+- Released.
+"#;
+        let entries = parse_changelog_from(changelog, "Unreleased");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].category, "Added");
+        assert_eq!(entries[0].text, "Sneak preview feature.");
+    }
+
+    // Helper for testing: parse from a given string instead of the embedded file.
+    fn parse_changelog_from(content: &str, version: &str) -> Vec<ChangelogEntry> {
+        let section = extract_version_section(content, version);
+        if section.is_none() {
+            return Vec::new();
+        }
+        let section = section.unwrap();
+        parse_section_entries(&section)
+    }
+}

--- a/crates/aish-i18n/src/lib.rs
+++ b/crates/aish-i18n/src/lib.rs
@@ -13,6 +13,7 @@
     clippy::too_many_arguments
 )]
 
+pub mod changelog;
 pub mod manager;
 
 pub use manager::I18nManager;

--- a/crates/aish-pty/src/persistent.rs
+++ b/crates/aish-pty/src/persistent.rs
@@ -299,6 +299,14 @@ pub(crate) struct Ps1EchoSuppressor {
     /// pattern split across two PTY reads is still stripped. Used by the
     /// byte-exact path only.
     pub(crate) pending: Vec<u8>,
+    /// When Some, an echo's `\r\n` has been stripped (ERASE_LINE emitted) but
+    /// the trailing `printf '\33[A\33[J'` sequence — which bash sends as the
+    /// last step of the injected command — has only partially arrived. Holds
+    /// the bytes after the echo's `\n` that could still be a prefix of
+    /// PRINTF_ERASE. Without this, a chunk boundary between `\n` and
+    /// `\x1b[A\x1b[J` would let the cursor-positioning escapes leak to the
+    /// user's terminal and corrupt cursor tracking.
+    pub(crate) pending_printf_erase: Option<Vec<u8>>,
 }
 
 impl Ps1EchoSuppressor {
@@ -316,6 +324,7 @@ pub(crate) fn build_ps1_echo_suppressor(host: &str, enable_git: bool) -> Ps1Echo
         remaining: 2,
         started: std::time::Instant::now(),
         pending: Vec::new(),
+        pending_printf_erase: None,
     }
 }
 
@@ -376,7 +385,7 @@ fn strip_ps1_echo_exact(data: &[u8], sup: &mut Ps1EchoSuppressor) -> Vec<u8> {
         };
         out.extend_from_slice(&region[..pos]);
         cursor += pos + sup.pattern.len();
-        sup.remaining -= 1;
+        sup.remaining = sup.remaining.saturating_sub(1);
     }
     if cursor < combined.len() {
         out.extend_from_slice(&combined[cursor..]);
@@ -411,9 +420,47 @@ fn strip_ps1_echo_anchor(data: &[u8], sup: &mut Ps1EchoSuppressor) -> Vec<u8> {
     // amount of real output.
     const PENDING_LIMIT: usize = 1024;
 
-    // Prepend any bytes held back from the previous chunk so an echo split
-    // across PTY reads is reassembled before scanning.
-    let combined: Vec<u8> = if sup.pending.is_empty() {
+    let mut out: Vec<u8> = Vec::with_capacity(data.len() + 16);
+
+    // If the previous chunk left us with bytes that could still be a prefix
+    // of PRINTF_ERASE (i.e. we committed an echo strip but the trailing
+    // `\x1b[A\x1b[J` hadn't fully arrived), resolve that state first.
+    // Without this branch, those bytes would leak to the user's terminal
+    // and corrupt cursor tracking — bash/readline would think the cursor
+    // is one line below where it visually is, causing symptoms like
+    // "cursor position abnormal" and "space needs multiple presses".
+    let combined: Vec<u8> = if let Some(pending) = sup.pending_printf_erase.take() {
+        let mut v = pending;
+        v.extend_from_slice(data);
+        // We have at least 1 byte after the echo's \n. Decide whether the
+        // combined buffer confirms or refutes PRINTF_ERASE.
+        if v.len() >= PRINTF_ERASE.len() {
+            if v.starts_with(PRINTF_ERASE) {
+                // PRINTF_ERASE confirmed — strip it. This finalises the
+                // echo we partially stripped last chunk.
+                sup.remaining = sup.remaining.saturating_sub(1);
+                v[PRINTF_ERASE.len()..].to_vec()
+            } else {
+                // Enough bytes and they don't match — no PRINTF_ERASE was
+                // sent. Emit the held bytes (they're real output) and
+                // finalise the echo.
+                out.extend_from_slice(&v);
+                sup.remaining = sup.remaining.saturating_sub(1);
+                Vec::new()
+            }
+        } else if PRINTF_ERASE.starts_with(&v) {
+            // Still a strict prefix of PRINTF_ERASE — keep buffering until
+            // we can confirm or refute.
+            sup.pending_printf_erase = Some(v);
+            return out;
+        } else {
+            // Shorter than PRINTF_ERASE and not a prefix — definitely not
+            // PRINTF_ERASE. Emit and finalise.
+            out.extend_from_slice(&v);
+            sup.remaining = sup.remaining.saturating_sub(1);
+            Vec::new()
+        }
+    } else if sup.pending.is_empty() {
         data.to_vec()
     } else {
         let mut v = std::mem::take(&mut sup.pending);
@@ -425,7 +472,6 @@ fn strip_ps1_echo_anchor(data: &[u8], sup: &mut Ps1EchoSuppressor) -> Vec<u8> {
     // because the injected command can be echoed twice (local PTY echo +
     // remote bash echo). Strip each occurrence independently so neither
     // leaks to the terminal.
-    let mut out: Vec<u8> = Vec::with_capacity(combined.len());
     let mut cursor: usize = 0;
     while sup.remaining > 0 && cursor < combined.len() {
         let region = &combined[cursor..];
@@ -479,14 +525,6 @@ fn strip_ps1_echo_anchor(data: &[u8], sup: &mut Ps1EchoSuppressor) -> Vec<u8> {
         };
         let after_newline = after_anchor + newline_rel + 1;
 
-        let end = if combined.len() >= after_newline + PRINTF_ERASE.len()
-            && &combined[after_newline..after_newline + PRINTF_ERASE.len()] == PRINTF_ERASE
-        {
-            after_newline + PRINTF_ERASE.len()
-        } else {
-            after_newline
-        };
-
         let strip_start = match combined[cursor..abs_anchor]
             .iter()
             .rposition(|&b| b == b'\n')
@@ -495,10 +533,36 @@ fn strip_ps1_echo_anchor(data: &[u8], sup: &mut Ps1EchoSuppressor) -> Vec<u8> {
             None => abs_anchor,
         };
 
+        // Decide where this strip ends. Three cases:
+        //   1. PRINTF_ERASE fully present → strip through it.
+        //   2. PRINTF_ERASE refuted (enough bytes, no match) → strip
+        //      through the echo's \n only.
+        //   3. PRINTF_ERASE could still be arriving (chunk ended at or
+        //      inside a prefix of PRINTF_ERASE) → emit ERASE_LINE now,
+        //      buffer the bytes after \n, and DON'T decrement remaining.
+        //      The next chunk resolves case 1 vs 2 via the preamble above.
+        let end = if combined.len() >= after_newline + PRINTF_ERASE.len() {
+            if &combined[after_newline..after_newline + PRINTF_ERASE.len()] == PRINTF_ERASE {
+                after_newline + PRINTF_ERASE.len()
+            } else {
+                after_newline
+            }
+        } else {
+            let tail = &combined[after_newline..];
+            if PRINTF_ERASE.starts_with(tail) {
+                // Case 3: emit ERASE_LINE and buffer the pending prefix.
+                out.extend_from_slice(&combined[cursor..strip_start]);
+                out.extend_from_slice(ERASE_LINE);
+                sup.pending_printf_erase = Some(tail.to_vec());
+                return out;
+            }
+            after_newline
+        };
+
         out.extend_from_slice(&combined[cursor..strip_start]);
         out.extend_from_slice(ERASE_LINE);
         cursor = end;
-        sup.remaining -= 1;
+        sup.remaining = sup.remaining.saturating_sub(1);
     }
 
     if cursor < combined.len() {
@@ -5957,6 +6021,7 @@ mod tests {
             remaining: 0,
             started: std::time::Instant::now(),
             pending: Vec::new(),
+            pending_printf_erase: None,
         };
         let data = b"hello world\n";
         assert_eq!(strip_ps1_echo(data, &mut sup), data.to_vec());
@@ -5971,6 +6036,7 @@ mod tests {
             remaining: 2,
             started: std::time::Instant::now(),
             pending: Vec::new(),
+            pending_printf_erase: None,
         };
         // Construct an echoed chunk: leading banner + the echoed command (pattern
         // already ends with \r) + trailing prompt fragment.
@@ -5997,6 +6063,7 @@ mod tests {
             remaining: 1, // simulating local echo already consumed
             started: std::time::Instant::now(),
             pending: Vec::new(),
+            pending_printf_erase: None,
         };
         // Strip the trailing \r from pattern, simulate \r\n line ending, then escape.
         let mut data = pattern.clone();
@@ -6029,6 +6096,7 @@ mod tests {
             remaining: 2,
             started: std::time::Instant::now(),
             pending: Vec::new(),
+            pending_printf_erase: None,
         };
         let mut data = pattern.clone(); // local echo (ends with \r)
                                         // Remote echo: pattern without trailing \r, then \r\n, then escape bytes.
@@ -6055,6 +6123,7 @@ mod tests {
             remaining: 2,
             started: std::time::Instant::now(),
             pending: Vec::new(),
+            pending_printf_erase: None,
         };
         let data = b"totally unrelated output\n";
         assert_eq!(strip_ps1_echo(data, &mut sup), data.to_vec());
@@ -6074,6 +6143,7 @@ mod tests {
             remaining: 1,
             started: std::time::Instant::now(),
             pending: Vec::new(),
+            pending_printf_erase: None,
         };
         let split_at = pattern.len() / 2;
         let chunk1 = &pattern[..split_at];
@@ -6309,6 +6379,171 @@ mod tests {
             !s.contains("PROMPT_COMMAND"),
             "PROMPT_COMMAND leaked in combined chunk: {}",
             s
+        );
+    }
+
+    #[test]
+    fn test_ps1_echo_suppressor_git_aware_printf_erase_split_across_chunks() {
+        // Regression: when the bash echo's terminating \r\n arrives in one
+        // PTY read but the printf escape sequence (\x1b[A\x1b[J) arrives in
+        // the next, the suppressor must NOT commit the strip on the first
+        // chunk. Committing decrements `remaining` and lets the unanchored
+        // PRINTF_ERASE leak through in the next chunk — those bytes move the
+        // user's cursor up one line and erase to end of screen, producing
+        // wrong cursor position and "swallowed" keystrokes after SSH login.
+        let mut sup = build_ps1_echo_suppressor("v25", true);
+        let cmd = build_ps1_marker_command("v25", true);
+
+        // Chunk 1: full echo + trailing CRLF, but NO printf erase yet.
+        let mut chunk1 = cmd.clone();
+        chunk1.extend_from_slice(b"\r\n");
+        // Chunk 2: PRINTF_ERASE arrives, followed by the new prompt.
+        let mut chunk2 = b"\x1b[A\x1b[J".to_vec();
+        chunk2.extend_from_slice(b"[ssh:v25] [root@host ~]# ");
+
+        let out1 = strip_ps1_echo(&chunk1, &mut sup);
+        assert!(
+            sup.remaining >= 1,
+            "suppressor must stay armed (still expecting PRINTF_ERASE): out1={:?}, remaining={}",
+            String::from_utf8_lossy(&out1),
+            sup.remaining,
+        );
+
+        let out2 = strip_ps1_echo(&chunk2, &mut sup);
+        let s = String::from_utf8_lossy(&out2);
+        assert!(
+            !s.contains("\x1b[A\x1b[J"),
+            "PRINTF_ERASE must be stripped from chunk 2, got {:?}",
+            s,
+        );
+    }
+
+    #[test]
+    fn test_ps1_echo_suppressor_git_aware_printf_erase_partial_prefix_split() {
+        // Edge case for the PRINTF_ERASE split fix: chunk 1 ends with a
+        // partial prefix of PRINTF_ERASE (e.g. `\x1b[A` — the first 3 of 6
+        // bytes). Pending must bridge the partial prefix so chunk 2 can
+        // either complete PRINTF_ERASE (strip it) or refute it (emit it).
+        let mut sup = build_ps1_echo_suppressor("v25", true);
+        let cmd = build_ps1_marker_command("v25", true);
+
+        // Chunk 1: echo + CRLF + first 3 bytes of PRINTF_ERASE.
+        let mut chunk1 = cmd.clone();
+        chunk1.extend_from_slice(b"\r\n\x1b[A");
+        // Chunk 2: last 3 bytes of PRINTF_ERASE + new prompt.
+        let mut chunk2 = b"\x1b[J".to_vec();
+        chunk2.extend_from_slice(b"[ssh:v25] [root@host ~]# ");
+
+        let out1 = strip_ps1_echo(&chunk1, &mut sup);
+        let s1 = String::from_utf8_lossy(&out1);
+        assert!(
+            !s1.contains("\x1b[A"),
+            "partial PRINTF_ERASE prefix must not leak via chunk 1: {:?}",
+            s1,
+        );
+
+        let out2 = strip_ps1_echo(&chunk2, &mut sup);
+        let s2 = String::from_utf8_lossy(&out2);
+        assert!(
+            !s2.contains("\x1b[A\x1b[J"),
+            "PRINTF_ERASE must be stripped once completed in chunk 2: {:?}",
+            s2,
+        );
+    }
+
+    #[test]
+    fn test_ps1_echo_suppressor_git_aware_printf_erase_three_way_split() {
+        // Stress the pending_printf_erase re-buffer logic: chunk 1 ends with
+        // a strict prefix of PRINTF_ERASE, chunk 2 *also* ends with a strict
+        // prefix (extending what chunk 1 started), and only chunk 3 completes
+        // the sequence. The suppressor must keep re-buffering until it can
+        // confirm or refute — without this, an intermediate chunk would
+        // either leak bytes or decrement `remaining` at the wrong time.
+        let mut sup = build_ps1_echo_suppressor("v25", true);
+        let cmd = build_ps1_marker_command("v25", true);
+
+        // Chunk 1: echo + CRLF + byte 1 of PRINTF_ERASE (\x1b).
+        let mut chunk1 = cmd.clone();
+        chunk1.extend_from_slice(b"\r\n\x1b");
+        // Chunk 2: bytes 2-3 of PRINTF_ERASE ([A) — still a strict prefix.
+        let chunk2 = b"[A".to_vec();
+        // Chunk 3: bytes 4-6 of PRINTF_ERASE (\x1b[J) + new prompt.
+        let mut chunk3 = b"\x1b[J".to_vec();
+        chunk3.extend_from_slice(b"[ssh:v25] [root@host ~]# ");
+
+        let out1 = strip_ps1_echo(&chunk1, &mut sup);
+        assert!(
+            sup.remaining >= 1,
+            "after chunk 1 suppressor must stay armed: remaining={}, out={:?}",
+            sup.remaining,
+            String::from_utf8_lossy(&out1),
+        );
+
+        let out2 = strip_ps1_echo(&chunk2, &mut sup);
+        assert!(
+            sup.remaining >= 1,
+            "after chunk 2 (still partial prefix) suppressor must stay armed: remaining={}, out={:?}",
+            sup.remaining,
+            String::from_utf8_lossy(&out2),
+        );
+
+        let out3 = strip_ps1_echo(&chunk3, &mut sup);
+        let s3 = String::from_utf8_lossy(&out3);
+        assert!(
+            !s3.contains("\x1b[A\x1b[J"),
+            "PRINTF_ERASE must be stripped once completed in chunk 3: {:?}",
+            s3,
+        );
+    }
+
+    #[test]
+    fn test_ps1_echo_suppressor_git_aware_printf_erase_prefix_then_refute() {
+        // When chunk 1 ends with a strict prefix of PRINTF_ERASE but chunk 2
+        // arrives with bytes that DON'T extend PRINTF_ERASE, the suppressor
+        // must emit the buffered prefix verbatim (it's real output, not the
+        // escape sequence) and decrement `remaining` exactly once for the
+        // echo that was already stripped in chunk 1.
+        let mut sup = build_ps1_echo_suppressor("v25", true);
+        let cmd = build_ps1_marker_command("v25", true);
+
+        // Chunk 1: echo + CRLF + first 3 bytes of PRINTF_ERASE (\x1b[A).
+        let mut chunk1 = cmd.clone();
+        chunk1.extend_from_slice(b"\r\n\x1b[A");
+        // Chunk 2: NOT the rest of PRINTF_ERASE — starts with 'X' which
+        // refutes the match. Followed by real prompt output.
+        let mut chunk2 = b"Xreal output\n".to_vec();
+        chunk2.extend_from_slice(b"[ssh:v25] [root@host ~]# ");
+
+        let out1 = strip_ps1_echo(&chunk1, &mut sup);
+        let s1 = String::from_utf8_lossy(&out1);
+        assert!(
+            !s1.contains("\x1b[A"),
+            "partial PRINTF_ERASE prefix must not leak via chunk 1: {:?}",
+            s1,
+        );
+
+        let remaining_after_1 = sup.remaining;
+
+        let out2 = strip_ps1_echo(&chunk2, &mut sup);
+        let s2 = String::from_utf8_lossy(&out2);
+
+        // The buffered `\x1b[A` (3 bytes) must be emitted as real output
+        // because the refute proves it wasn't a PRINTF_ERASE sequence.
+        assert!(
+            s2.contains("\x1b[A"),
+            "refuted prefix bytes must be emitted as real output: {:?}",
+            s2,
+        );
+        assert!(
+            s2.contains("Xreal output"),
+            "bytes after the refuted prefix must pass through: {:?}",
+            s2,
+        );
+        // Exactly one decrement for the echo stripped in chunk 1.
+        assert_eq!(
+            sup.remaining,
+            remaining_after_1.saturating_sub(1),
+            "remaining must decrement exactly once across the refute path",
         );
     }
 

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -1385,12 +1385,24 @@ impl AishShell {
 
         let version = env!("CARGO_PKG_VERSION").to_string();
 
-        // Print welcome banner
+        // Print welcome banner with changelog
+        let changelog = aish_i18n::changelog::parse_current_changelog(&version);
         print!(
             "{}",
-            prompt::render_welcome(&version, &config.model, skill_count)
+            prompt::render_welcome(&version, &config.model, skill_count, changelog.clone())
         );
         let _ = io::stdout().flush();
+
+        // Store full changelog in expand_history so Ctrl+O can show all entries
+        // when the welcome panel truncates them with "and N more".
+        if changelog.len() > 2 {
+            let full_text = prompt::format_changelog_full(&version, &changelog);
+            let cl_title = prompt::changelog_title(&version);
+            expand_history
+                .lock()
+                .unwrap()
+                .add(format!("[changelog] {}", cl_title), full_text);
+        }
 
         // Initialize persistent PTY session
         let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));

--- a/crates/aish-shell/src/expand_history.rs
+++ b/crates/aish-shell/src/expand_history.rs
@@ -35,7 +35,15 @@ impl ExpandHistory {
 
     /// Add a new record. Returns the record index.
     /// Evicts oldest records if over the limit.
+    ///
+    /// Changelog records (command starts with `[changelog]`) are ephemeral:
+    /// they exist only to surface "what's new" before the user starts real
+    /// work. Once any real command arrives, drop them so they don't clutter
+    /// Ctrl+O history for the rest of the session.
     pub fn add(&mut self, command: String, mut output: String) -> usize {
+        if !command.starts_with("[changelog]") {
+            self.remove_changelog_records();
+        }
         if output.len() > MAX_OUTPUT_BYTES {
             let mut end = MAX_OUTPUT_BYTES;
             while end > 0 && !output.is_char_boundary(end) {
@@ -68,6 +76,12 @@ impl ExpandHistory {
     /// Whether history is empty.
     pub fn is_empty(&self) -> bool {
         self.records.is_empty()
+    }
+
+    /// Remove all changelog records (command starts with `[changelog]`).
+    pub fn remove_changelog_records(&mut self) {
+        self.records
+            .retain(|r| !r.command.starts_with("[changelog]"));
     }
 
     /// Clone all records (for use without holding the mutex).
@@ -117,5 +131,35 @@ mod tests {
         assert_eq!(h.len(), 3);
         let records = h.clone_records();
         assert_eq!(records[1].command, "cmd2");
+    }
+
+    #[test]
+    fn changelog_records_auto_evict_on_real_command() {
+        // Welcome banner stores a `[changelog] ...` record so Ctrl+O can
+        // expand "what's new". The first real command must evict it —
+        // otherwise the changelog entry lingers in history all session
+        // for users who never run AI commands.
+        let mut h = ExpandHistory::new();
+        h.add(
+            "[changelog] v0.3.4 更新内容".into(),
+            "entry1\nentry2".into(),
+        );
+        assert_eq!(h.len(), 1);
+
+        h.add("ls -la".into(), "file.txt".into());
+        let records = h.clone_records();
+        assert_eq!(records.len(), 1, "changelog record must be evicted");
+        assert_eq!(records[0].command, "ls -la");
+    }
+
+    #[test]
+    fn changelog_records_persist_when_only_changelog_added() {
+        // Adding another changelog record must NOT evict existing ones —
+        // the eviction trigger is "real command arrived", not "any add".
+        let mut h = ExpandHistory::new();
+        h.add("[changelog] v0.3.4".into(), "first".into());
+        h.add("[changelog] v0.3.5".into(), "second".into());
+        let records = h.clone_records();
+        assert_eq!(records.len(), 2, "multiple changelog records coexist");
     }
 }

--- a/crates/aish-shell/src/prompt.rs
+++ b/crates/aish-shell/src/prompt.rs
@@ -92,6 +92,54 @@ fn strip_ansi_len(s: &str) -> usize {
     len
 }
 
+/// Localized changelog title for the current version (e.g. "v0.3.4 更新内容").
+/// Shared between the welcome panel header and the Ctrl+O record title so
+/// they never drift apart.
+pub fn changelog_title(version: &str) -> String {
+    let mut args = HashMap::new();
+    args.insert("version".to_string(), format!("v{}", version));
+    t_with_args("shell.welcome2.changelog_title", &args)
+}
+
+/// Truncate a string with ANSI codes to a maximum visible length.
+///
+/// Only handles SGR sequences (`\x1b[...m`) — changelog lines use color codes
+/// only, so cursor-movement escapes are not expected here. If broader ANSI
+/// coverage is needed later, switch to a proper parser.
+fn truncate_ansi(s: &str, max_visible: usize) -> String {
+    let mut result = String::new();
+    let mut visible = 0;
+    let mut i = 0;
+    let bytes = s.as_bytes();
+    while i < bytes.len() {
+        if bytes[i] == b'\x1b' && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
+            // Find the end of the ANSI escape sequence
+            let end = bytes[i + 2..]
+                .iter()
+                .position(|&b| b == b'm')
+                .map(|p| i + 2 + p + 1);
+            if let Some(end_pos) = end {
+                result.push_str(&s[i..end_pos]);
+                i = end_pos;
+                continue;
+            }
+        }
+        let ch = s[i..].chars().next().unwrap();
+        let ch_len = ch.len_utf8();
+        // Use display width (CJK = 2 columns) so the result matches what
+        // strip_ansi_len measured — otherwise wide glyphs would still push
+        // the line past inner_width after truncation.
+        let ch_width = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+        if visible + ch_width > max_visible {
+            break;
+        }
+        result.push(ch);
+        visible += ch_width;
+        i += ch_len;
+    }
+    result
+}
+
 /// Render the shell prompt in compact.aish theme style.
 ///
 /// Format: `<mode> ~/n/x/g/aish|branch●➜ `
@@ -152,7 +200,13 @@ pub fn render_prompt(
 /// - Rounded box info panel
 /// - Quick start tips
 /// - Risk warning
-pub fn render_welcome(version: &str, model: &str, skill_count: usize) -> String {
+/// - Changelog entries (up to 2 shown; Ctrl+O expands to full list)
+pub fn render_welcome(
+    version: &str,
+    model: &str,
+    skill_count: usize,
+    changelog: Vec<aish_i18n::changelog::ChangelogEntry>,
+) -> String {
     let mut out = String::new();
     out.push('\n');
 
@@ -187,7 +241,7 @@ pub fn render_welcome(version: &str, model: &str, skill_count: usize) -> String 
     let model_hint = t("shell.welcome2.model_hint");
     let skills_suffix = t("shell.welcome2.skills_loaded_suffix");
 
-    let content_lines = vec![
+    let mut content_lines = vec![
         String::new(),
         format!(
             "  \x1b[1m{}:\x1b[0m {} \x1b[2m{}\x1b[0m",
@@ -200,6 +254,54 @@ pub fn render_welcome(version: &str, model: &str, skill_count: usize) -> String 
         ),
         String::new(),
     ];
+
+    // Changelog section (inside the panel)
+    if !changelog.is_empty() {
+        let title = changelog_title(version);
+
+        let max_entries = 2usize;
+        let entries_to_show = changelog.len().min(max_entries);
+        let has_more = changelog.len() > max_entries;
+
+        // Title line. When the panel already shows every entry, omit the
+        // "Ctrl+O 查看全部" hint — there's nothing more to expand, and the
+        // hint would mislead users into opening Ctrl+O expecting hidden
+        // entries.
+        let header = if has_more {
+            let mut hint_args = HashMap::new();
+            hint_args.insert("version".to_string(), format!("v{}", version));
+            hint_args.insert("count".to_string(), changelog.len().to_string());
+            let hint_prefix = t_with_args("shell.welcome2.changelog_hint_prefix", &hint_args);
+            let hint_suffix = t("shell.welcome2.changelog_hint_suffix");
+            format!(
+                "  \x1b[1;36m{}\x1b[0m \x1b[2m·\x1b[0m \x1b[2m{} \x1b[1;36mCtrl+O\x1b[0m\x1b[2m {}\x1b[0m",
+                title, hint_prefix, hint_suffix,
+            )
+        } else {
+            format!("  \x1b[1;36m{}\x1b[0m", title)
+        };
+        content_lines.push(header);
+
+        for entry in &changelog[..entries_to_show] {
+            let cat = entry.category.as_str();
+            let (badge, color) = match cat {
+                "Added" => ("[+]", "\x1b[32m"),
+                "Changed" => ("[*]", "\x1b[33m"),
+                "Fixed" => ("[!]", "\x1b[31m"),
+                _ => ("[-]", "\x1b[37m"),
+            };
+            let mut line = format!("  {}{} {}{}", color, badge, entry.text, "\x1b[0m");
+            let visible = strip_ansi_len(&line);
+            if visible > inner_width {
+                let truncated = truncate_ansi(&line, inner_width - 3);
+                // Re-append reset: truncate_ansi may have stopped before the
+                // trailing \x1b[0m, leaving the active color to leak into the
+                // panel padding that follows on the same rendered line.
+                line = format!("{}...\x1b[0m", truncated);
+            }
+            content_lines.push(line);
+        }
+    }
 
     // Render rounded box top with the same title as the Python panel.
     let title = format!(" {} ", header);
@@ -305,6 +407,90 @@ pub fn render_welcome(version: &str, model: &str, skill_count: usize) -> String 
     out.push_str(&format!("\x1b[2m{}\x1b[0m\n", risk));
 
     out
+}
+
+/// Format all changelog entries as plain text for Ctrl+O ExpandPanel view.
+/// No ANSI codes — ratatui renders raw escape sequences as visible text.
+/// Lines are wrapped at 76 chars to fit the panel.
+///
+/// Returns an empty `String` when `entries` is empty so the caller can skip
+/// without leaving a header-only stub in the ExpandPanel.
+pub fn format_changelog_full(
+    version: &str,
+    entries: &[aish_i18n::changelog::ChangelogEntry],
+) -> String {
+    if entries.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::new();
+
+    let title = changelog_title(version);
+    out.push_str(&title);
+    out.push_str("\n\n");
+
+    for entry in entries {
+        let badge = match entry.category.as_str() {
+            "Added" => "[+]",
+            "Changed" => "[*]",
+            "Fixed" => "[!]",
+            _ => "[-]",
+        };
+        // Wrap long descriptions to fit panel width (~76 visible chars)
+        let prefix = format!("{} ", badge);
+        let prefix_len = prefix.chars().count();
+        let max_line = 76usize.saturating_sub(prefix_len);
+        let text = &entry.text;
+        let mut first = true;
+        for chunk in wrap_text(text, max_line) {
+            if first {
+                out.push_str(&prefix);
+                out.push_str(&chunk);
+                out.push('\n');
+                first = false;
+            } else {
+                // Continuation line indented to align with badge text
+                let indent = " ".repeat(prefix_len);
+                out.push_str(&indent);
+                out.push_str(&chunk);
+                out.push('\n');
+            }
+        }
+    }
+
+    out
+}
+
+/// Wrap text at `max` characters per line, breaking at word boundaries.
+fn wrap_text(text: &str, max: usize) -> Vec<String> {
+    if text.is_empty() || max == 0 {
+        return vec![text.to_string()];
+    }
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    let mut current_len = 0;
+    for word in text.split_whitespace() {
+        let word_len = word.chars().count();
+        if current_len == 0 {
+            current.push_str(word);
+            current_len = word_len;
+        } else if current_len + 1 + word_len <= max {
+            current.push(' ');
+            current.push_str(word);
+            current_len += 1 + word_len;
+        } else {
+            lines.push(current);
+            current = word.to_string();
+            current_len = word_len;
+        }
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    if lines.is_empty() {
+        lines.push(text.to_string());
+    }
+    lines
 }
 
 #[cfg(test)]
@@ -445,6 +631,67 @@ mod tests {
     }
 
     #[test]
+    fn test_truncate_ansi_counts_display_width_for_cjk() {
+        // CJK glyphs occupy 2 terminal columns each. truncate_ansi must
+        // measure display width (matching strip_ansi_len), not char count —
+        // otherwise a "5-column" budget would let 5 CJK chars through (10
+        // visible columns), blowing past the panel boundary.
+        let s = "\x1b[32m中文字符串\x1b[0m"; // 5 CJK chars, display width 10
+        assert_eq!(strip_ansi_len(s), 10);
+        let truncated = truncate_ansi(s, 4);
+        assert_eq!(
+            strip_ansi_len(&truncated),
+            4,
+            "truncated display width must match budget, got {:?}",
+            truncated,
+        );
+        // Two CJK chars (4 columns) kept; the third would push to 6.
+        assert!(truncated.contains("中文"));
+        assert!(!truncated.contains("字"));
+    }
+
+    #[test]
+    fn test_truncate_ansi_preserves_inner_color_codes() {
+        // Color codes inside the kept prefix must be preserved verbatim so
+        // the truncated string keeps its styling up to the cut point.
+        let s = "\x1b[32mgreen\x1b[0m text overflow";
+        let truncated = truncate_ansi(s, 6);
+        assert!(
+            truncated.starts_with("\x1b[32m"),
+            "leading SGR code must be preserved: {:?}",
+            truncated,
+        );
+        assert!(
+            truncated.contains("green"),
+            "leading visible text must be preserved: {:?}",
+            truncated,
+        );
+    }
+
+    #[test]
+    fn test_render_welcome_changelog_truncated_appends_reset() {
+        // Long changelog lines get truncated to inner_width-3 chars plus
+        // "...". Without an explicit reset, the panel padding after the
+        // line would inherit the changelog entry's color. Verify the
+        // truncated line ends with \x1b[0m so the padding stays neutral.
+        let entry = aish_i18n::changelog::ChangelogEntry {
+            category: "Added".to_string(),
+            text: "X".repeat(120),
+        };
+        let result = render_welcome("0.3.5", "gpt-4", 0, vec![entry]);
+        let lines: Vec<&str> = result.lines().collect();
+        let truncated_line = lines
+            .iter()
+            .find(|line| line.contains("..."))
+            .expect("expected a truncated changelog line in the output");
+        assert!(
+            truncated_line.ends_with("\x1b[0m"),
+            "truncated line must end with reset so padding stays neutral: {:?}",
+            truncated_line,
+        );
+    }
+
+    #[test]
     fn test_render_prompt_recording_indicator() {
         let result = render_prompt("/tmp", "test-model", 0, "aish", true);
         assert!(
@@ -497,7 +744,7 @@ mod tests {
 
     #[test]
     fn test_render_welcome_contains_logo() {
-        let result = render_welcome("0.1.0", "gpt-4", 3);
+        let result = render_welcome("0.1.0", "gpt-4", 3, vec![]);
         assert!(result.contains("█████"), "should contain ASCII art logo");
         assert!(result.contains("╭"), "should contain rounded box top-left");
         assert!(result.contains("╮"), "should contain rounded box top-right");
@@ -519,7 +766,7 @@ mod tests {
 
     #[test]
     fn test_render_welcome_contains_quick_start() {
-        let result = render_welcome("0.1.0", "gpt-4", 0);
+        let result = render_welcome("0.1.0", "gpt-4", 0, vec![]);
         assert!(result.contains("•"), "should contain bullet points");
         assert!(result.contains("ls"), "should contain ls example command");
         assert!(result.contains("top"), "should contain top example command");
@@ -529,7 +776,7 @@ mod tests {
 
     #[test]
     fn test_render_welcome_uses_default_logo_color() {
-        let result = render_welcome("0.1.0", "gpt-4", 0);
+        let result = render_welcome("0.1.0", "gpt-4", 0, vec![]);
         assert!(
             !result.contains("\x1b[38;5;250m"),
             "logo should not use grayscale gradient colors"
@@ -538,7 +785,7 @@ mod tests {
 
     #[test]
     fn test_render_welcome_starts_with_blank_line() {
-        let result = render_welcome("0.1.0", "gpt-4", 0);
+        let result = render_welcome("0.1.0", "gpt-4", 0, vec![]);
         assert!(
             result.starts_with('\n'),
             "welcome banner should leave a blank line above the logo"
@@ -547,7 +794,7 @@ mod tests {
 
     #[test]
     fn test_render_welcome_aligns_quick_start_content() {
-        let result = render_welcome("0.1.0", "gpt-4", 0);
+        let result = render_welcome("0.1.0", "gpt-4", 0, vec![]);
         let item1_prefix = t("shell.welcome2.quick_start.item1_prefix");
         let item2_prefix = t("shell.welcome2.quick_start.item2_prefix");
         let item3_prefix = t("shell.welcome2.quick_start.item3_prefix");


### PR DESCRIPTION
## Summary

Two independent changes bundled here because they share a review surface and landed together.

### 1. `fix(pty)`: strip PRINTF_ERASE across PTY chunk boundaries

The PS1 echo suppressor committed its strip as soon as it saw an echo's terminating `\r\n`. When bash's trailing `printf '\33[A\33[J'` (cursor-up + erase-to-end-of-screen) arrived in the *next* PTY read, those bytes had no anchor to strip against and leaked to the user's terminal. The escape moved the cursor up one line and erased content, producing "cursor position abnormal" symptoms and swallowed keystrokes after SSH login.

Fix: a new `pending_printf_erase: Option<Vec<u8>>` field buffers a strict prefix of `PRINTF_ERASE` when the chunk ends before the full sequence arrives. The next chunk resolves one of three cases (confirm / refute / keep buffering) before decrementing `remaining`. Also switches all five `remaining -= 1` sites to `saturating_sub(1)` so a misbehaving remote that echoes the marker more than twice cannot panic on underflow.

Four regression tests: split across chunks, partial prefix split, three-way split (re-buffer path), prefix-then-refute (emit buffered + single decrement).

### 2. `feat(welcome)`: changelog panel on the welcome screen

Surface "what's new" right where users land. The panel shows up to two entries from `CHANGELOG.md` inside the existing rounded info box; when there are more, a "Ctrl+O 查看全部" hint points at the expand-history shortcut for the full list.

- New `aish-i18n::changelog` module parses the workspace-root `CHANGELOG.md` at compile time. Category-agnostic — handles the `### Removed` subsection shipped in v0.3.5.
- `prompt::render_welcome` gains a `changelog` parameter; hint is gated behind `len > max_entries` so it never teases an expand when nothing's hidden.
- `prompt::format_changelog_full` renders ANSI-free plain text for the Ctrl+O ExpandPanel (ratatui would draw raw escapes as visible text).
- `ExpandHistory::add` auto-evicts `[changelog]` records on the first real command, so they don't linger for users who never run AI commands.
- Shared `changelog_title(version)` helper keeps the panel header and the Ctrl+O record title in sync.

Three new i18n keys (`changelog_title`, `changelog_hint_prefix`, `changelog_hint_suffix`) in en-US and zh-CN.

## Test plan

- [x] `cargo test -p aish-i18n -p aish-shell -p aish-pty --lib` — 454 tests pass (includes new changelog round-trip test against real CHANGELOG.md, expand_history eviction tests, and four PTY PRINTF_ERASE split tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Branch based on `upstream/main` @ v0.3.5 (`31939c4`); rebase was clean, no upstream changes reverted
- [ ] Manual: SSH into a remote host with the marker injected, verify no cursor corruption after login
- [ ] Manual: launch aish, confirm the welcome panel shows up to 2 changelog entries with the Ctrl+O hint when there are more
- [ ] Manual: with >2 entries, press Ctrl+O, confirm the full list renders without ANSI garbage
- [ ] Manual: run a normal command (`ls`), reopen Ctrl+O, confirm the `[changelog]` record has vanished

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localized “What’s New” changelog section to the shell welcome screen, including colored category badges and an expand (Ctrl+O) hint when applicable.
  * Changelog content can now be expanded and stored for browsing via the shell history view.
* **Bug Fixes**
  * Improved terminal prompt/escape-sequence handling to prevent cursor/echo corruption when escape bytes arrive split across reads.
  * Fixed changelog parsing/display edge cases and improved history behavior so changelog entries are managed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->