### PR TITLE
feat(shell): inline AI completion with ghost text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "aish-skills",
  "aish-tools",
  "aish-ui",
+ "async-trait",
  "base64 0.22.1",
  "chrono",
  "cliclack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ serde_yaml = "0.9"
 # Async
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
+async-trait = "0.1"
 
 # HTTP
 reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls", "blocking"], default-features = false }
@@ -50,7 +51,7 @@ clap = { version = "4", features = ["derive"] }
 # Terminal
 crossterm = { version = "0.28", features = ["event-stream"] }
 ratatui = "0.30"
-unicode-width = "0.2"
+unicode-width = { version = "0.2", features = ["cjk"] }
 
 # System
 nix = { version = "0.29", features = ["term", "process", "signal", "fs", "ioctl", "poll", "user"] }

--- a/crates/aish-config/src/lib.rs
+++ b/crates/aish-config/src/lib.rs
@@ -18,6 +18,6 @@ pub mod model;
 
 pub use loader::ConfigLoader;
 pub use model::{
-    compile_remote_danger_patterns, ConfigModel, MemoryConfig, OutputOffloadConfig,
-    ToolArgPreviewConfig,
+    compile_remote_danger_patterns, ConfigModel, InlineCompletionConfig, MemoryConfig,
+    OutputOffloadConfig, ToolArgPreviewConfig,
 };

--- a/crates/aish-config/src/model.rs
+++ b/crates/aish-config/src/model.rs
@@ -248,9 +248,9 @@ impl Default for InlineCompletionConfig {
             // keeps the ghost text short regardless of token consumption.
             max_tokens: 512,
             min_input_chars: 3,
-            // Default ON: reasoning is pure waste for inline completion
-            // (a few-word suffix hint needs no chain-of-thought), and many
-            // models intermittently enable thinking, starving content.
+            // Default OFF: many gateways either ignore these flags (DeepSeek
+            // still generates reasoning) or process them slowly (moonshot
+            // response time doubles). See the field doc above for details.
             disable_thinking: false,
             enforce_json: false,
             timeout_secs: 30,

--- a/crates/aish-config/src/model.rs
+++ b/crates/aish-config/src/model.rs
@@ -183,6 +183,82 @@ impl Default for ContextAutoCompactConfig {
 }
 
 // ---------------------------------------------------------------------------
+// Inline AI completion sub-config
+// ---------------------------------------------------------------------------
+
+/// Configuration for inline AI completion (the gray ghost-text suggestions
+/// shown when the user types a `;`/`;`-prefixed AI prompt).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct InlineCompletionConfig {
+    /// Master toggle. When false, no InlineCompleter is constructed.
+    pub enabled: bool,
+
+    /// How long after the user stops typing before we fire a request.
+    pub debounce_ms: u64,
+
+    /// Number of recent shell-history lines to include as context.
+    pub context_lines: usize,
+
+    /// Hard cap on tokens for the suggested suffix.
+    pub max_tokens: u32,
+
+    /// Minimum non-prefix character count required to trigger.
+    pub min_input_chars: usize,
+
+    /// When true, send a bundle of "skip reasoning" flags in the request
+    /// body: `thinking: {type: disabled}` (Anthropic), `enable_thinking:
+    /// false` (Qwen/DeepSeek custom), `chat_template_kwargs: {enable_thinking:
+    /// false}` (vLLM), `reasoning_effort: low` (OpenAI o1-style).
+    /// Default is **false**: many gateways either ignore these fields
+    /// (DeepSeek still generates reasoning) or process them slowly
+    /// (moonshot response time doubles). Enable only if your model is a
+    /// Qwen3/vLLM deployment that genuinely honors `enable_thinking`.
+    pub disable_thinking: bool,
+
+    /// When true, send `{"response_format": {"type": "json_object"}}` to
+    /// force OpenAI-compatible JSON-mode output. Some gateways reject this
+    /// field with HTTP 400, so default is false — the system prompt alone
+    /// asks the model for JSON. Enable if your provider supports JSON mode
+    /// and you want stricter output enforcement.
+    pub enforce_json: bool,
+
+    /// Hard cap (seconds) on a single inline-completion LLM call. If the
+    /// model doesn't respond within this window, the request is abandoned
+    /// silently. The underlying `LlmClient` has its own 120s timeout —
+    /// this overrides that for inline completion because waiting two
+    /// minutes for a hint is unacceptable. Bump this if your gateway is
+    /// consistently slow.
+    pub timeout_secs: u64,
+}
+
+impl Default for InlineCompletionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            debounce_ms: 400,
+            context_lines: 5,
+            // Reasoning models (DeepSeek-R1, Qwen3, GLM, etc.) spend a lot
+            // of tokens on chain-of-thought before emitting visible content.
+            // `enable_thinking: false` is sent but many gateways (notably
+            // DeepSeek) ignore it and still produce 1000-2000 chars of
+            // reasoning_content. We need a budget large enough for the
+            // full reasoning + the JSON answer: 512 covers the ~480-token
+            // reasoning we've observed in the wild. cap_suffix_width()
+            // keeps the ghost text short regardless of token consumption.
+            max_tokens: 512,
+            min_input_chars: 3,
+            // Default ON: reasoning is pure waste for inline completion
+            // (a few-word suffix hint needs no chain-of-thought), and many
+            // models intermittently enable thinking, starving content.
+            disable_thinking: false,
+            enforce_json: false,
+            timeout_secs: 30,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Top-level config model
 // ---------------------------------------------------------------------------
 
@@ -327,6 +403,10 @@ pub struct ConfigModel {
     /// Terminal resize handling mode: full, pty_only, or off
     #[serde(default = "default_terminal_resize_mode")]
     pub terminal_resize_mode: String,
+
+    /// Inline AI completion (ghost-text suggestions in AI mode).
+    #[serde(default)]
+    pub inline_completion: InlineCompletionConfig,
 }
 
 impl Default for ConfigModel {
@@ -376,6 +456,7 @@ impl Default for ConfigModel {
             enable_scripts: default_true(),
             history_size: default_history_size(),
             terminal_resize_mode: default_terminal_resize_mode(),
+            inline_completion: InlineCompletionConfig::default(),
         }
     }
 }
@@ -716,5 +797,64 @@ api_key: sk-test
     fn test_compile_remote_danger_patterns_empty_input() {
         let compiled = compile_remote_danger_patterns(&[]);
         assert!(compiled.is_empty());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Inline completion
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn inline_completion_defaults_are_off() {
+        let cfg = InlineCompletionConfig::default();
+        assert!(!cfg.enabled, "must be opt-in (off by default)");
+        assert_eq!(cfg.debounce_ms, 400);
+        assert_eq!(cfg.context_lines, 5);
+        assert_eq!(cfg.max_tokens, 512);
+        assert_eq!(cfg.min_input_chars, 3);
+        assert!(
+            !cfg.disable_thinking,
+            "should be OFF by default — extras hurt non-reasoning models"
+        );
+        assert!(
+            !cfg.enforce_json,
+            "JSON mode should be opt-in (off by default)"
+        );
+        assert_eq!(cfg.timeout_secs, 30);
+    }
+
+    #[test]
+    fn config_model_default_includes_inline_completion() {
+        let m = ConfigModel::default();
+        assert!(!m.inline_completion.enabled);
+    }
+
+    #[test]
+    fn inline_completion_deserializes_from_yaml() {
+        let yaml = r#"
+inline_completion:
+  enabled: true
+  debounce_ms: 250
+  context_lines: 8
+  max_tokens: 16
+  min_input_chars: 2
+"#;
+        let m: ConfigModel = serde_yaml::from_str(yaml).unwrap();
+        assert!(m.inline_completion.enabled);
+        assert_eq!(m.inline_completion.debounce_ms, 250);
+        assert_eq!(m.inline_completion.context_lines, 8);
+        assert_eq!(m.inline_completion.max_tokens, 16);
+        assert_eq!(m.inline_completion.min_input_chars, 2);
+    }
+
+    #[test]
+    fn inline_completion_partial_uses_defaults_for_missing_fields() {
+        let yaml = r#"
+inline_completion:
+  enabled: true
+"#;
+        let m: ConfigModel = serde_yaml::from_str(yaml).unwrap();
+        assert!(m.inline_completion.enabled);
+        assert_eq!(m.inline_completion.debounce_ms, 400);
+        assert_eq!(m.inline_completion.max_tokens, 512);
     }
 }

--- a/crates/aish-llm/src/client.rs
+++ b/crates/aish-llm/src/client.rs
@@ -13,7 +13,7 @@ pub struct LlmClient {
     http: Client,
     api_base: String,
     api_key: String,
-    model: String,
+    model: std::sync::Mutex<String>,
 }
 
 impl LlmClient {
@@ -23,7 +23,7 @@ impl LlmClient {
             http: Client::new(),
             api_base: api_base.trim_end_matches('/').into(),
             api_key: api_key.into(),
-            model,
+            model: std::sync::Mutex::new(model),
         }
     }
 
@@ -38,13 +38,13 @@ impl LlmClient {
     }
 
     /// Return the model name used for this client.
