### PR TITLE
feat(tools): add read-only support for bash tool

### DIFF
--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -691,6 +691,9 @@ tools:
     execute_failed: "Failed to execute: {error}"
     output_truncated: "[...{bytes} bytes truncated...]\n{tail}"
     truncated_notice: "[...{bytes} bytes truncated...]"
+    read_only:
+      blocked: "Blocked: command is not read-only ({reason})"
+      unparseable: "Blocked: command could not be analyzed as read-only"
 
   fs:
     read_file:

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -690,6 +690,9 @@ tools:
     execute_failed: "执行失败: {error}"
     output_truncated: "[...截断了 {bytes} 字节...]\n{tail}"
     truncated_notice: "[...截断了 {bytes} 字节...]"
+    read_only:
+      blocked: "已拦截：命令不是只读操作（{reason}）"
+      unparseable: "已拦截：无法将该命令判定为只读"
 
   fs:
     read_file:

--- a/crates/aish-llm/src/diagnose_agent.rs
+++ b/crates/aish-llm/src/diagnose_agent.rs
@@ -53,6 +53,13 @@ impl DiagnoseAgent {
         // Set custom system prompt for diagnosis
         sub.config.system_prompt = Some(self.system_prompt.clone());
 
+        if self.config.enforce_read_only_bash {
+            sub.inner
+                .set_tool_execution_policy(crate::ToolExecutionPolicy {
+                    enforce_read_only_bash: true,
+                });
+        }
+
         // Register tools to the underlying session
         for tool in tools {
             sub.inner.register_tool(tool);

--- a/crates/aish-llm/src/lib.rs
+++ b/crates/aish-llm/src/lib.rs
@@ -24,6 +24,7 @@ pub mod providers;
 pub mod session;
 pub mod streaming;
 pub mod subsession;
+pub mod tool_context;
 pub mod types;
 pub mod usage;
 
@@ -48,5 +49,6 @@ pub use providers::{
 pub use session::LlmSession;
 pub use streaming::{SseEvent, StreamParser};
 pub use subsession::{SubSession, SubSessionConfig};
+pub use tool_context::{ToolContext, ToolExecutionPolicy};
 pub use types::*;
 pub use usage::{TokenStats, TokenUsage};

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -289,10 +289,14 @@ impl LlmSession {
         name: &str,
         args: serde_json::Value,
     ) -> Result<ToolResult, String> {
-        match self.tools.get(name) {
-            Some(tool) => Ok(tool.as_ref().execute_async(args).await),
-            None => Err(format!("Unknown tool: {}", name)),
+        let tool = self
+            .tools
+            .get(name)
+            .ok_or_else(|| format!("Unknown tool: {}", name))?;
+        if let Some(result) = self.run_tool_preflight(name, tool.as_ref(), &args) {
+            return Ok(result);
         }
+        Ok(tool.as_ref().execute_async(args).await)
     }
 
     /// Emit an event through the callback (public for agent use).
@@ -1051,49 +1055,8 @@ impl LlmSession {
             serde_json::from_str(&tool_call.arguments).unwrap_or(serde_json::Value::Null);
 
         if let Some(tool) = self.tools.get(&tool_call.name) {
-            let ctx = crate::tool_context::ToolContext::for_session(self);
-            // Run preflight check before execution
-            match tool.preflight_with_context(&args, &ctx) {
-                PreflightResult::Allow => {}
-                PreflightResult::Confirm { message, security } => {
-                    let security = security.unwrap_or_else(|| {
-                        PreflightSecurityContext::fallback(
-                            tool_call.name.clone(),
-                            None,
-                            message.clone(),
-                            SecurityPanelMode::Confirm,
-                        )
-                    });
-                    let approved = if let Some(ref cb) = self.confirmation_callback {
-                        cb(&security)
-                    } else {
-                        true // No callback = allow (backward compatible)
-                    };
-                    if !approved {
-                        return ToolResult::error(format!("Tool execution denied: {}", message));
-                    }
-                }
-                PreflightResult::Block { message, security } => {
-                    let security = security.unwrap_or_else(|| {
-                        PreflightSecurityContext::fallback(
-                            tool_call.name.clone(),
-                            None,
-                            message.clone(),
-                            SecurityPanelMode::Blocked,
-                        )
-                    });
-                    if let Some(ref cb) = self.security_notice_callback {
-                        cb(&security);
-                    }
-                    return ToolResult {
-                        ok: false,
-                        output: format!("Blocked by security policy: {}", message),
-                        meta: Some(serde_json::json!({
-                            "dispatch_status": "short_circuit",
-                            "reason": "security_blocked"
-                        })),
-                    };
-                }
+            if let Some(result) = self.run_tool_preflight(&tool_call.name, tool.as_ref(), &args) {
+                return result;
             }
 
             self.emit_event(LlmEvent {
@@ -1262,7 +1225,63 @@ impl LlmSession {
             compact_consecutive_failures: std::sync::Mutex::new(0),
             plan_state: Arc::new(Mutex::new(PlanModeState::default())),
             token_stats: std::sync::Mutex::new(crate::usage::TokenStats::default()),
-            tool_execution_policy: crate::tool_context::ToolExecutionPolicy::default(),
+            tool_execution_policy: self.tool_execution_policy,
+        }
+    }
+
+    fn run_tool_preflight(
+        &self,
+        tool_name: &str,
+        tool: &dyn Tool,
+        args: &serde_json::Value,
+    ) -> Option<ToolResult> {
+        let ctx = crate::tool_context::ToolContext::for_session(self);
+        match tool.preflight_with_context(args, &ctx) {
+            PreflightResult::Allow => None,
+            PreflightResult::Confirm { message, security } => {
+                let security = security.unwrap_or_else(|| {
+                    PreflightSecurityContext::fallback(
+                        tool_name.to_string(),
+                        None,
+                        message.clone(),
+                        SecurityPanelMode::Confirm,
+                    )
+                });
+                let approved = if let Some(ref cb) = self.confirmation_callback {
+                    cb(&security)
+                } else {
+                    true
+                };
+                if approved {
+                    None
+                } else {
+                    Some(ToolResult::error(format!(
+                        "Tool execution denied: {}",
+                        message
+                    )))
+                }
+            }
+            PreflightResult::Block { message, security } => {
+                let security = security.unwrap_or_else(|| {
+                    PreflightSecurityContext::fallback(
+                        tool_name.to_string(),
+                        None,
+                        message.clone(),
+                        SecurityPanelMode::Blocked,
+                    )
+                });
+                if let Some(ref cb) = self.security_notice_callback {
+                    cb(&security);
+                }
+                Some(ToolResult {
+                    ok: false,
+                    output: format!("Blocked by security policy: {}", message),
+                    meta: Some(serde_json::json!({
+                        "dispatch_status": "short_circuit",
+                        "reason": "security_blocked"
+                    })),
+                })
+            }
         }
     }
 
@@ -2436,6 +2455,16 @@ mod tests {
         assert!(sub.tool_specs().is_empty());
         // Subsession has independent cancellation (not cancelled)
         assert!(!sub.cancellation_token().is_cancelled());
+    }
+
+    #[test]
+    fn test_create_subsession_inherits_tool_execution_policy() {
+        let mut session = LlmSession::new("http://localhost", "key", "model", None, None);
+        session.set_tool_execution_policy(crate::ToolExecutionPolicy {
+            enforce_read_only_bash: true,
+        });
+        let sub = session.create_subsession();
+        assert!(sub.tool_execution_policy().enforce_read_only_bash);
     }
 
     #[test]

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -49,6 +49,8 @@ pub struct LlmSession {
     plan_state: Arc<Mutex<PlanModeState>>,
     /// Cumulative token usage statistics for this session.
     token_stats: std::sync::Mutex<crate::usage::TokenStats>,
+    /// Per-session tool execution policy (read-only bash enforcement, etc.).
+    tool_execution_policy: crate::tool_context::ToolExecutionPolicy,
 }
 
 impl LlmSession {
@@ -77,7 +79,16 @@ impl LlmSession {
             compact_consecutive_failures: std::sync::Mutex::new(0),
             plan_state: Arc::new(Mutex::new(PlanModeState::default())),
             token_stats: std::sync::Mutex::new(crate::usage::TokenStats::default()),
+            tool_execution_policy: crate::tool_context::ToolExecutionPolicy::default(),
         }
+    }
+
+    pub fn tool_execution_policy(&self) -> crate::tool_context::ToolExecutionPolicy {
+        self.tool_execution_policy
+    }
+
+    pub fn set_tool_execution_policy(&mut self, policy: crate::tool_context::ToolExecutionPolicy) {
+        self.tool_execution_policy = policy;
     }
 
     pub fn register_tool(&mut self, tool: Box<dyn Tool>) {
@@ -1040,8 +1051,9 @@ impl LlmSession {
             serde_json::from_str(&tool_call.arguments).unwrap_or(serde_json::Value::Null);
 
         if let Some(tool) = self.tools.get(&tool_call.name) {
+            let ctx = crate::tool_context::ToolContext::for_session(self);
             // Run preflight check before execution
-            match tool.preflight(&args) {
+            match tool.preflight_with_context(&args, &ctx) {
                 PreflightResult::Allow => {}
                 PreflightResult::Confirm { message, security } => {
                     let security = security.unwrap_or_else(|| {
@@ -1250,6 +1262,7 @@ impl LlmSession {
             compact_consecutive_failures: std::sync::Mutex::new(0),
             plan_state: Arc::new(Mutex::new(PlanModeState::default())),
             token_stats: std::sync::Mutex::new(crate::usage::TokenStats::default()),
+            tool_execution_policy: crate::tool_context::ToolExecutionPolicy::default(),
         }
     }
 

--- a/crates/aish-llm/src/subsession.rs
+++ b/crates/aish-llm/src/subsession.rs
@@ -131,6 +131,7 @@ mod tests {
         assert_eq!(config.max_context_messages, 50);
         assert_eq!(config.max_iterations, 10);
         assert!(config.system_prompt.is_none());
+        assert!(!config.enforce_read_only_bash);
     }
 
     #[test]

--- a/crates/aish-llm/src/subsession.rs
+++ b/crates/aish-llm/src/subsession.rs
@@ -16,6 +16,8 @@ pub struct SubSessionConfig {
     pub max_iterations: usize,
     /// Optional custom system prompt.
     pub system_prompt: Option<String>,
+    /// When true, bash tool preflight blocks non-read-only commands.
+    pub enforce_read_only_bash: bool,
 }
 
 impl Default for SubSessionConfig {
@@ -24,6 +26,7 @@ impl Default for SubSessionConfig {
             max_context_messages: 50,
             max_iterations: 10,
             system_prompt: None,
+            enforce_read_only_bash: false,
         }
     }
 }
@@ -136,10 +139,12 @@ mod tests {
             max_context_messages: 100,
             max_iterations: 20,
             system_prompt: Some("Custom prompt".to_string()),
+            enforce_read_only_bash: true,
         };
         assert_eq!(config.max_context_messages, 100);
         assert_eq!(config.max_iterations, 20);
         assert_eq!(config.system_prompt, Some("Custom prompt".to_string()));
+        assert!(config.enforce_read_only_bash);
     }
 
     #[test]

--- a/crates/aish-llm/src/tool_context.rs
+++ b/crates/aish-llm/src/tool_context.rs
@@ -1,0 +1,33 @@
+use crate::session::LlmSession;
+
+/// Tool execution policy for the current session context.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ToolExecutionPolicy {
+    /// When true, bash preflight blocks commands that are not read-only.
+    pub enforce_read_only_bash: bool,
+}
+
+/// Context passed to tools during preflight and execution.
+pub struct ToolContext<'a> {
+    pub session: &'a LlmSession,
+    pub parent: Option<&'a LlmSession>,
+    pub policy: ToolExecutionPolicy,
+}
+
+impl<'a> ToolContext<'a> {
+    pub fn for_session(session: &'a LlmSession) -> Self {
+        Self {
+            session,
+            parent: None,
+            policy: session.tool_execution_policy(),
+        }
+    }
+
+    pub fn with_policy(session: &'a LlmSession, policy: ToolExecutionPolicy) -> Self {
+        Self {
+            session,
+            parent: None,
+            policy,
+        }
+    }
+}

--- a/crates/aish-llm/src/types.rs
+++ b/crates/aish-llm/src/types.rs
@@ -526,6 +526,16 @@ pub trait Tool: Send + Sync {
         PreflightResult::Allow
     }
 
+    /// Context-aware preflight. Default delegates to [`Self::preflight`].
+    fn preflight_with_context(
+        &self,
+        args: &serde_json::Value,
+        ctx: &crate::tool_context::ToolContext<'_>,
+    ) -> PreflightResult {
+        let _ = ctx;
+        self.preflight(args)
+    }
+
     fn execute(&self, args: serde_json::Value) -> ToolResult;
 
     /// Async variant of `execute`. The default implementation delegates to the

--- a/crates/aish-llm/tests/llm_integration_test.rs
+++ b/crates/aish-llm/tests/llm_integration_test.rs
@@ -130,6 +130,7 @@ fn test_diagnose_agent_construction() {
         max_iterations: 20,
         max_context_messages: 100,
         system_prompt: Some("Custom prompt".to_string()),
+        enforce_read_only_bash: false,
     };
     let _agent2 = DiagnoseAgent::with_config(config);
 }
@@ -165,6 +166,7 @@ fn test_subsession_custom_config() {
         max_context_messages: 100,
         max_iterations: 20,
         system_prompt: Some("Custom system prompt".to_string()),
+        enforce_read_only_bash: false,
     };
     assert_eq!(config.max_context_messages, 100);
     assert_eq!(config.max_iterations, 20);

--- a/crates/aish-shell/src/ai_handler.rs
+++ b/crates/aish-shell/src/ai_handler.rs
@@ -374,6 +374,7 @@ impl AiHandler {
             max_context_messages: 30,
             max_iterations: 10,
             system_prompt: Some(system_prompt),
+            enforce_read_only_bash: true,
         };
 
         let agent = DiagnoseAgent::with_config(config);
@@ -1089,91 +1090,6 @@ fn parse_diagnose_confidence(s: &str) -> DiagnoseConfidence {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ReadonlyVerdict {
-    pub allowed: bool,
-    pub reason: Option<String>,
-}
-
-pub(crate) fn readonly_command_verdict(command: &str) -> ReadonlyVerdict {
-    let trimmed = command.trim();
-    if trimmed.is_empty() {
-        return ReadonlyVerdict {
-            allowed: false,
-            reason: Some("empty command".into()),
-        };
-    }
-
-    for segment in split_command_segments(trimmed) {
-        let seg = segment.trim();
-        if seg.is_empty() {
-            continue;
-        }
-        if let Some(reason) = non_readonly_segment_reason(seg) {
-            return ReadonlyVerdict {
-                allowed: false,
-                reason: Some(reason),
-            };
-        }
-    }
-
-    ReadonlyVerdict {
-        allowed: true,
-        reason: None,
-    }
-}
-
-fn split_command_segments(command: &str) -> Vec<String> {
-    let mut segments = vec![command.to_string()];
-    for sep in [";", "&&", "||", "|"] {
-        segments = segments
-            .into_iter()
-            .flat_map(|s| s.split(sep).map(|p| p.to_string()).collect::<Vec<_>>())
-            .collect();
-    }
-    segments
-}
-
-fn non_readonly_segment_reason(segment: &str) -> Option<String> {
-    let lower = segment.to_lowercase();
-    if lower.contains('>') && !lower.contains("/dev/null") {
-        return Some("write redirect".into());
-    }
-    if lower.contains("<<") && !lower.contains("/dev/null") {
-        return Some("heredoc write".into());
-    }
-
-    let first = segment.split_whitespace().next().unwrap_or("");
-    let base = first.rsplit('/').next().unwrap_or(first).to_lowercase();
-
-    const BLOCKED: &[&str] = &[
-        "rm", "mv", "cp", "chmod", "chown", "mkdir", "touch", "tee", "truncate", "install", "apt",
-        "yum", "dnf", "pip", "npm", "cargo", "sed", "vim", "vi", "nano", "reboot", "shutdown",
-        "kill", "pkill", "killall",
-    ];
-    if BLOCKED.iter().any(|b| base == *b) {
-        return Some(format!("blocked command: {base}"));
-    }
-
-    if base == "systemctl" || base == "service" {
-        for token in segment.split_whitespace().skip(1) {
-            let t = token.to_lowercase();
-            if matches!(
-                t.as_str(),
-                "start" | "stop" | "restart" | "reload" | "enable" | "disable"
-            ) {
-                return Some(format!("service control: {t}"));
-            }
-        }
-    }
-
-    if base == "sed" && lower.contains("-i") {
-        return Some("in-place edit".into());
-    }
-
-    None
-}
-
 /// Map a verification command's exit code and output to pass/fail.
 pub(crate) fn verify_outcome_from_execution(exit_code: i32, output: &str) -> VerifyOutcome {
     let effective = aish_pty::exit_code::infer_exit_code_from_output(exit_code, output);
@@ -1722,10 +1638,22 @@ mod tests {
 
     #[test]
     fn test_readonly_command_guard() {
-        assert!(readonly_command_verdict("systemctl status nginx").allowed);
-        assert!(readonly_command_verdict("which foo").allowed);
-        assert!(!readonly_command_verdict("systemctl restart nginx").allowed);
-        assert!(!readonly_command_verdict("rm -rf /").allowed);
+        use aish_tools::bash::{BashTool, ReadOnlyVerdict};
+
+        assert!(BashTool::is_read_only("systemctl status nginx"));
+        assert_eq!(
+            BashTool::classify_read_only("systemctl status nginx"),
+            ReadOnlyVerdict::ReadOnly
+        );
+        assert!(BashTool::is_read_only("which foo"));
+        assert!(matches!(
+            BashTool::classify_read_only("systemctl restart nginx"),
+            ReadOnlyVerdict::NotReadOnly { .. }
+        ));
+        assert!(matches!(
+            BashTool::classify_read_only("rm -rf /"),
+            ReadOnlyVerdict::NotReadOnly { .. }
+        ));
     }
 
     #[test]

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -109,6 +109,17 @@ fn truncate_ssh_history(h: &mut Vec<ChatMessage>) {
     }
 }
 
+/// ReAct sub-sessions (`/diagnose`, `system_diagnose_agent`) tag events with this source.
+/// Their UI should keep one thinking spinner for the whole `OpStart`..`OpEnd` window.
+fn react_agent_llm_event(event: &LlmEvent) -> bool {
+    event
+        .metadata
+        .as_ref()
+        .and_then(|meta| meta.get("source"))
+        .and_then(|value| value.as_str())
+        == Some("react_agent")
+}
+
 fn context_compaction_notice(event: &LlmEvent) -> Option<String> {
     let changed = event
         .data
@@ -974,6 +985,7 @@ impl AishShell {
                             }
                         }
                     }
+                    LlmEventType::GenerationStart if react_agent_llm_event(&event) => {}
                     LlmEventType::GenerationStart => {
                         compaction_active_ref.store(false, Ordering::SeqCst);
                         animation_ref.stop();
@@ -990,6 +1002,7 @@ impl AishShell {
                         renderer_ref.lock().unwrap().reset();
                         animation_ref.start(&t("shell.status.thinking"));
                     }
+                    LlmEventType::GenerationEnd if react_agent_llm_event(&event) => {}
                     LlmEventType::GenerationEnd => {
                         animation_ref.stop();
                         clear_reasoning();
@@ -1132,8 +1145,10 @@ impl AishShell {
                     }
                     LlmEventType::ToolExecutionStart => {
                         if let Some(name) = event.data.get("tool_name").and_then(|n| n.as_str()) {
-                            animation_ref.stop();
-                            clear_reasoning();
+                            if !react_agent_llm_event(&event) {
+                                animation_ref.stop();
+                                clear_reasoning();
+                            }
                             let args_preview = event
                                 .data
                                 .get("tool_args")
@@ -2501,11 +2516,12 @@ impl AishShell {
     fn handle_failure_diagnose_command(&mut self) {
         use crate::ai_handler::{
             effective_verify_exit_code, format_failure_diagnose_error,
-            print_failure_diagnose_report, readonly_command_verdict,
-            summarize_verification_conclusion, verify_outcome_from_execution, DiagnoseParseOutcome,
-            FailureDiagnoseConclusion, VerifyOutcome, VerifyStepResult,
+            print_failure_diagnose_report, summarize_verification_conclusion,
+            verify_outcome_from_execution, DiagnoseParseOutcome, FailureDiagnoseConclusion,
+            VerifyOutcome, VerifyStepResult,
         };
         use aish_i18n::{t, t_with_args};
+        use aish_tools::bash::{BashTool, ReadOnlyVerdict};
         use std::collections::HashMap;
 
         if !self.state.can_correct_error {
@@ -2604,9 +2620,13 @@ impl AishShell {
             println!("{}", t("shell.failure_diagnose.verifying"));
             let mut steps = Vec::new();
             for verify_cmd in &report.verify_commands {
-                let verdict = readonly_command_verdict(verify_cmd);
-                if !verdict.allowed {
-                    let reason = verdict.reason.unwrap_or_else(|| "non-readonly".to_string());
+                let verdict = BashTool::classify_read_only(verify_cmd);
+                if !matches!(verdict, ReadOnlyVerdict::ReadOnly) {
+                    let reason = match verdict {
+                        ReadOnlyVerdict::NotReadOnly { reason } => reason,
+                        ReadOnlyVerdict::Unparseable => "unparseable command".to_string(),
+                        ReadOnlyVerdict::ReadOnly => unreachable!(),
+                    };
                     println!(
                         "{}",
                         t_with_args(
@@ -3862,6 +3882,7 @@ impl AishShell {
                                     }
                                 }
                             }
+                            LlmEventType::GenerationStart if react_agent_llm_event(&event) => {}
                             LlmEventType::GenerationStart => {
                                 compaction_active.store(false, std::sync::atomic::Ordering::SeqCst);
                                 anim.stop();
@@ -3872,6 +3893,7 @@ impl AishShell {
                                 reasoning_buf.lock().unwrap().clear();
                                 anim.start(&t("shell.status.thinking"));
                             }
+                            LlmEventType::GenerationEnd if react_agent_llm_event(&event) => {}
                             LlmEventType::GenerationEnd => {
                                 anim.stop();
                                 clear_reasoning();
@@ -4762,6 +4784,7 @@ impl AishShell {
                                     }
                                 }
                             }
+                            LlmEventType::GenerationStart if react_agent_llm_event(&event) => {}
                             LlmEventType::GenerationStart => {
                                 compaction_active.store(false, std::sync::atomic::Ordering::SeqCst);
                                 anim.stop();
@@ -4772,6 +4795,7 @@ impl AishShell {
                                 reasoning_buf.lock().unwrap().clear();
                                 anim.start(&t("shell.status.thinking"));
                             }
+                            LlmEventType::GenerationEnd if react_agent_llm_event(&event) => {}
                             LlmEventType::GenerationEnd => {
                                 anim.stop();
                                 clear_reasoning();

--- a/crates/aish-tools/src/bash/bash.rs
+++ b/crates/aish-tools/src/bash/bash.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use aish_i18n;
 use aish_llm::{
     CancellationToken, PreflightResult, PreflightSecurityContext, SecurityPanelMode, Tool,
-    ToolResult,
+    ToolContext, ToolResult,
 };
 use aish_pty::{BashOffloadSettings, BashOutputOffload, CancelToken, PtyExecutor};
 use aish_security::{
@@ -14,6 +14,7 @@ use aish_security::{
 };
 
 use super::prompt;
+use super::read_only::{self, preflight_enforce, ReadOnlyVerdict};
 
 /// Large keep_bytes for the silent PTY executor to capture full command output.
 /// The BashOutputOffload will handle threshold-based truncation and disk offload.
@@ -174,6 +175,26 @@ fn security_preflight_with_socket(
     PreflightResult::Allow
 }
 
+fn bash_preflight(
+    tool: &BashTool,
+    args: &serde_json::Value,
+    enforce_read_only_bash: bool,
+) -> PreflightResult {
+    let Some(command) = args.get("command").and_then(|c| c.as_str()) else {
+        return PreflightResult::Allow;
+    };
+
+    // Restore secret placeholders so security checks run on the actual command.
+    let (command, _) = tool.restore_secrets(command);
+
+    if let Some(result) = preflight_enforce(&command, enforce_read_only_bash) {
+        return result;
+    }
+
+    let cwd = std::env::current_dir().ok();
+    security_preflight(&command, cwd.as_deref(), None)
+}
+
 fn format_security_message(decision: &SecurityDecision) -> String {
     if let Some(confirm_message) = decision.analysis.confirm_message.as_deref() {
         let trimmed = confirm_message.trim();
@@ -245,6 +266,16 @@ impl BashTool {
             pty_slot: Arc::new(Mutex::new(None)),
             secret_vault: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// Whether a command is read-only in the literal shell sense.
+    pub fn is_read_only(command: &str) -> bool {
+        read_only::is_read_only(command)
+    }
+
+    /// Classify a command for read-only semantics.
+    pub fn classify_read_only(command: &str) -> ReadOnlyVerdict {
+        read_only::classify(command)
     }
 
     /// Set the shared cancellation token from the AI handler.
@@ -490,15 +521,15 @@ impl Tool for BashTool {
     }
 
     fn preflight(&self, args: &serde_json::Value) -> PreflightResult {
-        let Some(command) = args.get("command").and_then(|c| c.as_str()) else {
-            return PreflightResult::Allow;
-        };
+        bash_preflight(self, args, false)
+    }
 
-        // Restore secret placeholders so security checks run on the actual command.
-        let (command, _) = self.restore_secrets(command);
-
-        let cwd = std::env::current_dir().ok();
-        security_preflight(&command, cwd.as_deref(), None)
+    fn preflight_with_context(
+        &self,
+        args: &serde_json::Value,
+        ctx: &ToolContext<'_>,
+    ) -> PreflightResult {
+        bash_preflight(self, args, ctx.policy.enforce_read_only_bash)
     }
 
     fn execute(&self, args: serde_json::Value) -> ToolResult {
@@ -752,6 +783,20 @@ mod tests {
             }
             other => panic!("unexpected preflight result: {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_bash_tool_preflight_blocks_non_readonly_when_enforced() {
+        let tool = BashTool::new();
+        let session = aish_llm::LlmSession::new("http://localhost", "key", "model", None, None);
+        let ctx = aish_llm::ToolContext::with_policy(
+            &session,
+            aish_llm::ToolExecutionPolicy {
+                enforce_read_only_bash: true,
+            },
+        );
+        let result = tool.preflight_with_context(&serde_json::json!({"command": "rm -rf /"}), &ctx);
+        assert!(matches!(result, PreflightResult::Block { .. }));
     }
 
     #[test]

--- a/crates/aish-tools/src/bash/bash.rs
+++ b/crates/aish-tools/src/bash/bash.rs
@@ -799,6 +799,21 @@ mod tests {
         assert!(matches!(result, PreflightResult::Block { .. }));
     }
 
+    #[tokio::test]
+    async fn test_execute_tool_by_name_blocks_non_readonly_when_enforced() {
+        let mut session = aish_llm::LlmSession::new("http://localhost", "key", "model", None, None);
+        session.set_tool_execution_policy(aish_llm::ToolExecutionPolicy {
+            enforce_read_only_bash: true,
+        });
+        session.register_tool(Box::new(BashTool::new()));
+        let result = session
+            .execute_tool_by_name("bash", serde_json::json!({"command": "rm -rf /"}))
+            .await
+            .expect("bash tool should be registered");
+        assert!(!result.ok);
+        assert!(result.output.contains("Blocked by security policy"));
+    }
+
     #[test]
     fn test_bash_tool_preflight_allows_low_risk_commands() {
         let dir = tempdir().unwrap();

--- a/crates/aish-tools/src/bash/read_only.rs
+++ b/crates/aish-tools/src/bash/read_only.rs
@@ -24,19 +24,18 @@ pub fn classify(command: &str) -> ReadOnlyVerdict {
         return ReadOnlyVerdict::Unparseable;
     }
 
-    let (stripped, _sudo_detected, sudo_ok) = strip_sudo_prefix(trimmed);
-    if !sudo_ok {
-        return ReadOnlyVerdict::Unparseable;
-    }
-    let effective = stripped.trim();
-    if effective.is_empty() {
-        return ReadOnlyVerdict::Unparseable;
-    }
-
-    for segment in split_compound_segments(effective) {
+    for segment in split_compound_segments(trimmed) {
         let seg = segment.trim();
         if seg.is_empty() {
             continue;
+        }
+        let (stripped, _sudo_detected, sudo_ok) = strip_sudo_prefix(seg);
+        if !sudo_ok {
+            return ReadOnlyVerdict::Unparseable;
+        }
+        let seg = stripped.trim();
+        if seg.is_empty() {
+            return ReadOnlyVerdict::Unparseable;
         }
         if let Some(reason) = non_readonly_segment_reason(seg) {
             return ReadOnlyVerdict::NotReadOnly { reason };
@@ -94,7 +93,7 @@ fn split_compound_segments(command: &str) -> Vec<String> {
             current.push(ch);
             continue;
         }
-        if ch == '\\' && !in_single_quote && in_double_quote {
+        if ch == '\\' && !in_single_quote {
             current.push(ch);
             if let Some(next) = chars.next() {
                 current.push(next);
@@ -218,6 +217,14 @@ fn scan_outside_quotes(segment: &str, mut predicate: impl FnMut(&str) -> bool) -
 
     while index < segment.len() {
         let ch = segment[index..].chars().next().expect("valid utf8");
+        if ch == '\\' && !in_single_quote {
+            index += ch.len_utf8();
+            if index < segment.len() {
+                let next = segment[index..].chars().next().expect("valid utf8");
+                index += next.len_utf8();
+            }
+            continue;
+        }
         if ch == '\'' && !in_double_quote {
             in_single_quote = !in_single_quote;
             index += ch.len_utf8();
@@ -336,6 +343,18 @@ mod tests {
     fn sudo_stripped_before_analysis() {
         assert_read_only("sudo systemctl status nginx");
         assert_not_read_only("sudo rm -rf /");
+    }
+
+    #[test]
+    fn sudo_in_later_compound_segment_is_stripped() {
+        assert_not_read_only("ls && sudo rm -rf /tmp/x");
+        assert_not_read_only("true; sudo touch /tmp/x");
+    }
+
+    #[test]
+    fn escaped_quotes_do_not_hide_writes_or_separators() {
+        assert_not_read_only(r"echo \' > /tmp/a");
+        assert_not_read_only(r"echo \' ; rm -rf /tmp/a");
     }
 
     #[test]

--- a/crates/aish-tools/src/bash/read_only.rs
+++ b/crates/aish-tools/src/bash/read_only.rs
@@ -23,6 +23,11 @@ pub fn classify(command: &str) -> ReadOnlyVerdict {
     if trimmed.is_empty() {
         return ReadOnlyVerdict::Unparseable;
     }
+    if has_background_operator(trimmed) {
+        return ReadOnlyVerdict::NotReadOnly {
+            reason: "background job".into(),
+        };
+    }
 
     for segment in split_compound_segments(trimmed) {
         let seg = segment.trim();
@@ -144,11 +149,44 @@ fn split_compound_segments(command: &str) -> Vec<String> {
     segments
 }
 
+fn has_background_operator(command: &str) -> bool {
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut chars = command.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\'' && !in_double_quote {
+            in_single_quote = !in_single_quote;
+            continue;
+        }
+        if ch == '"' && !in_single_quote {
+            in_double_quote = !in_double_quote;
+            continue;
+        }
+        if ch == '\\' && !in_single_quote {
+            chars.next();
+            continue;
+        }
+        if !in_single_quote && !in_double_quote && ch == '&' {
+            if chars.peek() == Some(&'&') {
+                chars.next();
+                continue;
+            }
+            return true;
+        }
+    }
+
+    false
+}
+
 fn non_readonly_segment_reason(segment: &str) -> Option<String> {
     if scan_outside_quotes(segment, |window| {
-        window.starts_with("$(") || window.starts_with('`')
+        window.starts_with("$(")
+            || window.starts_with('`')
+            || window.starts_with("<(")
+            || window.starts_with(">(")
     }) {
-        return Some("command substitution".into());
+        return Some("command or process substitution".into());
     }
     if scan_outside_quotes(segment, |window| window.starts_with('*')) {
         return Some("unquoted glob".into());
@@ -172,8 +210,16 @@ fn non_readonly_segment_reason(segment: &str) -> Option<String> {
         return Some("heredoc write".into());
     }
 
-    let first = segment.split_whitespace().next().unwrap_or("");
-    let base = first.rsplit('/').next().unwrap_or(first).to_lowercase();
+    let tokens = tokenize_shell_words(segment);
+    let first = tokens
+        .first()
+        .map(|token| normalize_shell_word(token))
+        .unwrap_or_default();
+    let base = first
+        .rsplit('/')
+        .next()
+        .unwrap_or(&first)
+        .to_ascii_lowercase();
 
     const BLOCKED: &[&str] = &[
         "rm", "mv", "cp", "chmod", "chown", "mkdir", "touch", "tee", "truncate", "install", "ln",
@@ -196,8 +242,15 @@ fn non_readonly_segment_reason(segment: &str) -> Option<String> {
         }
     }
 
-    if base == "find" && segment.to_lowercase().contains("-delete") {
-        return Some("find delete".into());
+    if base == "find"
+        && tokens.iter().any(|token| {
+            matches!(
+                token.to_ascii_lowercase().as_str(),
+                "-delete" | "-exec" | "-execdir" | "-ok" | "-okdir"
+            )
+        })
+    {
+        return Some("find mutating or command execution".into());
     }
 
     if base == "curl" && curl_writes_or_mutates(segment) {
@@ -464,6 +517,33 @@ fn unquote_shell_word(word: &str) -> String {
     }
 }
 
+fn normalize_shell_word(word: &str) -> String {
+    let mut out = String::new();
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut chars = word.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\'' && !in_double_quote {
+            in_single_quote = !in_single_quote;
+            continue;
+        }
+        if ch == '"' && !in_single_quote {
+            in_double_quote = !in_double_quote;
+            continue;
+        }
+        if ch == '\\' && !in_single_quote {
+            if let Some(next) = chars.next() {
+                out.push(next);
+            }
+            continue;
+        }
+        out.push(ch);
+    }
+
+    out
+}
+
 fn scan_outside_quotes(segment: &str, mut predicate: impl FnMut(&str) -> bool) -> bool {
     let mut in_single_quote = false;
     let mut in_double_quote = false;
@@ -641,6 +721,28 @@ mod tests {
     #[test]
     fn blocks_background_job_segments() {
         assert_not_read_only("sleep 1 & rm -rf /tmp/x");
+    }
+
+    #[test]
+    fn blocks_trailing_background_operator() {
+        assert_not_read_only("sleep 9999 &");
+    }
+
+    #[test]
+    fn blocks_find_exec_and_ok() {
+        assert_not_read_only("find . -exec rm {} \\;");
+        assert_not_read_only("find . -ok rm {} \\;");
+    }
+
+    #[test]
+    fn blocks_escaped_command_names() {
+        assert_not_read_only(r"r\m -rf /tmp/x");
+        assert_not_read_only(r"'r'm -rf /tmp/x");
+    }
+
+    #[test]
+    fn blocks_process_substitution() {
+        assert_not_read_only("cat <(rm -rf /tmp/x)");
     }
 
     #[test]

--- a/crates/aish-tools/src/bash/read_only.rs
+++ b/crates/aish-tools/src/bash/read_only.rs
@@ -40,6 +40,9 @@ pub fn classify(command: &str) -> ReadOnlyVerdict {
         if let Some(reason) = non_readonly_segment_reason(seg) {
             return ReadOnlyVerdict::NotReadOnly { reason };
         }
+        if let Some(verdict) = wrapper_or_subshell_verdict(seg) {
+            return verdict;
+        }
     }
 
     ReadOnlyVerdict::ReadOnly
@@ -102,6 +105,17 @@ fn split_compound_segments(command: &str) -> Vec<String> {
         }
 
         if !in_single_quote && !in_double_quote {
+            if ch == '&' {
+                if chars.peek() == Some(&'&') {
+                    chars.next();
+                    segments.push(current.clone());
+                    current.clear();
+                    continue;
+                }
+                segments.push(current.clone());
+                current.clear();
+                continue;
+            }
             if ch == ';' {
                 segments.push(current.clone());
                 current.clear();
@@ -114,12 +128,6 @@ fn split_compound_segments(command: &str) -> Vec<String> {
                     current.clear();
                     continue;
                 }
-                segments.push(current.clone());
-                current.clear();
-                continue;
-            }
-            if ch == '&' && chars.peek() == Some(&'&') {
-                chars.next();
                 segments.push(current.clone());
                 current.clear();
                 continue;
@@ -169,8 +177,8 @@ fn non_readonly_segment_reason(segment: &str) -> Option<String> {
 
     const BLOCKED: &[&str] = &[
         "rm", "mv", "cp", "chmod", "chown", "mkdir", "touch", "tee", "truncate", "install", "ln",
-        "apt", "yum", "dnf", "pip", "npm", "cargo", "sed", "vim", "vi", "nano", "reboot",
-        "shutdown", "kill", "pkill", "killall",
+        "apt", "yum", "dnf", "pip", "npm", "cargo", "vim", "vi", "nano", "reboot", "shutdown",
+        "kill", "pkill", "killall",
     ];
     if BLOCKED.iter().any(|b| base == *b) {
         return Some(format!("blocked command: {base}"));
@@ -192,14 +200,8 @@ fn non_readonly_segment_reason(segment: &str) -> Option<String> {
         return Some("find delete".into());
     }
 
-    if base == "curl" {
-        let lower = segment.to_lowercase();
-        if lower.contains("-x post") || lower.contains("-xput") || lower.contains("-x delete") {
-            return Some("curl mutating method".into());
-        }
-        if lower.contains(" -o ") || lower.contains(" --output ") {
-            return Some("curl output file".into());
-        }
+    if base == "curl" && curl_writes_or_mutates(segment) {
+        return Some("curl mutating or output write".into());
     }
 
     let lower = segment.to_lowercase();
@@ -208,6 +210,258 @@ fn non_readonly_segment_reason(segment: &str) -> Option<String> {
     }
 
     None
+}
+
+fn curl_writes_or_mutates(segment: &str) -> bool {
+    let compact = segment
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect::<String>()
+        .to_ascii_lowercase();
+    if compact.contains("-xpost")
+        || compact.contains("-xput")
+        || compact.contains("-xdelete")
+        || compact.contains("-xpatch")
+    {
+        return true;
+    }
+    let lower = segment.to_ascii_lowercase();
+    if lower.contains("--request") {
+        let rest = lower.split("--request").nth(1).unwrap_or("");
+        let method = rest.split_whitespace().next().unwrap_or("");
+        if matches!(
+            method,
+            "post" | "put" | "delete" | "patch" | "connect" | "trace"
+        ) {
+            return true;
+        }
+    }
+    for token in tokenize_shell_words(segment).iter().skip(1) {
+        let t = token.to_ascii_lowercase();
+        if t == "-d" || t == "--data" || t == "--data-raw" || t == "--data-binary" {
+            return true;
+        }
+        if t == "-o" || t == "--output" {
+            return true;
+        }
+        if let Some(path) = t.strip_prefix("-o") {
+            if !path.is_empty() {
+                return true;
+            }
+        }
+        if let Some(path) = t.strip_prefix("--output=") {
+            if !path.is_empty() {
+                return true;
+            }
+        }
+        if let Some(method) = t.strip_prefix("-x") {
+            if matches!(
+                method,
+                "post" | "put" | "delete" | "patch" | "connect" | "trace"
+            ) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn wrapper_or_subshell_verdict(segment: &str) -> Option<ReadOnlyVerdict> {
+    if let Some(inner) = extract_subshell_inner(segment) {
+        return propagate_inner_verdict(&inner);
+    }
+
+    match extract_wrapper_script(segment) {
+        None => None,
+        Some(WrapperScript::Unparseable) => Some(ReadOnlyVerdict::Unparseable),
+        Some(WrapperScript::WithoutScript) => Some(ReadOnlyVerdict::NotReadOnly {
+            reason: "shell or interpreter wrapper".into(),
+        }),
+        Some(WrapperScript::Script(script)) => propagate_inner_verdict(&script),
+    }
+}
+
+fn propagate_inner_verdict(inner: &str) -> Option<ReadOnlyVerdict> {
+    match classify(inner) {
+        ReadOnlyVerdict::ReadOnly => None,
+        other => Some(other),
+    }
+}
+
+enum WrapperScript {
+    WithoutScript,
+    Unparseable,
+    Script(String),
+}
+
+fn extract_subshell_inner(segment: &str) -> Option<String> {
+    let trimmed = segment.trim();
+    if !trimmed.starts_with('(') {
+        return None;
+    }
+    let mut depth = 0i32;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut end_index = None;
+
+    for (index, ch) in trimmed.char_indices() {
+        if ch == '\'' && !in_double_quote {
+            in_single_quote = !in_single_quote;
+            continue;
+        }
+        if ch == '"' && !in_single_quote {
+            in_double_quote = !in_double_quote;
+            continue;
+        }
+        if in_single_quote || in_double_quote {
+            continue;
+        }
+        if ch == '(' {
+            depth += 1;
+        } else if ch == ')' {
+            depth -= 1;
+            if depth == 0 {
+                end_index = Some(index);
+                break;
+            }
+        }
+    }
+
+    let end = end_index?;
+    if trimmed[end + ')'.len_utf8()..].trim().is_empty() {
+        Some(trimmed[1..end].trim().to_string())
+    } else {
+        None
+    }
+}
+
+fn extract_wrapper_script(segment: &str) -> Option<WrapperScript> {
+    let tokens = tokenize_shell_words(segment);
+    if tokens.is_empty() {
+        return None;
+    }
+    let base = tokens[0]
+        .rsplit('/')
+        .next()
+        .unwrap_or(&tokens[0])
+        .to_ascii_lowercase();
+
+    const SHELL_WRAPPERS: &[&str] = &["bash", "sh", "dash", "zsh", "fish", "ksh", "ash"];
+    const INTERPRETERS: &[&str] = &["python", "python3", "perl", "node", "ruby", "php"];
+
+    if base == "env" || base == "command" {
+        let inner = tokens[1..].join(" ");
+        return Some(if inner.is_empty() {
+            WrapperScript::WithoutScript
+        } else {
+            WrapperScript::Script(inner)
+        });
+    }
+
+    if SHELL_WRAPPERS.contains(&base.as_str()) {
+        return Some(parse_script_flag(&tokens[1..]));
+    }
+
+    if INTERPRETERS.contains(&base.as_str()) {
+        if let Some(script) = parse_script_flag_value(&tokens[1..]) {
+            return Some(WrapperScript::Script(script));
+        }
+        return Some(WrapperScript::WithoutScript);
+    }
+
+    None
+}
+
+fn parse_script_flag(tokens: &[String]) -> WrapperScript {
+    if let Some(script) = parse_script_flag_value(tokens) {
+        WrapperScript::Script(script)
+    } else if tokens.iter().any(|t| is_script_flag_token(t)) {
+        WrapperScript::Unparseable
+    } else {
+        WrapperScript::WithoutScript
+    }
+}
+
+fn is_script_flag_token(token: &str) -> bool {
+    let t = token.to_ascii_lowercase();
+    t == "-c" || t == "-e" || t == "--command" || t.starts_with("-c") || t.starts_with("-e")
+}
+
+fn parse_script_flag_value(tokens: &[String]) -> Option<String> {
+    let mut index = 0;
+    while index < tokens.len() {
+        let token = &tokens[index];
+        let lower = token.to_ascii_lowercase();
+        if lower == "-c" || lower == "-e" || lower == "--command" {
+            if let Some(next) = tokens.get(index + 1) {
+                return Some(next.clone());
+            }
+            return None;
+        }
+        if let Some(rest) = lower.strip_prefix("-c") {
+            if !rest.is_empty() {
+                return Some(rest.to_string());
+            }
+        }
+        if let Some(rest) = lower.strip_prefix("-e") {
+            if !rest.is_empty() {
+                return Some(rest.to_string());
+            }
+        }
+        index += 1;
+    }
+    None
+}
+
+fn tokenize_shell_words(segment: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut chars = segment.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\'' && !in_double_quote {
+            in_single_quote = !in_single_quote;
+            current.push(ch);
+            continue;
+        }
+        if ch == '"' && !in_single_quote {
+            in_double_quote = !in_double_quote;
+            current.push(ch);
+            continue;
+        }
+        if ch == '\\' && !in_single_quote {
+            current.push(ch);
+            if let Some(next) = chars.next() {
+                current.push(next);
+            }
+            continue;
+        }
+        if ch.is_whitespace() && !in_single_quote && !in_double_quote {
+            if !current.is_empty() {
+                tokens.push(unquote_shell_word(&current));
+                current.clear();
+            }
+            continue;
+        }
+        current.push(ch);
+    }
+    if !current.is_empty() {
+        tokens.push(unquote_shell_word(&current));
+    }
+    tokens
+}
+
+fn unquote_shell_word(word: &str) -> String {
+    if word.len() >= 2
+        && ((word.starts_with('\'') && word.ends_with('\''))
+            || (word.starts_with('"') && word.ends_with('"')))
+    {
+        word[1..word.len() - 1].to_string()
+    } else {
+        word.to_string()
+    }
 }
 
 fn scan_outside_quotes(segment: &str, mut predicate: impl FnMut(&str) -> bool) -> bool {
@@ -373,6 +627,37 @@ mod tests {
         assert_not_read_only("apt update");
         assert_not_read_only("npm install foo");
         assert_not_read_only("cargo build");
+    }
+
+    #[test]
+    fn blocks_shell_wrapper_commands() {
+        assert_not_read_only("bash -c 'rm -rf /'");
+        assert_not_read_only("sh -c 'rm -rf /'");
+        assert_read_only("bash -c 'systemctl status nginx'");
+        assert_not_read_only("env rm -rf /tmp/x");
+        assert_not_read_only("python3 -c 'rm -rf /tmp/x'");
+    }
+
+    #[test]
+    fn blocks_background_job_segments() {
+        assert_not_read_only("sleep 1 & rm -rf /tmp/x");
+    }
+
+    #[test]
+    fn blocks_subshell_commands() {
+        assert_not_read_only("( rm -rf /tmp/x )");
+    }
+
+    #[test]
+    fn allows_read_only_sed_without_inplace_edit() {
+        assert_read_only("sed -n '1,20p' file");
+    }
+
+    #[test]
+    fn blocks_curl_compact_mutators_and_output() {
+        assert_not_read_only("curl -XPOST https://example.com");
+        assert_not_read_only("curl -o/tmp/x https://example.com");
+        assert_not_read_only("curl --request POST https://example.com");
     }
 
     #[test]

--- a/crates/aish-tools/src/bash/read_only.rs
+++ b/crates/aish-tools/src/bash/read_only.rs
@@ -1,0 +1,399 @@
+//! Bash command read-only analysis for the bash tool.
+//!
+//! Classifies whether a command string is read-only in the literal shell sense.
+//! Enforcement (block vs allow) is decided by callers: bash preflight policy,
+//! `/diagnose` verify gate, future sub-agents, etc.
+
+use aish_i18n::{t, t_with_args};
+use aish_llm::PreflightResult;
+use aish_security::sudo::strip_sudo_prefix;
+use std::collections::HashMap;
+
+/// Result of classifying a bash command for read-only semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReadOnlyVerdict {
+    ReadOnly,
+    NotReadOnly { reason: String },
+    Unparseable,
+}
+
+/// Classify whether a bash command string is read-only.
+pub fn classify(command: &str) -> ReadOnlyVerdict {
+    let trimmed = command.trim();
+    if trimmed.is_empty() {
+        return ReadOnlyVerdict::Unparseable;
+    }
+
+    let (stripped, _sudo_detected, sudo_ok) = strip_sudo_prefix(trimmed);
+    if !sudo_ok {
+        return ReadOnlyVerdict::Unparseable;
+    }
+    let effective = stripped.trim();
+    if effective.is_empty() {
+        return ReadOnlyVerdict::Unparseable;
+    }
+
+    for segment in split_compound_segments(effective) {
+        let seg = segment.trim();
+        if seg.is_empty() {
+            continue;
+        }
+        if let Some(reason) = non_readonly_segment_reason(seg) {
+            return ReadOnlyVerdict::NotReadOnly { reason };
+        }
+    }
+
+    ReadOnlyVerdict::ReadOnly
+}
+
+/// Returns `true` when the command is classified as read-only.
+pub fn is_read_only(command: &str) -> bool {
+    matches!(classify(command), ReadOnlyVerdict::ReadOnly)
+}
+
+/// When `enforce` is true, return a preflight block for non-read-only commands.
+pub fn preflight_enforce(command: &str, enforce: bool) -> Option<PreflightResult> {
+    if !enforce {
+        return None;
+    }
+
+    match classify(command) {
+        ReadOnlyVerdict::ReadOnly => None,
+        ReadOnlyVerdict::NotReadOnly { reason } => Some(PreflightResult::Block {
+            message: block_message(&reason),
+            security: None,
+        }),
+        ReadOnlyVerdict::Unparseable => Some(PreflightResult::Block {
+            message: t("tools.bash.read_only.unparseable"),
+            security: None,
+        }),
+    }
+}
+
+fn block_message(reason: &str) -> String {
+    let mut args = HashMap::new();
+    args.insert("reason".to_string(), reason.to_string());
+    t_with_args("tools.bash.read_only.blocked", &args)
+}
+
+fn split_compound_segments(command: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut chars = command.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\'' && !in_double_quote {
+            in_single_quote = !in_single_quote;
+            current.push(ch);
+            continue;
+        }
+        if ch == '"' && !in_single_quote {
+            in_double_quote = !in_double_quote;
+            current.push(ch);
+            continue;
+        }
+        if ch == '\\' && !in_single_quote && in_double_quote {
+            current.push(ch);
+            if let Some(next) = chars.next() {
+                current.push(next);
+            }
+            continue;
+        }
+
+        if !in_single_quote && !in_double_quote {
+            if ch == ';' {
+                segments.push(current.clone());
+                current.clear();
+                continue;
+            }
+            if ch == '|' {
+                if chars.peek() == Some(&'|') {
+                    chars.next();
+                    segments.push(current.clone());
+                    current.clear();
+                    continue;
+                }
+                segments.push(current.clone());
+                current.clear();
+                continue;
+            }
+            if ch == '&' && chars.peek() == Some(&'&') {
+                chars.next();
+                segments.push(current.clone());
+                current.clear();
+                continue;
+            }
+        }
+
+        current.push(ch);
+    }
+
+    if !current.is_empty() {
+        segments.push(current);
+    }
+
+    segments
+}
+
+fn non_readonly_segment_reason(segment: &str) -> Option<String> {
+    if scan_outside_quotes(segment, |window| {
+        window.starts_with("$(") || window.starts_with('`')
+    }) {
+        return Some("command substitution".into());
+    }
+    if scan_outside_quotes(segment, |window| window.starts_with('*')) {
+        return Some("unquoted glob".into());
+    }
+    if scan_outside_quotes(segment, |window| {
+        if let Some(rest) = window.strip_prefix(">>") {
+            return !rest.trim_start().starts_with("/dev/null");
+        }
+        if let Some(rest) = window.strip_prefix('>') {
+            return !rest.trim_start().starts_with("/dev/null");
+        }
+        false
+    }) {
+        return Some("write redirect".into());
+    }
+    if scan_outside_quotes(segment, |window| {
+        window
+            .strip_prefix("<<")
+            .is_some_and(|rest| !rest.contains("/dev/null"))
+    }) {
+        return Some("heredoc write".into());
+    }
+
+    let first = segment.split_whitespace().next().unwrap_or("");
+    let base = first.rsplit('/').next().unwrap_or(first).to_lowercase();
+
+    const BLOCKED: &[&str] = &[
+        "rm", "mv", "cp", "chmod", "chown", "mkdir", "touch", "tee", "truncate", "install", "ln",
+        "apt", "yum", "dnf", "pip", "npm", "cargo", "sed", "vim", "vi", "nano", "reboot",
+        "shutdown", "kill", "pkill", "killall",
+    ];
+    if BLOCKED.iter().any(|b| base == *b) {
+        return Some(format!("blocked command: {base}"));
+    }
+
+    if base == "systemctl" || base == "service" {
+        for token in segment.split_whitespace().skip(1) {
+            let t = token.to_lowercase();
+            if matches!(
+                t.as_str(),
+                "start" | "stop" | "restart" | "reload" | "enable" | "disable"
+            ) {
+                return Some(format!("service control: {t}"));
+            }
+        }
+    }
+
+    if base == "find" && segment.to_lowercase().contains("-delete") {
+        return Some("find delete".into());
+    }
+
+    if base == "curl" {
+        let lower = segment.to_lowercase();
+        if lower.contains("-x post") || lower.contains("-xput") || lower.contains("-x delete") {
+            return Some("curl mutating method".into());
+        }
+        if lower.contains(" -o ") || lower.contains(" --output ") {
+            return Some("curl output file".into());
+        }
+    }
+
+    let lower = segment.to_lowercase();
+    if base == "sed" && lower.contains("-i") {
+        return Some("in-place edit".into());
+    }
+
+    None
+}
+
+fn scan_outside_quotes(segment: &str, mut predicate: impl FnMut(&str) -> bool) -> bool {
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut index = 0;
+
+    while index < segment.len() {
+        let ch = segment[index..].chars().next().expect("valid utf8");
+        if ch == '\'' && !in_double_quote {
+            in_single_quote = !in_single_quote;
+            index += ch.len_utf8();
+            continue;
+        }
+        if ch == '"' && !in_single_quote {
+            in_double_quote = !in_double_quote;
+            index += ch.len_utf8();
+            continue;
+        }
+        if !in_single_quote && !in_double_quote && predicate(&segment[index..]) {
+            return true;
+        }
+        index += ch.len_utf8();
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_read_only(command: &str) {
+        assert_eq!(classify(command), ReadOnlyVerdict::ReadOnly, "{command}");
+        assert!(is_read_only(command));
+    }
+
+    fn assert_not_read_only(command: &str) {
+        assert!(matches!(
+            classify(command),
+            ReadOnlyVerdict::NotReadOnly { .. }
+        ));
+        assert!(!is_read_only(command));
+    }
+
+    #[test]
+    fn empty_command_is_unparseable() {
+        assert_eq!(classify("   "), ReadOnlyVerdict::Unparseable);
+    }
+
+    #[test]
+    fn read_only_status_commands() {
+        assert_read_only("systemctl status nginx");
+        assert_read_only("journalctl -u foo --no-pager");
+        assert_read_only("ss -tlnp");
+        assert_read_only("ps aux");
+        assert_read_only("which foo");
+    }
+
+    #[test]
+    fn read_only_file_inspection() {
+        assert_read_only("cat /etc/hosts");
+        assert_read_only("head -n 5 file.txt");
+        assert_read_only("tail -f /var/log/syslog");
+        assert_read_only("rg pattern src/");
+        assert_read_only("grep -R foo .");
+        assert_read_only("find . -name '*.rs'");
+    }
+
+    #[test]
+    fn read_only_resource_commands() {
+        assert_read_only("df -h");
+        assert_read_only("free -m");
+        assert_read_only("curl -s https://example.com");
+    }
+
+    #[test]
+    fn blocks_write_redirect() {
+        assert_not_read_only("echo x > /tmp/foo");
+        assert_not_read_only("echo x >> /tmp/foo");
+    }
+
+    #[test]
+    fn allows_redirect_to_dev_null() {
+        assert_read_only("cmd 2>/dev/null");
+        assert_read_only("cmd >>/dev/null");
+    }
+
+    #[test]
+    fn quote_redirect_is_not_write() {
+        assert_read_only(r#"echo 'foo > bar'"#);
+        assert_read_only(r#"echo "foo > bar""#);
+    }
+
+    #[test]
+    fn blocks_destructive_commands() {
+        assert_not_read_only("rm -rf /");
+        assert_not_read_only("mv a b");
+        assert_not_read_only("cp a b");
+        assert_not_read_only("touch /tmp/x");
+        assert_not_read_only("chmod +x script.sh");
+    }
+
+    #[test]
+    fn blocks_service_control() {
+        assert_not_read_only("systemctl restart nginx");
+        assert_not_read_only("service nginx restart");
+    }
+
+    #[test]
+    fn blocks_compound_if_any_segment_writes() {
+        assert_not_read_only("systemctl status nginx && rm x");
+        assert_not_read_only("true; echo x > /tmp/a");
+        assert_not_read_only("cat file || systemctl restart nginx");
+        assert_not_read_only("ls | tee out.txt");
+    }
+
+    #[test]
+    fn compound_all_read_only() {
+        assert_read_only("systemctl status nginx && journalctl -u nginx --no-pager");
+        assert_read_only("ps aux | grep nginx");
+    }
+
+    #[test]
+    fn sudo_stripped_before_analysis() {
+        assert_read_only("sudo systemctl status nginx");
+        assert_not_read_only("sudo rm -rf /");
+    }
+
+    #[test]
+    fn blocks_command_substitution() {
+        assert_not_read_only("echo $(rm -rf /)");
+        assert_not_read_only("echo `rm -rf /`");
+    }
+
+    #[test]
+    fn blocks_unquoted_glob() {
+        assert_not_read_only("ls *.txt");
+    }
+
+    #[test]
+    fn blocks_package_managers() {
+        assert_not_read_only("apt update");
+        assert_not_read_only("npm install foo");
+        assert_not_read_only("cargo build");
+    }
+
+    #[test]
+    fn blocks_sed_inplace() {
+        assert_not_read_only("sed -i 's/a/b/' file");
+    }
+
+    #[test]
+    fn blocks_find_delete() {
+        assert_not_read_only("find . -name '*.tmp' -delete");
+    }
+
+    #[test]
+    fn blocks_curl_write() {
+        assert_not_read_only("curl -o /tmp/x https://example.com");
+        assert_not_read_only("curl -X POST https://example.com");
+    }
+
+    #[test]
+    fn split_respects_quotes_for_separators() {
+        let segments = split_compound_segments(r#"echo 'a;b' && ls"#);
+        assert_eq!(segments.len(), 2);
+        assert!(segments[0].contains("'a;b'"));
+    }
+
+    #[test]
+    fn preflight_skips_when_not_enforced() {
+        assert!(preflight_enforce("rm -rf /", false).is_none());
+    }
+
+    #[test]
+    fn preflight_blocks_when_enforced() {
+        assert!(matches!(
+            preflight_enforce("rm -rf /", true),
+            Some(PreflightResult::Block { .. })
+        ));
+    }
+
+    #[test]
+    fn preflight_allows_read_only_when_enforced() {
+        assert!(preflight_enforce("systemctl status nginx", true).is_none());
+    }
+}

--- a/crates/aish-tools/src/lib.rs
+++ b/crates/aish-tools/src/lib.rs
@@ -26,8 +26,10 @@ pub mod ask_user {
 pub mod bash {
     mod bash;
     mod prompt;
+    mod read_only;
 
     pub use self::bash::*;
+    pub use self::read_only::{classify, is_read_only, preflight_enforce, ReadOnlyVerdict};
 }
 
 pub mod channel_ask_user {

--- a/crates/aish-tools/src/secure_bash/secure_bash.rs
+++ b/crates/aish-tools/src/secure_bash/secure_bash.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use aish_llm::{CancellationToken, Tool, ToolResult};
+use aish_llm::{CancellationToken, Tool, ToolContext, ToolResult};
 use aish_security::SecurityDecision;
 
-use crate::bash::PtySlot;
+use crate::bash::{preflight_enforce, PtySlot};
 
 /// Type of the security check callback.
 type SecurityCheckFn = Box<dyn Fn(&str) -> SecurityDecision + Send + Sync>;
@@ -115,47 +115,66 @@ impl Tool for SecureBashTool {
     }
 
     fn preflight(&self, args: &serde_json::Value) -> aish_llm::PreflightResult {
-        let command = match args.get("command").and_then(|c| c.as_str()) {
-            Some(cmd) => cmd,
-            None => return aish_llm::PreflightResult::Allow,
-        };
+        secure_bash_preflight(self, args, false)
+    }
 
-        // Strip sudo prefix before security check
-        let effective_command = strip_sudo(command);
-
-        if let Some(ref check) = self.security_check {
-            let decision = check(effective_command);
-            if !decision.allow {
-                let reason = decision
-                    .analysis
-                    .confirm_message
-                    .clone()
-                    .unwrap_or_else(|| decision.analysis.impact_description.clone());
-                aish_llm::PreflightResult::Block {
-                    message: reason,
-                    security: None,
-                }
-            } else if decision.require_confirmation {
-                let reason = decision
-                    .analysis
-                    .confirm_message
-                    .clone()
-                    .unwrap_or_else(|| decision.analysis.impact_description.clone());
-                aish_llm::PreflightResult::Confirm {
-                    message: reason,
-                    security: None,
-                }
-            } else {
-                aish_llm::PreflightResult::Allow
-            }
-        } else {
-            aish_llm::PreflightResult::Allow
-        }
+    fn preflight_with_context(
+        &self,
+        args: &serde_json::Value,
+        ctx: &ToolContext<'_>,
+    ) -> aish_llm::PreflightResult {
+        secure_bash_preflight(self, args, ctx.policy.enforce_read_only_bash)
     }
 
     fn execute(&self, args: serde_json::Value) -> ToolResult {
         // Security check is now handled by preflight()
         self.inner.execute(args)
+    }
+}
+
+fn secure_bash_preflight(
+    tool: &SecureBashTool,
+    args: &serde_json::Value,
+    enforce_read_only_bash: bool,
+) -> aish_llm::PreflightResult {
+    let command = match args.get("command").and_then(|c| c.as_str()) {
+        Some(cmd) => cmd,
+        None => return aish_llm::PreflightResult::Allow,
+    };
+
+    let effective_command = strip_sudo(command);
+
+    if let Some(result) = preflight_enforce(effective_command, enforce_read_only_bash) {
+        return result;
+    }
+
+    if let Some(ref check) = tool.security_check {
+        let decision = check(effective_command);
+        if !decision.allow {
+            let reason = decision
+                .analysis
+                .confirm_message
+                .clone()
+                .unwrap_or_else(|| decision.analysis.impact_description.clone());
+            aish_llm::PreflightResult::Block {
+                message: reason,
+                security: None,
+            }
+        } else if decision.require_confirmation {
+            let reason = decision
+                .analysis
+                .confirm_message
+                .clone()
+                .unwrap_or_else(|| decision.analysis.impact_description.clone());
+            aish_llm::PreflightResult::Confirm {
+                message: reason,
+                security: None,
+            }
+        } else {
+            aish_llm::PreflightResult::Allow
+        }
+    } else {
+        aish_llm::PreflightResult::Allow
     }
 }
 

--- a/crates/aish-tools/src/system_diagnose/system_diagnose.rs
+++ b/crates/aish-tools/src/system_diagnose/system_diagnose.rs
@@ -169,6 +169,7 @@ impl Tool for SystemDiagnoseTool {
                 max_context_messages: 30,
                 max_iterations: 10,
                 system_prompt: Some(prompt),
+                enforce_read_only_bash: false,
             };
 
             let agent = DiagnoseAgent::with_config(config);


### PR DESCRIPTION
## Summary

- Add read-only command classification for the bash tool in `aish-tools::bash` (`ReadOnlyVerdict`, `classify`, `is_read_only`, `preflight_enforce`), with quote-aware segment parsing and 20+ unit tests.
- Introduce `ToolExecutionPolicy.enforce_read_only_bash` and `Tool::preflight_with_context` so bash/secure_bash can block non-read-only commands when policy is enabled.
- Wire `/diagnose`: verify commands are gated by read-only classification; failure diagnose sub-sessions set `enforce_read_only_bash: true` and remove duplicate shell-side readonly logic.
- Fix ReAct diagnose spinner flicker by ignoring `react_agent` generation end/start for spinner stop/restart.

Main session behavior is unchanged (`enforce_read_only_bash` defaults to `false`).

## Test plan

- [x] `make format-check && make lint`
- [x] `cargo test -p aish-tools -p aish-llm -p aish-shell`
- [ ] Manual: `/diagnose` with a non-read-only verify command → blocked with i18n message
- [ ] Manual: failure diagnose sub-agent attempts `rm`/`echo >` → preflight block
- [ ] Manual: `/diagnose` run → thinking spinner no longer flickers mid-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced Bash read-only classification and matching block/unparseable outcomes.
  * Introduced context-aware tool execution policies so Bash read-only enforcement can be applied reliably during tool preflight.
* **Bug Fixes**
  * Ensured read-only enforcement behavior is consistent across diagnostic and secure Bash flows when enabled.
  * Improved failure-diagnose command verification messaging and UI state handling during ReAct-style sub-sessions.
* **Documentation**
  * Updated user-facing English and Chinese messages for read-only enforcement outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->