### PR TITLE
feat(shell): bash-style multi-column tab completion with custom pager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,9 +2890,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustyline"
-version = "18.0.0"
+version = "18.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a990b25f351b25139ddc7f21ee3f6f56f86d6846b74ac8fad3a719a287cd4a0"
+checksum = "53f6a737db68eb1a8ccff86b584b2fc13eca6a7bb6f78ebc7c529547e3ab9684"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ base64 = "0.22"
 rand = "0.9"
 
 # Readline
-rustyline = { version = "18", features = ["derive"] }
+rustyline = { version = "18", features = ["derive", "with-dirs"] }
 
 # UUID
 uuid = { version = "1", features = ["v4"] }

--- a/crates/aish-pty/src/lib.rs
+++ b/crates/aish-pty/src/lib.rs
@@ -46,7 +46,7 @@ pub use offload::{
 };
 pub use output_buffer::OutputBuffer;
 pub use persistent::{is_interactive_command, shell_quote_escape, PersistentPty};
-pub use readline_tab::ReadlineTabResult;
+pub use readline_tab::{should_complete_path_locally, ReadlineTabResult};
 pub use session_interceptor::{
     pop_last_utf8_char, AiCallback, AiEvent, AiQuery, AiResponse, AskUserAnswer, AskUserChannel,
     AskUserOption, AskUserRequest, BashExecResult, FollowupCallback, InterceptorState,

--- a/crates/aish-pty/src/readline_tab.rs
+++ b/crates/aish-pty/src/readline_tab.rs
@@ -45,13 +45,26 @@ pub fn word_start_at(line: &str, pos: usize) -> usize {
         .unwrap_or(0)
 }
 
-pub fn is_path_like_token(token: &str) -> bool {
+fn is_path_like_token(token: &str) -> bool {
     !token.is_empty()
         && (token.starts_with('/')
             || token.starts_with("./")
             || token.starts_with("../")
             || token.starts_with('~')
             || token.contains('/'))
+}
+
+fn is_quoted_token(token: &str) -> bool {
+    token.starts_with('"') || token.starts_with('\'')
+}
+
+fn looks_like_remote_path(token: &str) -> bool {
+    token.contains("://") || (token.contains('@') && token.contains(':'))
+}
+
+/// True when Rust `FilenameCompleter` should handle the token (not PTY/bash path logic).
+pub fn should_complete_path_locally(token: &str) -> bool {
+    is_path_like_token(token) && !is_quoted_token(token) && !looks_like_remote_path(token)
 }
 
 /// Build keystrokes for PTY readline: optional Ctrl-U, line text, cursor, Tab×n.
@@ -217,6 +230,13 @@ fn parse_inline_line(text: &str, input_line: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn should_complete_path_locally_excludes_quoted_and_remote() {
+        assert!(should_complete_path_locally("~/.config/"));
+        assert!(!should_complete_path_locally("\"~/.config\""));
+        assert!(!should_complete_path_locally("user@host:/path"));
+    }
 
     #[test]
     fn parse_gi_list_and_inline_extend() {

--- a/crates/aish-pty/src/readline_tab.rs
+++ b/crates/aish-pty/src/readline_tab.rs
@@ -59,7 +59,21 @@ fn is_quoted_token(token: &str) -> bool {
 }
 
 fn looks_like_remote_path(token: &str) -> bool {
-    token.contains("://") || (token.contains('@') && token.contains(':'))
+    if token.contains("://") {
+        return true;
+    }
+
+    if token.starts_with('/')
+        || token.starts_with("./")
+        || token.starts_with("../")
+        || token.starts_with('~')
+    {
+        return false;
+    }
+
+    token.split_once(':').is_some_and(|(host, path)| {
+        !host.is_empty() && !host.contains('/') && path.starts_with('/')
+    })
 }
 
 /// True when Rust `FilenameCompleter` should handle the token (not PTY/bash path logic).
@@ -236,6 +250,7 @@ mod tests {
         assert!(should_complete_path_locally("~/.config/"));
         assert!(!should_complete_path_locally("\"~/.config\""));
         assert!(!should_complete_path_locally("user@host:/path"));
+        assert!(!should_complete_path_locally("host:/path"));
     }
 
     #[test]

--- a/crates/aish-shell/src/completion.rs
+++ b/crates/aish-shell/src/completion.rs
@@ -1,0 +1,133 @@
+//! Tab completion: local paths + PTY JSON, rustyline bash-style listing.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use rustyline::completion::{FilenameCompleter, Pair};
+
+use aish_pty::readline_tab::{clamp_pos, should_complete_path_locally, word_start_at};
+
+const PTY_COMPLETION_TIMEOUT: Duration = Duration::from_millis(1200);
+
+pub struct CompletionEngine {
+    pty: Arc<Mutex<aish_pty::PersistentPty>>,
+}
+
+impl CompletionEngine {
+    pub fn new(pty: Arc<Mutex<aish_pty::PersistentPty>>) -> Self {
+        Self { pty }
+    }
+
+    /// Return `(word_start, candidates)` for rustyline to extend or list below the line.
+    pub fn complete(&self, line: &str, pos: usize) -> Option<(usize, Vec<Pair>)> {
+        let pos = clamp_pos(line, pos);
+        let before = line.get(..pos).unwrap_or(line);
+
+        if before.starts_with(';') || before.starts_with('\u{ff1b}') || before.trim().is_empty() {
+            return None;
+        }
+
+        let (word_start, pairs) = if should_complete_path_locally(
+            line.get(word_start_at(line, pos)..pos).unwrap_or(""),
+        ) {
+            Self::complete_path_local(line, pos)?
+        } else {
+            let word_start = word_start_at(line, pos);
+            (word_start, self.complete_via_pty(line, pos)?)
+        };
+
+        let pairs = filter_extending_pairs(line, pos, word_start, pairs);
+        if pairs.is_empty() {
+            return None;
+        }
+
+        Some((word_start, pairs))
+    }
+
+    fn complete_via_pty(&self, line: &str, pos: usize) -> Option<Vec<Pair>> {
+        let mut pty = self.pty.lock().ok()?;
+        if !pty.is_running() {
+            return None;
+        }
+        let resp = pty
+            .query_completions(line, pos, PTY_COMPLETION_TIMEOUT)
+            .ok()?;
+        if resp.candidates.is_empty() {
+            return None;
+        }
+        Some(
+            resp.candidates
+                .into_iter()
+                .map(|c| Pair {
+                    display: c.display,
+                    replacement: c.replacement,
+                })
+                .collect(),
+        )
+    }
+
+    /// Keep FilenameCompleter `replacement` values intact for line editing / LCP.
+    fn complete_path_local(line: &str, pos: usize) -> Option<(usize, Vec<Pair>)> {
+        let pos = clamp_pos(line, pos);
+        let (start, pairs) = FilenameCompleter::new().complete_path(line, pos).ok()?;
+        if pairs.is_empty() {
+            None
+        } else {
+            Some((start, pairs))
+        }
+    }
+}
+
+fn filter_extending_pairs(
+    line: &str,
+    pos: usize,
+    word_start: usize,
+    pairs: Vec<Pair>,
+) -> Vec<Pair> {
+    let current = line.get(word_start..pos).unwrap_or("");
+    pairs
+        .into_iter()
+        .filter(|p| p.replacement != current)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustyline::completion::FilenameCompleter;
+
+    #[test]
+    fn filter_extending_pairs_drops_exact_match() {
+        let pairs = vec![Pair {
+            display: "git".into(),
+            replacement: "git".into(),
+        }];
+        let filtered = filter_extending_pairs("git", 3, 0, pairs);
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn ls_usr_lcp_extends_with_full_paths_not_r_slash() {
+        if !std::path::Path::new("/usr").is_dir() {
+            return;
+        }
+        let line = "ls /usr";
+        let pos = line.len();
+        let (start, pairs) = FilenameCompleter::new().complete_path(line, pos).unwrap();
+        assert_eq!(start, 3);
+        assert!(!pairs.is_empty());
+        for p in &pairs {
+            assert!(
+                p.replacement.starts_with("/usr/"),
+                "expected full path replacement, got {:?}",
+                p.replacement
+            );
+        }
+        let lcp = rustyline::completion::longest_common_prefix(&pairs).unwrap_or("");
+        assert!(
+            lcp.starts_with("/usr"),
+            "LCP should extend /usr prefix, got {lcp:?}"
+        );
+        assert_ne!(lcp, "r/");
+    }
+}

--- a/crates/aish-shell/src/completion_list.rs
+++ b/crates/aish-shell/src/completion_list.rs
@@ -1,0 +1,463 @@
+//! Bash-style multi-column completion listing with a custom pager.
+
+use std::io::{self, Write};
+use std::time::Instant;
+
+use rustyline::completion::Pair;
+use unicode_width::UnicodeWidthStr;
+
+/// Match rustyline default: ask before listing very large sets.
+pub const COMPLETION_PROMPT_LIMIT: usize = 100;
+
+const MORE_PROMPT: &str = "--More--";
+
+/// Format candidates into display strings (deduped, sorted like bash columns).
+pub fn display_strings(pairs: &[Pair]) -> Vec<String> {
+    let mut out: Vec<String> = pairs.iter().map(|p| listing_display(&p.display)).collect();
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+/// Short names for column layout (basename for paths, keep trailing `/` on dirs).
+fn listing_display(raw: &str) -> String {
+    let s = raw.trim_end();
+    if !s.contains('/') {
+        return s.to_string();
+    }
+    if s.ends_with('/') {
+        let trimmed = s.trim_end_matches('/');
+        if let Some(base) = trimmed.rsplit('/').next().filter(|b| !b.is_empty()) {
+            return format!("{base}/");
+        }
+        return s.to_string();
+    }
+    s.rsplit('/').next().unwrap_or(s).to_string()
+}
+
+/// Print a bash-style column listing with paging. Returns `Ok(false)` if the user
+/// declined "display all", or stopped early at `--More--` with `q` / `n` / Backspace.
+///
+/// Caller must `Cmd::Repaint` afterward so rustyline redraws the prompt + input line;
+/// manual stdout redraw corrupts the line when the prompt contains ANSI sequences.
+pub fn print_completion_list(pairs: &[Pair]) -> io::Result<bool> {
+    let displays = display_strings(pairs);
+    if displays.is_empty() {
+        return Ok(true);
+    }
+
+    if displays.len() > COMPLETION_PROMPT_LIMIT && !prompt_display_all(displays.len())? {
+        return Ok(false);
+    }
+
+    drain_stdin_typeahead();
+    let (cols, rows) = terminal_size();
+    let layout_rows = format_column_rows(&displays, cols as usize);
+    page_rows(&layout_rows, rows)?;
+    drain_stdin_typeahead();
+    Ok(true)
+}
+
+/// Drop buffered keys so rustyline / the pager do not mis-read them.
+fn drain_stdin_typeahead() {
+    let stdin_fd = libc::STDIN_FILENO;
+    let mut buf = [0u8; 256];
+    let deadline = Instant::now() + std::time::Duration::from_millis(200);
+    loop {
+        if Instant::now() >= deadline {
+            break;
+        }
+        let mut fds: libc::fd_set = unsafe { std::mem::zeroed() };
+        unsafe {
+            libc::FD_ZERO(&mut fds);
+            libc::FD_SET(stdin_fd, &mut fds);
+        }
+        let mut tv = libc::timeval {
+            tv_sec: 0,
+            tv_usec: 20_000,
+        };
+        let ready = unsafe {
+            libc::select(
+                stdin_fd + 1,
+                &mut fds,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut tv,
+            )
+        };
+        if ready <= 0 {
+            break;
+        }
+        let n = unsafe { libc::read(stdin_fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+        if n <= 0 {
+            break;
+        }
+    }
+}
+
+/// Prefer rustyline's cached size, then ioctl / `$LINES` / `$COLUMNS`.
+fn terminal_size() -> (u16, u16) {
+    let (mut cols, mut rows) = crate::readline::current_terminal_size();
+    for fd in [libc::STDOUT_FILENO, libc::STDIN_FILENO, libc::STDERR_FILENO] {
+        if let Some((c, r)) = winsize_ioctl(fd) {
+            cols = cols.max(c);
+            rows = rows.max(r);
+        }
+    }
+    if let Ok(n) = std::env::var("COLUMNS") {
+        if let Ok(n) = n.parse::<u16>() {
+            cols = cols.max(n);
+        }
+    }
+    if let Ok(n) = std::env::var("LINES") {
+        if let Ok(n) = n.parse::<u16>() {
+            rows = rows.max(n);
+        }
+    }
+    // Do not clamp cols to 80 minimum: on a narrow terminal that forces line wrap
+    // and looks like a single-column list. Fall back only when size is unknown.
+    let cols = if cols == 0 { 80 } else { cols.min(512) };
+    let rows = if rows == 0 { 24 } else { rows.min(5000) };
+    (cols, rows)
+}
+
+fn winsize_ioctl(fd: i32) -> Option<(u16, u16)> {
+    unsafe {
+        let mut size: libc::winsize = std::mem::zeroed();
+        if libc::ioctl(fd, libc::TIOCGWINSZ, &mut size) != 0 {
+            return None;
+        }
+        let cols = if size.ws_col == 0 {
+            80
+        } else {
+            size.ws_col as u16
+        };
+        let rows = if size.ws_row == 0 {
+            u16::MAX
+        } else {
+            size.ws_row as u16
+        };
+        Some((cols, rows))
+    }
+}
+
+/// Lines of candidates to print before `--More--` (reserve one row for the prompt).
+fn page_size(terminal_rows: u16, content_rows: usize) -> usize {
+    let rows = terminal_rows as usize;
+    if rows == 0 || rows > 5000 {
+        return content_rows.max(1);
+    }
+    rows.saturating_sub(1).max(1)
+}
+
+fn prompt_display_all(count: usize) -> io::Result<bool> {
+    let mut stdout = io::stdout();
+    write!(stdout, "\r\nDisplay all {count} possibilities? (y/n) ")?;
+    stdout.flush()?;
+
+    loop {
+        match read_pager_byte()? {
+            PagerByte::Char(b'y') | PagerByte::Char(b'Y') => {
+                stdout.flush()?;
+                // Drop a trailing Enter users often press after `y`.
+                drain_stdin_typeahead();
+                return Ok(true);
+            }
+            PagerByte::Char(b'n') | PagerByte::Char(b'N') | PagerByte::Backspace => {
+                stdout.flush()?;
+                drain_stdin_typeahead();
+                return Ok(false);
+            }
+            PagerByte::Interrupt => {
+                stdout.flush()?;
+                drain_stdin_typeahead();
+                return Ok(false);
+            }
+            PagerByte::Ignored | PagerByte::Char(_) => {}
+        }
+    }
+}
+
+/// Column-major layout (same strategy as bash / GNU readline / rustyline).
+pub fn format_column_rows(items: &[String], cols: usize) -> Vec<String> {
+    if items.is_empty() {
+        return Vec::new();
+    }
+
+    let cols = cols.max(1);
+    let min_col_pad = 2;
+    let max_width = items
+        .iter()
+        .map(|s| s.width())
+        .max()
+        .unwrap_or(0)
+        .saturating_add(min_col_pad)
+        .min(cols);
+    let num_cols = (cols / max_width.max(1)).max(1);
+    let num_rows = items.len().div_ceil(num_cols);
+
+    let mut rows = Vec::with_capacity(num_rows);
+    for row in 0..num_rows {
+        let mut line = String::new();
+        for col in 0..num_cols {
+            let idx = col * num_rows + row;
+            if idx >= items.len() {
+                continue;
+            }
+            let item = &items[idx];
+            line.push_str(item);
+            if (col + 1) * num_rows + row < items.len() {
+                let pad = max_width.saturating_sub(item.width());
+                line.extend(std::iter::repeat_n(' ', pad));
+            }
+        }
+        rows.push(line);
+    }
+    rows
+}
+
+fn page_rows(rows: &[String], terminal_rows: u16) -> io::Result<()> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+
+    let mut stdout = io::stdout();
+    let page_size = page_size(terminal_rows, rows.len());
+    let mut lines_on_page = 0usize;
+    let mut reuse_more_line = false;
+
+    for row in rows {
+        while lines_on_page >= page_size {
+            write!(stdout, "\n{MORE_PROMPT}")?;
+            stdout.flush()?;
+            drain_stdin_typeahead();
+            match read_more_action()? {
+                MoreAction::NextPage => lines_on_page = 0,
+                MoreAction::NextLine => lines_on_page = page_size.saturating_sub(1),
+                MoreAction::Stop => {
+                    dismiss_more_prompt(&mut stdout)?;
+                    return Ok(());
+                }
+            }
+            erase_more_prompt(&mut stdout)?;
+            reuse_more_line = true;
+        }
+        if reuse_more_line {
+            write!(stdout, "{row}")?;
+            reuse_more_line = false;
+        } else {
+            writeln!(stdout)?;
+            write!(stdout, "{row}")?;
+        }
+        stdout.flush()?;
+        lines_on_page += 1;
+    }
+
+    writeln!(stdout)?;
+    stdout.flush()?;
+    Ok(())
+}
+
+/// Clear `--More--` text but keep the line for the next candidate row.
+fn erase_more_prompt(stdout: &mut io::Stdout) -> io::Result<()> {
+    write!(stdout, "\r\x1b[2K")?;
+    stdout.flush()?;
+    Ok(())
+}
+
+/// Clear and remove the `--More--` pager line when the user stops (q / Ctrl+C).
+fn dismiss_more_prompt(stdout: &mut io::Stdout) -> io::Result<()> {
+    write!(stdout, "\r\x1b[2K\x1b[M")?;
+    stdout.flush()?;
+    Ok(())
+}
+
+enum MoreAction {
+    NextPage,
+    NextLine,
+    Stop,
+}
+
+enum PagerByte {
+    Char(u8),
+    Backspace,
+    Interrupt,
+    Ignored,
+}
+
+/// Map one raw byte to a pager key (escape sequences are skipped in `read_stdin_byte`).
+fn read_pager_byte() -> io::Result<PagerByte> {
+    let byte = read_stdin_byte()?;
+    match byte {
+        b'\n' | b'\r' => Ok(PagerByte::Char(b'\n')),
+        0x03 => Ok(PagerByte::Interrupt),
+        0x7f | 0x08 => Ok(PagerByte::Backspace),
+        0x01..=0x1a | 0x7e => Ok(PagerByte::Ignored),
+        b => Ok(PagerByte::Char(b)),
+    }
+}
+
+fn read_stdin_byte() -> io::Result<u8> {
+    let mut buf = [0u8; 1];
+    loop {
+        let n = unsafe { libc::read(libc::STDIN_FILENO, buf.as_mut_ptr() as *mut libc::c_void, 1) };
+        if n < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if n == 0 {
+            return Err(io::Error::from(io::ErrorKind::UnexpectedEof));
+        }
+        let byte = buf[0];
+        if byte == 0x1b {
+            skip_escape_sequence()?;
+            continue;
+        }
+        return Ok(byte);
+    }
+}
+
+fn skip_escape_sequence() -> io::Result<()> {
+    let mut buf = [0u8; 1];
+    if !stdin_has_data(50_000)? {
+        return Ok(());
+    }
+    let n = unsafe { libc::read(libc::STDIN_FILENO, buf.as_mut_ptr() as *mut libc::c_void, 1) };
+    if n <= 0 {
+        return Ok(());
+    }
+    if buf[0] == b'[' {
+        loop {
+            if !stdin_has_data(100_000)? {
+                break;
+            }
+            let n =
+                unsafe { libc::read(libc::STDIN_FILENO, buf.as_mut_ptr() as *mut libc::c_void, 1) };
+            if n <= 0 {
+                break;
+            }
+            if (0x40..=0x7e).contains(&buf[0]) {
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn stdin_has_data(timeout_usec: libc::suseconds_t) -> io::Result<bool> {
+    let stdin_fd = libc::STDIN_FILENO;
+    let mut fds: libc::fd_set = unsafe { std::mem::zeroed() };
+    unsafe {
+        libc::FD_ZERO(&mut fds);
+        libc::FD_SET(stdin_fd, &mut fds);
+    }
+    let mut tv = libc::timeval {
+        tv_sec: 0,
+        tv_usec: timeout_usec,
+    };
+    let ready = unsafe {
+        libc::select(
+            stdin_fd + 1,
+            &mut fds,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            &mut tv,
+        )
+    };
+    if ready < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(ready > 0)
+}
+
+/// Keys match GNU readline / rustyline `page_completions`.
+fn read_more_action() -> io::Result<MoreAction> {
+    loop {
+        match read_pager_byte()? {
+            PagerByte::Char(b' ') | PagerByte::Char(b'y') | PagerByte::Char(b'Y') => {
+                return Ok(MoreAction::NextPage);
+            }
+            PagerByte::Char(b'\n') | PagerByte::Char(b'\r') => {
+                return Ok(MoreAction::NextLine);
+            }
+            PagerByte::Char(b'q')
+            | PagerByte::Char(b'Q')
+            | PagerByte::Char(b'n')
+            | PagerByte::Char(b'N')
+            | PagerByte::Backspace
+            | PagerByte::Interrupt => {
+                return Ok(MoreAction::Stop);
+            }
+            PagerByte::Ignored | PagerByte::Char(_) => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_column_rows_multi_column_for_binaries() {
+        let items: Vec<String> = vec![
+            "arj",
+            "arj-register",
+            "as",
+            "autoconf",
+            "automake-1.17",
+            "bash",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+        let cols = 120;
+        let rows = format_column_rows(&items, cols);
+        assert_eq!(rows.len(), 1, "expected one layout row: {rows:?}");
+        assert!(rows[0].contains("arj"));
+        assert!(rows[0].contains("bash"));
+        assert!(rows[0].width() <= cols);
+    }
+
+    #[test]
+    fn format_column_rows_respects_narrow_terminal() {
+        let items: Vec<String> = (0..12).map(|i| format!("cmd{i}")).collect();
+        let cols = 40;
+        let rows = format_column_rows(&items, cols);
+        assert!(rows.len() < items.len());
+        for row in &rows {
+            assert!(row.width() <= cols, "row {} wider than {cols}", row.width());
+        }
+    }
+
+    #[test]
+    fn listing_display_uses_basename() {
+        assert_eq!(listing_display("/usr/bin/arj"), "arj");
+        assert_eq!(listing_display("/usr/bin/foo/"), "foo/");
+    }
+
+    #[test]
+    fn display_strings_dedupes_and_sorts() {
+        let pairs = vec![
+            Pair {
+                display: "git".into(),
+                replacement: "git ".into(),
+            },
+            Pair {
+                display: "git".into(),
+                replacement: "git ".into(),
+            },
+            Pair {
+                display: "grep".into(),
+                replacement: "grep ".into(),
+            },
+        ];
+        assert_eq!(display_strings(&pairs), vec!["git", "grep"]);
+    }
+
+    #[test]
+    fn page_size_matches_rustyline() {
+        assert_eq!(page_size(0, 50), 50);
+        assert_eq!(page_size(u16::MAX, 50), 50);
+        assert_eq!(page_size(24, 50), 23);
+        assert_eq!(page_size(61, 200), 60);
+    }
+}

--- a/crates/aish-shell/src/completion_list.rs
+++ b/crates/aish-shell/src/completion_list.rs
@@ -228,9 +228,9 @@ fn page_rows(rows: &[String], terminal_rows: u16) -> io::Result<()> {
 
     for row in rows {
         while lines_on_page >= page_size {
+            drain_stdin_typeahead();
             write!(stdout, "\n{MORE_PROMPT}")?;
             stdout.flush()?;
-            drain_stdin_typeahead();
             match read_more_action()? {
                 MoreAction::NextPage => lines_on_page = 0,
                 MoreAction::NextLine => lines_on_page = page_size.saturating_sub(1),

--- a/crates/aish-shell/src/lib.rs
+++ b/crates/aish-shell/src/lib.rs
@@ -19,6 +19,8 @@ pub mod animation;
 pub mod app;
 pub mod autosuggest;
 pub mod commands;
+pub mod completion;
+pub mod completion_list;
 pub mod doctor;
 pub mod environment;
 pub mod esc_watcher;

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
+use std::cell::Cell;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::Instant;
 
 use rustyline::completion::{Completer, Pair};
 use rustyline::config::Configurer;
@@ -14,11 +15,10 @@ use rustyline::{
     EventContext, EventHandler, KeyCode, KeyEvent, Modifiers, RepeatCount,
 };
 
-use aish_pty::readline_tab::{
-    clamp_pos, is_path_like_token, to_replacement_pairs, word_start_at, TAB_PROBE_TIMEOUT,
-};
+use aish_pty::readline_tab::clamp_pos;
 
 use crate::autosuggest::AutoSuggest;
+use crate::completion::CompletionEngine;
 
 /// Slash commands with descriptions for popup completion.
 pub const SLASH_COMMANDS: &[(&str, &str)] = &[
@@ -36,9 +36,6 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/status", "Show system environment status"),
 ];
 
-/// Timeout for PTY completion queries.
-const COMPLETION_TIMEOUT: Duration = Duration::from_millis(1200);
-
 // ---------------------------------------------------------------------------
 // Mode toggle key binding handler
 // ---------------------------------------------------------------------------
@@ -51,6 +48,105 @@ static CTRL_O_REQUESTED: AtomicBool = AtomicBool::new(false);
 
 /// Flag set by `SlashHandler` when `/` is pressed on an empty line.
 static SLASH_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+/// Max gap between Tab presses to count as "double Tab" (bash second-tab list).
+const DOUBLE_TAB_MS: u128 = 800;
+
+struct TabCompletionState {
+    last_tab_at: Option<Instant>,
+    pending_list: bool,
+}
+
+static TAB_STATE: Mutex<TabCompletionState> = Mutex::new(TabCompletionState {
+    last_tab_at: None,
+    pending_list: false,
+});
+
+thread_local! {
+    static CURRENT_TERMINAL_SIZE: Cell<(u16, u16)> = const { Cell::new((80, 24)) };
+}
+
+/// Terminal size last seen by rustyline (cols, rows).
+pub fn current_terminal_size() -> (u16, u16) {
+    CURRENT_TERMINAL_SIZE.with(|s| s.get())
+}
+
+fn refresh_terminal_size<H: Helper>(editor: &mut Editor<H, rustyline::history::DefaultHistory>) {
+    if let Some((cols, rows)) = editor.dimensions() {
+        CURRENT_TERMINAL_SIZE.with(|s| s.set((cols, rows)));
+    }
+}
+
+/// Reset double-Tab tracking so a new prompt line starts clean.
+pub fn clear_tab_completion_state() {
+    if let Ok(mut state) = TAB_STATE.lock() {
+        state.last_tab_at = None;
+        state.pending_list = false;
+    }
+}
+
+/// Intercept the second Tab to print a bash-style column list ourselves.
+struct TabCompletionHandler {
+    engine: Arc<CompletionEngine>,
+}
+
+impl ConditionalEventHandler for TabCompletionHandler {
+    fn handle(
+        &self,
+        evt: &Event,
+        _n_repeat: RepeatCount,
+        _positive: bool,
+        ctx: &EventContext<'_>,
+    ) -> Option<Cmd> {
+        let Event::KeySeq(keys) = evt else {
+            return None;
+        };
+        let key = keys.first()?;
+        if key.0 != KeyCode::Tab || key.1 != Modifiers::NONE {
+            return None;
+        }
+
+        let line = ctx.line();
+        let pos = clamp_pos(line, ctx.pos());
+        let Some((_word_start, pairs)) = self.engine.complete(line, pos) else {
+            if let Ok(mut state) = TAB_STATE.lock() {
+                state.pending_list = false;
+            }
+            return None;
+        };
+
+        let now = Instant::now();
+        let Ok(mut state) = TAB_STATE.lock() else {
+            return None;
+        };
+
+        let consecutive = state
+            .last_tab_at
+            .is_some_and(|t| now.duration_since(t).as_millis() < DOUBLE_TAB_MS);
+        if !consecutive {
+            state.pending_list = false;
+        }
+        state.last_tab_at = Some(now);
+
+        if pairs.len() <= 1 {
+            state.pending_list = false;
+            return None;
+        }
+
+        let show_list = consecutive && state.pending_list;
+        if show_list {
+            state.pending_list = false;
+            drop(state);
+            let _ = crate::completion_list::print_completion_list(&pairs);
+            // Repaint: rustyline must redraw prompt+line; manual stdout redraw
+            // overwrites the buffer when the aish prompt uses ANSI/control chars.
+            return Some(Cmd::Repaint);
+        }
+
+        state.pending_list = true;
+        None
+    }
+}
 
 /// Event handler that sets a flag when Shift+Tab or F2 is pressed,
 /// then returns `Cmd::Interrupt` to break out of `read_line`.
@@ -113,79 +209,18 @@ impl ConditionalEventHandler for SlashHandler {
     }
 }
 
-/// Shell readline helper: tab completion delegates to PTY bash.
+/// Shell readline helper: tab completion via CompletionEngine.
 struct ShellHelper {
-    /// Shared reference to the persistent PTY session.
-    pty: Arc<Mutex<aish_pty::PersistentPty>>,
-    /// Shared autosuggest engine.
+    engine: Arc<CompletionEngine>,
     autosuggest: Arc<Mutex<AutoSuggest>>,
 }
 
 impl ShellHelper {
-    fn new(pty: Arc<Mutex<aish_pty::PersistentPty>>, autosuggest: Arc<Mutex<AutoSuggest>>) -> Self {
-        Self { pty, autosuggest }
-    }
-
-    /// Drop candidates that would not change the current word (rustyline re-applies
-    /// single-candidate replacements even when the word is already complete).
-    fn filter_extending_candidates(
-        line: &str,
-        pos: usize,
-        word_start: usize,
-        candidates: Vec<aish_pty::CompletionCandidate>,
-    ) -> Vec<Pair> {
-        let current = line.get(word_start..pos).unwrap_or("");
-        candidates
-            .into_iter()
-            .filter(|c| c.replacement != current)
-            .map(|c| Pair {
-                display: c.display,
-                replacement: c.replacement,
-            })
-            .collect()
-    }
-
-    fn complete_via_pty(&self, line: &str, pos: usize) -> Option<(usize, Vec<Pair>)> {
-        let pos = clamp_pos(line, pos);
-        let mut pty = self.pty.lock().ok()?;
-        if !pty.is_running() {
-            return None;
+    fn new(engine: Arc<CompletionEngine>, autosuggest: Arc<Mutex<AutoSuggest>>) -> Self {
+        Self {
+            engine,
+            autosuggest,
         }
-
-        let word_start = word_start_at(line, pos);
-        let current_word = line.get(word_start..pos).unwrap_or("");
-
-        // Readline Tab probe only when completing the command name (cword == 0).
-        // Subcommands and arguments use __aish_complete directly: injecting the
-        // full line into interactive readline can leave bash busy on slow native
-        // completions (e.g. systemctl), causing query_completions to time out.
-        if word_start == 0 && !is_path_like_token(current_word) {
-            if let Some(tab) = pty.forward_readline_tab(line, pos, TAB_PROBE_TIMEOUT) {
-                let (ws, raw_pairs) = to_replacement_pairs(&tab, line, pos);
-                if !raw_pairs.is_empty() {
-                    return Some((
-                        ws,
-                        raw_pairs
-                            .into_iter()
-                            .map(|(display, replacement)| Pair {
-                                display,
-                                replacement,
-                            })
-                            .collect(),
-                    ));
-                }
-            }
-        }
-
-        pty.query_completions(line, pos, COMPLETION_TIMEOUT)
-            .ok()
-            .filter(|resp| !resp.candidates.is_empty())
-            .map(|resp| {
-                (
-                    resp.word_start,
-                    Self::filter_extending_candidates(line, pos, resp.word_start, resp.candidates),
-                )
-            })
     }
 }
 
@@ -230,24 +265,26 @@ impl Completer for ShellHelper {
         _ctx: &Context<'_>,
     ) -> rustyline::Result<(usize, Vec<Pair>)> {
         let pos = clamp_pos(line, pos);
-        let before = &line[..pos];
-
-        // Skip completion for AI queries
-        if before.starts_with(';') || before.starts_with('\u{ff1b}') {
+        let Some((start, pairs)) = self.engine.complete(line, pos) else {
             return Ok((0, Vec::new()));
+        };
+
+        // If our Tab handler already armed a list, block rustyline's own column listing
+        // on the matching second Tab (handler normally Interrupts before we get here).
+        if pairs.len() > 1 {
+            if let Ok(state) = TAB_STATE.lock() {
+                if state.pending_list {
+                    if let Some(last) = state.last_tab_at {
+                        let elapsed = last.elapsed().as_millis();
+                        if (100..DOUBLE_TAB_MS).contains(&elapsed) {
+                            return Ok((start, Vec::new()));
+                        }
+                    }
+                }
+            }
         }
 
-        // Empty input: no completion (bash semantics)
-        if before.trim().is_empty() {
-            return Ok((0, Vec::new()));
-        }
-
-        if let Some((word_start, pairs)) = self.complete_via_pty(line, pos) {
-            return Ok((word_start, pairs));
-        }
-
-        // PTY unavailable — no fallback (bash is the single source of truth).
-        Ok((0, Vec::new()))
+        Ok((start, pairs))
     }
 }
 
@@ -262,6 +299,7 @@ pub struct ShellReadline {
 impl ShellReadline {
     pub fn new(pty: Arc<Mutex<aish_pty::PersistentPty>>) -> rustyline::Result<Self> {
         let autosuggest = Arc::new(Mutex::new(AutoSuggest::new(5000)));
+        let engine = Arc::new(CompletionEngine::new(pty));
 
         let builder = Config::builder()
             .completion_type(CompletionType::List)
@@ -270,8 +308,15 @@ impl ShellReadline {
         let config = builder.history_ignore_dups(true)?.build();
 
         let mut editor = Editor::with_config(config)?;
-        editor.set_helper(Some(ShellHelper::new(pty, autosuggest.clone())));
+        editor.set_helper(Some(ShellHelper::new(engine.clone(), autosuggest.clone())));
         editor.set_max_history_size(500)?;
+
+        editor.bind_sequence(
+            KeyEvent(KeyCode::Tab, Modifiers::NONE),
+            EventHandler::Conditional(Box::new(TabCompletionHandler {
+                engine: engine.clone(),
+            })),
+        );
 
         // Bind Shift+Tab (BackTab) and F2 for mode toggle
         editor.bind_sequence(
@@ -326,6 +371,8 @@ impl ShellReadline {
         prompt: &str,
         initial: (&str, &str),
     ) -> rustyline::Result<Option<String>> {
+        clear_tab_completion_state();
+        refresh_terminal_size(&mut self.editor);
         match self.editor.readline_with_initial(prompt, initial) {
             Ok(line) => Ok(Some(line)),
             Err(rustyline::error::ReadlineError::Eof) => Ok(None),
@@ -338,6 +385,8 @@ impl ShellReadline {
     /// Supports backslash continuation: lines ending with `\` read
     /// additional lines with a `> ` prompt.
     pub fn read_line(&mut self, prompt: &str) -> rustyline::Result<Option<String>> {
+        clear_tab_completion_state();
+        refresh_terminal_size(&mut self.editor);
         let line = match self.editor.readline(prompt) {
             Ok(line) => line,
             Err(rustyline::error::ReadlineError::Eof) => return Ok(None),
@@ -417,16 +466,6 @@ impl ShellReadline {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_filter_extending_candidates_drops_unchanged() {
-        let candidates = vec![aish_pty::CompletionCandidate {
-            display: "usr/".into(),
-            replacement: "/usr/".into(),
-        }];
-        let pairs = ShellHelper::filter_extending_candidates("/usr/", 5, 0, candidates);
-        assert!(pairs.is_empty(), "unchanged replacement should be filtered");
-    }
 
     #[test]
     fn test_slash_commands_format() {


### PR DESCRIPTION
## Summary

- Add `CompletionEngine` to route local path tokens through `FilenameCompleter` and everything else through PTY `query_completions` (no `forward_readline_tab` probe in the shell layer).
- Implement bash-like multi-column completion listing with a custom `--More--` pager (Space/y next page, Enter next line, q/n/Backspace/Ctrl+C stop).
- Intercept double-Tab within 800ms to print the list ourselves and return `Cmd::Repaint` so ANSI prompts are not corrupted by manual stdout redraw.

## Test plan

- [x] `make format-check && make lint`
- [x] `cargo test -p aish-shell completion`
- [x] `cargo test -p aish-pty readline_tab`
- [ ] Manual: `ls /usr/bin` → Tab Tab → multi-column list appears
- [ ] Manual: Space to page, `q` / Ctrl+C to stop without extra blank line
- [ ] Manual: `ls /usr` Tab → LCP extends to `/usr/…` (not `r/`)
- [ ] Manual: `systemctl rest` Tab → completes without timeout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tab `CompletionEngine` that chooses local filesystem completion or PTY-backed completion, improving behavior around cursor position and word detection.
  * Double-pressing Tab now displays a Bash-style, paged multi-column completion list.
  * Local path completion is disabled for quoted and remote-style paths (e.g., `user@host:/path`, `host:/path`).
* **Bug Fixes**
  * Prevents redundant suggestions by filtering exact-match candidates and avoids duplicate/conflicting completion output.
* **Chores**
  * Enabled an additional `rustyline` feature for directory-aware behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->