-    pub fn model_name(&self) -> &str {
-        &self.model
+    pub fn model_name(&self) -> String {
+        self.model.lock().unwrap().clone()
     }
 
     /// Update the model name (used for runtime model switching).
-    pub fn update_model(&mut self, model: &str) {
-        self.model = resolve_model_for_api(model, &self.api_base);
+    pub fn update_model(&self, model: &str) {
+        *self.model.lock().unwrap() = resolve_model_for_api(model, &self.api_base);
     }
 
     /// Update the API key.
@@ -137,8 +137,32 @@ impl LlmClient {
         temperature: Option<f32>,
         max_tokens: Option<u32>,
     ) -> Result<LlmResponse, AishError> {
+        self.chat_completion_with_extras(
+            messages,
+            tools,
+            stream,
+            temperature,
+            max_tokens,
+            serde_json::Map::new(),
+        )
+        .await
+    }
+
+    /// Like `chat_completion`, but merges provider-specific extra fields into
+    /// the JSON request body. Used for vendor extensions such as
+    /// `{"thinking": {"type": "disabled"}}` (Anthropic-style reasoning toggle)
+    /// or `{"enable_thinking": false}` (DeepSeek/Qwen-style).
+    pub async fn chat_completion_with_extras(
+        &self,
+        messages: &[ChatMessage],
+        tools: Option<&[ToolSpec]>,
+        stream: bool,
+        temperature: Option<f32>,
+        max_tokens: Option<u32>,
+        extras: serde_json::Map<String, serde_json::Value>,
+    ) -> Result<LlmResponse, AishError> {
         let mut body = serde_json::json!({
-            "model": self.model,
+            "model": self.model.lock().unwrap().clone(),
             "messages": messages,
             "stream": stream,
         });
@@ -150,6 +174,11 @@ impl LlmClient {
         if let Some(tools) = tools {
             body["tools"] = serde_json::json!(tools);
             body["tool_choice"] = serde_json::json!("auto");
+        }
+        if let serde_json::Value::Object(body_map) = &mut body {
+            for (k, v) in extras {
+                body_map.insert(k, v);
+            }
         }
 
         let url = format!("{}/chat/completions", self.api_base);
@@ -228,7 +257,7 @@ mod tests {
 
     #[test]
     fn test_update_model() {
-        let mut client = LlmClient::new("https://api.example.com/v1", "sk-test", "gpt-4");
+        let client = LlmClient::new("https://api.example.com/v1", "sk-test", "gpt-4");
         assert_eq!(client.model_name(), "gpt-4");
         client.update_model("gpt-4o");
         assert_eq!(client.model_name(), "gpt-4o");
@@ -268,7 +297,7 @@ mod tests {
 
     #[test]
     fn test_update_model_preserves_prefix_for_non_openai() {
-        let mut client = LlmClient::new("https://gateway.example.com/v1", "sk-test", "gpt-4");
+        let client = LlmClient::new("https://gateway.example.com/v1", "sk-test", "gpt-4");
         client.update_model("provider/model-name");
         assert_eq!(client.model_name(), "provider/model-name");
     }

--- a/crates/aish-shell/Cargo.toml
+++ b/crates/aish-shell/Cargo.toml
@@ -26,6 +26,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 tokio.workspace = true
+async-trait.workspace = true
 crossterm.workspace = true
 ratatui.workspace = true
 tracing.workspace = true

--- a/crates/aish-shell/src/ai_handler.rs
+++ b/crates/aish-shell/src/ai_handler.rs
@@ -1001,7 +1001,10 @@ fn is_diagnose_report_candidate(json: &serde_json::Value) -> bool {
         .is_some_and(|s| !s.trim().is_empty())
 }
 
-fn extract_json_object_from_text(text: &str) -> Option<serde_json::Value> {
+/// Brute-force scan: iterate every `{` × `}` combination and return the first
+/// slice that parses as a valid JSON object. Used to recover JSON from prose-
+/// wrapped or non-fenced model output.
+pub(crate) fn extract_json_object_from_text(text: &str) -> Option<serde_json::Value> {
     for (start, _) in text.match_indices('{') {
         let slice = &text[start..];
         if let Ok(value) = serde_json::from_str::<serde_json::Value>(slice) {

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -346,6 +346,9 @@ pub struct AishShell {
     expand_history: Arc<Mutex<crate::expand_history::ExpandHistory>>,
     /// Shared terminal session recorder for asciinema v2 recording.
     shared_recorder: crate::recorder::SharedRecorder,
+    /// Inline AI completer (None when disabled). Stored so `/model` can
+    /// update its model at runtime without restarting the shell.
+    inline_ai: Option<Arc<crate::inline_completion::InlineCompleter>>,
 }
 
 impl AishShell {
@@ -1499,6 +1502,7 @@ impl AishShell {
             animation,
             expand_history,
             shared_recorder,
+            inline_ai: None,
         })
     }
 
@@ -1566,8 +1570,42 @@ impl AishShell {
             sigterm_flag.store(true, Ordering::SeqCst);
         });
 
+        // Build the shared AutoSuggest engine up here, before ShellReadline::new.
+        let autosuggest = Arc::new(Mutex::new(crate::autosuggest::AutoSuggest::new(5000)));
+        let runtime_handle = runtime.handle().clone();
+
+        let inline_ai: Option<Arc<crate::inline_completion::InlineCompleter>> = {
+            let cfg = &self.config.inline_completion;
+            if !cfg.enabled {
+                None
+            } else if self.config.api_key.is_empty() {
+                tracing::info!("inline_completion enabled but no api_key configured; skipping");
+                None
+            } else {
+                let llm_client = Arc::new(aish_llm::LlmClient::new(
+                    &self.config.api_base,
+                    &self.config.api_key,
+                    &self.config.model,
+                ));
+                let provider = crate::inline_completion::build_default_provider(
+                    llm_client,
+                    cfg.disable_thinking,
+                    cfg.enforce_json,
+                );
+                Some(crate::inline_completion::InlineCompleter::new(
+                    provider,
+                    autosuggest.clone(),
+                    cfg.clone(),
+                    runtime_handle,
+                ))
+            }
+        };
+
+        // Store inline_ai on self so `/model` can update its model at runtime.
+        self.inline_ai = inline_ai.clone();
+
         // Initialize readline with history, tab completion, and line editing
-        let mut rl = ShellReadline::new(self.pty.clone()).map_err(|e| {
+        let mut rl = ShellReadline::new(self.pty.clone(), autosuggest, inline_ai).map_err(|e| {
             let mut args = std::collections::HashMap::new();
             args.insert("error".to_string(), e.to_string());
             aish_core::AishError::Config(t_with_args("shell.readline_init_failed", &args))
@@ -3054,6 +3092,11 @@ impl AishShell {
             Some(&self.config.api_base),
             Some(&self.config.api_key),
         );
+
+        // Update inline completion model so it follows `/model` switches
+        if let Some(ai) = &self.inline_ai {
+            ai.update_model(&new_model);
+        }
 
         // Update config
         self.config.model = new_model.clone();

--- a/crates/aish-shell/src/autosuggest.rs
+++ b/crates/aish-shell/src/autosuggest.rs
@@ -48,6 +48,11 @@ impl AutoSuggest {
             self.add(&cmd);
         }
     }
+
+    /// Return the `n` most-recently-added commands, most recent first.
+    pub fn recent_n(&self, n: usize) -> Vec<String> {
+        self.history.iter().take(n).cloned().collect()
+    }
 }
 
 #[cfg(test)]
@@ -118,5 +123,34 @@ mod tests {
         assert_eq!(sug.suggest("git"), Some("git push"));
         assert_eq!(sug.suggest("cargo"), Some("cargo test"));
         assert_eq!(sug.suggest("car"), Some("cargo test"));
+    }
+
+    #[test]
+    fn test_recent_n_returns_most_recent_first() {
+        let mut sug = AutoSuggest::new(100);
+        sug.add("git status");
+        sug.add("git push");
+        sug.add("cargo build");
+        let recent = sug.recent_n(2);
+        assert_eq!(
+            recent,
+            vec!["cargo build".to_string(), "git push".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_recent_n_returns_all_when_n_exceeds_size() {
+        let mut sug = AutoSuggest::new(100);
+        sug.add("a");
+        sug.add("b");
+        let recent = sug.recent_n(10);
+        assert_eq!(recent, vec!["b".to_string(), "a".to_string()]);
+    }
+
+    #[test]
+    fn test_recent_n_zero_returns_empty() {
+        let mut sug = AutoSuggest::new(100);
+        sug.add("a");
+        assert!(sug.recent_n(0).is_empty());
     }
 }

--- a/crates/aish-shell/src/inline_completion.rs
+++ b/crates/aish-shell/src/inline_completion.rs
@@ -1,0 +1,1535 @@
+/// Clean the LLM's raw output into a hint suffix suitable for `Hinter`.
+///
+/// Rules:
+/// 1. Strip surrounding quotes (single or double) and triple backticks.
+/// 2. Take only the first line (rustyline Hinter is single-line).
+/// 3. Trim leading/trailing whitespace.
+/// 4. If the model repeated the user's input as a prefix, strip that prefix.
+/// 5. Return None when the result is empty.
+/// 6. Never prepend a space — the model is responsible for including one
+///    in its own output when the language needs it (English etc.). CJK
+///    text does not use word separators, so a glued-on space reads as a
+///    typo there.
+pub fn sanitize_suffix(raw: &str, current_question: &str) -> Option<String> {
+    let mut s = raw.trim();
+
+    s = s.trim_start_matches("```").trim_end_matches("```");
+
+    // Skip a leading language-identifier line like ```bash\n...
+    if let Some(first_line) = s.split('\n').next() {
+        if !first_line.contains(' ') && !first_line.is_empty() {
+            if let Some(newline_pos) = s.find('\n') {
+                s = &s[newline_pos + 1..];
+            }
+        }
+    }
+
+    if (s.starts_with('"') && s.ends_with('"') && s.len() >= 2)
+        || (s.starts_with('\'') && s.ends_with('\'') && s.len() >= 2)
+    {
+        s = &s[1..s.len() - 1];
+    }
+
+    let first_line = s.split('\n').next().unwrap_or("").trim();
+    if first_line.is_empty() {
+        return None;
+    }
+
+    let question_trimmed = current_question.trim();
+    let stripped = if !question_trimmed.is_empty() && first_line.starts_with(question_trimmed) {
+        &first_line[question_trimmed.len()..]
+    } else {
+        first_line
+    }
+    .trim();
+
+    if stripped.is_empty() {
+        return None;
+    }
+
+    // Cap the visible width so the ghost text stays a short hint, not a
+    // paragraph. Models routinely ignore the "3-15 tokens" instruction in
+    // the system prompt and return full sentences. We truncate at the last
+    // natural boundary (punctuation / space) within the width budget.
+    let capped = cap_suffix_width(stripped, 20);
+
+    // Never prepend a space — the model includes one when the language
+    // needs it. CJK doesn't use word separators, so a glued-on space reads
+    // as a typo.
+    Some(capped)
+}
+
+/// Truncate `suffix` so its visible terminal width ≤ `max_width`. If
+/// truncation is needed, break at the last natural boundary (CJK/ASCII
+/// punctuation or space) within the budget so the result reads naturally.
+fn cap_suffix_width(suffix: &str, max_width: usize) -> String {
+    if crate::prompt::term_width(suffix) <= max_width {
+        return suffix.to_string();
+    }
+    // Walk char-by-char, tracking the position of the last natural break
+    // point (punctuation or space) that still fits within max_width.
+    let natural_breaks = "，。、；：！？,.;:!? \t—–-";
+    let mut cum_width = 0usize;
+    let mut last_break_end = None; // byte index just past the break char
+    for (idx, ch) in suffix.char_indices() {
+        let w = crate::prompt::term_char_width(ch);
+        if cum_width + w > max_width {
+            break;
+        }
+        cum_width += w;
+        if natural_breaks.contains(ch) {
+            // Position BEFORE the punctuation char so it's excluded from
+            // the result (e.g. "形式输出，..." → "形式输出", not "形式输出，").
+            last_break_end = Some(idx);
+        }
+    }
+    match last_break_end {
+        // Break at the last punctuation within budget.
+        Some(end) => suffix[..end].trim_end().to_string(),
+        // No punctuation found — hard-cut at the width boundary.
+        None => {
+            let mut out = String::new();
+            let mut w = 0;
+            for ch in suffix.chars() {
+                let cw = crate::prompt::term_char_width(ch);
+                if w + cw > max_width {
+                    break;
+                }
+                w += cw;
+                out.push(ch);
+            }
+            out
+        }
+    }
+}
+
+use std::io::Write;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+/// Abstraction over the LLM call used for inline completion.
+/// Production wraps `aish_llm::LlmClient`; tests inject a fake.
+#[async_trait]
+pub trait CompletionProvider: Send + Sync {
+    /// Return ONLY the suffix text to append. Empty string is a valid
+    /// "no suggestion" answer. `Err(())` means any failure.
+    async fn complete(&self, prompt: &str, max_tokens: u32) -> Result<String, ()>;
+
+    /// Update the underlying model (for runtime `/model` switching).
+    /// Default no-op; only `LlmCompletionProvider` implements it.
+    fn update_model(&self, _model: &str) {}
+}
+
+/// Fake provider for tests and for the `AISH_INLINE_COMPLETION_FAUX` runtime hook.
+pub struct FakeCompletionProvider {
+    pub canned: String,
+    pub fail: bool,
+    pub calls: AtomicUsize,
+}
+
+impl FakeCompletionProvider {
+    pub fn new(canned: impl Into<String>) -> Self {
+        Self {
+            canned: canned.into(),
+            fail: false,
+            calls: AtomicUsize::new(0),
+        }
+    }
+    pub fn new_failing() -> Self {
+        Self {
+            canned: String::new(),
+            fail: true,
+            calls: AtomicUsize::new(0),
+        }
+    }
+    pub fn call_count(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl CompletionProvider for FakeCompletionProvider {
+    async fn complete(&self, _prompt: &str, _max_tokens: u32) -> Result<String, ()> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if self.fail {
+            Err(())
+        } else {
+            Ok(self.canned.clone())
+        }
+    }
+}
+
+use aish_llm::{ChatMessage, LlmResponse};
+
+/// Production `CompletionProvider` backed by `aish_llm::LlmClient`.
+pub struct LlmCompletionProvider {
+    client: Arc<aish_llm::LlmClient>,
+    /// Provider-specific extras (reasoning-toggle flags, JSON-mode marker)
+    /// built once at construction and cloned per call. The two construction
+    /// flags `disable_thinking` / `enforce_json` are not retained as bools
+    /// because nothing reads them after this map is assembled.
+    extras: serde_json::Map<String, serde_json::Value>,
+}
+
+impl LlmCompletionProvider {
+    pub fn new(
+        client: Arc<aish_llm::LlmClient>,
+        disable_thinking: bool,
+        enforce_json: bool,
+    ) -> Self {
+        Self {
+            client,
+            extras: build_extras(disable_thinking, enforce_json),
+        }
+    }
+
+    /// Single-entry wrapper for `chat_completion_with_extras` so the call
+    /// site doesn't repeat the 6 fixed arguments three times.
+    async fn request(
+        &self,
+        messages: &[ChatMessage],
+        max_tokens: u32,
+        extras: serde_json::Map<String, serde_json::Value>,
+    ) -> Result<LlmResponse, aish_core::AishError> {
+        self.client
+            .chat_completion_with_extras(messages, None, false, Some(0.2), Some(max_tokens), extras)
+            .await
+    }
+}
+
+/// Assemble the provider-extras map. Different reasoning-model gateways use
+/// different field names to suppress thinking — we send all known variants
+/// simultaneously. Providers that don't recognize a field ignore it.
+fn build_extras(
+    disable_thinking: bool,
+    enforce_json: bool,
+) -> serde_json::Map<String, serde_json::Value> {
+    let mut extras = serde_json::Map::new();
+    if disable_thinking {
+        // Anthropic / Claude extended-thinking toggle.
+        extras.insert(
+            "thinking".to_string(),
+            serde_json::json!({"type": "disabled"}),
+        );
+        // Qwen3 / DeepSeek / vLLM direct flag.
+        extras.insert("enable_thinking".to_string(), serde_json::json!(false));
+        // Qwen3 via vLLM with template kwargs.
+        extras.insert(
+            "chat_template_kwargs".to_string(),
+            serde_json::json!({"enable_thinking": false}),
+        );
+        // OpenAI o1-style gateways reject "minimal"; "low" is the most
+        // aggressive reduction they accept.
+        extras.insert("reasoning_effort".to_string(), serde_json::json!("low"));
+    }
+    if enforce_json {
+        extras.insert(
+            "response_format".to_string(),
+            serde_json::json!({"type": "json_object"}),
+        );
+    }
+    extras
+}
+
+#[async_trait]
+impl CompletionProvider for LlmCompletionProvider {
+    async fn complete(&self, prompt: &str, max_tokens: u32) -> Result<String, ()> {
+        let system_prompt =
+            INLINE_COMPLETION_SYSTEM_PROMPT.replace("{max_tokens}", &max_tokens.to_string());
+        let messages = vec![
+            ChatMessage::system(system_prompt),
+            ChatMessage::user(prompt.to_string()),
+        ];
+
+        // Try with extras (thinking suppression, JSON mode) first; if the
+        // gateway rejects unknown fields (HTTP 400), retry bare.
+        let resp = if self.extras.is_empty() {
+            self.request(&messages, max_tokens, serde_json::Map::new())
+                .await
+        } else {
+            match self
+                .request(&messages, max_tokens, self.extras.clone())
+                .await
+            {
+                Ok(r) => Ok(r),
+                Err(e) => {
+                    tracing::debug!(error = %e, "inline completion: extras rejected, retrying bare");
+                    self.request(&messages, max_tokens, serde_json::Map::new())
+                        .await
+                }
+            }
+        };
+        let resp = resp.map_err(|e| {
+            tracing::debug!(error = %e, "inline completion: request error");
+        })?;
+
+        let LlmResponse::Json(value) = resp else {
+            return Err(());
+        };
+        let (content, _reasoning, _tools, _usage) =
+            aish_llm::streaming::StreamParser::parse_response(&value);
+
+        // Simple: take content, extract JSON suffix. Ignore reasoning_content
+        // entirely — the model's chain-of-thought is irrelevant to the ghost
+        // text. If content is empty or has no JSON, there's nothing to show.
+        Ok(content
+            .as_deref()
+            .and_then(extract_suffix_from_json)
+            .unwrap_or_default())
+    }
+
+    fn update_model(&self, model: &str) {
+        self.client.update_model(model);
+    }
+}
+
+/// Try to extract the `suffix` field from a model response that should be a
+/// strict JSON object wrapped in a ```json code fence. Tolerates a wide
+/// variety of malformations: missing fence, prose-wrapped JSON, double-braced
+/// `{{...}}`, single-quoted values, etc.
+///
+/// Three layers: fence extraction → shared `{`×`}` brute-force scan
+/// (`ai_handler::extract_json_object_from_text`) → regex-extract the suffix
+/// value as last line of defense.
+fn extract_suffix_from_json(content: &str) -> Option<String> {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Layer 1: code-fence extraction. The prompt asks for ```json fence.
+    use regex::Regex;
+    static FENCE_RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    let fence_re = FENCE_RE
+        .get_or_init(|| Regex::new(r"(?s)```(?:json)?\s*\n?(.*?)```").expect("fence regex"));
+    for caps in fence_re.captures_iter(trimmed) {
+        let block = caps.get(1).map(|m| m.as_str().trim()).unwrap_or("");
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(block) {
+            if let Some(s) = suffix_of_value(&value) {
+                return Some(s);
+            }
+        }
+    }
+
+    // Layer 2: brute-force `{` × `}` scan via the shared helper.
+    if let Some(value) = crate::ai_handler::extract_json_object_from_text(trimmed) {
+        if let Some(s) = suffix_of_value(&value) {
+            return Some(s);
+        }
+    }
+
+    // Layer 3: regex extract the suffix value directly. For models that
+    // return `{{"suffix": "..."}}` or otherwise broken JSON, this is the
+    // last line of defense.
+    static SUFFIX_RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    let re = SUFFIX_RE
+        .get_or_init(|| Regex::new(r#""suffix"\s*:\s*"((?:[^"\\]|\\.)*)""#).expect("suffix regex"));
+    let caps = re.captures(trimmed)?;
+    let raw = caps.get(1)?.as_str();
+    let unescaped = raw
+        .replace(r#"\""#, "\"")
+        .replace(r"\\", r"\")
+        .replace(r"\n", "\n")
+        .replace(r"\t", "\t");
+    if unescaped.is_empty() {
+        None
+    } else {
+        Some(unescaped)
+    }
+}
+
+/// Pull the non-empty `suffix` field out of a parsed JSON value.
+fn suffix_of_value(value: &serde_json::Value) -> Option<String> {
+    value
+        .get("suffix")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty())
+}
+
+const INLINE_COMPLETION_SYSTEM_PROMPT: &str = "\
+Predict the short text to append to the user's partial AI-shell instruction.\n\
+Respond with ONLY a raw JSON object — no markdown, no ```fence```, no text before or after.\n\
+\n\
+Format: {\"suffix\": \"<text>\"}\n\
+\n\
+Rules:\n\
+- suffix is appended directly to the user's input. Do NOT repeat what they already typed.\n\
+- Stop at the first natural boundary. Keep it SHORT — a few words, ~10 chars max.\n\
+- Match the user's language. English: prefix a space. CJK: never prefix a space.\n\
+- If truly unpredictable, return {\"suffix\": \"\"}.\n\
+\n\
+Examples (input → output):\n\
+查看当前系统的 → {\"suffix\": \"CPU使用率\"}\n\
+检查哪些端口 → {\"suffix\": \"正在监听\"}\n\
+分析 → {\"suffix\": \"磁盘占用\"}\n\
+how do I find → {\"suffix\": \" large files\"}\n\
+监控 → {\"suffix\": \"CPU温度\"}\n\
+\n\
+Output ONLY the JSON. No code fence. No explanation. Max {max_tokens} tokens.\n\
+";
+
+/// Inspect the runtime environment and decide which provider to use.
+/// Honors `AISH_INLINE_COMPLETION_FAUX` for end-to-end tests:
+///   - `txt:<string>` → FakeCompletionProvider returning `<string>`
+///   - `err:<anything>` → FakeCompletionProvider that always fails
+///   - unset          → real LlmCompletionProvider
+pub fn build_default_provider(
+    client: Arc<aish_llm::LlmClient>,
+    disable_thinking: bool,
+    enforce_json: bool,
+) -> Arc<dyn CompletionProvider> {
+    if let Ok(spec) = std::env::var("AISH_INLINE_COMPLETION_FAUX") {
+        if let Some(canned) = spec.strip_prefix("txt:") {
+            return Arc::new(FakeCompletionProvider::new(canned));
+        }
+        if spec.starts_with("err:") {
+            return Arc::new(FakeCompletionProvider::new_failing());
+        }
+    }
+    Arc::new(LlmCompletionProvider::new(
+        client,
+        disable_thinking,
+        enforce_json,
+    ))
+}
+
+use std::sync::Mutex;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use aish_config::InlineCompletionConfig;
+use aish_llm::CancellationToken;
+
+use crate::autosuggest::AutoSuggest;
+use crate::input::extract_ai_question;
+
+/// Single-cell spinner that replaces the `<aish>` mode badge in the prompt
+/// while an inline-completion LLM call is in flight.
+///
+/// Each frame is `<` + 4 chars + `>` (6 cols) — a dot bouncing through 4
+/// positions inside the angle brackets. The width matches `<aish>` exactly
+/// so the rest of the prompt never shifts.
+///
+/// Writes go directly to stderr via `\x1b7` (save cursor) + optional
+/// `\x1b[<N>A` (move up N lines, navigating to the prompt line when input
+/// wraps) + `\x1b[1G` (move to column 1) + frame + `\x1b8` (restore cursor).
+/// `lines_up` is recomputed at each tick from current prompt width + input
+/// width + terminal cols so it stays correct as the user keeps typing. The
+/// up-sequence is omitted entirely when `lines_up == 0` because ANSI
+/// `CSI 0 A` is interpreted as `CSI 1 A` by most terminals (parameter 0
+/// falls back to the default of 1) — emitting it would push the spinner
+/// onto the previous line.
+///
+/// All geometry values are stored as atomics rather than read from the
+/// `thread_local` globals in `readline.rs` (`CURRENT_PROMPT_WIDTH` /
+/// `CURRENT_TERMINAL_SIZE`). Those thread-locals are set on the main
+/// (readline) thread, but this spinner task runs on a tokio **worker**
+/// thread (the runtime is multi-threaded — see `app.rs`), where the
+/// thread-locals fall back to their defaults (`0` and `(80, 24)`) and
+/// produce a wrong `lines_up` when input wraps.
+struct PromptSpinner {
+    token: Mutex<Option<Arc<CancellationToken>>>,
+    handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Visible width of the current input line. Updated by
+    /// `InlineCompleter::hint` on every keystroke.
+    current_input_width: AtomicUsize,
+    /// Visible width of the prompt for the current `read_line` call.
+    /// Captured from the main thread on every `hint()`.
+    prompt_width: AtomicUsize,
+    /// Terminal column count, captured alongside `prompt_width`.
+    terminal_cols: AtomicUsize,
+}
+
+impl PromptSpinner {
+    fn new() -> Self {
+        Self {
+            token: Mutex::new(None),
+            handle: Mutex::new(None),
+            current_input_width: AtomicUsize::new(0),
+            prompt_width: AtomicUsize::new(0),
+            terminal_cols: AtomicUsize::new(80),
+        }
+    }
+
+    fn set_input_width(&self, width: usize) {
+        self.current_input_width.store(width, Ordering::SeqCst);
+    }
+
+    /// Capture prompt width and terminal column count from the main thread.
+    /// Must be called on every `hint()` (which runs on the readline thread
+    /// where these values are current) so the spinner task — running on a
+    /// tokio worker thread — can compute `lines_up` correctly.
+    fn set_layout(&self, prompt_width: usize, cols: u16) {
+        self.prompt_width.store(prompt_width, Ordering::SeqCst);
+        self.terminal_cols.store(cols as usize, Ordering::SeqCst);
+    }
+
+    /// How many lines above the cursor's current row the prompt starts on.
+    /// 0 when the input fits on one line; >0 when it wraps. Computed from
+    /// `current_prompt_width + current_input_width` divided by terminal cols.
+    fn lines_up(&self) -> u16 {
+        let cols = self.terminal_cols.load(Ordering::SeqCst);
+        if cols == 0 {
+            return 0;
+        }
+        let prompt_w = self.prompt_width.load(Ordering::SeqCst);
+        let input_w = self.current_input_width.load(Ordering::SeqCst);
+        let total = prompt_w + input_w;
+        let lines = total.div_ceil(cols);
+        lines.saturating_sub(1).min(u16::MAX as usize) as u16
+    }
+
+    /// Remaining columns on the current cursor line that ghost text may
+    /// occupy without wrapping to the next line. Returns 0 when the cursor
+    /// sits at the last column (any suffix would wrap). Computed from the
+    /// captured prompt_width + input_width and terminal_cols.
+    fn available_ghost_width(&self) -> usize {
+        let cols = self.terminal_cols.load(Ordering::SeqCst);
+        if cols == 0 {
+            return 0;
+        }
+        let prompt_w = self.prompt_width.load(Ordering::SeqCst);
+        let input_w = self.current_input_width.load(Ordering::SeqCst);
+        let used = (prompt_w + input_w) % cols;
+        cols.saturating_sub(used)
+    }
+
+    /// Build the cursor-up prefix. Empty when `lines_up == 0` because
+    /// `CSI 0 A` is treated as `CSI 1 A` by most terminals.
+    fn up_prefix(lines_up: u16) -> String {
+        if lines_up == 0 {
+            String::new()
+        } else {
+            format!("\x1b[{}A", lines_up)
+        }
+    }
+
+    fn start(self: &Arc<Self>, runtime: &tokio::runtime::Handle) {
+        self.stop_internal();
+
+        // Skip the spinner when the cursor sits at an exact line boundary
+        // (prompt_width + input_width is a multiple of cols). At the
+        // boundary, the terminal leaves the cursor either at "pending
+        // wrap" (last column of the current line) or auto-wraps it to the
+        // next line — and we cannot tell which from width alone. Guessing
+        // wrong makes lines_up off-by-one, so the animation (and the
+        // stop() restore that writes <aish>) lands on the wrong row,
+        // overwriting the wrapped input instead of the prompt badge.
+        // Skipping start() also makes stop() a no-op (no token set), so
+        // the prompt's original <aish> stays untouched. The ghost text
+        // still renders normally — only the spinner animation is skipped.
+        let cols = self.terminal_cols.load(Ordering::SeqCst);
+        let total = self.prompt_width.load(Ordering::SeqCst)
+            + self.current_input_width.load(Ordering::SeqCst);
+        if cols > 0 && total > 0 && total.is_multiple_of(cols) {
+            tracing::debug!(
+                total,
+                cols,
+                "spinner: skipping — cursor at exact line boundary (ambiguous position)"
+            );
+            return;
+        }
+
+        let tok = Arc::new(CancellationToken::new());
+        *self.token.lock().unwrap() = Some(tok.clone());
+
+        let me = self.clone();
+        let handle = runtime.spawn(async move {
+            let frames = bounce_frames();
+            let mut idx = 0usize;
+            loop {
+                if tok.is_cancelled() {
+                    return;
+                }
+                {
+                    let mut stderr = std::io::stderr().lock();
+                    if tok.is_cancelled() {
+                        return;
+                    }
+                    let up = Self::up_prefix(me.lines_up());
+                    let _ = write!(
+                        stderr,
+                        "\x1b7{}\x1b[1G{}\x1b8",
+                        up,
+                        frames[idx % frames.len()]
+                    );
+                }
+                idx = idx.wrapping_add(1);
+                let mut elapsed_ms: u64 = 0;
+                while elapsed_ms < 120 {
+                    if tok.is_cancelled() {
+                        return;
+                    }
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    elapsed_ms += 20;
+                }
+            }
+        });
+        *self.handle.lock().unwrap() = Some(handle);
+    }
+
+    /// Cancel current task and synchronously write the restore sequence.
+    /// No-op if no spinner was started. Idempotent.
+    fn stop(&self) {
+        let prev = self.token.lock().unwrap().take();
+        let Some(tok) = prev else {
+            return;
+        };
+        tok.cancel();
+        self.handle.lock().unwrap().take();
+        let up = Self::up_prefix(self.lines_up());
+        let mut stderr = std::io::stderr().lock();
+        let _ = write!(stderr, "\x1b7{}\x1b[1G\x1b[35m<aish>\x1b[0m\x1b8", up);
+    }
+
+    /// Cancel current task without writing restore (used internally by
+    /// `start()` so the new spinner task's first frame is the next visible
+    /// write, not our restore).
+    fn stop_internal(&self) {
+        if let Some(tok) = self.token.lock().unwrap().take() {
+            tok.cancel();
+        }
+        self.handle.lock().unwrap().take();
+    }
+}
+
+/// Bouncing-dot frame sequence: `<•   >` → `<   •>` → back. 6 frames
+/// per cycle (forward 4 + reverse 2, excluding endpoints to avoid dup).
+/// Each frame is exactly 6 visible cols: `<` + 4 chars + `>`, matching
+/// `<aish>` width.
+fn bounce_frames() -> &'static [String] {
+    static FRAMES: OnceLock<Vec<String>> = OnceLock::new();
+    FRAMES.get_or_init(|| {
+        let positions: [usize; 6] = [0, 1, 2, 3, 2, 1];
+        positions
+            .iter()
+            .map(|&pos| {
+                let mut f = String::with_capacity(24);
+                f.push_str("\x1b[35m<");
+                for i in 0..4usize {
+                    if i == pos {
+                        f.push('•');
+                    } else {
+                        f.push(' ');
+                    }
+                }
+                f.push_str(">\x1b[0m");
+                f
+            })
+            .collect()
+    })
+}
+
+/// RAII guard: stops the spinner on drop. Used in `prefetch()` to guarantee
+/// the restore sequence fires on every return path (cancel, timeout, error,
+/// sanitize None, success). No-op if `start()` was never called.
+struct SpinnerGuard<'a>(&'a PromptSpinner);
+impl Drop for SpinnerGuard<'_> {
+    fn drop(&mut self) {
+        self.0.stop();
+    }
+}
+
+struct State {
+    /// Currently in-flight task: `(input, cancel_token)`. None when idle.
+    /// The input doubles as the "last dispatched" marker — if a new hint()
+    /// call arrives with the same input, we skip re-dispatching.
+    pending: Option<(String, Arc<CancellationToken>)>,
+    /// Latest suggestion awaiting acceptance. Written by the prefetch task
+    /// after LLM success; consumed (taken) by the accept key handler.
+    hint: Option<String>,
+}
+
+pub struct InlineCompleter {
+    state: Arc<Mutex<State>>,
+    provider: Arc<dyn CompletionProvider>,
+    history: Arc<Mutex<AutoSuggest>>,
+    config: InlineCompletionConfig,
+    runtime: tokio::runtime::Handle,
+    spinner: Arc<PromptSpinner>,
+}
+
+impl InlineCompleter {
+    pub fn new(
+        provider: Arc<dyn CompletionProvider>,
+        history: Arc<Mutex<AutoSuggest>>,
+        config: InlineCompletionConfig,
+        runtime: tokio::runtime::Handle,
+    ) -> Arc<Self> {
+        // Clamp nonsensical config values to safe minima.
+        let mut config = config;
+        if config.max_tokens == 0 {
+            tracing::warn!("inline_completion.max_tokens was 0, clamping to 1");
+            config.max_tokens = 1;
+        }
+        if config.debounce_ms < 50 {
+            tracing::warn!(
+                "inline_completion.debounce_ms={} < 50, clamping to 50",
+                config.debounce_ms
+            );
+            config.debounce_ms = 50;
+        }
+        Arc::new(Self {
+            state: Arc::new(Mutex::new(State {
+                pending: None,
+                hint: None,
+            })),
+            provider,
+            history,
+            config,
+            runtime,
+            spinner: Arc::new(PromptSpinner::new()),
+        })
+    }
+
+    /// Synchronous, called by `Hinter::hint()` through an Arc. Triggers a
+    /// prefetch when the input is new and long enough. The ghost is rendered
+    /// directly via ANSI escapes from the prefetch task (so it appears after
+    /// the LLM returns, without requiring another keystroke). Acceptance is
+    /// handled by the `AcceptInlineHintHandler` key binding.
+    pub fn hint(self: &Arc<Self>, line: &str) {
+        if !crate::input::is_ai_prompt_line(line) {
+            return;
+        }
+
+        // Capture terminal geometry HERE (on the readline/main thread) and
+        // stash it into atomics, because the spinner task runs on a tokio
+        // worker thread where the thread_local CURRENT_PROMPT_WIDTH /
+        // CURRENT_TERMINAL_SIZE are unavailable (they'd default to 0 / 80
+        // and produce a wrong lines_up when input wraps).
+        let (cols, _rows) = crate::readline::current_terminal_size();
+        self.spinner
+            .set_layout(crate::readline::current_prompt_width(), cols);
+        // Track input width so the spinner can compute lines_up at write
+        // time and navigate to the prompt's actual line when input wraps.
+        self.spinner
+            .set_input_width(crate::prompt::term_width(line));
+
+        let question = extract_ai_question(line);
+        let char_count = question.trim().chars().count();
+        if char_count < self.config.min_input_chars {
+            return;
+        }
+
+        let mut state = self.state.lock().unwrap();
+        // Already dispatched for this exact input — don't fire again.
+        // Crucially, do NOT clear state.hint here: a prior prefetch may have
+        // already filled the slot and if we wipe it the user's accept key
+        // (Right/Ctrl+F) finds nothing.
+        if state.pending.as_ref().is_some_and(|(inp, _)| inp == line) {
+            return;
+        }
+        // Input changed — any pending hint is now stale.
+        state.hint = None;
+        // Cancel any in-flight task. Stop the spinner immediately so the
+        // prompt snaps back to `<aish>` on this keypress — the cancelled
+        // prefetch task will exit on its own within ~20ms.
+        if let Some((_, tok)) = state.pending.take() {
+            tok.cancel();
+            self.spinner.stop();
+        }
+        let tok = Arc::new(CancellationToken::new());
+        state.pending = Some((line.to_string(), tok.clone()));
+        drop(state);
+        tracing::debug!(input = %line, "inline hint: dispatched prefetch");
+
+        let me = self.clone();
+        let input_owned = line.to_string();
+        self.runtime.spawn(async move {
+            me.prefetch(input_owned, tok).await;
+        });
+    }
+
+    /// Take the current hint, if any (clears the slot). Called by
+    /// `AcceptInlineHintHandler` when the user presses Right/Ctrl+F.
+    pub fn take_hint(&self) -> Option<String> {
+        self.state.lock().unwrap().hint.take()
+    }
+
+    /// Update the model used for inline completion (called on `/model` switch).
+    pub fn update_model(&self, model: &str) {
+        self.provider.update_model(model);
+    }
+
+    /// Cancel any in-flight prefetch, clear the hint slot, and stop the
+    /// spinner. Idempotent — `spinner.stop()` is a no-op when no spinner is
+    /// running, so callers can invoke this unconditionally on submit /
+    /// mode-change / drop without tracking whether a task is in flight.
+    pub fn cancel(&self) {
+        let cancelled = {
+            let mut state = self.state.lock().unwrap();
+            let tok = state.pending.take().map(|(_, t)| t);
+            state.hint = None;
+            tok
+        };
+        if let Some(tok) = cancelled {
+            tok.cancel();
+        }
+        self.spinner.stop();
+    }
+
+    async fn prefetch(self: Arc<Self>, input: String, token: Arc<CancellationToken>) {
+        // 1) Debounce with cancellation via polling (CancellationToken is
+        //    not an async future; we poll is_cancelled() every 20ms).
+        let mut elapsed_ms: u64 = 0;
+        let step_ms: u64 = 20;
+        while elapsed_ms < self.config.debounce_ms {
+            if token.is_cancelled() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(step_ms)).await;
+            elapsed_ms += step_ms;
+        }
+        if token.is_cancelled() {
+            return;
+        }
+        tracing::debug!(input = %input, "prefetch: debounce complete");
+
+        // The spinner runs from "LLM call starts" until "result applied"
+        // (success, error, cancel, or timeout). `SpinnerGuard` ensures the
+        // restore sequence fires on every return path.
+        self.spinner.start(&self.runtime);
+        let spinner_guard = SpinnerGuard(&self.spinner);
+
+        // 2) Snapshot context synchronously.
+        let history_lines = {
+            let g = self.history.lock().unwrap();
+            g.recent_n(self.config.context_lines)
+        };
+        let cwd = std::env::current_dir()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| "<unknown>".to_string());
+        let question = extract_ai_question(&input);
+
+        let prompt = build_prompt(&question, &cwd, &history_lines);
+        tracing::debug!("prefetch: firing LLM call");
+
+        // Hard cap from config (default 15s). The underlying LlmClient sets
+        // a 120s timeout which is far too long for inline completion; users
+        // on slow gateways can bump `timeout_secs` in their config.
+        let max_tokens = self.config.max_tokens;
+        let started = std::time::Instant::now();
+        let hard_cap = Duration::from_secs(self.config.timeout_secs.max(1));
+        let llm_fut = self.provider.complete(&prompt, max_tokens);
+        tokio::pin!(llm_fut);
+        let poll_step: u64 = 50;
+        let result: Result<String, ()> = loop {
+            if token.is_cancelled() {
+                tracing::debug!(
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    "prefetch: cancelled during LLM poll"
+                );
+                return;
+            }
+            if started.elapsed() > hard_cap {
+                tracing::debug!(
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    cap_secs = hard_cap.as_secs(),
+                    "prefetch: timed out"
+                );
+                return;
+            }
+            tokio::select! {
+                r = &mut llm_fut => break r,
+                _ = tokio::time::sleep(Duration::from_millis(poll_step)) => {}
+            }
+        };
+        tracing::debug!(
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "prefetch: LLM call finished"
+        );
+
+        let raw = match result {
+            Ok(s) => s,
+            Err(_) => {
+                tracing::debug!("prefetch: provider error");
+                return;
+            }
+        };
+        tracing::debug!(raw = %raw, "prefetch: raw response");
+
+        let suffix = match sanitize_suffix(&raw, &question) {
+            Some(s) => s,
+            None => {
+                tracing::debug!("prefetch: sanitize returned None");
+                return;
+            }
+        };
+        tracing::debug!(suffix = %suffix, "prefetch: sanitized");
+
+        // Cap the suffix to the remaining columns on the current cursor
+        // line so the ghost text doesn't wrap mid-word. But when even the
+        // first character can't fit (e.g., 1 col left but a CJK char needs
+        // 2), show the full suffix anyway — a wrapping suggestion is more
+        // useful than no suggestion at all. The render_ghost DECSC/DECRC
+        // pair keeps the cursor position correct regardless of wrapping.
+        let avail = self.spinner.available_ghost_width();
+        let suffix = if crate::prompt::term_width(&suffix) > avail {
+            let capped = cap_suffix_width(&suffix, avail);
+            if capped.is_empty() {
+                tracing::debug!(
+                    avail_cols = avail,
+                    "prefetch: no room for first char on current line, \
+                     showing full suffix (will wrap)"
+                );
+                suffix
+            } else {
+                tracing::debug!(
+                    avail_cols = avail,
+                    capped = %capped,
+                    "prefetch: truncated suffix to fit current line"
+                );
+                capped
+            }
+        } else {
+            suffix
+        };
+
+        // Stop the spinner BEFORE rendering the ghost text. stop() computes
+        // lines_up() from the input width (without the ghost), and its
+        // DECSC saves the cursor position to navigate back to the prompt
+        // badge row. If the restore ran AFTER render_ghost and the ghost
+        // wrapped the cursor onto a new line, the saved position would be
+        // wrong and <aish> would land on the wrapped input row. Dropping
+        // the guard here ensures stop() runs while the cursor is still at
+        // the input end. On early-return paths (cancel/timeout/error above)
+        // the guard still drops automatically.
+        drop(spinner_guard);
+
+        // 3) Freshness check + render ghost + write hint slot. Render first
+        //    so the user sees the suggestion before the slot is readable;
+        //    a quick Right-Arrow that hits an empty slot falls through to
+        //    default cursor-move behavior, which is the safer failure mode.
+        let mut state = self.state.lock().unwrap();
+        let fresh =
+            !token.is_cancelled() && state.pending.as_ref().is_some_and(|(inp, _)| inp == &input);
+        if fresh {
+            render_ghost(&suffix);
+            state.hint = Some(suffix);
+            tracing::debug!("prefetch: ghost rendered + slot filled");
+        } else {
+            tracing::debug!(
+                cancelled = token.is_cancelled(),
+                "prefetch: stale, discarding"
+            );
+        }
+    }
+}
+
+/// Render the ghost suggestion directly to stderr in ANSI 256-color gray
+/// (242), then move the cursor back so it sits BEFORE the ghost — the same
+/// position rustyline's Hinter would put it. `\x1b[K` clears any longer
+/// prior ghost first so a shorter new suffix fully overwrites it.
+fn render_ghost(suffix: &str) {
+    use std::io::Write;
+    let width = crate::prompt::term_width(suffix);
+    if width == 0 {
+        return;
+    }
+    let mut stderr = std::io::stderr().lock();
+    // DECSC (\x1b7) saves the cursor before writing the ghost; DECRC
+    // (\x1b8) restores it afterward. This is critical when the suffix
+    // wraps across lines: the previous approach used \x1b[<N>D to move
+    // the cursor back, but that sequence can only move left within the
+    // current row. A wrapped ghost stranded the cursor on the wrong line,
+    // which in turn made the spinner's <aish> restore (via SpinnerGuard)
+    // write to the wrong row.
+    let _ = write!(stderr, "\x1b7\x1b[K\x1b[38;5;242m{}\x1b[0m\x1b8", suffix);
+    let _ = stderr.flush();
+}
+
+fn build_prompt(question: &str, cwd: &str, history_lines: &[String]) -> String {
+    let history_block = if history_lines.is_empty() {
+        "(none)".to_string()
+    } else {
+        history_lines
+            .iter()
+            .map(|h| format!("  {}", h))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    format!(
+        "Current working directory: {cwd}\n\n\
+         Recent shell commands (most recent first):\n\
+         {history_block}\n\n\
+         Current partial input (the part after \";\"):\n\
+         {question}\n\n\
+         Return only the suffix to append:"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_suffix_parses_clean_json() {
+        assert_eq!(
+            extract_suffix_from_json(r#"{"suffix": "文件"}"#),
+            Some("文件".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_suffix_parses_json_wrapped_in_prose() {
+        assert_eq!(
+            extract_suffix_from_json(r#"Sure, here: {"suffix": "files"}"#),
+            Some("files".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_suffix_strips_markdown_fences() {
+        assert_eq!(
+            extract_suffix_from_json("```json\n{\"suffix\": \"abc\"}\n```"),
+            Some("abc".to_string())
+        );
+    }
+
+    /// Happy path for the new prompt format: a single ```json fence with
+    /// the JSON inside. Mirrors what the prompt asks the model to return.
+    #[test]
+    fn extract_suffix_from_fenced_block() {
+        let resp = "```json\n{\"suffix\": \"地址是什么\"}\n```";
+        assert_eq!(
+            extract_suffix_from_json(resp),
+            Some("地址是什么".to_string())
+        );
+    }
+
+    /// Model adds prose around the fence. Layer 1 still finds it.
+    #[test]
+    fn extract_suffix_from_fenced_block_with_prose() {
+        let resp = "Sure, here's the completion:\n```json\n{\"suffix\": \"文件\"}\n```\nDone.";
+        assert_eq!(extract_suffix_from_json(resp), Some("文件".to_string()));
+    }
+
+    /// Regression: some models return the JSON example wrapped in extra
+    /// braces (e.g. `{{"suffix": "..."}}`), which is not valid JSON. The
+    /// regex fallback should still extract the suffix value.
+    #[test]
+    fn extract_suffix_handles_double_braces() {
+        assert_eq!(
+            extract_suffix_from_json(r#"{{"suffix": "地址是什么"}}"#),
+            Some("地址是什么".to_string())
+        );
+    }
+
+    /// Regression: model wraps the JSON in prose + extra braces.
+    #[test]
+    fn extract_suffix_handles_prose_with_double_braces() {
+        assert_eq!(
+            extract_suffix_from_json(r#"Sure! Here you go: {{"suffix": "文件"}}. Done."#),
+            Some("文件".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_suffix_unescapes_basic_escapes() {
+        assert_eq!(
+            extract_suffix_from_json(r#"{"suffix": "hello \"world\""}"#),
+            Some("hello \"world\"".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_suffix_returns_none_for_missing_field() {
+        assert_eq!(extract_suffix_from_json(r#"{"foo": "bar"}"#), None);
+    }
+
+    #[test]
+    fn extract_suffix_returns_none_for_empty_input() {
+        assert_eq!(extract_suffix_from_json(""), None);
+        assert_eq!(extract_suffix_from_json("   "), None);
+    }
+
+    #[test]
+    fn extract_suffix_returns_none_for_invalid_json() {
+        assert_eq!(extract_suffix_from_json("not json at all"), None);
+    }
+
+    #[test]
+    fn sanitize_passes_through_clean_text() {
+        assert_eq!(
+            sanitize_suffix("list all files", "how do I"),
+            Some("list all files".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_surrounding_quotes() {
+        assert_eq!(
+            sanitize_suffix("\"list files\"", "how do I"),
+            Some("list files".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_code_fences() {
+        assert_eq!(
+            sanitize_suffix("```bash\nlist files\n```", "how do I"),
+            Some("list files".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_truncates_at_first_newline() {
+        assert_eq!(
+            sanitize_suffix("list files\nmore stuff", "how do I"),
+            Some("list files".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_repeated_prefix() {
+        // Model echoed back the user's partial input.
+        assert_eq!(
+            sanitize_suffix("how do I list files", "how do I"),
+            Some("list files".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_returns_none_for_empty() {
+        assert_eq!(sanitize_suffix("", "how do I"), None);
+    }
+
+    #[test]
+    fn sanitize_returns_none_for_only_quotes() {
+        assert_eq!(sanitize_suffix("\"\"", "how do I"), None);
+    }
+
+    #[test]
+    fn sanitize_returns_none_for_only_whitespace() {
+        assert_eq!(sanitize_suffix("   \n  ", "how do I"), None);
+    }
+
+    #[test]
+    fn sanitize_trims_leading_whitespace() {
+        // We never prepend a space — the model is responsible for including
+        // one in its output when the language needs it.
+        assert_eq!(
+            sanitize_suffix("   list files", "how do I"),
+            Some("list files".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_no_leading_space_for_cjk_input() {
+        // CJK input never wants a leading space glued onto the suffix.
+        assert_eq!(
+            sanitize_suffix("系统IP地址", "如何查看"),
+            Some("系统IP地址".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_no_leading_space_when_question_ends_with_space() {
+        assert_eq!(
+            sanitize_suffix("list files", "how do I "),
+            Some("list files".to_string())
+        );
+    }
+
+    #[test]
+    fn cap_suffix_short_text_unchanged() {
+        assert_eq!(cap_suffix_width("形式输出", 20), "形式输出");
+        assert_eq!(cap_suffix_width("list files", 20), "list files");
+    }
+
+    #[test]
+    fn cap_suffix_long_cjk_truncates_at_punctuation() {
+        // 16 CJK chars = 32 cols > 20. Break at the ，(comma) at col 10.
+        let long = "形式输出，包含所有接口信息";
+        let capped = cap_suffix_width(long, 20);
+        assert_eq!(capped, "形式输出");
+    }
+
+    #[test]
+    fn cap_suffix_long_ascii_truncates_at_space() {
+        let long = "processes consuming the most memory and CPU";
+        let capped = cap_suffix_width(long, 20);
+        // Break at the last space within 20 cols.
+        assert!(capped.chars().count() <= 20);
+        assert!(!capped.is_empty());
+    }
+
+    #[test]
+    fn cap_suffix_no_punctuation_hard_cuts() {
+        // No punctuation within budget → hard cut at width boundary.
+        let long = "abcdefghijklmnopqrstuvwxyz";
+        let capped = cap_suffix_width(long, 10);
+        assert_eq!(capped, "abcdefghij");
+    }
+
+    #[test]
+    fn cap_suffix_empty_input() {
+        assert_eq!(cap_suffix_width("", 20), "");
+    }
+
+    #[tokio::test]
+    async fn fake_provider_returns_canned_value() {
+        let p = FakeCompletionProvider::new("list files");
+        let r = p.complete("anything", 32).await.unwrap();
+        assert_eq!(r, "list files");
+        assert_eq!(p.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn fake_provider_failure_propagates() {
+        let p = FakeCompletionProvider::new_failing();
+        assert!(p.complete("x", 32).await.is_err());
+    }
+}
+
+#[cfg(test)]
+mod completer_tests {
+    use super::*;
+    use crate::autosuggest::AutoSuggest;
+    use aish_config::InlineCompletionConfig;
+    use std::sync::Mutex;
+    use std::time::Duration;
+    use tokio::runtime::Runtime;
+
+    fn mk_completer(
+        provider: Arc<dyn CompletionProvider>,
+        config: InlineCompletionConfig,
+    ) -> (Arc<InlineCompleter>, Arc<Mutex<AutoSuggest>>, Runtime) {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let history = Arc::new(Mutex::new(AutoSuggest::new(100)));
+        let completer =
+            InlineCompleter::new(provider, history.clone(), config, rt.handle().clone());
+        (completer, history, rt)
+    }
+
+    fn fast_config() -> InlineCompletionConfig {
+        InlineCompletionConfig {
+            enabled: true,
+            debounce_ms: 10,
+            context_lines: 3,
+            max_tokens: 32,
+            min_input_chars: 3,
+            disable_thinking: false,
+            enforce_json: false,
+            timeout_secs: 15,
+        }
+    }
+
+    #[test]
+    fn hint_no_op_for_too_short_input() {
+        let provider = Arc::new(FakeCompletionProvider::new("list files"));
+        let (c, _h, _rt) = mk_completer(provider, fast_config());
+        // After stripping the `;` prefix, "h" is 1 char < min_input_chars.
+        c.hint("; h");
+        assert_eq!(c.take_hint(), None);
+    }
+
+    #[test]
+    fn hint_eventually_populates_slot_after_debounce() {
+        let provider = Arc::new(FakeCompletionProvider::new("list files"));
+        let (c, _h, rt) = mk_completer(provider, fast_config());
+
+        // hint() spawns the prefetch task on the runtime and returns
+        // immediately. The ghost is rendered directly via ANSI escapes,
+        // not via Hinter display, so the suffix is observable only via
+        // take_hint() — the same path the accept key handler uses.
+        c.hint("; how do I");
+
+        rt.block_on(async {
+            tokio::time::sleep(Duration::from_millis(80)).await;
+        });
+
+        // Do NOT call hint() again here — every hint() call clears the
+        // slot on the assumption that input may have changed.
+        let suffix = c.take_hint();
+        assert_eq!(suffix, Some("list files".to_string()));
+    }
+
+    #[test]
+    fn hint_clears_slot_when_input_diverges() {
+        let provider = Arc::new(FakeCompletionProvider::new("list files"));
+        let (c, _h, rt) = mk_completer(provider, fast_config());
+
+        c.hint("; how do I");
+        rt.block_on(async {
+            tokio::time::sleep(Duration::from_millis(80)).await;
+        });
+
+        // Different input — hint() clears the slot before dispatching.
+        c.hint("; list");
+        assert_eq!(c.take_hint(), None);
+    }
+
+    /// Regression: ghost text must NOT wrap to the next line. When the
+    /// current input line is nearly full, the suffix is truncated to fit
+    /// the remaining columns instead of being rendered as-is.
+    #[test]
+    fn hint_truncates_suffix_to_fit_remaining_cols() {
+        let provider = Arc::new(FakeCompletionProvider::new("list files"));
+        let (c, _h, rt) = mk_completer(provider, fast_config());
+
+        // cols defaults to 80 in tests; bump prompt_width so "; abc"
+        // (5 cols) leaves only 1 col on the line (74 + 5 = 79 → avail = 1).
+        crate::readline::set_current_prompt_width(74);
+        c.hint("; abc");
+        rt.block_on(async {
+            tokio::time::sleep(Duration::from_millis(80)).await;
+        });
+        crate::readline::set_current_prompt_width(0);
+
+        // "list files" (10 cols) truncated to 1 col → "l".
+        assert_eq!(c.take_hint(), Some("l".to_string()));
+    }
+
+    /// Regression: when the remaining columns can't fit even the first
+    /// character of the suffix (e.g. CJK on a 1-col slot), the full suffix
+    /// is shown anyway (wrapping to the next line) rather than being
+    /// suppressed. A wrapping suggestion is more useful than no suggestion.
+    #[test]
+    fn hint_shows_full_suffix_when_no_room_for_first_char() {
+        let provider = Arc::new(FakeCompletionProvider::new("中文建议"));
+        let (c, _h, rt) = mk_completer(provider, fast_config());
+
+        // avail = 1 col, but every CJK char is 2 cols → cap returns "".
+        // The full suffix "中文建议" should still be stored as the hint.
+        crate::readline::set_current_prompt_width(74);
+        c.hint("; abc");
+        rt.block_on(async {
+            tokio::time::sleep(Duration::from_millis(80)).await;
+        });
+        crate::readline::set_current_prompt_width(0);
+
+        assert_eq!(c.take_hint(), Some("中文建议".to_string()));
+    }
+
+    #[test]
+    fn cancel_clears_state() {
+        let provider = Arc::new(FakeCompletionProvider::new("list files"));
+        let (c, _h, rt) = mk_completer(provider, fast_config());
+
+        c.hint("; how do I");
+        c.cancel();
+        rt.block_on(async {
+            tokio::time::sleep(Duration::from_millis(80)).await;
+        });
+
+        // After cancel + settling, the slot must not have been populated
+        // for the cancelled dispatch.
+        c.hint("; how do I");
+        assert_eq!(c.take_hint(), None);
+    }
+
+    #[test]
+    fn cancel_is_idempotent() {
+        let provider = Arc::new(FakeCompletionProvider::new("x"));
+        let (c, _h, _rt) = mk_completer(provider, fast_config());
+        c.cancel();
+        c.cancel();
+        c.cancel();
+    }
+
+    #[test]
+    fn non_ai_input_does_not_dispatch() {
+        let provider = Arc::new(FakeCompletionProvider::new("list files"));
+        let p = provider.clone();
+        let (c, _h, rt) = mk_completer(provider, fast_config());
+
+        // Plain command — InlineCompleter itself never sees this in
+        // production (ShellHelper::hint branches first), but the call must
+        // be safe.
+        c.hint("ls -la");
+        rt.block_on(async {
+            tokio::time::sleep(Duration::from_millis(80)).await;
+        });
+        assert_eq!(p.call_count(), 0);
+    }
+
+    #[test]
+    fn cancellation_aborts_in_flight_llm_call() {
+        use async_trait::async_trait;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        struct Slow {
+            started: Arc<AtomicUsize>,
+            finished: Arc<AtomicUsize>,
+        }
+        #[async_trait]
+        impl CompletionProvider for Slow {
+            async fn complete(&self, _: &str, _: u32) -> Result<String, ()> {
+                self.started.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                self.finished.fetch_add(1, Ordering::SeqCst);
+                Ok("should not see me".to_string())
+            }
+        }
+        let started = Arc::new(AtomicUsize::new(0));
+        let finished = Arc::new(AtomicUsize::new(0));
+        let provider: Arc<dyn CompletionProvider> = Arc::new(Slow {
+            started: started.clone(),
+            finished: finished.clone(),
+        });
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let history = Arc::new(Mutex::new(AutoSuggest::new(100)));
+        let config = InlineCompletionConfig {
+            enabled: true,
+            debounce_ms: 10,
+            context_lines: 3,
+            max_tokens: 32,
+            min_input_chars: 3,
+            disable_thinking: false,
+            enforce_json: false,
+            timeout_secs: 15,
+        };
+        let c = InlineCompleter::new(provider, history, config, rt.handle().clone());
+        c.hint("; how do I");
+        // Wait for debounce (10ms) + some extra time for the LLM call to start
+        rt.block_on(async {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        });
+        // Now cancel while the LLM call is in-flight (sleeping for 5 seconds)
+        c.cancel();
+        rt.block_on(async {
+            tokio::time::sleep(Duration::from_millis(80)).await;
+        });
+        // No panic, no hang; slot stays empty.
+        c.hint("; how do I");
+        assert_eq!(c.take_hint(), None);
+        // Prove the future was started but never completed (cancelled mid-sleep).
+        assert_eq!(started.load(Ordering::SeqCst), 1);
+        assert_eq!(finished.load(Ordering::SeqCst), 0);
+        drop(c);
+    }
+
+    /// Regression for the thread_local bug: the spinner task runs on a tokio
+    /// worker thread, where `CURRENT_PROMPT_WIDTH` / `CURRENT_TERMINAL_SIZE`
+    /// thread-locals are unavailable (default to 0 / 80). `lines_up` must
+    /// read the atomic values captured by `set_layout` instead, so it stays
+    /// correct regardless of which thread it runs on.
+    #[test]
+    fn spinner_lines_up_uses_captured_layout() {
+        let s = PromptSpinner::new();
+
+        // prompt 50 cols + input 40 cols = 90 > 80 → wraps → 1 line up.
+        s.set_layout(50, 80);
+        s.set_input_width(40);
+        assert_eq!(s.lines_up(), 1);
+
+        // total exactly 80 → fits → 0 lines up.
+        s.set_input_width(30);
+        assert_eq!(s.lines_up(), 0);
+
+        // Wraps to 3 lines: 50 + 130 = 180 / 80 = 3 → 2 lines up.
+        s.set_layout(50, 80);
+        s.set_input_width(130);
+        assert_eq!(s.lines_up(), 2);
+
+        // CJK: prompt_width and input_width are visible-cell counts, so a
+        // wide-char-heavy input still computes correctly.
+        s.set_layout(10, 30);
+        s.set_input_width(25); // 35 / 30 = 2 lines
+        assert_eq!(s.lines_up(), 1);
+    }
+
+    /// Regression for the wrap bug: when the input nearly fills the
+    /// terminal width, `available_ghost_width` must report only the
+    /// remaining columns on the current cursor line so the caller can
+    /// truncate or skip the ghost instead of letting it wrap.
+    #[test]
+    fn spinner_available_ghost_width_matches_remaining_cols() {
+        let s = PromptSpinner::new();
+
+        // 80-col terminal, prompt 50 + input 20 = 70 → 10 cols remain.
+        s.set_layout(50, 80);
+        s.set_input_width(20);
+        assert_eq!(s.available_ghost_width(), 10);
+
+        // Input fills the line exactly: 50 + 30 = 80, cursor wrapped to
+        // col 0 of line 2 → full line (80) available there.
+        s.set_input_width(30);
+        assert_eq!(s.available_ghost_width(), 80);
+
+        // Input wraps past one full line: 50 + 90 = 140, 140 % 80 = 60
+        // → cursor at col 60 of line 2 → 20 cols remain.
+        s.set_input_width(90);
+        assert_eq!(s.available_ghost_width(), 20);
+
+        // Cursor at the very last column: 50 + 29 = 79 → 1 col remain.
+        s.set_input_width(29);
+        assert_eq!(s.available_ghost_width(), 1);
+
+        // cols == 0 (uninitialized / weird terminal) → no room reported.
+        s.set_layout(50, 0);
+        assert_eq!(s.available_ghost_width(), 0);
+    }
+
+    /// Regression: when prompt_width + input_width is an exact multiple of
+    /// cols, the cursor position is ambiguous (pending-wrap vs actually
+    /// wrapped). The spinner must NOT start in this state — guessing wrong
+    /// makes the animation and the stop() restore land on the wrong row.
+    #[test]
+    fn spinner_skips_start_at_exact_line_boundary() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let s = Arc::new(PromptSpinner::new());
+
+        // total = 80 = 1 × 80 → exact boundary → skip.
+        s.set_layout(50, 80);
+        s.set_input_width(30);
+        s.clone().start(rt.handle());
+        assert!(
+            s.token.lock().unwrap().is_none(),
+            "spinner should not start when total is an exact multiple of cols"
+        );
+
+        // total = 160 = 2 × 80 → exact boundary at 2 lines → skip.
+        s.set_layout(50, 80);
+        s.set_input_width(110);
+        s.clone().start(rt.handle());
+        assert!(
+            s.token.lock().unwrap().is_none(),
+            "spinner should not start at multi-line exact boundary"
+        );
+    }
+
+    /// Counterpart: the spinner DOES start when total is not at a boundary.
+    #[test]
+    fn spinner_starts_when_not_at_boundary() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let s = Arc::new(PromptSpinner::new());
+
+        // total = 79 < 80 → single line, not at boundary → start.
+        s.set_layout(50, 80);
+        s.set_input_width(29);
+        s.clone().start(rt.handle());
+        assert!(
+            s.token.lock().unwrap().is_some(),
+            "spinner should start when input fits on one line"
+        );
+
+        // Clean up: stop the spawned task.
+        s.stop_internal();
+
+        // total = 90, 90 % 80 = 10 ≠ 0 → wrapped but not at boundary → start.
+        s.set_layout(50, 80);
+        s.set_input_width(40);
+        s.clone().start(rt.handle());
+        assert!(
+            s.token.lock().unwrap().is_some(),
+            "spinner should start when wrapped but not at exact boundary"
+        );
+        s.stop_internal();
+    }
+}

--- a/crates/aish-shell/src/inline_completion.rs
+++ b/crates/aish-shell/src/inline_completion.rs
@@ -328,16 +328,42 @@ fn extract_suffix_from_json(content: &str) -> Option<String> {
         .get_or_init(|| Regex::new(r#""suffix"\s*:\s*"((?:[^"\\]|\\.)*)""#).expect("suffix regex"));
     let caps = re.captures(trimmed)?;
     let raw = caps.get(1)?.as_str();
-    let unescaped = raw
-        .replace(r#"\""#, "\"")
-        .replace(r"\\", r"\")
-        .replace(r"\n", "\n")
-        .replace(r"\t", "\t");
+    // Single-pass unescape: process \\, \", \n, \t left-to-right so that
+    // a literal "\\n" (backslash + n) is NOT mistaken for a newline.
+    // The previous chained-replace approach first collapsed "\\\\" → "\\"
+    // and then mis-read the result as "\n" → newline.
+    let unescaped = unescape_json_suffix(raw);
     if unescaped.is_empty() {
         None
     } else {
         Some(unescaped)
     }
+}
+
+/// Decode JSON string escapes in a single left-to-right pass. Handles
+/// `\\"`, `\\\\`, `\\n`, `\\t`; any unrecognized escape is passed through
+/// literally (backslash + char).
+fn unescape_json_suffix(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut chars = raw.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            match chars.next() {
+                Some('"') => out.push('"'),
+                Some('\\') => out.push('\\'),
+                Some('n') => out.push('\n'),
+                Some('t') => out.push('\t'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => out.push('\\'),
+            }
+        } else {
+            out.push(ch);
+        }
+    }
+    out
 }
 
 /// Pull the non-empty `suffix` field out of a parsed JSON value.
@@ -1032,6 +1058,24 @@ mod tests {
         assert_eq!(
             extract_suffix_from_json(r#"{"suffix": "hello \"world\""}"#),
             Some("hello \"world\"".to_string())
+        );
+    }
+
+    /// Regression: a literal backslash-n in the JSON (`\\n` — two chars)
+    /// must NOT be turned into an actual newline. The old chained-replace
+    /// approach first collapsed `\\` → `\`, then mis-read the result as
+    /// `\n` → newline. The single-pass scanner avoids this.
+    #[test]
+    fn extract_suffix_preserves_literal_backslash_n() {
+        // JSON: "foo\\nbar" → should decode to "foo\nbar" (literal \ + n)
+        assert_eq!(
+            extract_suffix_from_json(r#"{"suffix": "foo\\nbar"}"#),
+            Some("foo\\nbar".to_string())
+        );
+        // But a real JSON newline (\n) should still decode to a newline.
+        assert_eq!(
+            extract_suffix_from_json("{\"suffix\": \"a\\nb\"}"),
+            Some("a\nb".to_string())
         );
     }
 

--- a/crates/aish-shell/src/input.rs
+++ b/crates/aish-shell/src/input.rs
@@ -1,12 +1,19 @@
 use crate::types::{CommandCategory, InputIntent};
 
+/// True if the line begins (after leading whitespace) with a `;` or
+/// full-width `；`, marking it as an AI prompt.
+pub fn is_ai_prompt_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with(';') || trimmed.starts_with('\u{ff1b}')
+}
+
 /// Classify user input into an intent category.
 pub fn classify_input(input: &str) -> InputIntent {
     let trimmed = input.trim();
     if trimmed.is_empty() {
         return InputIntent::Empty;
     }
-    if trimmed.starts_with(';') || trimmed.starts_with('\u{ff1b}') {
+    if is_ai_prompt_line(trimmed) {
         return InputIntent::Ai;
     }
     if trimmed == "help" {

--- a/crates/aish-shell/src/lib.rs
+++ b/crates/aish-shell/src/lib.rs
@@ -27,6 +27,7 @@ pub mod esc_watcher;
 pub mod expand_history;
 pub mod feedback;
 pub mod image;
+pub mod inline_completion;
 pub mod input;
 pub mod keyboard;
 pub mod nl_detect;

--- a/crates/aish-shell/src/prompt.rs
+++ b/crates/aish-shell/src/prompt.rs
@@ -1,7 +1,46 @@
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::OnceLock;
 
 use aish_i18n::{t, t_with_args};
+
+/// Whether the current locale is a CJK (Chinese/Japanese/Korean) locale.
+/// Cached after the first call. When true, ambiguous-width Unicode
+/// characters (●, ➜, etc.) should be treated as 2 columns wide — matching
+/// how CJK terminals render them.
+fn is_cjk_locale() -> bool {
+    static CJK: OnceLock<bool> = OnceLock::new();
+    *CJK.get_or_init(|| {
+        let lang = std::env::var("LC_ALL")
+            .or_else(|_| std::env::var("LC_CTYPE"))
+            .or_else(|_| std::env::var("LANG"))
+            .unwrap_or_default();
+        let lang = lang.to_lowercase();
+        lang.contains("zh") || lang.contains("ja") || lang.contains("ko")
+    })
+}
+
+/// Compute the visible terminal width of a string, respecting the current
+/// locale's handling of ambiguous-width characters. On CJK locales,
+/// ambiguous chars count as 2 columns (matching the terminal); on other
+/// locales, they count as 1.
+pub fn term_width(s: &str) -> usize {
+    if is_cjk_locale() {
+        unicode_width::UnicodeWidthStr::width_cjk(s)
+    } else {
+        unicode_width::UnicodeWidthStr::width(s)
+    }
+}
+
+/// Compute the visible terminal width of a single character, respecting
+/// the current locale's handling of ambiguous-width characters.
+pub fn term_char_width(ch: char) -> usize {
+    if is_cjk_locale() {
+        unicode_width::UnicodeWidthChar::width_cjk(ch).unwrap_or(0)
+    } else {
+        unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0)
+    }
+}
 
 /// Walk up from `cwd` to find a `.git/HEAD` file and extract the branch name.
 ///
@@ -75,7 +114,7 @@ fn abbreviate_path(path: &str, home: &str) -> String {
 
 /// Calculate the visible display width of a string, ignoring ANSI escape sequences.
 /// Accounts for CJK double-width characters.
-fn strip_ansi_len(s: &str) -> usize {
+pub fn strip_ansi_len(s: &str) -> usize {
     let mut len = 0;
     let mut in_escape = false;
     for ch in s.chars() {
@@ -86,7 +125,7 @@ fn strip_ansi_len(s: &str) -> usize {
                 in_escape = false;
             }
         } else {
-            len += unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+            len += term_char_width(ch);
         }
     }
     len
@@ -552,7 +591,9 @@ mod tests {
     #[test]
     fn test_strip_ansi_len_with_escape() {
         assert_eq!(strip_ansi_len("\x1b[32mhello\x1b[0m"), 5);
-        assert_eq!(strip_ansi_len("\x1b[1;36m•\x1b[0m"), 1); // • is 1 display column
+        // Use ASCII 'A' (always 1 col) instead of '•' (ambiguous: 1 or 2
+        // cols depending on locale) so the test is locale-independent.
+        assert_eq!(strip_ansi_len("\x1b[1;36mA\x1b[0m"), 1);
     }
 
     #[test]
@@ -560,6 +601,24 @@ mod tests {
         let line = format!("  \x1b[1m{}:\x1b[0m {}", "model", "gpt-4");
         // "  model: gpt-4" visible = 14
         assert_eq!(strip_ansi_len(&line), 14);
+    }
+
+    /// Ambiguous-width characters (●, ➜, •) have different widths depending
+    /// on locale: 1 col in non-CJK, 2 cols in CJK. `term_width` must match
+    /// the locale so the inline-completion spinner's `lines_up` calculation
+    /// agrees with the terminal's actual rendering. This test verifies the
+    /// locale-dependent behavior is consistent — on a CJK locale, ambiguous
+    /// chars are wider; ASCII is always 1 col regardless.
+    #[test]
+    fn test_term_width_locale_consistency() {
+        // ASCII is always 1 col, regardless of locale.
+        assert_eq!(term_width("hello"), 5);
+        // CJK characters are always 2 cols (Wide, not Ambiguous).
+        assert_eq!(term_width("中文"), 4);
+        // The width of the ambiguous char ● depends on the locale — just
+        // verify it's one of the two valid values (1 or 2).
+        let bullet_width = term_char_width('●');
+        assert!(bullet_width == 1 || bullet_width == 2);
     }
 
     #[test]

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -64,11 +64,23 @@ static TAB_STATE: Mutex<TabCompletionState> = Mutex::new(TabCompletionState {
 
 thread_local! {
     static CURRENT_TERMINAL_SIZE: Cell<(u16, u16)> = const { Cell::new((80, 24)) };
+    static CURRENT_PROMPT_WIDTH: Cell<usize> = const { Cell::new(0) };
 }
 
 /// Terminal size last seen by rustyline (cols, rows).
 pub fn current_terminal_size() -> (u16, u16) {
     CURRENT_TERMINAL_SIZE.with(|s| s.get())
+}
+
+/// Visible width (terminal columns) of the prompt for the current `read_line`
+/// call. Set just before each readline; read by `InlineCompleter` to detect
+/// input wrap.
+pub fn current_prompt_width() -> usize {
+    CURRENT_PROMPT_WIDTH.with(|c| c.get())
+}
+
+pub(crate) fn set_current_prompt_width(width: usize) {
+    CURRENT_PROMPT_WIDTH.with(|c| c.set(width));
 }
 
 fn refresh_terminal_size<H: Helper>(editor: &mut Editor<H, rustyline::history::DefaultHistory>) {
@@ -209,17 +221,111 @@ impl ConditionalEventHandler for SlashHandler {
     }
 }
 
+/// Accept the inline AI completion ghost text (if any) when the user presses
+/// Right Arrow or Ctrl+F while in AI mode with the cursor at end of line.
+/// Falls through to default behavior otherwise.
+struct AcceptInlineHintHandler {
+    inline_ai: Arc<crate::inline_completion::InlineCompleter>,
+}
+
+impl ConditionalEventHandler for AcceptInlineHintHandler {
+    fn handle(
+        &self,
+        _evt: &Event,
+        _n_repeat: RepeatCount,
+        _positive: bool,
+        ctx: &EventContext<'_>,
+    ) -> Option<Cmd> {
+        if ctx.pos() != ctx.line().len() {
+            return None;
+        }
+        if !crate::input::is_ai_prompt_line(ctx.line()) {
+            return None;
+        }
+        self.inline_ai
+            .take_hint()
+            .map(|suffix| Cmd::Insert(1, suffix))
+    }
+}
+
+/// On Enter (or any line-submit key): clear the visible ghost text before
+/// rustyline accepts the line. Our ghost is rendered directly via ANSI
+/// escapes, so rustyline doesn't know to clear it during its own repaint.
+/// Without this, the ghost would remain frozen on the submitted line.
+struct ClearGhostOnSubmitHandler {
+    inline_ai: Arc<crate::inline_completion::InlineCompleter>,
+}
+
+impl ConditionalEventHandler for ClearGhostOnSubmitHandler {
+    fn handle(
+        &self,
+        _evt: &Event,
+        _n_repeat: RepeatCount,
+        _positive: bool,
+        _ctx: &EventContext<'_>,
+    ) -> Option<Cmd> {
+        // Take the hint BEFORE cancel clears the slot, so we know whether
+        // a ghost was visible and needs `\x1b[K` to erase it.
+        let had_hint = self.inline_ai.take_hint().is_some();
+        // Cancel any in-flight prefetch (debounce / LLM call) and stop the
+        // spinner. Without this, a prefetch task dispatched before Enter
+        // would keep running — the spinner would re-appear mid-execution
+        // of the submitted line, and any late LLM result would render a
+        // stale ghost on the already-submitted line.
+        self.inline_ai.cancel();
+        if had_hint {
+            eprint!("\x1b[K");
+            use std::io::Write;
+            let _ = std::io::stderr().flush();
+        }
+        None
+    }
+}
+
+/// Which inline-AI handler to attach for a given key.
+enum HandlerKind {
+    AcceptInline,
+    ClearGhost,
+}
+
+/// Bind multiple (key, handler-kind) pairs to the same `InlineCompleter`.
+/// Exists because rustyline's `EventHandler` is not `Clone`, so each key
+/// needs its own handler instance — this helper hides the repetition.
+fn bind_conditional_handlers(
+    editor: &mut Editor<ShellHelper, rustyline::history::DefaultHistory>,
+    bindings: &[(KeyEvent, HandlerKind)],
+    ai: &Arc<crate::inline_completion::InlineCompleter>,
+) {
+    for (key, kind) in bindings {
+        let handler: Box<dyn ConditionalEventHandler> = match kind {
+            HandlerKind::AcceptInline => Box::new(AcceptInlineHintHandler {
+                inline_ai: Arc::clone(ai),
+            }),
+            HandlerKind::ClearGhost => Box::new(ClearGhostOnSubmitHandler {
+                inline_ai: Arc::clone(ai),
+            }),
+        };
+        editor.bind_sequence(*key, EventHandler::Conditional(handler));
+    }
+}
+
 /// Shell readline helper: tab completion via CompletionEngine.
 struct ShellHelper {
     engine: Arc<CompletionEngine>,
     autosuggest: Arc<Mutex<AutoSuggest>>,
+    inline_ai: Option<Arc<crate::inline_completion::InlineCompleter>>,
 }
 
 impl ShellHelper {
-    fn new(engine: Arc<CompletionEngine>, autosuggest: Arc<Mutex<AutoSuggest>>) -> Self {
+    fn new(
+        engine: Arc<CompletionEngine>,
+        autosuggest: Arc<Mutex<AutoSuggest>>,
+        inline_ai: Option<Arc<crate::inline_completion::InlineCompleter>>,
+    ) -> Self {
         Self {
             engine,
             autosuggest,
+            inline_ai,
         }
     }
 }
@@ -236,10 +342,23 @@ impl Hinter for ShellHelper {
     type Hint = String;
 
     fn hint(&self, line: &str, pos: usize, _ctx: &Context<'_>) -> Option<String> {
-        // Only hint at the end of the line
+        // Cursor not at end-of-line: just bail. Don't cancel the in-flight
+        // prefetch — a cursor move alone isn't an input change, and the
+        // Right-Arrow accept handler already guards against stale hints via
+        // its own `pos == line.len()` check, so no need to abort the request.
         if pos == 0 || pos < line.len() {
             return None;
         }
+
+        let is_ai = crate::input::is_ai_prompt_line(line);
+        if let Some(ai) = &self.inline_ai {
+            if is_ai {
+                ai.hint(line);
+                return None;
+            }
+            ai.cancel();
+        }
+
         let trimmed = line.trim_start();
         let guard = self.autosuggest.lock().unwrap();
         guard.suggest(trimmed).and_then(|s| {
@@ -294,11 +413,20 @@ pub struct ShellReadline {
     /// Shared autosuggest engine so both Hinter and external callers can add
     /// suggestions without needing Editor::helper_mut().
     autosuggest: Arc<Mutex<AutoSuggest>>,
+    /// Inline AI completer, kept here so we can cancel any in-flight
+    /// spinner / prefetch on every readline entry. The submit keys
+    /// (Enter/Ctrl+J/Ctrl+M/Ctrl+C) also clear it via bound handlers,
+    /// but this guard covers every return path (Interrupted, error, EOF)
+    /// so a spinner can never outlive its `read_line` call.
+    inline_ai: Option<Arc<crate::inline_completion::InlineCompleter>>,
 }
 
 impl ShellReadline {
-    pub fn new(pty: Arc<Mutex<aish_pty::PersistentPty>>) -> rustyline::Result<Self> {
-        let autosuggest = Arc::new(Mutex::new(AutoSuggest::new(5000)));
+    pub fn new(
+        pty: Arc<Mutex<aish_pty::PersistentPty>>,
+        autosuggest: Arc<Mutex<AutoSuggest>>,
+        inline_ai: Option<Arc<crate::inline_completion::InlineCompleter>>,
+    ) -> rustyline::Result<Self> {
         let engine = Arc::new(CompletionEngine::new(pty));
 
         let builder = Config::builder()
@@ -308,7 +436,11 @@ impl ShellReadline {
         let config = builder.history_ignore_dups(true)?.build();
 
         let mut editor = Editor::with_config(config)?;
-        editor.set_helper(Some(ShellHelper::new(engine.clone(), autosuggest.clone())));
+        editor.set_helper(Some(ShellHelper::new(
+            engine.clone(),
+            autosuggest.clone(),
+            inline_ai.clone(),
+        )));
         editor.set_max_history_size(500)?;
 
         editor.bind_sequence(
@@ -340,9 +472,55 @@ impl ShellReadline {
             EventHandler::Conditional(Box::new(SlashHandler)),
         );
 
+        // Bind Right Arrow and Ctrl+F to accept the inline AI ghost, and
+        // bind the line-submit keys to clear it before rustyline repaints.
+        // rustyline's `EventHandler` is not `Clone`, so each binding needs
+        // its own handler instance — the helpers below hide that.
+        if let Some(ref ai) = inline_ai {
+            bind_conditional_handlers(
+                &mut editor,
+                &[
+                    (
+                        KeyEvent(KeyCode::Right, Modifiers::NONE),
+                        HandlerKind::AcceptInline,
+                    ),
+                    (
+                        KeyEvent(KeyCode::Char('f'), Modifiers::CTRL),
+                        HandlerKind::AcceptInline,
+                    ),
+                    (
+                        KeyEvent(KeyCode::Enter, Modifiers::NONE),
+                        HandlerKind::ClearGhost,
+                    ),
+                    (
+                        KeyEvent(KeyCode::Enter, Modifiers::SHIFT),
+                        HandlerKind::ClearGhost,
+                    ),
+                    (
+                        KeyEvent(KeyCode::Char('j'), Modifiers::CTRL),
+                        HandlerKind::ClearGhost,
+                    ),
+                    (
+                        KeyEvent(KeyCode::Char('m'), Modifiers::CTRL),
+                        HandlerKind::ClearGhost,
+                    ),
+                    // Ctrl+C: cancel the spinner / clear the ghost BEFORE
+                    // rustyline raises `Interrupted`. Without this the
+                    // animation keeps running because nothing calls cancel()
+                    // on the Interrupted path.
+                    (
+                        KeyEvent(KeyCode::Char('c'), Modifiers::CTRL),
+                        HandlerKind::ClearGhost,
+                    ),
+                ],
+                ai,
+            );
+        }
+
         Ok(Self {
             editor,
             autosuggest,
+            inline_ai,
         })
     }
 
@@ -373,6 +551,12 @@ impl ShellReadline {
     ) -> rustyline::Result<Option<String>> {
         clear_tab_completion_state();
         refresh_terminal_size(&mut self.editor);
+        set_current_prompt_width(crate::prompt::strip_ansi_len(prompt));
+        // Cancel any spinner / prefetch left over from a previous readline
+        // (e.g. after Ctrl+C, an error, or a mode-toggle Interrupted).
+        if let Some(ai) = &self.inline_ai {
+            ai.cancel();
+        }
         match self.editor.readline_with_initial(prompt, initial) {
             Ok(line) => Ok(Some(line)),
             Err(rustyline::error::ReadlineError::Eof) => Ok(None),
@@ -387,6 +571,12 @@ impl ShellReadline {
     pub fn read_line(&mut self, prompt: &str) -> rustyline::Result<Option<String>> {
         clear_tab_completion_state();
         refresh_terminal_size(&mut self.editor);
+        set_current_prompt_width(crate::prompt::strip_ansi_len(prompt));
+        // Cancel any spinner / prefetch left over from a previous readline
+        // (e.g. after Ctrl+C, an error, or a mode-toggle Interrupted).
+        if let Some(ai) = &self.inline_ai {
+            ai.cancel();
+        }
         let line = match self.editor.readline(prompt) {
             Ok(line) => line,
             Err(rustyline::error::ReadlineError::Eof) => return Ok(None),
@@ -443,6 +633,13 @@ impl ShellReadline {
     /// Useful for pre-loading history entries so they appear as hints.
     pub fn add_suggestion(&self, command: &str) {
         self.autosuggest.lock().unwrap().add(command);
+    }
+
+    /// Update the inline-completion model (called on `/model` switch).
+    pub fn update_inline_model(&self, model: &str) {
+        if let Some(ai) = &self.inline_ai {
+            ai.update_model(model);
+        }
     }
 
     /// Load history from a file (best-effort).


### PR DESCRIPTION
## Summary

Copilot-style inline completion for AI-mode prompts (`;` or `；` prefix). As the user types an AI question, a gray ghost-text suffix is predicted via LLM and rendered inline. Right Arrow or Ctrl+F accepts.

## Changes

- **aish-config**: new `InlineCompletionConfig` block (enabled, debounce_ms, context_lines, max_tokens, min_input_chars, timeout_secs)
- **aish-shell**: new `inline_completion` module — LLM-backed suffix prediction, gray ghost-text rendering via DECSC/DECRC, debounce + cancellation, faux provider for testing
- **PromptSpinner**: bounces-dot animation replacing `<aish>` badge during LLM calls, with locale-aware CJK width calculation (`unicode-width` cjk feature) so cursor navigation stays correct on CJK terminals
- **AcceptInlineHintHandler** (Right/Ctrl+F) and **ClearGhostOnSubmitHandler** wired into rustyline key bindings
- **LlmClient**: model field made `Mutex` for runtime `/model` switching; new `chat_completion_with_extras` for provider-specific flags (thinking suppression, JSON mode)
- Ghost width capping prevents suffix wrapping; full suffix shown when even the first char cannot fit (wraps rather than suppressing)

## Test plan

- [x] `cargo test -p aish-shell --lib inline_completion` — 42 unit tests pass
- [x] `cargo test -p aish-shell --lib prompt::tests` — 29 tests pass
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual test: type `；现在开始分析`, verify ghost text appears, Right accepts
- [x] Manual test: wrapped input — spinner stays on prompt line, no misplaced `<aish>`
- [x] Manual test: second completion after accept — ghost shows even when cursor near line end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable inline AI “ghost text” completions (opt-in) with debounce/context/max-token defaults.
  * Added smarter recent-history suggestions (most-recent-first subset queries).
  * Added support for real-time inline suggestion updates when switching models.
* **Bug Fixes**
  * Improved extraction and rendering of inline completion suffixes (better handling of JSON/prose-wrapped outputs and terminal width truncation).
  * Improved AI prompt-line detection and ensured inline ghost text is properly accepted/cleared on key actions.
  * Made terminal width calculations more locale-accurate for ambiguous and CJK characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->