### PR TITLE
feat(llm): sub-agent tool loop and spawn test infrastructure (#330)

### DIFF
--- a/crates/aish-llm/src/agents/mock_llm.rs
+++ b/crates/aish-llm/src/agents/mock_llm.rs
@@ -1,0 +1,59 @@
+//! Helpers for building scripted LLM JSON responses in tests.
+
+use crate::client::LlmResponse;
+
+/// Build a non-streaming JSON response with plain assistant text and no tool calls.
+pub fn mock_text_response(text: &str) -> LlmResponse {
+    LlmResponse::Json(serde_json::json!({
+        "choices": [{
+            "message": {
+                "content": text,
+            }
+        }]
+    }))
+}
+
+/// Build a non-streaming JSON response with one or more tool calls.
+///
+/// Each tuple is `(call_id, tool_name, arguments_json)`.
+pub fn mock_tool_call_response(calls: &[(&str, &str, &str)]) -> LlmResponse {
+    let tool_calls: Vec<serde_json::Value> = calls
+        .iter()
+        .map(|(id, name, args)| {
+            serde_json::json!({
+                "id": id,
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "arguments": args,
+                }
+            })
+        })
+        .collect();
+
+    LlmResponse::Json(serde_json::json!({
+        "choices": [{
+            "message": {
+                "content": null,
+                "tool_calls": tool_calls,
+            }
+        }]
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::streaming::StreamParser;
+
+    #[test]
+    fn mock_tool_call_response_parses_tool_calls() {
+        let response = mock_tool_call_response(&[("c1", "grep", r#"{"pattern":"nginx"}"#)]);
+        let LlmResponse::Json(json) = response else {
+            panic!("expected json");
+        };
+        let (_, _, tool_calls, _) = StreamParser::parse_response(&json);
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].name, "grep");
+    }
+}

--- a/crates/aish-llm/src/agents/mod.rs
+++ b/crates/aish-llm/src/agents/mod.rs
@@ -1,0 +1,11 @@
+//! Sub-agent spawn infrastructure (Phase 1).
+//!
+//! Issue #330: reusable native tool calling loop, cancel cascade, mock LLM tests.
+
+mod mock_llm;
+mod spawn;
+mod tool_loop;
+
+pub use mock_llm::{mock_text_response, mock_tool_call_response};
+pub use spawn::{spawn, SpawnConfig, SpawnResult};
+pub use tool_loop::{run_tool_loop_until_done, LoopOutcome, LoopStatus, ToolLoopConfig};

--- a/crates/aish-llm/src/agents/spawn.rs
+++ b/crates/aish-llm/src/agents/spawn.rs
@@ -1,0 +1,239 @@
+//! Sub-agent spawn with parent cancel cascade.
+
+use crate::session::LlmSession;
+use crate::types::ChatMessage;
+
+use super::tool_loop::{run_tool_loop_until_done, LoopStatus, ToolLoopConfig};
+
+/// Configuration for [`spawn`].
+#[derive(Debug, Clone)]
+pub struct SpawnConfig {
+    pub max_turns: u32,
+    pub system_message: Option<String>,
+}
+
+impl Default for SpawnConfig {
+    fn default() -> Self {
+        Self {
+            max_turns: 20,
+            system_message: None,
+        }
+    }
+}
+
+/// Result of a synchronous sub-agent spawn.
+#[derive(Debug, Clone)]
+pub struct SpawnResult {
+    pub text: String,
+    pub status: LoopStatus,
+}
+
+/// Create an isolated sub-session from `parent`, apply `configure`, then run the tool loop
+/// with parent→child cancellation cascade.
+pub async fn spawn<F>(
+    parent: &LlmSession,
+    prompt: &str,
+    config: SpawnConfig,
+    configure: F,
+) -> SpawnResult
+where
+    F: FnOnce(&mut LlmSession),
+{
+    let mut sub = parent.create_subsession();
+    configure(&mut sub);
+
+    let parent_cancel = parent.cancellation_token_arc();
+    let sub_cancel = sub.cancellation_token_arc();
+
+    let loop_config = ToolLoopConfig {
+        max_turns: config.max_turns,
+        system_message: config.system_message,
+        ..ToolLoopConfig::default()
+    };
+    let user_msg = ChatMessage::user(prompt);
+    let run = run_tool_loop_until_done(&sub, &user_msg, &[], &loop_config);
+
+    let outcome = tokio::select! {
+        outcome = run => outcome,
+        () = forward_cancellation(parent_cancel, sub_cancel) => {
+            super::tool_loop::LoopOutcome::cancelled()
+        }
+    };
+
+    SpawnResult {
+        text: outcome.text,
+        status: outcome.status,
+    }
+}
+
+async fn forward_cancellation(
+    parent: std::sync::Arc<crate::types::CancellationToken>,
+    sub: std::sync::Arc<crate::types::CancellationToken>,
+) {
+    while !parent.is_cancelled() {
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    sub.cancel();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::{mock_text_response, mock_tool_call_response};
+    use crate::types::Tool;
+    use aish_context::ContextBudgetPolicy;
+
+    fn disable_context_budget(session: &mut LlmSession) {
+        session.set_context_budget_policy(ContextBudgetPolicy {
+            enabled: false,
+            ..Default::default()
+        });
+    }
+
+    struct MockTool {
+        name: String,
+    }
+
+    impl MockTool {
+        fn new(name: &str) -> Self {
+            Self {
+                name: name.to_string(),
+            }
+        }
+    }
+
+    impl Tool for MockTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn description(&self) -> &str {
+            "mock"
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {}})
+        }
+
+        fn execute(&self, _args: serde_json::Value) -> crate::types::ToolResult {
+            crate::types::ToolResult::success("ok")
+        }
+    }
+
+    #[tokio::test]
+    async fn test_spawn_mock_llm_tool_sequence() {
+        let parent = LlmSession::new("http://localhost", "key", "model", None, None);
+
+        let result = spawn(
+            &parent,
+            "find nginx",
+            SpawnConfig {
+                max_turns: 5,
+                ..Default::default()
+            },
+            |sub| {
+                disable_context_budget(sub);
+                sub.set_test_chat_responses(vec![
+                    Ok(mock_tool_call_response(&[("c1", "grep", "{}")])),
+                    Ok(mock_text_response("nginx at /etc/nginx")),
+                ]);
+                sub.register_tool(Box::new(MockTool::new("grep")));
+            },
+        )
+        .await;
+
+        assert_eq!(result.status, LoopStatus::Complete);
+        assert_eq!(result.text, "nginx at /etc/nginx");
+    }
+
+    #[tokio::test]
+    async fn test_spawn_cascades_parent_cancel() {
+        let parent = LlmSession::new("http://localhost", "key", "model", None, None);
+        parent.cancellation_token().cancel();
+
+        let result = spawn(
+            &parent,
+            "long task",
+            SpawnConfig {
+                max_turns: 10,
+                ..Default::default()
+            },
+            |sub| {
+                disable_context_budget(sub);
+                sub.set_test_chat_responses(vec![Ok(mock_tool_call_response(&[(
+                    "c1", "grep", "{}",
+                )]))]);
+                sub.register_tool(Box::new(MockTool::new("grep")));
+            },
+        )
+        .await;
+
+        assert_eq!(result.status, LoopStatus::Cancelled);
+    }
+
+    struct SlowMockTool {
+        name: String,
+    }
+
+    impl Tool for SlowMockTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn description(&self) -> &str {
+            "mock"
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {}})
+        }
+
+        fn execute(&self, _args: serde_json::Value) -> crate::types::ToolResult {
+            crate::types::ToolResult::success("ok")
+        }
+
+        fn execute_async<'a>(
+            &'a self,
+            _args: serde_json::Value,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = crate::types::ToolResult> + Send + 'a>,
+        > {
+            Box::pin(async {
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                crate::types::ToolResult::success("ok")
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_spawn_cascades_parent_cancel_while_running() {
+        let parent = LlmSession::new("http://localhost", "key", "model", None, None);
+        let parent_cancel = parent.cancellation_token_arc();
+
+        let run = spawn(
+            &parent,
+            "long task",
+            SpawnConfig {
+                max_turns: 10,
+                ..Default::default()
+            },
+            |sub| {
+                disable_context_budget(sub);
+                sub.set_test_chat_responses(vec![Ok(mock_tool_call_response(&[(
+                    "c1", "grep", "{}",
+                )]))]);
+                sub.register_tool(Box::new(SlowMockTool {
+                    name: "grep".to_string(),
+                }));
+            },
+        );
+
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            parent_cancel.cancel();
+        });
+
+        let result = run.await;
+        assert_eq!(result.status, LoopStatus::Cancelled);
+    }
+}

--- a/crates/aish-llm/src/agents/tool_loop.rs
+++ b/crates/aish-llm/src/agents/tool_loop.rs
@@ -1,0 +1,332 @@
+//! Reusable native tool calling loop for sub-agent spawn paths.
+
+use crate::client::LlmResponse;
+use crate::session::LlmSession;
+use crate::streaming::{extract_message_text, StreamParser};
+use crate::types::{ChatMessage, MessageContent};
+use aish_core::AishError;
+
+/// Configuration for [`run_tool_loop_until_done`].
+#[derive(Debug, Clone)]
+pub struct ToolLoopConfig {
+    /// Maximum LLM turns before returning [`LoopStatus::Incomplete`].
+    pub max_turns: u32,
+    /// Optional system prompt prepended to the message list.
+    pub system_message: Option<String>,
+    /// Prefix prepended to the final text when max turns is reached.
+    pub incomplete_prefix: String,
+}
+
+impl Default for ToolLoopConfig {
+    fn default() -> Self {
+        Self {
+            max_turns: 20,
+            system_message: None,
+            incomplete_prefix: "[incomplete: max turns reached]\n".to_string(),
+        }
+    }
+}
+
+/// Termination status of a tool calling loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoopStatus {
+    Complete,
+    Incomplete,
+    Cancelled,
+    Fatal,
+}
+
+/// Result of running the tool calling loop to completion or a terminal condition.
+#[derive(Debug)]
+pub struct LoopOutcome {
+    pub status: LoopStatus,
+    pub text: String,
+    pub new_messages: Vec<ChatMessage>,
+    pub error: Option<AishError>,
+}
+
+impl LoopOutcome {
+    fn complete(text: String, new_messages: Vec<ChatMessage>) -> Self {
+        Self {
+            status: LoopStatus::Complete,
+            text,
+            new_messages,
+            error: None,
+        }
+    }
+
+    fn incomplete(prefix: &str, last_text: &str, new_messages: Vec<ChatMessage>) -> Self {
+        let text = if last_text.is_empty() {
+            prefix.to_string()
+        } else {
+            format!("{prefix}{last_text}")
+        };
+        Self {
+            status: LoopStatus::Incomplete,
+            text,
+            new_messages,
+            error: None,
+        }
+    }
+
+    pub fn cancelled() -> Self {
+        Self {
+            status: LoopStatus::Cancelled,
+            text: String::new(),
+            new_messages: Vec::new(),
+            error: Some(AishError::Cancelled),
+        }
+    }
+
+    fn fatal(error: AishError) -> Self {
+        Self {
+            status: LoopStatus::Fatal,
+            text: String::new(),
+            new_messages: Vec::new(),
+            error: Some(error),
+        }
+    }
+}
+
+/// Run the native (non-streaming) tool calling loop until the assistant stops calling tools,
+/// cancellation, max turns, or a fatal LLM error.
+pub async fn run_tool_loop_until_done(
+    session: &LlmSession,
+    user_msg: &ChatMessage,
+    context_messages: &[ChatMessage],
+    config: &ToolLoopConfig,
+) -> LoopOutcome {
+    let mut messages: Vec<ChatMessage> = Vec::new();
+    if let Some(sys) = &config.system_message {
+        messages.push(ChatMessage::system(
+            session.system_prompt_with_tool_prompts(sys),
+        ));
+    }
+    messages.extend_from_slice(context_messages);
+    messages.push(user_msg.clone());
+
+    let tool_specs = session.filtered_tool_specs();
+    let has_tools = !tool_specs.is_empty();
+
+    let mut iterations = 0u32;
+    let mut last_assistant_text = String::new();
+    let mut loop_messages: Vec<ChatMessage> = Vec::new();
+
+    loop {
+        if session.cancellation_token().is_cancelled() {
+            return LoopOutcome::cancelled();
+        }
+
+        if iterations >= config.max_turns {
+            return LoopOutcome::incomplete(
+                &config.incomplete_prefix,
+                &last_assistant_text,
+                loop_messages,
+            );
+        }
+        iterations += 1;
+
+        messages = session.prepare_messages_for_send(messages).await;
+
+        let response = match session
+            .chat_completion_raw(
+                &messages,
+                if has_tools { Some(&tool_specs) } else { None },
+                false,
+                session.loop_temperature(),
+                session.loop_max_tokens(),
+            )
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => return LoopOutcome::fatal(e),
+        };
+
+        let LlmResponse::Json(json) = response else {
+            return LoopOutcome::fatal(AishError::Llm(
+                "run_tool_loop_until_done requires non-streaming responses".into(),
+            ));
+        };
+
+        let (content, _reasoning, tool_calls, usage) = StreamParser::parse_response(&json);
+        if let Some(u) = usage {
+            session.record_usage_public(u);
+        }
+
+        if tool_calls.is_empty() {
+            return LoopOutcome::complete(content.unwrap_or_default(), loop_messages);
+        }
+
+        if let Some(text) = content {
+            last_assistant_text = text;
+        }
+
+        let assistant_msg = json
+            .get("choices")
+            .and_then(|c| c.as_array())
+            .and_then(|a| a.first())
+            .and_then(|c| c.get("message"));
+
+        if let Some(msg) = assistant_msg {
+            let mut chat_msg = ChatMessage::assistant("");
+            chat_msg.content = extract_message_text(msg.get("content")).map(MessageContent::Text);
+            chat_msg.tool_calls = Some(tool_calls.clone());
+            messages.push(chat_msg.clone());
+            loop_messages.push(chat_msg);
+        }
+
+        for tc in &tool_calls {
+            let result = session.execute_tool_external(tc).await;
+            let tool_msg = ChatMessage::tool_result(&tc.id, result.output);
+            messages.push(tool_msg.clone());
+            loop_messages.push(tool_msg);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::{mock_text_response, mock_tool_call_response};
+    use crate::types::Tool;
+    use aish_context::ContextBudgetPolicy;
+    use aish_core::AishError;
+
+    fn disable_context_budget(session: &mut LlmSession) {
+        session.set_context_budget_policy(ContextBudgetPolicy {
+            enabled: false,
+            ..Default::default()
+        });
+    }
+
+    struct MockTool {
+        name: String,
+        output: String,
+    }
+
+    impl MockTool {
+        fn new(name: &str, output: &str) -> Self {
+            Self {
+                name: name.to_string(),
+                output: output.to_string(),
+            }
+        }
+    }
+
+    impl Tool for MockTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn description(&self) -> &str {
+            "mock"
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {}})
+        }
+
+        fn execute(&self, _args: serde_json::Value) -> crate::types::ToolResult {
+            crate::types::ToolResult::success(&self.output)
+        }
+    }
+
+    fn test_session_with_responses(responses: Vec<Result<LlmResponse, AishError>>) -> LlmSession {
+        let mut session = LlmSession::new("http://localhost", "key", "model", None, None);
+        disable_context_budget(&mut session);
+        session.set_test_chat_responses(responses);
+        session
+    }
+
+    #[tokio::test]
+    async fn test_loop_completes_on_text_response() {
+        let mut session = test_session_with_responses(vec![Ok(mock_text_response("done"))]);
+        session.register_tool(Box::new(MockTool::new("grep", "hits")));
+
+        let outcome = run_tool_loop_until_done(
+            &session,
+            &ChatMessage::user("search"),
+            &[],
+            &ToolLoopConfig {
+                max_turns: 5,
+                ..Default::default()
+            },
+        )
+        .await;
+
+        assert_eq!(outcome.status, LoopStatus::Complete);
+        assert_eq!(outcome.text, "done");
+    }
+
+    #[tokio::test]
+    async fn test_loop_executes_tool_calls_then_completes() {
+        let mut session = test_session_with_responses(vec![
+            Ok(mock_tool_call_response(&[(
+                "c1",
+                "grep",
+                r#"{"pattern":"nginx"}"#,
+            )])),
+            Ok(mock_text_response("found nginx.conf")),
+        ]);
+        session.register_tool(Box::new(MockTool::new("grep", "grep output")));
+
+        let outcome = run_tool_loop_until_done(
+            &session,
+            &ChatMessage::user("find nginx"),
+            &[],
+            &ToolLoopConfig {
+                max_turns: 5,
+                ..Default::default()
+            },
+        )
+        .await;
+
+        assert_eq!(outcome.status, LoopStatus::Complete);
+        assert_eq!(outcome.text, "found nginx.conf");
+        assert!(outcome
+            .new_messages
+            .iter()
+            .any(|m| { m.role == "tool" && m.text_content() == Some("grep output") }));
+    }
+
+    #[tokio::test]
+    async fn test_loop_incomplete_at_max_turns() {
+        let mut session = test_session_with_responses(vec![
+            Ok(mock_tool_call_response(&[("c1", "grep", "{}")])),
+            Ok(mock_tool_call_response(&[("c2", "grep", "{}")])),
+        ]);
+        session.register_tool(Box::new(MockTool::new("grep", "out")));
+
+        let outcome = run_tool_loop_until_done(
+            &session,
+            &ChatMessage::user("keep going"),
+            &[],
+            &ToolLoopConfig {
+                max_turns: 1,
+                ..Default::default()
+            },
+        )
+        .await;
+
+        assert_eq!(outcome.status, LoopStatus::Incomplete);
+        assert!(outcome.text.starts_with("[incomplete: max turns reached]"));
+    }
+
+    #[tokio::test]
+    async fn test_loop_cancelled_when_token_fired() {
+        let mut session =
+            test_session_with_responses(vec![Ok(mock_tool_call_response(&[("c1", "grep", "{}")]))]);
+        session.register_tool(Box::new(MockTool::new("grep", "out")));
+        session.cancellation_token().cancel();
+
+        let outcome = run_tool_loop_until_done(
+            &session,
+            &ChatMessage::user("task"),
+            &[],
+            &ToolLoopConfig::default(),
+        )
+        .await;
+
+        assert_eq!(outcome.status, LoopStatus::Cancelled);
+    }
+}

