### PR TITLE
Release v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] - 2026-07-03
+
+### Added
+
+- Added `/diagnose` for read-only failure diagnosis when shell commands are blocked.
+- Added read-only mode support for the bash tool, with hardened parsing for sudo segments and escapes.
+- Added bash-style multi-column tab completion with a custom pager.
+- Added environment-aware remote PS1 with danger escalation, including SSH host and git branch display.
+- Added a welcome changelog panel on startup.
+- Added a cliclack-based setup wizard with Codex OAuth login and OpenClaw-aligned auth flows.
+- Added bundled ops skills that seed to the user directory on install.
+- Added a multi API dialect registry for Anthropic and Codex, with streaming via an OpenAI SSE bridge.
+
+### Changed
+
+- Improved setup wizard UX, provider copy, and localized verification error messages.
+- Normalized model IDs for setup/runtime and adjusted default `max_tokens`.
+
+### Fixed
+
+- Fixed read-only bash enforcement gaps in the parser and session.
+- Fixed remote path detection for `host:/path` syntax and stdin draining before `--More--` prompts.
+- Fixed `send_command_interactive` blocking after sudo/PAM authentication.
+- Fixed PTY `PRINTF_ERASE` chunk-boundary leak.
+- Fixed Codex auth, SSE streaming, and Responses adapter `temperature` / `max_tokens` passthrough.
+
 ## [0.3.5] - 2026-06-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "aish-cli"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "aish-config"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "aish-context"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aish-core",
  "serde",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "aish-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "aish-hosts"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "aish-i18n"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "aish-llm"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aish-context",
  "aish-core",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "aish-memory"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aish-core",
  "chrono",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "aish-prompts"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "aish-pty"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "aish-scripts"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "aish-security"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "libc",
  "regex",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "aish-session"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aish-core",
  "chrono",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "aish-shell"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aish-config",
  "aish-context",
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "aish-skills"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "aish-tools"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aish-core",
  "aish-i18n",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "aish-ui"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "crossterm 0.28.1",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"


### PR DESCRIPTION
## Summary

- Bump version to `0.3.6`

## Changelog highlights

**Added**
- `/diagnose` for read-only failure diagnosis
- Read-only mode for bash tool
- Multi-column tab completion with custom pager
- Environment-aware remote PS1 with danger escalation
- Welcome changelog panel
- Cliclack setup wizard with Codex OAuth
- Bundled ops skills seeded on install
- Multi API dialect registry (Anthropic/Codex) with SSE streaming

**Changed**
- Setup wizard UX and localized verification errors
- Model ID normalization and default `max_tokens`

**Fixed**
- Read-only bash enforcement gaps
- Remote `host:/path` detection and `--More--` stdin draining
- Sudo/PAM auth blocking in interactive commands
- PTY `PRINTF_ERASE` leak
- Codex auth/SSE and Responses adapter passthrough

## Test plan

- [x] `make packaging-test`
- [x] `make test` (cargo test --workspace + release script smoke)
- [x] `release_metadata.py --expected-version 0.3.6` metadata validation
- [ ] `Release Preparation` workflow (version `0.3.6`, ref `release/v0.3.6-prep`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new release entry highlighting onboarding improvements, richer command completion, remote shell polish, a welcome panel, and broader model/provider support.
  * Introduced a setup flow with login/auth options and bundled tools installed automatically.

* **Bug Fixes**
  * Improved handling of read-only shells, remote paths, stdin prompts, interactive command execution, and terminal output rendering.
  * Fixed passthrough of key model settings in API integrations.

* **Chores**
  * Bumped the workspace version to `0.3.6`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->