### PR TITLE
fix(cli): align tool-support probe with interactive shell path

### DIFF
--- a/crates/aish-cli/src/main.rs
+++ b/crates/aish-cli/src/main.rs
@@ -457,37 +457,19 @@ fn check_tool_support(
     println!("Checking tool calling support for: {}", model);
     println!("API Base: {}", api_base);
 
-    // Send a simple request with a tool definition to test support
+    // Mirror interactive shell: dialect-aware streaming request with normal token budget.
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let result = rt.block_on(async {
-        let client = aish_llm::LlmClient::new(&api_base, &api_key, &model);
-        let messages = vec![aish_llm::ChatMessage::user(
-            "Reply with just 'ok'. Do not use any tools.",
-        )];
-        let tool = aish_llm::ToolSpec {
-            r#type: "function".to_string(),
-            function: aish_llm::FunctionSpec {
-                name: "test_tool".to_string(),
-                description: "A test tool".to_string(),
-                parameters: serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "input": {"type": "string"}
-                    }
-                }),
-            },
-        };
-        client
-            .chat_completion(&messages, Some(&[tool]), false, Some(0.0), Some(10))
-            .await
-    });
+    let result = rt.block_on(aish_llm::probe_live_tool_support(
+        &api_base, &api_key, &model,
+    ));
 
     match result {
-        Ok(_) => {
+        Ok(()) => {
             println!("\x1b[32mTool calling is supported.\x1b[0m");
         }
         Err(e) => {
-            println!("\x1b[31mTool calling may not be supported: {}\x1b[0m", e);
+            eprintln!("\x1b[31mTool calling may not be supported: {}\x1b[0m", e);
+            std::process::exit(1);
         }
     }
 }

--- a/crates/aish-llm/src/lib.rs
+++ b/crates/aish-llm/src/lib.rs
@@ -23,6 +23,7 @@ pub mod model_id;
 pub mod models;
 pub mod oauth;
 pub mod openai_sse_bridge;
+pub mod probe;
 pub mod provider;
 pub mod providers;
 pub mod session;
@@ -49,6 +50,7 @@ pub use oauth::{
     exchange_code_for_tokens, generate_pkce, generate_state, load_tokens, login_with_browser,
     login_with_device_code, open_url, save_tokens, OAuthProviderSpec, OAuthTokens, PkcePair,
 };
+pub use probe::probe_live_tool_support;
 pub use provider::{
     detect_provider, detect_provider_from_model, refine_provider_from_api_base, ProviderInfo,
 };

--- a/crates/aish-llm/src/probe.rs
+++ b/crates/aish-llm/src/probe.rs
@@ -1,0 +1,57 @@
+//! Live probes used by CLI checks and setup verification.
+//!
+//! Probes mirror the interactive shell request path (dialect routing + streaming
+//! + normal token budget) so proxy backends can remap models without breaking CI.
+
+use aish_core::AishError;
+
+use crate::api::{resolve_api_dialect, stream_simple, StreamContext};
+use crate::client::LlmResponse;
+use crate::types::{ChatMessage, ToolSpec};
+
+/// Verify that the configured endpoint supports tool calling via the production path.
+pub async fn probe_live_tool_support(
+    api_base: &str,
+    api_key: &str,
+    model: &str,
+) -> Result<(), AishError> {
+    let ctx = StreamContext::new(api_base, api_key, model, None);
+    let dialect = resolve_api_dialect(&ctx.config_model, &ctx.api_base, &ctx.api_key);
+    let messages = vec![ChatMessage::user(
+        "Reply with just 'ok'. Do not use any tools.",
+    )];
+    let tool = ToolSpec {
+        r#type: "function".into(),
+        function: crate::types::FunctionSpec {
+            name: "test_tool".into(),
+            description: "A test tool".into(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "input": {"type": "string"}
+                }
+            }),
+        },
+    };
+
+    let response = stream_simple(
+        dialect,
+        &ctx,
+        &messages,
+        Some(&[tool]),
+        true,
+        Some(0.0),
+        None,
+    )
+    .await?;
+
+    match response {
+        LlmResponse::Json(_) => Ok(()),
+        LlmResponse::Stream(mut stream) => match stream.chunk().await? {
+            Some(_) => Ok(()),
+            None => Err(AishError::Llm(
+                "empty streaming response from API".to_string(),
+            )),
+        },
+    }
+}

--- a/crates/aish-shell/src/wizard/verification.rs
+++ b/crates/aish-shell/src/wizard/verification.rs
@@ -6,6 +6,7 @@
 use aish_i18n::t_with_args;
 use aish_llm::api::resolve_anthropic_messages_url;
 use aish_llm::providers::codex::{load_codex_auth, probe_codex_oauth_connectivity};
+use aish_llm::DEFAULT_MAX_TOKENS;
 use serde_json::json;
 use std::collections::HashMap;
 use tracing::debug;
