### PR TITLE
feat(subagent): explore vertical slice — Agent tool end-to-end (#331)

### DIFF
--- a/crates/aish-llm/src/agents/mod.rs
+++ b/crates/aish-llm/src/agents/mod.rs
@@ -1,11 +1,16 @@
 //! Sub-agent spawn infrastructure (Phase 1).
 //!
 //! Issue #330: reusable native tool calling loop, cancel cascade, mock LLM tests.
+//! Issue #331: explore vertical slice — registry, tool filter, spawn_builtin.
 
 mod mock_llm;
+mod registry;
 mod spawn;
 mod tool_loop;
+mod tools;
 
 pub use mock_llm::{mock_text_response, mock_tool_call_response};
-pub use spawn::{spawn, SpawnConfig, SpawnResult};
+pub use registry::{AgentDefinition, AgentRegistry, ToolStrategy};
+pub use spawn::{spawn, spawn_builtin, SpawnConfig, SpawnResult, GLOBAL_MAX_TURNS};
 pub use tool_loop::{run_tool_loop_until_done, LoopOutcome, LoopStatus, ToolLoopConfig};
+pub use tools::{resolve_tool_names_for_agent, resolve_tools_for_agent};

--- a/crates/aish-llm/src/agents/registry.rs
+++ b/crates/aish-llm/src/agents/registry.rs
@@ -1,0 +1,119 @@
+//! Built-in sub-agent definitions and registry (Phase 1 explore slice).
+
+use std::collections::HashMap;
+
+/// Tool filtering strategy for a built-in sub-agent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolStrategy {
+    /// Only tools in the allowlist (intersected with parent pool).
+    Allowlist(Vec<String>),
+}
+
+/// Definition of a built-in sub-agent type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentDefinition {
+    pub subagent_type: String,
+    pub when_to_use: String,
+    pub system_prompt: String,
+    pub max_turns: u32,
+    pub tool_strategy: ToolStrategy,
+}
+
+impl AgentDefinition {
+    pub fn explore() -> Self {
+        Self {
+            subagent_type: "explore".to_string(),
+            when_to_use: "Search logs, configs, services, network state, or code locations; read-only investigation.".to_string(),
+            system_prompt: "You are a read-only explore sub-agent for shell operations. Investigate using only your allowed tools. Do not modify files or spawn nested agents. Return a concise conclusion.".to_string(),
+            max_turns: 15,
+            tool_strategy: ToolStrategy::Allowlist(vec![
+                "grep".to_string(),
+                "glob".to_string(),
+                "read_file".to_string(),
+                "bash".to_string(),
+            ]),
+        }
+    }
+}
+
+/// Registry of built-in sub-agent types available via the `Agent` tool.
+#[derive(Debug, Clone)]
+pub struct AgentRegistry {
+    agents: HashMap<String, AgentDefinition>,
+}
+
+impl AgentRegistry {
+    /// Phase 1 explore slice: only `explore` is registered.
+    pub fn builtin() -> Self {
+        let explore = AgentDefinition::explore();
+        let mut agents = HashMap::new();
+        agents.insert(explore.subagent_type.clone(), explore);
+        Self { agents }
+    }
+
+    pub fn resolve(&self, subagent_type: &str) -> Result<&AgentDefinition, String> {
+        self.agents
+            .get(subagent_type)
+            .ok_or_else(|| format!("Unknown subagent_type: {subagent_type}"))
+    }
+
+    /// Format built-in descriptions for the `Agent` tool description.
+    pub fn list_for_tool_description(&self) -> String {
+        let mut lines: Vec<String> = self
+            .agents
+            .values()
+            .map(|def| format!("- `{}`: {}", def.subagent_type, def.when_to_use))
+            .collect();
+        lines.sort();
+        lines.join("\n")
+    }
+}
+
+impl Default for AgentRegistry {
+    fn default() -> Self {
+        Self::builtin()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_explore_succeeds() {
+        let registry = AgentRegistry::builtin();
+        let def = registry.resolve("explore").expect("explore should exist");
+        assert_eq!(def.subagent_type, "explore");
+        assert_eq!(def.max_turns, 15);
+    }
+
+    #[test]
+    fn test_resolve_unknown_type_errors() {
+        let registry = AgentRegistry::builtin();
+        let err = registry.resolve("plan").unwrap_err();
+        assert!(err.contains("Unknown subagent_type"));
+    }
+
+    #[test]
+    fn test_list_for_tool_description_includes_explore_when_to_use() {
+        let registry = AgentRegistry::builtin();
+        let desc = registry.list_for_tool_description();
+        assert!(desc.contains("`explore`"));
+        assert!(desc.contains("read-only"));
+    }
+
+    #[test]
+    fn test_explore_allowlist_is_read_only_tools() {
+        let def = AgentDefinition::explore();
+        let ToolStrategy::Allowlist(tools) = &def.tool_strategy;
+        assert_eq!(
+            tools,
+            &vec![
+                "grep".to_string(),
+                "glob".to_string(),
+                "read_file".to_string(),
+                "bash".to_string(),
+            ]
+        );
+    }
+}

--- a/crates/aish-llm/src/agents/spawn.rs
+++ b/crates/aish-llm/src/agents/spawn.rs
@@ -1,9 +1,20 @@
 //! Sub-agent spawn with parent cancel cascade.
 
-use crate::session::LlmSession;
-use crate::types::ChatMessage;
+use std::sync::Arc;
 
+use aish_core::LlmEvent;
+use uuid::Uuid;
+
+use crate::session::LlmSession;
+use crate::tool_context::ToolExecutionPolicy;
+use crate::types::{ChatMessage, LlmCallbackResult, ToolSpec};
+
+use super::registry::AgentRegistry;
 use super::tool_loop::{run_tool_loop_until_done, LoopStatus, ToolLoopConfig};
+use super::tools::resolve_tools_for_agent;
+
+/// Global ceiling on sub-agent turns (applied via `min(def.max_turns, GLOBAL_MAX_TURNS)`).
+pub const GLOBAL_MAX_TURNS: u32 = 30;
 
 /// Configuration for [`spawn`].
 #[derive(Debug, Clone)]
@@ -66,6 +77,82 @@ where
     }
 }
 
