### PR TITLE
fix(llm): normalize model IDs for setup/runtime and default max_tokens

### DIFF
--- a/crates/aish-llm/src/client.rs
+++ b/crates/aish-llm/src/client.rs
@@ -1,7 +1,11 @@
 use aish_core::AishError;
 use reqwest::Client;
 
+use crate::model_id::resolve_model_for_api;
 use crate::types::{ChatMessage, ToolSpec};
+
+/// Default max_tokens when config does not specify a value.
+pub const DEFAULT_MAX_TOKENS: u32 = 4096;
 
 /// HTTP client for OpenAI-compatible chat completion APIs.
 pub struct LlmClient {
@@ -13,7 +17,7 @@ pub struct LlmClient {
 
 impl LlmClient {
     pub fn new(api_base: &str, api_key: &str, model: &str) -> Self {
-        let model = strip_provider_prefix_if_openai(model, api_base);
+        let model = resolve_model_for_api(model, api_base);
         Self {
             http: Client::new(),
             api_base: api_base.trim_end_matches('/').into(),
@@ -39,7 +43,7 @@ impl LlmClient {
 
     /// Update the model name (used for runtime model switching).
     pub fn update_model(&mut self, model: &str) {
-        self.model = strip_provider_prefix_if_openai(model, &self.api_base);
+        self.model = resolve_model_for_api(model, &self.api_base);
     }
 
     /// Update the API key.
@@ -141,9 +145,7 @@ impl LlmClient {
         if let Some(temp) = temperature {
             body["temperature"] = serde_json::json!(temp);
         }
-        if let Some(tokens) = max_tokens {
-            body["max_tokens"] = serde_json::json!(tokens);
-        }
+        body["max_tokens"] = serde_json::json!(effective_max_tokens(max_tokens));
         if let Some(tools) = tools {
             body["tools"] = serde_json::json!(tools);
             body["tool_choice"] = serde_json::json!("auto");
@@ -181,17 +183,10 @@ impl LlmClient {
     }
 }
 
-/// Strip LiteLLM-style provider prefix only when targeting OpenAI's official API.
-/// Unified gateways (e.g. ai.uniontech.com) require the full prefixed model name.
-fn strip_provider_prefix_if_openai(model: &str, api_base: &str) -> String {
-    let is_openai = api_base.contains("api.openai.com");
-    if is_openai {
-        match model.split_once('/') {
-            Some((_provider, name)) => name.to_string(),
-            None => model.to_string(),
-        }
-    } else {
-        model.to_string()
+fn effective_max_tokens(max_tokens: Option<u32>) -> u32 {
+    match max_tokens {
+        None | Some(0) => DEFAULT_MAX_TOKENS,
+        Some(n) => n,
     }
 }
 
@@ -252,6 +247,22 @@ mod tests {
             "provider/model-name",
         );
         assert_eq!(client.model_name(), "provider/model-name");
+    }
+
+    #[test]
+    fn test_new_client_strips_openai_prefix_for_custom_gateway() {
+        let client = LlmClient::new(
+            "http://www.aishell.ai:8080/aitest/v1",
+            "sk-test",
+            "openai/gpt-5.1",
+        );
+        assert_eq!(client.model_name(), "gpt-5.1");
+    }
+
+    #[test]
+    fn test_new_client_preserves_prefix_for_openrouter() {
+        let client = LlmClient::new("https://openrouter.ai/api/v1", "sk-test", "openai/gpt-4o");
+        assert_eq!(client.model_name(), "openai/gpt-4o");
     }
 
     #[test]
@@ -326,6 +337,13 @@ mod tests {
         let msg = format_http_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR, "Internal error");
         assert!(msg.contains("500"));
         assert!(msg.contains("Server error"));
+    }
+
+    #[test]
+    fn test_effective_max_tokens() {
+        assert_eq!(effective_max_tokens(None), DEFAULT_MAX_TOKENS);
+        assert_eq!(effective_max_tokens(Some(0)), DEFAULT_MAX_TOKENS);
+        assert_eq!(effective_max_tokens(Some(1000)), 1000);
     }
 
     #[test]

--- a/crates/aish-llm/src/lib.rs
+++ b/crates/aish-llm/src/lib.rs
@@ -17,6 +17,7 @@ pub mod agent;
 pub mod client;
 pub mod diagnose_agent;
 pub mod langfuse;
+pub mod model_id;
 pub mod models;
 pub mod oauth;
 pub mod provider;
@@ -29,9 +30,10 @@ pub mod types;
 pub mod usage;
 
 pub use agent::{AgentConfig, AgentStep, ReActAgent};
-pub use client::{LlmClient, LlmResponse};
+pub use client::{LlmClient, LlmResponse, DEFAULT_MAX_TOKENS};
 pub use diagnose_agent::DiagnoseAgent;
 pub use langfuse::{LangfuseClient, LangfuseConfig};
+pub use model_id::{normalize_model_for_provider, resolve_model_for_api, trim_model_name};
 pub use models::{
     fetch_models_from_api, fetch_ollama_models, filter_by_tool_support, get_predefined_models,
     model_supports_tools, ModelInfo,

--- a/crates/aish-llm/src/model_id.rs
+++ b/crates/aish-llm/src/model_id.rs
@@ -1,0 +1,150 @@
+//! Model ID normalization for setup (config storage) and runtime (HTTP requests).
+
+const COMMON_STRIP_PREFIXES: &[&str] = &["openai/", "anthropic/"];
+
+/// Trim whitespace from a model name (used when fetching model lists).
+pub fn trim_model_name(model: &str) -> String {
+    model.trim().to_string()
+}
+
+/// Normalize a model name for storage in config, based on the selected provider.
+///
+/// Setup-layer logic: decides what goes into `config.yaml`.
+pub fn normalize_model_for_provider(provider_key: &str, model: &str) -> String {
+    let trimmed = model.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    if trimmed.contains('/') {
+        if provider_key == "openai" {
+            return strip_first_provider_segment(trimmed);
+        }
+        return trimmed.to_string();
+    }
+
+    if provider_key == "openrouter" {
+        return format!("openai/{trimmed}");
+    }
+
+    trimmed.to_string()
+}
+
+/// Resolve the model name to send in HTTP requests, based on the API base URL.
+///
+/// Runtime-layer logic: replicates LiteLLM behavior for OpenAI-compatible proxies.
+pub fn resolve_model_for_api(model: &str, api_base: &str) -> String {
+    let trimmed = model.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let base_lower = api_base.to_lowercase();
+    if base_lower.contains("api.openai.com") {
+        return strip_first_provider_segment(trimmed);
+    }
+    if base_lower.contains("openrouter.ai") {
+        return trimmed.to_string();
+    }
+    strip_common_provider_prefix(trimmed)
+}
+
+fn strip_first_provider_segment(model: &str) -> String {
+    match model.split_once('/') {
+        Some((_provider, name)) => name.to_string(),
+        None => model.to_string(),
+    }
+}
+
+fn strip_common_provider_prefix(model: &str) -> String {
+    for prefix in COMMON_STRIP_PREFIXES {
+        if let Some(stripped) = model.strip_prefix(prefix) {
+            return stripped.to_string();
+        }
+    }
+    model.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_trim_model_name() {
+        assert_eq!(trim_model_name("  gpt-4o  "), "gpt-4o");
+        assert_eq!(trim_model_name(""), "");
+    }
+
+    #[test]
+    fn test_normalize_openrouter_bare() {
+        assert_eq!(
+            normalize_model_for_provider("openrouter", "gpt-5.1"),
+            "openai/gpt-5.1"
+        );
+    }
+
+    #[test]
+    fn test_normalize_openrouter_prefixed() {
+        assert_eq!(
+            normalize_model_for_provider("openrouter", "openai/gpt-5.1"),
+            "openai/gpt-5.1"
+        );
+    }
+
+    #[test]
+    fn test_normalize_custom_bare() {
+        assert_eq!(normalize_model_for_provider("custom", "gpt-5.1"), "gpt-5.1");
+    }
+
+    #[test]
+    fn test_normalize_custom_prefixed() {
+        assert_eq!(
+            normalize_model_for_provider("custom", "openai/gpt-5.1"),
+            "openai/gpt-5.1"
+        );
+    }
+
+    #[test]
+    fn test_normalize_openai_strips_prefix() {
+        assert_eq!(
+            normalize_model_for_provider("openai", "openai/gpt-4o"),
+            "gpt-4o"
+        );
+    }
+
+    #[test]
+    fn test_normalize_openai_bare() {
+        assert_eq!(normalize_model_for_provider("openai", "gpt-4o"), "gpt-4o");
+    }
+
+    #[test]
+    fn test_resolve_openai_official() {
+        assert_eq!(
+            resolve_model_for_api("openai/gpt-4o", "https://api.openai.com/v1"),
+            "gpt-4o"
+        );
+    }
+
+    #[test]
+    fn test_resolve_openrouter() {
+        assert_eq!(
+            resolve_model_for_api("openai/gpt-4o", "https://openrouter.ai/api/v1"),
+            "openai/gpt-4o"
+        );
+    }
+
+    #[test]
+    fn test_resolve_custom_gateway() {
+        let base = "http://www.aishell.ai:8080/aitest/v1";
+        assert_eq!(resolve_model_for_api("openai/gpt-5.1", base), "gpt-5.1");
+        assert_eq!(resolve_model_for_api("gpt-5.1", base), "gpt-5.1");
+    }
+
+    #[test]
+    fn test_resolve_custom_preserves_unknown_prefix() {
+        assert_eq!(
+            resolve_model_for_api("provider/model-name", "https://gateway.example.com/v1"),
+            "provider/model-name"
+        );
+    }
+}

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -239,13 +239,13 @@ impl LlmSession {
 
     /// Update the model, optionally also updating API base and key.
     pub fn update_model(&mut self, model: &str, api_base: Option<&str>, api_key: Option<&str>) {
-        self.client.update_model(model);
         if let Some(base) = api_base {
             self.client.update_api_base(base);
         }
         if let Some(key) = api_key {
             self.client.update_api_key(key);
         }
+        self.client.update_model(model);
     }
 
     /// Return the current model name.
@@ -2529,7 +2529,22 @@ mod tests {
             Some(1000),
         );
         session.update_model("gpt-4o", None, None);
-        // compile-time check that method exists
+        assert_eq!(session.model_name(), "gpt-4o");
+    }
+
+    #[test]
+    fn test_session_update_model_resolves_after_api_base_change() {
+        let mut session = LlmSession::new(
+            "https://openrouter.ai/api/v1",
+            "sk-test",
+            "openai/gpt-4o",
+            None,
+            None,
+        );
+        assert_eq!(session.model_name(), "openai/gpt-4o");
+
+        session.update_model("openai/gpt-4o", Some("https://api.openai.com/v1"), None);
+        assert_eq!(session.model_name(), "gpt-4o");
     }
 
     #[test]

--- a/crates/aish-llm/tests/llm_integration_test.rs
+++ b/crates/aish-llm/tests/llm_integration_test.rs
@@ -8,8 +8,9 @@
 // 5. SubSessionConfig defaults
 
 use aish_llm::{
-    detect_provider, detect_provider_from_model, refine_provider_from_api_base, ChatMessage,
-    DiagnoseAgent, LlmClient, SubSessionConfig,
+    detect_provider, detect_provider_from_model, normalize_model_for_provider,
+    refine_provider_from_api_base, resolve_model_for_api, ChatMessage, DiagnoseAgent, LlmClient,
+    SubSessionConfig, DEFAULT_MAX_TOKENS,
 };
 
 #[test]
@@ -41,6 +42,76 @@ fn test_provider_prefix_stripping() {
         "deepseek/deepseek-coder",
     );
     assert_eq!(client4.model_name(), "deepseek-coder");
+}
+
+#[test]
+fn test_model_id_setup_normalize_matrix() {
+    assert_eq!(
+        normalize_model_for_provider("openrouter", "gpt-5.1"),
+        "openai/gpt-5.1"
+    );
+    assert_eq!(
+        normalize_model_for_provider("openrouter", "openai/gpt-5.1"),
+        "openai/gpt-5.1"
+    );
+    assert_eq!(normalize_model_for_provider("custom", "gpt-5.1"), "gpt-5.1");
+    assert_eq!(
+        normalize_model_for_provider("custom", "openai/gpt-5.1"),
+        "openai/gpt-5.1"
+    );
+    assert_eq!(
+        normalize_model_for_provider("openai", "openai/gpt-4o"),
+        "gpt-4o"
+    );
+}
+
+#[test]
+fn test_model_id_runtime_resolve_matrix() {
+    assert_eq!(
+        resolve_model_for_api("openai/gpt-4o", "https://api.openai.com/v1"),
+        "gpt-4o"
+    );
+    assert_eq!(
+        resolve_model_for_api("openai/gpt-4o", "https://openrouter.ai/api/v1"),
+        "openai/gpt-4o"
+    );
+    let custom_base = "http://www.aishell.ai:8080/aitest/v1";
+    assert_eq!(
+        resolve_model_for_api("openai/gpt-5.1", custom_base),
+        "gpt-5.1"
+    );
+    assert_eq!(resolve_model_for_api("gpt-5.1", custom_base), "gpt-5.1");
+}
+
+#[test]
+fn test_llm_client_custom_gateway_model_resolution() {
+    let client = LlmClient::new(
+        "http://www.aishell.ai:8080/aitest/v1",
+        "sk-test",
+        "openai/gpt-5.1",
+    );
+    assert_eq!(client.model_name(), "gpt-5.1");
+
+    let client2 = LlmClient::new("https://openrouter.ai/api/v1", "sk-test", "openai/gpt-4o");
+    assert_eq!(client2.model_name(), "openai/gpt-4o");
+}
+
+#[test]
+fn test_setup_verification_uses_runtime_model_resolution() {
+    let config_model = "openai/gpt-4o";
+    assert_eq!(
+        resolve_model_for_api(config_model, "https://api.openai.com/v1"),
+        "gpt-4o"
+    );
+    assert_eq!(
+        resolve_model_for_api(config_model, "https://openrouter.ai/api/v1"),
+        "openai/gpt-4o"
+    );
+}
+
+#[test]
+fn test_default_max_tokens_constant() {
+    assert_eq!(DEFAULT_MAX_TOKENS, 4096);
 }
 
 #[test]

--- a/crates/aish-shell/src/wizard/mod.rs
+++ b/crates/aish-shell/src/wizard/mod.rs
@@ -20,6 +20,7 @@ use std::path::PathBuf;
 use aish_config::ConfigModel;
 use aish_core::AishError;
 use aish_i18n::{t, t_with_args};
+use aish_llm::{normalize_model_for_provider, resolve_model_for_api};
 
 use crate::tui::{DialogOption, DialogResult, CUSTOM_DIALOG_VALUE};
 use ui::{show_searchable_selection, show_selection};
@@ -342,6 +343,24 @@ impl SetupWizard {
         &self.config_dir
     }
 
+    fn set_normalized_model(&mut self, raw: &str) {
+        let provider_key = self
+            .selected_provider
+            .as_ref()
+            .map(|p| p.key.as_str())
+            .unwrap_or("custom");
+        let normalized = normalize_model_for_provider(provider_key, raw);
+        if normalized != raw.trim() {
+            let mut args = std::collections::HashMap::new();
+            args.insert("model".to_string(), normalized.clone());
+            println!(
+                "  \x1b[2m{}\x1b[0m",
+                t_with_args("cli.setup.model_custom_saved_as", &args)
+            );
+        }
+        self.selected_model = Some(normalized);
+    }
+
     /// Prompt the user to choose setup entry mode.
     fn select_entry_mode(&self) -> Result<String, AishError> {
         let mut options = vec![
@@ -451,15 +470,15 @@ impl SetupWizard {
                     } else {
                         Some(result.api_base)
                     };
-                    self.selected_model = if result.model.is_empty() {
-                        None
-                    } else {
-                        Some(model_fetch::normalize_model_name(&result.model))
-                    };
                     self.selected_provider = Some(ProviderInfo::new(
                         "free_key",
                         t("cli.setup.free_key_provider_label"),
                     ));
+                    if result.model.is_empty() {
+                        self.selected_model = None;
+                    } else {
+                        self.set_normalized_model(&result.model);
+                    }
                     self.is_free_key = true;
 
                     // If all fields are present, verify and save.
@@ -759,7 +778,7 @@ impl SetupWizard {
                     return self.prompt_custom_model();
                 }
                 DialogResult::Selected(model) => {
-                    self.selected_model = Some(model_fetch::normalize_model_name(&model));
+                    self.set_normalized_model(&model);
                     return Ok(());
                 }
                 DialogResult::Cancelled => {
@@ -780,7 +799,7 @@ impl SetupWizard {
             self.state = WizardState::ProviderSelection;
             return Ok(());
         }
-        self.selected_model = Some(model_fetch::normalize_model_name(&model));
+        self.set_normalized_model(&model);
         Ok(())
     }
 
@@ -805,6 +824,7 @@ impl SetupWizard {
             .as_ref()
             .ok_or_else(|| AishError::Config("No API key configured".to_string()))?
             .clone();
+        let api_model = resolve_model_for_api(&model, &api_base);
 
         let connectivity_msg = t("cli.setup.verify_connectivity_in_progress");
         clack_log::step(&connectivity_msg);
@@ -812,7 +832,7 @@ impl SetupWizard {
             verification::check_connectivity(
                 &api_base,
                 &api_key,
-                &model,
+                &api_model,
                 verification::DEFAULT_CONNECTIVITY_TIMEOUT_S,
             )
         });
@@ -834,7 +854,7 @@ impl SetupWizard {
             verification::check_tool_support(
                 &api_base,
                 &api_key,
-                &model,
+                &api_model,
                 verification::DEFAULT_TOOL_SUPPORT_TIMEOUT_S,
             )
         });

--- a/crates/aish-shell/src/wizard/model_fetch.rs
+++ b/crates/aish-shell/src/wizard/model_fetch.rs
@@ -5,6 +5,8 @@
 
 use tracing::debug;
 
+use aish_llm::trim_model_name;
+
 use super::get_provider_models;
 
 // ---------------------------------------------------------------------------
@@ -85,7 +87,7 @@ pub fn fetch_models_from_api(
         if let Some(data) = body.get("data").and_then(|d| d.as_array()) {
             for entry in data {
                 if let Some(id) = entry.get("id").and_then(|v| v.as_str()) {
-                    all_models.push(normalize_model_name(id));
+                    all_models.push(trim_model_name(id));
                 }
             }
         } else {
@@ -150,7 +152,7 @@ pub fn fetch_ollama_models(timeout_s: u64) -> Result<Vec<String>, String> {
     if let Some(arr) = body.get("models").and_then(|v| v.as_array()) {
         for entry in arr {
             if let Some(name) = entry.get("name").and_then(|v| v.as_str()) {
-                models.push(normalize_model_name(name));
+                models.push(trim_model_name(name));
             }
         }
     }
@@ -226,27 +228,6 @@ pub fn get_models_for_provider(
     Vec::new()
 }
 
-/// Normalize a model name by trimming whitespace and removing common prefixes.
-pub fn normalize_model_name(model: &str) -> String {
-    let trimmed = model.trim();
-
-    // Common prefixes users might accidentally include.
-    let prefixes_to_strip = [
-        "openai/",    // e.g. "openai/gpt-4o" from some aggregators
-        "anthropic/", // e.g. "anthropic/claude-3-opus"
-    ];
-
-    let mut result = trimmed;
-    for prefix in &prefixes_to_strip {
-        if let Some(stripped) = result.strip_prefix(prefix) {
-            result = stripped;
-            break; // Only strip one prefix
-        }
-    }
-
-    result.to_string()
-}
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -275,30 +256,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_normalize_model_name_basic() {
-        assert_eq!(normalize_model_name("  gpt-4o  "), "gpt-4o");
-        assert_eq!(normalize_model_name("gpt-4o"), "gpt-4o");
-    }
-
-    #[test]
-    fn test_normalize_model_name_strip_prefix() {
-        assert_eq!(normalize_model_name("openai/gpt-4o"), "gpt-4o");
+    fn test_trim_model_name_in_fetch() {
+        assert_eq!(trim_model_name("  gpt-4o  "), "gpt-4o");
+        assert_eq!(trim_model_name("openai/gpt-4o"), "openai/gpt-4o");
         assert_eq!(
-            normalize_model_name("anthropic/claude-3-opus"),
-            "claude-3-opus"
+            trim_model_name("anthropic/claude-3-opus"),
+            "anthropic/claude-3-opus"
         );
     }
 
     #[test]
-    fn test_normalize_model_name_no_strip() {
-        // Should NOT strip unknown prefixes.
-        assert_eq!(normalize_model_name("my-custom-model"), "my-custom-model");
-    }
-
-    #[test]
-    fn test_normalize_model_name_empty() {
-        assert_eq!(normalize_model_name(""), "");
-        assert_eq!(normalize_model_name("   "), "");
+    fn test_trim_model_name_empty() {
+        assert_eq!(trim_model_name(""), "");
+        assert_eq!(trim_model_name("   "), "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `model_id` module with setup-layer `normalize_model_for_provider` and runtime-layer `resolve_model_for_api` (LiteLLM-style stripping on custom OpenAI-compatible gateways).
- Wire `LlmClient` to resolve models at construction/update time and always send `max_tokens` (default 4096 when unset or 0).
- Update setup wizard: fetch lists use trim-only; saved models use provider-aware normalization; verification uses the same runtime model resolution as the client.
- Fix `LlmSession::update_model` to apply `api_base` changes before re-resolving the model (fixes resume/model switch across gateway types).

## Test plan
- [x] `make format-check`
- [x] `make lint`
- [x] `cargo test -p aish-llm -p aish-shell`
- [ ] Manual: custom gateway with config `openai/gpt-5.1` — setup verify passes and runtime sends bare model name
- [ ] Manual: OpenRouter bare model saved as `openai/...` and sent unchanged to OpenRouter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model names are now handled more consistently across setup, saved settings, and API requests, including better support for different providers and gateways.
  * Setup checks now use the resolved API model, improving validation accuracy.

* **Bug Fixes**
  * Fixed cases where missing or zero token limits could result in unexpected request behavior; a sensible default is now always applied.
  * Improved handling of custom gateways and provider-prefixed model names during model selection and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->