### PR TITLE
fix(pty): unblock send_command_interactive after sudo/PAM auth

### DIFF
--- a/crates/aish-pty/src/exit_code.rs
+++ b/crates/aish-pty/src/exit_code.rs
@@ -1,14 +1,32 @@
 //! Heuristics for command exit codes when PTY/bash reporting is unreliable
 //! (e.g. polkit password prompts, stale prompt_ready events).
 
-/// True when captured output shows polkit (or similar) auth still in progress.
+/// True when captured output shows polkit auth still in progress.
+///
+/// Only matches the *polkit* pkttyagent banners. Generic password prompts
+/// (`password:`, `请输入密码`) are intentionally excluded because sudo, ssh
+/// and su all block bash until their auth finishes — by the time bash's
+/// PromptReady fires, that auth is necessarily complete and there is
+/// nothing to defer. Treating those prompts as "auth in progress" makes
+/// the PromptReady event get deferred forever whenever the success line
+/// does not match a hard-coded completion string (e.g. zh_CN PAM printing
+/// `验证成功` instead of polkit's `==== AUTHENTICATION COMPLETE ====`),
+/// which leaves `send_command_interactive` stuck and the shell without a
+/// prompt or echo.
+///
+/// **Known gap**: pkttyagent's banner strings are wrapped in `_()`/`gettext()`
+/// and translated under non-English locales. A localized polkit install may
+/// emit (for example) `==== 正在为 ... 进行身份验证 ====` instead of the
+/// English `==== AUTHENTICATING FOR ... ====` and slip past this check.
+/// We deliberately do NOT enumerate translated variants (that's the
+/// enumeration anti-pattern that re-introduced this bug once already). The
+/// failure mode is bounded by the iteration cap in `send_command_interactive`
+/// (see `DEFERRED_MAX_ITERS` in persistent.rs): if this heuristic stays
+/// `true` longer than the budget, the deferred events are flushed regardless.
 pub fn polkit_auth_in_progress(output: &str) -> bool {
-    let lower = output.to_ascii_lowercase();
-    let auth_started = output.contains("AUTHENTICATING FOR")
-        || output.contains("Authenticating as:")
-        || output.contains("请输入密码")
-        || lower.contains("password:");
-    if !auth_started {
+    let polkit_prompted = output.contains("AUTHENTICATING FOR")
+        || output.contains("Authenticating as:");
+    if !polkit_prompted {
         return false;
     }
     let auth_finished =
@@ -66,6 +84,56 @@ mod tests {
     #[test]
     fn polkit_not_in_progress_after_complete() {
         let out = "==== AUTHENTICATION COMPLETE ====\nFailed to restart foo.service: Unit foo not found.\n";
+        assert!(!polkit_auth_in_progress(out));
+    }
+
+    /// Regression: a sync auth flow (sudo + zh_CN PAM, sudo + English PAM,
+    /// ssh) must NOT be mistaken for polkit auth in progress. These flows
+    /// block bash, so when PromptReady fires the auth is already done and
+    /// must not be deferred. Previously the generic `请输入密码` /
+    /// `password:` markers triggered the deferral and, because the success
+    /// line (`验证成功` / silent) was not in the hard-coded finish list,
+    /// `send_command_interactive` never returned — leaving the shell
+    /// without prompt or echo.
+    #[test]
+    fn sync_sudo_zh_pam_not_treated_as_polkit() {
+        let out = "请输入密码:\n验证成功\n";
+        assert!(!polkit_auth_in_progress(out));
+    }
+
+    #[test]
+    fn sync_sudo_en_not_treated_as_polkit() {
+        let out = "[sudo] password for user: \n";
+        assert!(!polkit_auth_in_progress(out));
+    }
+
+    #[test]
+    fn sync_ssh_password_not_treated_as_polkit() {
+        let out = "user@host's password: ";
+        assert!(!polkit_auth_in_progress(out));
+    }
+
+    /// Known limitation: `auth_finished` is a substring match over the whole
+    /// output buffer. Within a single `send_command_interactive` call that
+    /// triggers polkit auth more than once (e.g. `systemctl stop A && systemctl
+    /// stop B` as non-root), the first session's `AUTHENTICATION COMPLETE`
+    /// remains in the buffer and masks the second session's in-progress state.
+    /// This test documents the current (imperfect) behavior so a future fix
+    /// that switches to last-occurrence or per-section matching updates this
+    /// assertion intentionally. The `DEFERRED_MAX_ITERS` cap in persistent.rs
+    /// bounds the worst case to a ~10 s delay.
+    #[test]
+    fn known_limitation_stale_complete_masks_new_auth() {
+        let out = "\
+==== AUTHENTICATING FOR org.freedesktop.systemd1.manage-units ====
+Password:
+==== AUTHENTICATION COMPLETE ====
+==== AUTHENTICATING FOR org.freedesktop.systemd1.manage-units ====
+Password:
+";
+        // Ideally this should be `true` (second auth in progress), but the
+        // whole-buffer substring match returns `false` because the first
+        // session's COMPLETE line is still present.
         assert!(!polkit_auth_in_progress(out));
     }
 

--- a/crates/aish-pty/src/exit_code.rs
+++ b/crates/aish-pty/src/exit_code.rs
@@ -24,8 +24,8 @@
 /// (see `DEFERRED_MAX_ITERS` in persistent.rs): if this heuristic stays
 /// `true` longer than the budget, the deferred events are flushed regardless.
 pub fn polkit_auth_in_progress(output: &str) -> bool {
-    let polkit_prompted = output.contains("AUTHENTICATING FOR")
-        || output.contains("Authenticating as:");
+    let polkit_prompted =
+        output.contains("AUTHENTICATING FOR") || output.contains("Authenticating as:");
     if !polkit_prompted {
         return false;
     }

--- a/crates/aish-pty/src/persistent.rs
+++ b/crates/aish-pty/src/persistent.rs
@@ -1159,6 +1159,17 @@ impl PersistentPty {
         // commands.
         let mut draining = false;
         let mut deferred_control_events: Vec<crate::control::BackendControlEvent> = Vec::new();
+        // Iteration budget for the deferred-event replay loop. Each main-loop
+        // tick that ends with `deferred_control_events` still non-empty counts
+        // as one iteration (~50 ms poll interval). If the polkit heuristic
+        // keeps returning true longer than this budget — e.g. a translated
+        // polkit banner that no longer matches the hard-coded English strings,
+        // or some future regression in `polkit_auth_in_progress` — we abandon
+        // the deferral and flush the events through `handle_event`. This
+        // converts the failure mode from "shell hangs forever" (the bug this
+        // path once caused) to "shell pauses for ~10 s, then proceeds".
+        const DEFERRED_MAX_ITERS: u32 = 200;
+        let mut deferred_iters: u32 = 0;
         // The PTY may emit a bare leading newline from stale prompt
         // rendering.  Only skip a leading CR-LF or LF at the very start
         // of the first chunk -- never consume actual command output.
@@ -3527,7 +3538,10 @@ impl PersistentPty {
                             if let BackendControlEvent::PromptReady { .. } = event {
                                 let output_so_far =
                                     strip_ansi_escapes(&String::from_utf8_lossy(&output_buf));
-                                if crate::exit_code::polkit_auth_in_progress(&output_so_far) {
+                                let over_budget = deferred_iters >= DEFERRED_MAX_ITERS;
+                                if !over_budget
+                                    && crate::exit_code::polkit_auth_in_progress(&output_so_far)
+                                {
                                     deferred_control_events.push(event.clone());
                                     continue;
                                 }
@@ -3563,13 +3577,24 @@ impl PersistentPty {
             }
 
             if !deferred_control_events.is_empty() {
+                deferred_iters = deferred_iters.saturating_add(1);
+                let budget_exhausted = deferred_iters >= DEFERRED_MAX_ITERS;
+                if budget_exhausted {
+                    debug!(
+                        "deferred events exceeded {} iters (~{}s); flushing regardless of polkit heuristic",
+                        DEFERRED_MAX_ITERS,
+                        DEFERRED_MAX_ITERS / 20
+                    );
+                }
                 let output_so_far = strip_ansi_escapes(&String::from_utf8_lossy(&output_buf));
                 let mut still_deferred = Vec::new();
                 for event in deferred_control_events.drain(..) {
-                    if let BackendControlEvent::PromptReady { .. } = &event {
-                        if crate::exit_code::polkit_auth_in_progress(&output_so_far) {
-                            still_deferred.push(event);
-                            continue;
+                    if !budget_exhausted {
+                        if let BackendControlEvent::PromptReady { .. } = &event {
+                            if crate::exit_code::polkit_auth_in_progress(&output_so_far) {
+                                still_deferred.push(event);
+                                continue;
+                            }
                         }
                     }
                     if let Some(r) = self.command_state.handle_event(&event) {

--- a/crates/aish-pty/src/persistent.rs
+++ b/crates/aish-pty/src/persistent.rs
@@ -1159,17 +1159,23 @@ impl PersistentPty {
         // commands.
         let mut draining = false;
         let mut deferred_control_events: Vec<crate::control::BackendControlEvent> = Vec::new();
-        // Iteration budget for the deferred-event replay loop. Each main-loop
-        // tick that ends with `deferred_control_events` still non-empty counts
-        // as one iteration (~50 ms poll interval). If the polkit heuristic
-        // keeps returning true longer than this budget — e.g. a translated
-        // polkit banner that no longer matches the hard-coded English strings,
-        // or some future regression in `polkit_auth_in_progress` — we abandon
-        // the deferral and flush the events through `handle_event`. This
-        // converts the failure mode from "shell hangs forever" (the bug this
-        // path once caused) to "shell pauses for ~10 s, then proceeds".
-        const DEFERRED_MAX_ITERS: u32 = 200;
-        let mut deferred_iters: u32 = 0;
+        // Wall-clock budget for the deferred-event replay loop. If the polkit
+        // heuristic keeps returning true longer than this budget — e.g. a
+        // translated polkit banner that no longer matches the hard-coded
+        // English strings, or some future regression in
+        // `polkit_auth_in_progress` — we abandon the deferral and flush the
+        // events through `handle_event`. This converts the failure mode from
+        // "shell hangs forever" (the bug this path once caused) to "shell
+        // pauses for ~10 s, then proceeds".
+        //
+        // A wall-clock deadline (rather than an iteration count) is required
+        // because `select` returns immediately when PTY/control/stdin has
+        // data ready — under password entry with keystroke echoes or chatty
+        // PTY output, the loop can blow through an iteration budget in a
+        // fraction of the intended window and flush `PromptReady` while
+        // polkit auth is genuinely still in progress.
+        const DEFERRED_MAX_DELAY: std::time::Duration = std::time::Duration::from_secs(10);
+        let mut deferred_since: Option<std::time::Instant> = None;
         // The PTY may emit a bare leading newline from stale prompt
         // rendering.  Only skip a leading CR-LF or LF at the very start
         // of the first chunk -- never consume actual command output.
@@ -3538,10 +3544,12 @@ impl PersistentPty {
                             if let BackendControlEvent::PromptReady { .. } = event {
                                 let output_so_far =
                                     strip_ansi_escapes(&String::from_utf8_lossy(&output_buf));
-                                let over_budget = deferred_iters >= DEFERRED_MAX_ITERS;
+                                let over_budget = deferred_since
+                                    .is_some_and(|since| since.elapsed() >= DEFERRED_MAX_DELAY);
                                 if !over_budget
                                     && crate::exit_code::polkit_auth_in_progress(&output_so_far)
                                 {
+                                    deferred_since.get_or_insert_with(std::time::Instant::now);
                                     deferred_control_events.push(event.clone());
                                     continue;
                                 }
@@ -3577,13 +3585,12 @@ impl PersistentPty {
             }
 
             if !deferred_control_events.is_empty() {
-                deferred_iters = deferred_iters.saturating_add(1);
-                let budget_exhausted = deferred_iters >= DEFERRED_MAX_ITERS;
+                let budget_exhausted =
+                    deferred_since.is_some_and(|since| since.elapsed() >= DEFERRED_MAX_DELAY);
                 if budget_exhausted {
                     debug!(
-                        "deferred events exceeded {} iters (~{}s); flushing regardless of polkit heuristic",
-                        DEFERRED_MAX_ITERS,
-                        DEFERRED_MAX_ITERS / 20
+                        "deferred events exceeded {:?}; flushing regardless of polkit heuristic",
+                        DEFERRED_MAX_DELAY
                     );
                 }
                 let output_so_far = strip_ansi_escapes(&String::from_utf8_lossy(&output_buf));
@@ -3610,6 +3617,9 @@ impl PersistentPty {
                     }
                 }
                 deferred_control_events = still_deferred;
+                if deferred_control_events.is_empty() {
+                    deferred_since = None;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- `polkit_auth_in_progress` used generic `password:` / `请输入密码` markers as the trigger for deferred `PromptReady` handling. But sudo/ssh/su auth blocks bash synchronously — when bash's `PromptReady` fires their auth is necessarily complete, so the deferral is never needed for them.
- When the success line did not match polkit's hard-coded `==== AUTHENTICATION COMPLETE ====` banner (e.g. zh_CN PAM printing `验证成功`), `PromptReady` stayed deferred forever and `send_command_interactive` never returned. The shell showed no prompt and no echo after a successful `sudo` command, even though subsequent commands still ran (their output was visible).
- Two changes:
  1. Restrict `polkit_auth_in_progress` to pkttyagent's specific banners (`AUTHENTICATING FOR` / `Authenticating as:`).
  2. Add `DEFERRED_MAX_ITERS` (200 iterations, ~10s) budget to the deferred event replay loop. If a future regression (e.g. localized polkit banners that slip past the narrowed markers) keeps the heuristic returning `true`, events are force-flushed through `handle_event` instead of hanging forever. Converts the worst case from "shell hangs indefinitely" to "shell delays ~10s, then proceeds".

## Reproduction

On a zh_CN system, run `sudo systemctl stop docker.socket` and enter the password. Before the fix, the shell appears frozen after `验证成功` — typed characters are not echoed and no prompt is shown. Debug logs show `PromptReady` arrives but `done=false` keeps looping, and subsequent keystrokes bypass rustyline straight into the PTY.

## Test plan

- [x] `cargo test -p aish-pty --lib` — 254 tests pass (4 new)
- [x] `cargo clippy -p aish-pty --lib --tests -- -D warnings` — clean
- [x] `cargo build --release --bin aish` — succeeds
- [ ] Manual: `sudo systemctl stop docker.socket` on zh_CN system returns to a normal prompt
- [ ] Manual: `sudo ls /root` works on en_US system
- [ ] Manual: standard `systemctl` polkit prompt still defers correctly until `AUTHENTICATION COMPLETE`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of polkit authentication-in-progress by requiring specific pkttyagent banner output, so typical `sudo`/SSH password prompts are no longer misclassified.
  * Prevented interactive prompt deferrals from stalling by switching to a wall-clock delay budget and flushing deferred events once the budget is exceeded.
  * Kept authentication completion/failure detection working as expected.
* **Tests**
  * Added regression coverage for localized `sudo`/English prompts and SSH password requests, plus a documented edge case for prompt-state masking in the same buffer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->