+/// Spawn a built-in sub-agent (`explore` in Phase 1 slice) from `parent`.
+///
+/// `register_tools` receives the sub-session and filtered parent tool specs; it must
+/// register concrete tool implementations on the sub-session.
+pub async fn spawn_builtin<F>(
+    parent: &LlmSession,
+    registry: &AgentRegistry,
+    subagent_type: &str,
+    prompt: &str,
+    register_tools: F,
+) -> Result<SpawnResult, String>
+where
+    F: FnOnce(&mut LlmSession, &[ToolSpec]),
+{
+    let def = registry.resolve(subagent_type)?;
+    let allowed_specs = resolve_tools_for_agent(def, &parent.tool_specs());
+    let max_turns = def.max_turns.min(GLOBAL_MAX_TURNS);
+    let spawn_id = Uuid::new_v4().to_string();
+    let agent_type = def.subagent_type.clone();
+    let system_prompt = def.system_prompt.clone();
+
+    let result = spawn(
+        parent,
+        prompt,
+        SpawnConfig {
+            max_turns,
+            system_message: Some(system_prompt),
+        },
+        |sub| {
+            sub.set_tool_execution_policy(ToolExecutionPolicy {
+                enforce_read_only_bash: true,
+            });
+            install_sub_agent_event_proxy(sub, &agent_type, &spawn_id);
+            register_tools(sub, &allowed_specs);
+        },
+    )
+    .await;
+
+    Ok(result)
+}
+
+fn install_sub_agent_event_proxy(sub: &mut LlmSession, agent_type: &str, spawn_id: &str) {
+    let Some(parent_cb) = sub.event_callback_arc() else {
+        return;
+    };
+    let agent_type = agent_type.to_string();
+    let spawn_id = spawn_id.to_string();
+
+    let proxy: Arc<dyn Fn(LlmEvent) -> Option<LlmCallbackResult> + Send + Sync> =
+        Arc::new(move |event: LlmEvent| {
+            let modified_data = if let Some(obj) = event.data.as_object() {
+                let mut new_obj = obj.clone();
+                new_obj.insert("source".to_string(), serde_json::json!("sub_agent"));
+                new_obj.insert("agent_type".to_string(), serde_json::json!(agent_type));
+                new_obj.insert("depth".to_string(), serde_json::json!(1));
+                new_obj.insert("spawn_id".to_string(), serde_json::json!(spawn_id));
+                serde_json::Value::Object(new_obj)
+            } else {
+                serde_json::json!({
+                    "source": "sub_agent",
+                    "agent_type": agent_type,
+                    "depth": 1,
+                    "spawn_id": spawn_id,
+                    "original_data": event.data,
+                })
+            };
+            parent_cb(LlmEvent {
+                event_type: event.event_type,
+                data: modified_data,
+                timestamp: event.timestamp,
+                metadata: event.metadata,
+            })
+        });
+    sub.set_event_callback(proxy);
+}
+
 async fn forward_cancellation(
     parent: std::sync::Arc<crate::types::CancellationToken>,
     sub: std::sync::Arc<crate::types::CancellationToken>,
@@ -79,7 +166,7 @@ async fn forward_cancellation(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agents::{mock_text_response, mock_tool_call_response};
+    use crate::agents::{mock_text_response, mock_tool_call_response, AgentRegistry};
     use crate::types::Tool;
     use aish_context::ContextBudgetPolicy;
 
@@ -118,6 +205,74 @@ mod tests {
         fn execute(&self, _args: serde_json::Value) -> crate::types::ToolResult {
             crate::types::ToolResult::success("ok")
         }
+    }
+
+    fn register_mock_from_specs(sub: &mut LlmSession, specs: &[ToolSpec]) {
+        disable_context_budget(sub);
+        for spec in specs {
+            sub.register_tool(Box::new(MockTool::new(&spec.function.name)));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_spawn_builtin_explore_mock_sequence() {
+        let mut parent = LlmSession::new("http://localhost", "key", "model", None, None);
+        parent.register_tool(Box::new(MockTool::new("grep")));
+        parent.register_tool(Box::new(MockTool::new("write_file")));
+
+        let registry = AgentRegistry::builtin();
+        let result = spawn_builtin(&parent, &registry, "explore", "find nginx", |sub, specs| {
+            sub.set_test_chat_responses(vec![
+                Ok(mock_tool_call_response(&[("c1", "grep", "{}")])),
+                Ok(mock_tool_call_response(&[("c2", "read_file", "{}")])),
+                Ok(mock_text_response("nginx at /etc/nginx")),
+            ]);
+            register_mock_from_specs(sub, specs);
+            sub.register_tool(Box::new(MockTool::new("read_file")));
+        })
+        .await
+        .expect("spawn_builtin should succeed");
+
+        assert_eq!(result.status, LoopStatus::Complete);
+        assert_eq!(result.text, "nginx at /etc/nginx");
+    }
+
+    #[tokio::test]
+    async fn test_spawn_builtin_does_not_modify_parent_session() {
+        // Seam G: LlmSession does not persist op-loop messages; verify parent state
+        // (tool registry) is unchanged after spawn. Sub-session messages are discarded.
+        let mut parent = LlmSession::new("http://localhost", "key", "model", None, None);
+        parent.register_tool(Box::new(MockTool::new("grep")));
+        parent.register_tool(Box::new(MockTool::new("write_file")));
+        let specs_before = parent.tool_specs();
+
+        let registry = AgentRegistry::builtin();
+        let _ = spawn_builtin(&parent, &registry, "explore", "task", |sub, specs| {
+            sub.set_test_chat_responses(vec![Ok(mock_text_response("done"))]);
+            register_mock_from_specs(sub, specs);
+        })
+        .await
+        .expect("spawn_builtin should succeed");
+
+        assert_eq!(parent.tool_specs().len(), specs_before.len());
+        assert!(parent
+            .tool_specs()
+            .iter()
+            .any(|s| s.function.name == "write_file"));
+        assert!(!parent
+            .tool_specs()
+            .iter()
+            .any(|s| s.function.name == "read_file"));
+    }
+
+    #[tokio::test]
+    async fn test_spawn_builtin_unknown_type_errors() {
+        let parent = LlmSession::new("http://localhost", "key", "model", None, None);
+        let registry = AgentRegistry::builtin();
+        let err = spawn_builtin(&parent, &registry, "plan", "task", |_sub, _specs| {})
+            .await
+            .unwrap_err();
+        assert!(err.contains("Unknown subagent_type"));
     }
 
     #[tokio::test]

--- a/crates/aish-llm/src/agents/spawn.rs
+++ b/crates/aish-llm/src/agents/spawn.rs
@@ -218,6 +218,7 @@ mod tests {
     async fn test_spawn_builtin_explore_mock_sequence() {
         let mut parent = LlmSession::new("http://localhost", "key", "model", None, None);
         parent.register_tool(Box::new(MockTool::new("grep")));
+        parent.register_tool(Box::new(MockTool::new("read_file")));
         parent.register_tool(Box::new(MockTool::new("write_file")));
 
         let registry = AgentRegistry::builtin();
@@ -227,8 +228,13 @@ mod tests {
                 Ok(mock_tool_call_response(&[("c2", "read_file", "{}")])),
                 Ok(mock_text_response("nginx at /etc/nginx")),
             ]);
+            assert!(specs
+                .iter()
+                .any(|spec| spec.function.name.as_str() == "read_file"));
+            assert!(!specs
+                .iter()
+                .any(|spec| spec.function.name.as_str() == "write_file"));
             register_mock_from_specs(sub, specs);
-            sub.register_tool(Box::new(MockTool::new("read_file")));
         })
         .await
         .expect("spawn_builtin should succeed");

--- a/crates/aish-llm/src/agents/tools.rs
+++ b/crates/aish-llm/src/agents/tools.rs
@@ -1,0 +1,88 @@
+//! Tool filtering for sub-agent spawn paths.
+
+use super::registry::{AgentDefinition, ToolStrategy};
+use crate::types::ToolSpec;
+
+/// Resolve which parent tool names a sub-agent may use.
+pub fn resolve_tool_names_for_agent(
+    def: &AgentDefinition,
+    parent_tool_names: &[&str],
+) -> Vec<String> {
+    let ToolStrategy::Allowlist(allowed) = &def.tool_strategy;
+    allowed
+        .iter()
+        .filter(|name| parent_tool_names.contains(&name.as_str()))
+        .cloned()
+        .collect()
+}
+
+/// Resolve tool specs from the parent pool for a sub-agent definition.
+pub fn resolve_tools_for_agent(def: &AgentDefinition, parent_tools: &[ToolSpec]) -> Vec<ToolSpec> {
+    let parent_names: Vec<&str> = parent_tools
+        .iter()
+        .map(|spec| spec.function.name.as_str())
+        .collect();
+    let allowed = resolve_tool_names_for_agent(def, &parent_names);
+    parent_tools
+        .iter()
+        .filter(|spec| allowed.iter().any(|n| n == &spec.function.name))
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{FunctionSpec, ToolSpec};
+
+    fn spec(name: &str) -> ToolSpec {
+        ToolSpec {
+            r#type: "function".into(),
+            function: FunctionSpec {
+                name: name.into(),
+                description: String::new(),
+                parameters: serde_json::json!({}),
+            },
+        }
+    }
+
+    fn explore_def() -> AgentDefinition {
+        AgentDefinition::explore()
+    }
+
+    #[test]
+    fn test_explore_allowlist_excludes_write_edit_and_agent() {
+        let parent = vec![
+            "grep",
+            "glob",
+            "read_file",
+            "bash",
+            "write_file",
+            "edit_file",
+            "Agent",
+        ];
+        let names = resolve_tool_names_for_agent(&explore_def(), &parent);
+        assert_eq!(
+            names,
+            vec![
+                "grep".to_string(),
+                "glob".to_string(),
+                "read_file".to_string(),
+                "bash".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_explore_resolves_specs_from_parent_pool() {
+        let parent = vec![
+            spec("grep"),
+            spec("write_file"),
+            spec("read_file"),
+            spec("bash"),
+        ];
+        let resolved = resolve_tools_for_agent(&explore_def(), &parent);
+        let names: Vec<_> = resolved.iter().map(|s| s.function.name.as_str()).collect();
+        assert_eq!(names, vec!["grep", "read_file", "bash"]);
+    }
+}

--- a/crates/aish-llm/src/lib.rs
+++ b/crates/aish-llm/src/lib.rs
@@ -36,8 +36,9 @@ pub mod usage;
 
 pub use agent::{AgentConfig, AgentStep, ReActAgent};
 pub use agents::{
-    run_tool_loop_until_done, spawn, LoopOutcome, LoopStatus, SpawnConfig, SpawnResult,
-    ToolLoopConfig,
+    resolve_tool_names_for_agent, resolve_tools_for_agent, run_tool_loop_until_done, spawn,
+    spawn_builtin, AgentDefinition, AgentRegistry, LoopOutcome, LoopStatus, SpawnConfig,
+    SpawnResult, ToolLoopConfig, ToolStrategy, GLOBAL_MAX_TURNS,
 };
 pub use api::{
     resolve_anthropic_messages_url, resolve_api_dialect, stream_simple,

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -127,6 +127,13 @@ impl LlmSession {
         self.event_callback = Some(cb);
     }
 
+    /// Clone the current event callback, if any.
+    pub fn event_callback_arc(
+        &self,
+    ) -> Option<Arc<dyn Fn(LlmEvent) -> Option<LlmCallbackResult> + Send + Sync>> {
+        self.event_callback.clone()
+    }
+
     /// Set the confirmation callback invoked when a tool's preflight returns Confirm.
     /// The callback receives raw security context and returns true to approve.
     pub fn set_confirmation_callback(
@@ -1151,7 +1158,10 @@ impl LlmSession {
             // Execute with retry: try once, retry once on failure.
             // Mirrors Python's normalize_tool_result + error recovery pattern.
             let result = {
-                let first = tool.as_ref().execute_async(args.clone()).await;
+                let first = tool
+                    .as_ref()
+                    .execute_async_in_session(args.clone(), self)
+                    .await;
                 if first.ok {
                     first
                 } else {
@@ -1161,7 +1171,10 @@ impl LlmSession {
                         tool_call.name,
                         first.output
                     );
-                    let second = tool.as_ref().execute_async(args.clone()).await;
+                    let second = tool
+                        .as_ref()
+                        .execute_async_in_session(args.clone(), self)
+                        .await;
                     if second.ok {
                         second
                     } else {

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -381,7 +381,7 @@ impl LlmSession {
         if let Some(result) = self.run_tool_preflight(name, tool.as_ref(), &args) {
             return Ok(result);
         }
-        Ok(tool.as_ref().execute_async(args).await)
+        Ok(tool.as_ref().execute_async_in_session(args, self).await)
     }
 
     /// Emit an event through the callback (public for agent use).
@@ -1162,7 +1162,7 @@ impl LlmSession {
                     .as_ref()
                     .execute_async_in_session(args.clone(), self)
                     .await;
-                if first.ok {
+                if first.ok || is_short_circuit_result(&first) {
                     first
                 } else {
                     // Retry once — log the retry attempt

--- a/crates/aish-llm/src/types.rs
+++ b/crates/aish-llm/src/types.rs
@@ -562,6 +562,19 @@ pub trait Tool: Send + Sync {
             }
         })
     }
+
+    /// Async execution with access to the hosting [`LlmSession`].
+    ///
+    /// Tools that spawn sub-sessions (e.g. `Agent`) override this to inherit parent
+    /// credentials and tool pools. Default delegates to [`Self::execute_async`].
+    fn execute_async_in_session<'a>(
+        &'a self,
+        args: serde_json::Value,
+        session: &'a crate::session::LlmSession,
+    ) -> Pin<Box<dyn Future<Output = ToolResult> + Send + 'a>> {
+        let _ = session;
+        self.execute_async(args)
+    }
 }
 
 /// Token used to cancel an in-progress LLM request.

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -650,6 +650,7 @@ impl AishShell {
         )));
         tool_registry.register(Box::new(aish_tools::EnterPlanModeTool::new()));
         tool_registry.register(Box::new(aish_tools::ExitPlanModeTool::new()));
+        tool_registry.register(Box::new(aish_tools::AgentTool::new()));
 
         // System diagnose tool — needs session credentials to spawn sub-sessions.
         // The shared event callback holder allows setting the callback after

--- a/crates/aish-tools/src/agent_tool/agent_tool.rs
+++ b/crates/aish-tools/src/agent_tool/agent_tool.rs
@@ -73,8 +73,21 @@ impl AgentTool {
     fn spawn_result_to_tool_result(result: SpawnResult) -> ToolResult {
         match result.status {
             LoopStatus::Complete | LoopStatus::Incomplete => ToolResult::success(result.text),
-            LoopStatus::Cancelled => ToolResult::error("Sub-agent cancelled"),
-            LoopStatus::Fatal => ToolResult::error("Sub-agent failed"),
+            LoopStatus::Cancelled => {
+                Self::short_circuit_error("Sub-agent cancelled", "sub_agent_cancelled")
+            }
+            LoopStatus::Fatal => Self::short_circuit_error("Sub-agent failed", "sub_agent_fatal"),
+        }
+    }
+
+    fn short_circuit_error(output: impl Into<String>, reason: &str) -> ToolResult {
+        ToolResult {
+            ok: false,
+            output: output.into(),
+            meta: Some(serde_json::json!({
+                "dispatch_status": "short_circuit",
+                "reason": reason,
+            })),
         }
     }
 

--- a/crates/aish-tools/src/agent_tool/agent_tool.rs
+++ b/crates/aish-tools/src/agent_tool/agent_tool.rs
@@ -1,0 +1,176 @@
+//! `Agent` tool — synchronous sub-agent spawn entry point for the main LLM.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use aish_llm::{
+    spawn_builtin, AgentRegistry, LlmSession, LoopStatus, SpawnResult, Tool, ToolResult, ToolSpec,
+};
+
+use super::prompt;
+
+/// Injectable spawn backend for tests.
+pub type SpawnFn = Arc<
+    dyn for<'a> Fn(
+            &'a LlmSession,
+            &'a str,
+            &'a str,
+        )
+            -> Pin<Box<dyn Future<Output = Result<SpawnResult, String>> + Send + 'a>>
+        + Send
+        + Sync,
+>;
+
+/// Tool that spawns built-in sub-agents (Phase 1: `explore` only).
+pub struct AgentTool {
+    registry: AgentRegistry,
+    description: String,
+    spawn_fn: Option<SpawnFn>,
+}
+
+impl AgentTool {
+    pub fn new() -> Self {
+        let registry = AgentRegistry::builtin();
+        let description = format!(
+            "{}\n{}",
+            prompt::DESCRIPTION,
+            registry.list_for_tool_description()
+        );
+        Self {
+            registry,
+            description,
+            spawn_fn: None,
+        }
+    }
+
+    /// Test-only constructor that injects a custom spawn backend.
+    pub fn with_spawn_fn(spawn_fn: SpawnFn) -> Self {
+        let mut tool = Self::new();
+        tool.spawn_fn = Some(spawn_fn);
+        tool
+    }
+
+    fn validate_args(args: &serde_json::Value) -> Result<(&str, &str, &str), ToolResult> {
+        let description = args
+            .get("description")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| ToolResult::error("Missing required parameter: description"))?;
+        let prompt = args
+            .get("prompt")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| ToolResult::error("Missing required parameter: prompt"))?;
+        let subagent_type = args
+            .get("subagent_type")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| ToolResult::error("Missing required parameter: subagent_type"))?;
+        Ok((description, prompt, subagent_type))
+    }
+
+    fn spawn_result_to_tool_result(result: SpawnResult) -> ToolResult {
+        match result.status {
+            LoopStatus::Complete | LoopStatus::Incomplete => ToolResult::success(result.text),
+            LoopStatus::Cancelled => ToolResult::error("Sub-agent cancelled"),
+            LoopStatus::Fatal => ToolResult::error("Sub-agent failed"),
+        }
+    }
+
+    fn register_explore_tools(sub: &mut LlmSession, specs: &[ToolSpec]) {
+        for spec in specs {
+            match spec.function.name.as_str() {
+                "grep" => sub.register_tool(Box::new(crate::GrepTool::new())),
+                "glob" => sub.register_tool(Box::new(crate::GlobTool::new())),
+                "read_file" => sub.register_tool(Box::new(crate::ReadFileTool::new())),
+                "bash" => {
+                    let mut bash = crate::bash::BashTool::new();
+                    bash.set_cancellation_token(sub.cancellation_token_arc());
+                    sub.register_tool(Box::new(bash));
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+impl Default for AgentTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Tool for AgentTool {
+    fn name(&self) -> &str {
+        "Agent"
+    }
+
+    fn description(&self) -> &str {
+        &self.description
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        prompt::parameters()
+    }
+
+    fn execute(&self, _args: serde_json::Value) -> ToolResult {
+        ToolResult::error("Agent requires async execution; use execute_async_in_session")
+    }
+
+    fn execute_async_in_session<'a>(
+        &'a self,
+        args: serde_json::Value,
+        session: &'a LlmSession,
+    ) -> Pin<Box<dyn Future<Output = ToolResult> + Send + 'a>> {
+        Box::pin(async move {
+            let (_description, prompt, subagent_type) = match Self::validate_args(&args) {
+                Ok(v) => v,
+                Err(err) => return err,
+            };
+
+            if self.registry.resolve(subagent_type).is_err() {
+                return ToolResult::error(format!("Unknown subagent_type: {subagent_type}"));
+            }
+
+            if let Some(spawn_fn) = &self.spawn_fn {
+                let result = match spawn_fn(session, subagent_type, prompt).await {
+                    Ok(result) => result,
+                    Err(err) => return ToolResult::error(err),
+                };
+                return Self::spawn_result_to_tool_result(result);
+            }
+
+            let registry = self.registry.clone();
+            let result =
+                match spawn_builtin(session, &registry, subagent_type, prompt, |sub, specs| {
+                    Self::register_explore_tools(sub, specs)
+                })
+                .await
+                {
+                    Ok(result) => result,
+                    Err(err) => return ToolResult::error(err),
+                };
+
+            Self::spawn_result_to_tool_result(result)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_name_is_agent() {
+        let tool = AgentTool::new();
+        assert_eq!(tool.name(), "Agent");
+    }
+
+    #[test]
+    fn description_includes_explore_builtin() {
+        let tool = AgentTool::new();
+        assert!(tool.description().contains("explore"));
+        assert!(tool.description().contains("read-only"));
+    }
+}

--- a/crates/aish-tools/src/agent_tool/prompt.rs
+++ b/crates/aish-tools/src/agent_tool/prompt.rs
@@ -1,0 +1,28 @@
+//! Prompt and schema for the `Agent` tool.
+
+pub const DESCRIPTION: &str = "\
+Spawn a synchronous sub-agent to handle an isolated sub-task. Only the final conclusion \
+is returned to the parent session; intermediate tool output stays in the sub-session.\n\n\
+Available subagent types:";
+
+pub fn parameters() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "description": {
+                "type": "string",
+                "description": "3-5 word task summary for UI display"
+            },
+            "prompt": {
+                "type": "string",
+                "description": "Detailed task description for the sub-agent"
+            },
+            "subagent_type": {
+                "type": "string",
+                "enum": ["explore"],
+                "description": "Built-in sub-agent type to spawn"
+            }
+        },
+        "required": ["description", "prompt", "subagent_type"]
+    })
+}

--- a/crates/aish-tools/src/lib.rs
+++ b/crates/aish-tools/src/lib.rs
@@ -16,6 +16,13 @@
 
 pub mod registry;
 
+pub mod agent_tool {
+    mod agent_tool;
+    mod prompt;
+
+    pub use self::agent_tool::{AgentTool, SpawnFn};
+}
+
 pub mod ask_user {
     mod ask_user;
     mod prompt;
@@ -155,6 +162,7 @@ pub mod write_file {
     pub use self::write_file::*;
 }
 
+pub use agent_tool::{AgentTool, SpawnFn};
 pub use ask_user::AskUserTool;
 pub use channel_ask_user::ChannelAskUserTool;
 pub use channel_bash::ChannelBashTool;

--- a/crates/aish-tools/tests/agent_tool_test.rs
+++ b/crates/aish-tools/tests/agent_tool_test.rs
@@ -102,4 +102,12 @@ async fn test_agent_tool_mock_spawn_cancelled_errors() {
         .await;
     assert!(!result.ok);
     assert!(result.output.contains("cancelled"));
+    assert_eq!(
+        result
+            .meta
+            .as_ref()
+            .and_then(|m| m.get("dispatch_status"))
+            .and_then(|v| v.as_str()),
+        Some("short_circuit")
+    );
 }

--- a/crates/aish-tools/tests/agent_tool_test.rs
+++ b/crates/aish-tools/tests/agent_tool_test.rs
@@ -1,0 +1,105 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use aish_llm::{LoopStatus, SpawnResult, Tool};
+use aish_tools::{AgentTool, SpawnFn};
+
+fn mock_spawn_ok<'a>(
+    _session: &'a aish_llm::LlmSession,
+    _ty: &'a str,
+    _prompt: &'a str,
+) -> Pin<Box<dyn Future<Output = Result<SpawnResult, String>> + Send + 'a>> {
+    Box::pin(async {
+        Ok(SpawnResult {
+            text: "explore conclusion".to_string(),
+            status: LoopStatus::Complete,
+        })
+    })
+}
+
+fn mock_spawn_cancelled<'a>(
+    _session: &'a aish_llm::LlmSession,
+    _ty: &'a str,
+    _prompt: &'a str,
+) -> Pin<Box<dyn Future<Output = Result<SpawnResult, String>> + Send + 'a>> {
+    Box::pin(async {
+        Ok(SpawnResult {
+            text: String::new(),
+            status: LoopStatus::Cancelled,
+        })
+    })
+}
+
+#[tokio::test]
+async fn test_agent_tool_missing_prompt_errors() {
+    let tool = AgentTool::new();
+    let session = aish_llm::LlmSession::new("http://localhost", "key", "model", None, None);
+    let result = tool
+        .execute_async_in_session(
+            serde_json::json!({
+                "description": "find nginx",
+                "subagent_type": "explore"
+            }),
+            &session,
+        )
+        .await;
+    assert!(!result.ok);
+    assert!(result.output.contains("prompt"));
+}
+
+#[tokio::test]
+async fn test_agent_tool_unknown_subagent_type_errors() {
+    let tool = AgentTool::new();
+    let session = aish_llm::LlmSession::new("http://localhost", "key", "model", None, None);
+    let result = tool
+        .execute_async_in_session(
+            serde_json::json!({
+                "description": "plan task",
+                "prompt": "make a plan",
+                "subagent_type": "plan"
+            }),
+            &session,
+        )
+        .await;
+    assert!(!result.ok);
+    assert!(result.output.contains("Unknown subagent_type"));
+}
+
+#[tokio::test]
+async fn test_agent_tool_mock_spawn_success() {
+    let spawn_fn: SpawnFn = Arc::new(mock_spawn_ok);
+    let tool = AgentTool::with_spawn_fn(spawn_fn);
+    let session = aish_llm::LlmSession::new("http://localhost", "key", "model", None, None);
+    let result = tool
+        .execute_async_in_session(
+            serde_json::json!({
+                "description": "find nginx",
+                "prompt": "locate nginx config",
+                "subagent_type": "explore"
+            }),
+            &session,
+        )
+        .await;
+    assert!(result.ok);
+    assert_eq!(result.output, "explore conclusion");
+}
+
+#[tokio::test]
+async fn test_agent_tool_mock_spawn_cancelled_errors() {
+    let spawn_fn: SpawnFn = Arc::new(mock_spawn_cancelled);
+    let tool = AgentTool::with_spawn_fn(spawn_fn);
+    let session = aish_llm::LlmSession::new("http://localhost", "key", "model", None, None);
+    let result = tool
+        .execute_async_in_session(
+            serde_json::json!({
+                "description": "find nginx",
+                "prompt": "locate nginx config",
+                "subagent_type": "explore"
+            }),
+            &session,
+        )
+        .await;
+    assert!(!result.ok);
+    assert!(result.output.contains("cancelled"));
+}


### PR DESCRIPTION
## Summary
- Add `AgentRegistry` (explore only), tool allowlist filtering, and `spawn_builtin` on top of #330 spawn infrastructure
- Add `AgentTool` in `aish-tools` and register it in the main shell session
- Main LLM can synchronously call `Agent(subagent_type=explore, …)`; only the final conclusion returns to the parent loop

## Test plan
- [x] `make ci-check` (format, clippy, workspace tests)
- [x] L1: `AgentRegistry` + `resolve_tools_for_agent` unit tests
- [x] L2: `spawn_builtin` mock LLM sequence + parent session isolation
- [x] L3: `AgentTool` parameter validation + mock spawn paths
- [ ] Manual: ask aish to explore `/etc` nginx configs via explore sub-agent

Closes #331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an agent tool for launching built-in sub-agents from the shell.
  * Introduced a built-in agent registry with allowlisted tool filtering and configurable spawn behavior (including a global turn cap).
  * Exposed new public APIs for resolving agent/tool permissions and spawning built-in sub-agents.
* **Bug Fixes**
  * Improved tool execution to consistently run with active session context, with more reliable retry behavior.
  * Enhanced handling of unknown or invalid sub-agent requests.
* **Tests**
  * Added async test coverage for built-in sub-agent spawning, tool filtering, and agent tool success/cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->