--- a/crates/aish-llm/src/lib.rs
+++ b/crates/aish-llm/src/lib.rs
@@ -14,6 +14,7 @@
 )]
 
 pub mod agent;
+pub mod agents;
 pub mod api;
 pub mod client;
 pub mod diagnose_agent;
@@ -34,6 +35,10 @@ pub mod types;
 pub mod usage;
 
 pub use agent::{AgentConfig, AgentStep, ReActAgent};
+pub use agents::{
+    run_tool_loop_until_done, spawn, LoopOutcome, LoopStatus, SpawnConfig, SpawnResult,
+    ToolLoopConfig,
+};
 pub use api::{
     resolve_anthropic_messages_url, resolve_api_dialect, stream_simple,
     test_connection as test_api_connection, ApiDialect, StreamContext,

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -53,6 +53,9 @@ pub struct LlmSession {
     token_stats: std::sync::Mutex<crate::usage::TokenStats>,
     /// Per-session tool execution policy (read-only bash enforcement, etc.).
     tool_execution_policy: crate::tool_context::ToolExecutionPolicy,
+    /// Scripted chat completion responses for unit/integration tests (pop in order).
+    #[cfg(test)]
+    test_chat_responses: Option<Arc<std::sync::Mutex<Vec<Result<LlmResponse, AishError>>>>>,
 }
 
 impl LlmSession {
@@ -100,6 +103,8 @@ impl LlmSession {
             plan_state: Arc::new(Mutex::new(PlanModeState::default())),
             token_stats: std::sync::Mutex::new(crate::usage::TokenStats::default()),
             tool_execution_policy: crate::tool_context::ToolExecutionPolicy::default(),
+            #[cfg(test)]
+            test_chat_responses: None,
         }
     }
 
@@ -154,6 +159,12 @@ impl LlmSession {
     /// and other components to monitor cancellation without borrowing self.
     pub fn cancellation_token_arc(&self) -> Arc<CancellationToken> {
         Arc::clone(&self.cancellation_token)
+    }
+
+    /// Install scripted LLM responses for tests (consumed in FIFO order).
+    #[cfg(test)]
+    pub fn set_test_chat_responses(&mut self, responses: Vec<Result<LlmResponse, AishError>>) {
+        self.test_chat_responses = Some(Arc::new(std::sync::Mutex::new(responses)));
     }
 
     /// Set the maximum context token budget for message trimming.
@@ -253,6 +264,18 @@ impl LlmSession {
     }
 
     /// Record token usage from an API response.
+    pub(crate) fn record_usage_public(&self, usage: crate::usage::TokenUsage) {
+        self.record_usage(usage);
+    }
+
+    pub(crate) fn loop_temperature(&self) -> Option<f32> {
+        self.temperature
+    }
+
+    pub(crate) fn loop_max_tokens(&self) -> Option<u32> {
+        self.max_tokens
+    }
+
     fn record_usage(&self, usage: crate::usage::TokenUsage) {
         self.token_stats.lock().unwrap().record(usage);
     }
@@ -289,6 +312,14 @@ impl LlmSession {
         temperature: Option<f32>,
         max_tokens: Option<u32>,
     ) -> Result<LlmResponse, AishError> {
+        #[cfg(test)]
+        if let Some(ref queue) = self.test_chat_responses {
+            let mut q = queue.lock().expect("test chat response queue poisoned");
+            if !q.is_empty() {
+                return q.remove(0);
+            }
+        }
+
         stream_simple(
             self.api_dialect,
             &self.stream_ctx,
@@ -1270,6 +1301,8 @@ impl LlmSession {
             plan_state: Arc::new(Mutex::new(PlanModeState::default())),
             token_stats: std::sync::Mutex::new(crate::usage::TokenStats::default()),
             tool_execution_policy: self.tool_execution_policy,
+            #[cfg(test)]
+            test_chat_responses: None,
         }
     }
 
@@ -1376,7 +1409,10 @@ impl LlmSession {
         });
     }
 
-    async fn prepare_messages_for_send(&self, mut messages: Vec<ChatMessage>) -> Vec<ChatMessage> {
+    pub(crate) async fn prepare_messages_for_send(
+        &self,
+        mut messages: Vec<ChatMessage>,
+    ) -> Vec<ChatMessage> {
         let policy = &self.context_budget_policy;
         if !policy.enabled {
             return trim_messages(messages, self.max_context_tokens, 5);


### PR DESCRIPTION
## Summary

- Add `aish-llm::agents` with `run_tool_loop_until_done` (Complete / Incomplete / Cancelled / Fatal) for reusable native tool calling loops.
- Add `spawn()` with parent→child cancel cascade and FIFO mock LLM response injection for integration tests without network.
- No user-visible `Agent` tool yet; `/diagnose` and `system_diagnose_agent` unchanged.

Closes #330.

## Test plan

- [x] `cargo test -p aish-llm` (205 tests)
- [x] `make format-check && make lint`
- [x] Tool loop: text complete, tool-call chain, max_turns incomplete, token cancel
- [x] Spawn: mock LLM sequence, `test_spawn_cascades_parent_cancel`, cancel while running
- [ ] Interactive / WeTTY — not required for #330 (no user-facing Agent tool yet)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running sub-agent workflows with configurable turn limits and optional system prompts.
  * Introduced reusable helpers for building scripted assistant responses, including plain text replies and tool-call outputs.
  * Expanded the public API to expose agent spawning and tool-loop utilities.

* **Bug Fixes**
  * Improved cancellation handling so child agent runs stop promptly when the parent session is cancelled.

* **Tests**
  * Added coverage for tool-call parsing, completion flows, turn-limit behavior, and cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->