@@ -484,8 +485,8 @@ pub fn check_codex_tool_support(
 /// Check basic connectivity to the chat completions endpoint.
 ///
 /// Sends a minimal `POST {api_base}/chat/completions` with a single "Hi"
-/// user message and `max_tokens: 5`.  Returns latency on success or an
-/// explanatory error on failure.
+/// user message. Uses the normal runtime token budget so proxy backends with
+/// reasoning models do not return empty responses on tiny probes.
 pub fn check_connectivity(
     api_base: &str,
     api_key: &str,
@@ -515,7 +516,7 @@ pub fn check_connectivity(
     let body = json!({
         "model": model,
         "messages": [{"role": "user", "content": "Hi"}],
-        "max_tokens": 5,
+        "max_tokens": DEFAULT_MAX_TOKENS,
     });
 
     let start = std::time::Instant::now();
@@ -592,24 +593,15 @@ pub fn check_connectivity(
 
 /// Check whether the model supports tool/function calling.
 ///
-/// Sends a chat completion request that includes a trivial `ping` tool
-/// definition with `tool_choice: "auto"`.  If the response is successful
-/// we consider tool support to be present.  A 400-level error or an
-/// error message mentioning "tools" is interpreted as lack of support.
+/// Uses the same dialect-aware streaming probe as `aish check-tool-support`.
 pub fn check_tool_support(
     api_base: &str,
     api_key: &str,
     model: &str,
     timeout_s: u64,
 ) -> ToolSupportResult {
-    let url = format!("{}/chat/completions", api_base.trim_end_matches('/'));
-    debug!("Tool-support check: POST {}", url);
-
-    let client = match reqwest::blocking::Client::builder()
-        .timeout(std::time::Duration::from_secs(timeout_s))
-        .build()
-    {
-        Ok(c) => c,
+    let rt = match tokio::runtime::Runtime::new() {
+        Ok(rt) => rt,
         Err(e) => {
             return ToolSupportResult {
                 supports: false,
@@ -617,89 +609,34 @@ pub fn check_tool_support(
                     "cli.setup.verify_http_client_build_failed",
                     &[("detail", &e.to_string())],
                 )),
-            }
+            };
         }
     };
 
-    let tool_def = json!({
-        "type": "function",
-        "function": {
-            "name": "ping",
-            "description": "ping",
-            "parameters": {
-                "type": "object",
-                "properties": {}
-            }
-        }
+    let result = rt.block_on(async {
+        tokio::time::timeout(
+            std::time::Duration::from_secs(timeout_s),
+            aish_llm::probe_live_tool_support(api_base, api_key, model),
+        )
+        .await
     });
 
-    let body = json!({
-        "model": model,
-        "messages": [{"role": "user", "content": "Hi"}],
-        "max_tokens": 5,
-        "tools": [tool_def],
-        "tool_choice": "auto",
-    });
-
-    let response = client
-        .post(&url)
-        .header("Authorization", format!("Bearer {}", api_key))
-        .header("Content-Type", "application/json")
-        .json(&body)
-        .send();
-
-    match response {
-        Ok(resp) => {
-            let status = resp.status();
-            debug!("Tool-support response status: {}", status);
-
-            if status.is_success() {
-                ToolSupportResult {
-                    supports: true,
-                    error: None,
-                }
-            } else {
-                let status_code = status.as_u16();
-                let body_text = resp.text().unwrap_or_default();
-                let detail = if body_text.len() > 300 {
-                    let mut end = 300;
-                    while end > 0 && !body_text.is_char_boundary(end) {
-                        end -= 1;
-                    }
-                    format!("{}...", &body_text[..end])
-                } else {
-                    body_text
-                };
-                // A client error (4xx) likely means the endpoint rejected
-                // the tools parameter.
-                let supports = false;
-                ToolSupportResult {
-                    supports,
-                    error: Some(verify_msg(
-                        "cli.setup.verify_tool_http_error",
-                        &[("status", &status_code.to_string()), ("detail", &detail)],
-                    )),
-                }
-            }
-        }
-        Err(e) => {
-            debug!("Tool-support check error: {}", e);
-            let msg = if e.is_timeout() {
-                verify_msg(
-                    "cli.setup.verify_tool_timeout",
-                    &[("timeout", &timeout_s.to_string())],
-                )
-            } else {
-                verify_msg(
-                    "cli.setup.verify_tool_request_failed",
-                    &[("detail", &e.to_string())],
-                )
-            };
-            ToolSupportResult {
-                supports: false,
-                error: Some(msg),
-            }
-        }
+    match result {
+        Ok(Ok(())) => ToolSupportResult {
+            supports: true,
+            error: None,
+        },
+        Ok(Err(err)) => ToolSupportResult {
+            supports: false,
+            error: Some(err.to_string()),
+        },
+        Err(_) => ToolSupportResult {
+            supports: false,
+            error: Some(verify_msg(
+                "cli.setup.verify_tool_timeout",
+                &[("timeout", &timeout_s.to_string())],
+            )),
+        },
     }
 }
 


### PR DESCRIPTION
## Summary

- Add shared `probe_live_tool_support()` in `aish-llm` that mirrors the interactive shell request path (dialect routing + streaming + normal token budget)
- Route `aish check-tool-support` and setup wizard tool verification through this probe
- Exit non-zero when tool-support check fails so local behavior matches live smoke CI

## Problem

Live smoke uses `check-tool-support` with a narrow non-streaming probe (`max_tokens=10`). Proxy backends that silently remap models (e.g. `gpt-5.1` → Gemini) can pass interactive streaming use but fail this probe with `empty_response` 500.

## Test plan

- [x] `make format-check`
- [x] `make lint`
- [x] `cargo test -p aish-shell --lib wizard::verification`
- [x] `cargo test -p aish-llm`
- [x] `./target/debug/aish check-tool-support` against `aitest` endpoint (passes)

Unblocks Release Preparation for v0.3.6 after merge and release branch refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-support checking so failures now clearly report errors and exit with a non-zero status.
  * Made connection checks use a consistent token limit, reducing unexpected probe behavior.
  * Added timeout handling for tool-support verification, helping avoid hangs and giving clearer timeout feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->