### PR TITLE
feat(subagent): add plan and general-purpose built-ins

### DIFF
--- a/crates/aish-llm/src/agents/mod.rs
+++ b/crates/aish-llm/src/agents/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Issue #330: reusable native tool calling loop, cancel cascade, mock LLM tests.
 //! Issue #331: explore vertical slice — registry, tool filter, spawn_builtin.
+//! Issue #332: plan + general-purpose built-ins and tool filtering.
 
 mod mock_llm;
 mod registry;
@@ -13,4 +14,4 @@ pub use mock_llm::{mock_text_response, mock_tool_call_response};
 pub use registry::{AgentDefinition, AgentRegistry, ToolStrategy};
 pub use spawn::{spawn, spawn_builtin, SpawnConfig, SpawnResult, GLOBAL_MAX_TURNS};
 pub use tool_loop::{run_tool_loop_until_done, LoopOutcome, LoopStatus, ToolLoopConfig};
-pub use tools::{resolve_tool_names_for_agent, resolve_tools_for_agent};
+pub use tools::{parent_has_skill_tool, resolve_tool_names_for_agent, resolve_tools_for_agent};

--- a/crates/aish-llm/src/agents/registry.rs
+++ b/crates/aish-llm/src/agents/registry.rs
@@ -1,12 +1,17 @@
-//! Built-in sub-agent definitions and registry (Phase 1 explore slice).
+//! Built-in sub-agent definitions and registry (Phase 1).
 
 use std::collections::HashMap;
+
+/// Read-only tool allowlist shared by `explore` and `plan` built-ins.
+pub const READ_ONLY_ALLOWLIST: &[&str] = &["grep", "glob", "read_file", "bash"];
 
 /// Tool filtering strategy for a built-in sub-agent.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ToolStrategy {
     /// Only tools in the allowlist (intersected with parent pool).
     Allowlist(Vec<String>),
+    /// Parent pool minus denied tools (intersected with parent pool).
+    Denylist(Vec<String>),
 }
 
 /// Definition of a built-in sub-agent type.
@@ -19,6 +24,13 @@ pub struct AgentDefinition {
     pub tool_strategy: ToolStrategy,
 }
 
+fn read_only_allowlist() -> Vec<String> {
+    READ_ONLY_ALLOWLIST
+        .iter()
+        .map(|name| (*name).to_string())
+        .collect()
+}
+
 impl AgentDefinition {
     pub fn explore() -> Self {
         Self {
@@ -26,12 +38,27 @@ impl AgentDefinition {
             when_to_use: "Search logs, configs, services, network state, or code locations; read-only investigation.".to_string(),
             system_prompt: "You are a read-only explore sub-agent for shell operations. Investigate using only your allowed tools. Do not modify files or spawn nested agents. Return a concise conclusion.".to_string(),
             max_turns: 15,
-            tool_strategy: ToolStrategy::Allowlist(vec![
-                "grep".to_string(),
-                "glob".to_string(),
-                "read_file".to_string(),
-                "bash".to_string(),
-            ]),
+            tool_strategy: ToolStrategy::Allowlist(read_only_allowlist()),
+        }
+    }
+
+    pub fn plan() -> Self {
+        Self {
+            subagent_type: "plan".to_string(),
+            when_to_use: "Design changes, runbooks, or implementation plans; read-only planning.".to_string(),
+            system_prompt: "You are a read-only planning sub-agent for shell operations. Analyze and propose plans using only your allowed tools. Do not modify files, enter plan mode, or spawn nested agents. Return a concise plan or recommendation.".to_string(),
+            max_turns: 20,
+            tool_strategy: ToolStrategy::Allowlist(read_only_allowlist()),
+        }
+    }
+
+    pub fn general_purpose() -> Self {
+        Self {
+            subagent_type: "general-purpose".to_string(),
+            when_to_use: "General sub-tasks that need the parent's tools without nested Agent delegation.".to_string(),
+            system_prompt: "You are a general-purpose sub-agent. Complete the delegated task using your available tools. Do not spawn nested agents. Return a concise conclusion.".to_string(),
+            max_turns: 25,
+            tool_strategy: ToolStrategy::Denylist(vec!["Agent".to_string()]),
         }
     }
 }
@@ -43,11 +70,16 @@ pub struct AgentRegistry {
 }
 
 impl AgentRegistry {
-    /// Phase 1 explore slice: only `explore` is registered.
+    /// Phase 1 built-ins: `explore`, `plan`, and `general-purpose`.
     pub fn builtin() -> Self {
-        let explore = AgentDefinition::explore();
         let mut agents = HashMap::new();
-        agents.insert(explore.subagent_type.clone(), explore);
+        for def in [
+            AgentDefinition::explore(),
+            AgentDefinition::plan(),
+            AgentDefinition::general_purpose(),
+        ] {
+            agents.insert(def.subagent_type.clone(), def);
+        }
         Self { agents }
     }
 
@@ -55,6 +87,13 @@ impl AgentRegistry {
         self.agents
             .get(subagent_type)
             .ok_or_else(|| format!("Unknown subagent_type: {subagent_type}"))
+    }
+
+    /// Built-in type names for JSON schema enums.
+    pub fn subagent_types(&self) -> Vec<String> {
+        let mut types: Vec<String> = self.agents.keys().cloned().collect();
+        types.sort();
+        types
     }
 
     /// Format built-in descriptions for the `Agent` tool description.
@@ -88,32 +127,68 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_plan_succeeds() {
+        let registry = AgentRegistry::builtin();
+        let def = registry.resolve("plan").expect("plan should exist");
+        assert_eq!(def.subagent_type, "plan");
+        assert_eq!(def.max_turns, 20);
+        assert!(matches!(def.tool_strategy, ToolStrategy::Allowlist(_)));
+    }
+
+    #[test]
+    fn test_resolve_general_purpose_succeeds() {
+        let registry = AgentRegistry::builtin();
+        let def = registry
+            .resolve("general-purpose")
+            .expect("general-purpose should exist");
+        assert_eq!(def.subagent_type, "general-purpose");
+        assert_eq!(def.max_turns, 25);
+        assert!(matches!(def.tool_strategy, ToolStrategy::Denylist(_)));
+    }
+
+    #[test]
     fn test_resolve_unknown_type_errors() {
         let registry = AgentRegistry::builtin();
-        let err = registry.resolve("plan").unwrap_err();
+        let err = registry.resolve("troubleshoot").unwrap_err();
         assert!(err.contains("Unknown subagent_type"));
     }
 
     #[test]
-    fn test_list_for_tool_description_includes_explore_when_to_use() {
+    fn test_list_for_tool_description_includes_all_builtins_when_to_use() {
         let registry = AgentRegistry::builtin();
         let desc = registry.list_for_tool_description();
         assert!(desc.contains("`explore`"));
+        assert!(desc.contains("`plan`"));
+        assert!(desc.contains("`general-purpose`"));
         assert!(desc.contains("read-only"));
+    }
+
+    #[test]
+    fn test_subagent_types_lists_all_builtins() {
+        let registry = AgentRegistry::builtin();
+        assert_eq!(
+            registry.subagent_types(),
+            vec![
+                "explore".to_string(),
+                "general-purpose".to_string(),
+                "plan".to_string(),
+            ]
+        );
     }
 
     #[test]
     fn test_explore_allowlist_is_read_only_tools() {
         let def = AgentDefinition::explore();
-        let ToolStrategy::Allowlist(tools) = &def.tool_strategy;
         assert_eq!(
-            tools,
-            &vec![
-                "grep".to_string(),
-                "glob".to_string(),
-                "read_file".to_string(),
-                "bash".to_string(),
-            ]
+            def.tool_strategy,
+            ToolStrategy::Allowlist(read_only_allowlist()),
         );
+    }
+
+    #[test]
+    fn test_plan_allowlist_matches_explore() {
+        let explore = AgentDefinition::explore();
+        let plan = AgentDefinition::plan();
+        assert_eq!(explore.tool_strategy, plan.tool_strategy);
     }
 }

--- a/crates/aish-llm/src/agents/spawn.rs
+++ b/crates/aish-llm/src/agents/spawn.rs
@@ -9,9 +9,9 @@ use crate::session::LlmSession;
 use crate::tool_context::ToolExecutionPolicy;
 use crate::types::{ChatMessage, LlmCallbackResult, ToolSpec};
 
-use super::registry::AgentRegistry;
+use super::registry::{AgentRegistry, ToolStrategy};
 use super::tool_loop::{run_tool_loop_until_done, LoopStatus, ToolLoopConfig};
-use super::tools::resolve_tools_for_agent;
+use super::tools::{parent_has_skill_tool, resolve_tools_for_agent};
 
 /// Global ceiling on sub-agent turns (applied via `min(def.max_turns, GLOBAL_MAX_TURNS)`).
 pub const GLOBAL_MAX_TURNS: u32 = 30;
@@ -77,7 +77,7 @@ where
     }
 }
 
-/// Spawn a built-in sub-agent (`explore` in Phase 1 slice) from `parent`.
+/// Spawn a built-in sub-agent from `parent`.
 ///
 /// `register_tools` receives the sub-session and filtered parent tool specs; it must
 /// register concrete tool implementations on the sub-session.
@@ -92,7 +92,10 @@ where
     F: FnOnce(&mut LlmSession, &[ToolSpec]),
 {
     let def = registry.resolve(subagent_type)?;
-    let allowed_specs = resolve_tools_for_agent(def, &parent.tool_specs());
+    let parent_tools = parent.tool_specs();
+    let parent_has_skill = parent_has_skill_tool(&parent_tools);
+    let allowed_specs = resolve_tools_for_agent(def, &parent_tools, parent_has_skill);
+    let enforce_read_only_bash = matches!(def.tool_strategy, ToolStrategy::Allowlist(_));
     let max_turns = def.max_turns.min(GLOBAL_MAX_TURNS);
     let spawn_id = Uuid::new_v4().to_string();
     let agent_type = def.subagent_type.clone();
@@ -107,7 +110,7 @@ where
         },
         |sub| {
             sub.set_tool_execution_policy(ToolExecutionPolicy {
-                enforce_read_only_bash: true,
+                enforce_read_only_bash,
             });
             install_sub_agent_event_proxy(sub, &agent_type, &spawn_id);
             register_tools(sub, &allowed_specs);
@@ -272,12 +275,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_spawn_builtin_plan_mock_sequence() {
+        let mut parent = LlmSession::new("http://localhost", "key", "model", None, None);
+        parent.register_tool(Box::new(MockTool::new("grep")));
+        parent.register_tool(Box::new(MockTool::new("write_file")));
+        parent.register_tool(Box::new(MockTool::new("enter_plan_mode")));
+
+        let registry = AgentRegistry::builtin();
+        let result = spawn_builtin(
+            &parent,
+            &registry,
+            "plan",
+            "design rollout",
+            |sub, specs| {
+                sub.set_test_chat_responses(vec![Ok(mock_text_response("rollout plan"))]);
+                let names: Vec<_> = specs.iter().map(|s| s.function.name.as_str()).collect();
+                assert!(names.contains(&"grep"));
+                assert!(!names.contains(&"write_file"));
+                assert!(!names.contains(&"enter_plan_mode"));
+                register_mock_from_specs(sub, specs);
+            },
+        )
+        .await
+        .expect("spawn_builtin plan should succeed");
+
+        assert_eq!(result.status, LoopStatus::Complete);
+        assert_eq!(result.text, "rollout plan");
+    }
+
+    #[tokio::test]
+    async fn test_spawn_builtin_general_purpose_excludes_agent() {
+        let mut parent = LlmSession::new("http://localhost", "key", "model", None, None);
+        parent.register_tool(Box::new(MockTool::new("bash")));
+        parent.register_tool(Box::new(MockTool::new("read_file")));
+        parent.register_tool(Box::new(MockTool::new("Agent")));
+
+        let registry = AgentRegistry::builtin();
+        let result = spawn_builtin(
+            &parent,
+            &registry,
+            "general-purpose",
+            "run sub task",
+            |sub, specs| {
+                sub.set_test_chat_responses(vec![Ok(mock_text_response("sub task done"))]);
+                let names: Vec<_> = specs.iter().map(|s| s.function.name.as_str()).collect();
+                assert!(names.contains(&"bash"));
+                assert!(names.contains(&"read_file"));
+                assert!(!names.contains(&"Agent"));
+                register_mock_from_specs(sub, specs);
+            },
+        )
+        .await
+        .expect("spawn_builtin general-purpose should succeed");
+
+        assert_eq!(result.status, LoopStatus::Complete);
+        assert_eq!(result.text, "sub task done");
+    }
+
+    #[tokio::test]
     async fn test_spawn_builtin_unknown_type_errors() {
         let parent = LlmSession::new("http://localhost", "key", "model", None, None);
         let registry = AgentRegistry::builtin();
-        let err = spawn_builtin(&parent, &registry, "plan", "task", |_sub, _specs| {})
-            .await
-            .unwrap_err();
+        let err = spawn_builtin(
+            &parent,
+            &registry,
+            "troubleshoot",
+            "task",
+            |_sub, _specs| {},
+        )
+        .await
+        .unwrap_err();
         assert!(err.contains("Unknown subagent_type"));
     }
 

--- a/crates/aish-llm/src/agents/tools.rs
+++ b/crates/aish-llm/src/agents/tools.rs
@@ -3,26 +3,54 @@
 use super::registry::{AgentDefinition, ToolStrategy};
 use crate::types::ToolSpec;
 
+const SKILL_TOOL_NAME: &str = "skill";
+
+/// Whether the parent session exposes the `skill` tool.
+pub fn parent_has_skill_tool(parent_tools: &[ToolSpec]) -> bool {
+    parent_tools
+        .iter()
+        .any(|spec| spec.function.name == SKILL_TOOL_NAME)
+}
+
 /// Resolve which parent tool names a sub-agent may use.
 pub fn resolve_tool_names_for_agent(
     def: &AgentDefinition,
     parent_tool_names: &[&str],
+    parent_has_skill: bool,
 ) -> Vec<String> {
-    let ToolStrategy::Allowlist(allowed) = &def.tool_strategy;
-    allowed
-        .iter()
-        .filter(|name| parent_tool_names.contains(&name.as_str()))
-        .cloned()
-        .collect()
+    match &def.tool_strategy {
+        ToolStrategy::Allowlist(allowed) => allowed
+            .iter()
+            .filter(|name| parent_tool_names.contains(&name.as_str()))
+            .cloned()
+            .collect(),
+        ToolStrategy::Denylist(denied) => parent_tool_names
+            .iter()
+            .filter(|name| {
+                if denied.contains(&name.to_string()) {
+                    return false;
+                }
+                if **name == SKILL_TOOL_NAME && !parent_has_skill {
+                    return false;
+                }
+                true
+            })
+            .map(|name| (*name).to_string())
+            .collect(),
+    }
 }
 
 /// Resolve tool specs from the parent pool for a sub-agent definition.
-pub fn resolve_tools_for_agent(def: &AgentDefinition, parent_tools: &[ToolSpec]) -> Vec<ToolSpec> {
+pub fn resolve_tools_for_agent(
+    def: &AgentDefinition,
+    parent_tools: &[ToolSpec],
+    parent_has_skill: bool,
+) -> Vec<ToolSpec> {
     let parent_names: Vec<&str> = parent_tools
         .iter()
         .map(|spec| spec.function.name.as_str())
         .collect();
-    let allowed = resolve_tool_names_for_agent(def, &parent_names);
+    let allowed = resolve_tool_names_for_agent(def, &parent_names, parent_has_skill);
     parent_tools
         .iter()
         .filter(|spec| allowed.iter().any(|n| n == &spec.function.name))
@@ -33,6 +61,7 @@ pub fn resolve_tools_for_agent(def: &AgentDefinition, parent_tools: &[ToolSpec])
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agents::AgentDefinition;
     use crate::types::{FunctionSpec, ToolSpec};
 
     fn spec(name: &str) -> ToolSpec {
@@ -50,6 +79,14 @@ mod tests {
         AgentDefinition::explore()
     }
 
+    fn plan_def() -> AgentDefinition {
+        AgentDefinition::plan()
+    }
+
+    fn general_purpose_def() -> AgentDefinition {
+        AgentDefinition::general_purpose()
+    }
+
     #[test]
     fn test_explore_allowlist_excludes_write_edit_and_agent() {
         let parent = vec![
@@ -61,7 +98,7 @@ mod tests {
             "edit_file",
             "Agent",
         ];
-        let names = resolve_tool_names_for_agent(&explore_def(), &parent);
+        let names = resolve_tool_names_for_agent(&explore_def(), &parent, false);
         assert_eq!(
             names,
             vec![
@@ -81,8 +118,95 @@ mod tests {
             spec("read_file"),
             spec("bash"),
         ];
-        let resolved = resolve_tools_for_agent(&explore_def(), &parent);
+        let resolved = resolve_tools_for_agent(&explore_def(), &parent, false);
         let names: Vec<_> = resolved.iter().map(|s| s.function.name.as_str()).collect();
         assert_eq!(names, vec!["grep", "read_file", "bash"]);
+    }
+
+    #[test]
+    fn test_plan_allowlist_matches_explore_excludes_plan_mode_tools() {
+        let parent = vec![
+            "grep",
+            "glob",
+            "read_file",
+            "bash",
+            "write_file",
+            "edit_file",
+            "Agent",
+            "enter_plan_mode",
+            "exit_plan_mode",
+        ];
+        let names = resolve_tool_names_for_agent(&plan_def(), &parent, false);
+        assert_eq!(
+            names,
+            vec![
+                "grep".to_string(),
+                "glob".to_string(),
+                "read_file".to_string(),
+                "bash".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_plan_resolves_specs_without_plan_mode_tools() {
+        let parent = vec![
+            spec("grep"),
+            spec("enter_plan_mode"),
+            spec("exit_plan_mode"),
+            spec("read_file"),
+        ];
+        let resolved = resolve_tools_for_agent(&plan_def(), &parent, false);
+        let names: Vec<_> = resolved.iter().map(|s| s.function.name.as_str()).collect();
+        assert_eq!(names, vec!["grep", "read_file"]);
+    }
+
+    #[test]
+    fn test_general_purpose_denylist_excludes_agent_keeps_parent_tools() {
+        let parent = vec!["bash", "read_file", "write_file", "Agent", "grep"];
+        let names = resolve_tool_names_for_agent(&general_purpose_def(), &parent, false);
+        assert_eq!(
+            names,
+            vec![
+                "bash".to_string(),
+                "read_file".to_string(),
+                "write_file".to_string(),
+                "grep".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_general_purpose_includes_skill_when_parent_has_skill() {
+        let parent = vec![spec("bash"), spec("skill"), spec("Agent")];
+        let resolved = resolve_tools_for_agent(&general_purpose_def(), &parent, true);
+        let names: Vec<_> = resolved.iter().map(|s| s.function.name.as_str()).collect();
+        assert_eq!(names, vec!["bash", "skill"]);
+    }
+
+    #[test]
+    fn test_general_purpose_excludes_skill_when_parent_lacks_skill() {
+        let parent = vec![spec("bash"), spec("read_file"), spec("Agent")];
+        let resolved = resolve_tools_for_agent(&general_purpose_def(), &parent, false);
+        let names: Vec<_> = resolved.iter().map(|s| s.function.name.as_str()).collect();
+        assert_eq!(names, vec!["bash", "read_file"]);
+    }
+
+    #[test]
+    fn test_parent_has_skill_tool_detects_skill_in_pool() {
+        let parent = vec![spec("bash"), spec("skill")];
+        assert!(parent_has_skill_tool(&parent));
+        let without = vec![spec("bash")];
+        assert!(!parent_has_skill_tool(&without));
+    }
+
+    #[test]
+    fn test_explore_and_plan_do_not_include_skill_even_when_parent_has_skill() {
+        let parent = vec![spec("grep"), spec("skill"), spec("bash")];
+        for def in [explore_def(), plan_def()] {
+            let resolved = resolve_tools_for_agent(&def, &parent, true);
+            let names: Vec<_> = resolved.iter().map(|s| s.function.name.as_str()).collect();
+            assert!(!names.contains(&"skill"));
+        }
     }
 }

--- a/crates/aish-llm/src/lib.rs
+++ b/crates/aish-llm/src/lib.rs
@@ -36,9 +36,9 @@ pub mod usage;
 
 pub use agent::{AgentConfig, AgentStep, ReActAgent};
 pub use agents::{
-    resolve_tool_names_for_agent, resolve_tools_for_agent, run_tool_loop_until_done, spawn,
-    spawn_builtin, AgentDefinition, AgentRegistry, LoopOutcome, LoopStatus, SpawnConfig,
-    SpawnResult, ToolLoopConfig, ToolStrategy, GLOBAL_MAX_TURNS,
+    parent_has_skill_tool, resolve_tool_names_for_agent, resolve_tools_for_agent,
+    run_tool_loop_until_done, spawn, spawn_builtin, AgentDefinition, AgentRegistry, LoopOutcome,
+    LoopStatus, SpawnConfig, SpawnResult, ToolLoopConfig, ToolStrategy, GLOBAL_MAX_TURNS,
 };
 pub use api::{
     resolve_anthropic_messages_url, resolve_api_dialect, stream_simple,

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -653,7 +653,8 @@ impl AishShell {
         )));
         tool_registry.register(Box::new(aish_tools::EnterPlanModeTool::new()));
         tool_registry.register(Box::new(aish_tools::ExitPlanModeTool::new()));
-        tool_registry.register(Box::new(aish_tools::AgentTool::new()));
+        // AgentTool registration is deferred until after skill loading so general-purpose
+        // sub-agents can inherit skill callbacks when the parent session has skills.
 
         // System diagnose tool — needs session credentials to spawn sub-sessions.
         // The shared event callback holder allows setting the callback after
@@ -782,6 +783,16 @@ impl AishShell {
                     })
                     .collect();
             let skill_names: Vec<String> = skills_snapshot.keys().cloned().collect();
+            let agent_skills = skills_snapshot.clone();
+            let agent_skill_names = skill_names.clone();
+            let agent_lookup =
+                std::sync::Arc::new(move |name: &str| agent_skills.get(name).cloned())
+                    as std::sync::Arc<dyn Fn(&str) -> Option<aish_tools::SkillInfo> + Send + Sync>;
+            let agent_list = std::sync::Arc::new(move || agent_skill_names.clone())
+                as std::sync::Arc<dyn Fn() -> Vec<String> + Send + Sync>;
+            tool_registry.register(Box::new(aish_tools::AgentTool::with_skill_callbacks(Some(
+                (agent_lookup, agent_list),
+            ))));
             let lookup = Box::new(move |name: &str| skills_snapshot.get(name).cloned());
             let list = Box::new(move || skill_names.clone());
             aish_tools::SkillTool::new(lookup, list)

--- a/crates/aish-tools/src/agent_tool/agent_tool.rs
+++ b/crates/aish-tools/src/agent_tool/agent_tool.rs
@@ -5,7 +5,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use aish_llm::{
-    spawn_builtin, AgentRegistry, LlmSession, LoopStatus, SpawnResult, Tool, ToolResult, ToolSpec,
+    spawn_builtin, AgentDefinition, AgentRegistry, LlmSession, LoopStatus, SpawnResult, Tool,
+    ToolResult, ToolSpec,
 };
 
 use super::prompt;
@@ -22,15 +23,26 @@ pub type SpawnFn = Arc<
         + Sync,
 >;
 
-/// Tool that spawns built-in sub-agents (Phase 1: `explore` only).
+/// Optional skill callbacks for `general-purpose` sub-agents.
+pub type SkillLookupFn = Arc<dyn Fn(&str) -> Option<crate::SkillInfo> + Send + Sync>;
+pub type SkillListFn = Arc<dyn Fn() -> Vec<String> + Send + Sync>;
+pub type SkillCallbacks = (SkillLookupFn, SkillListFn);
+
+/// Tool that spawns built-in sub-agents (`explore`, `plan`, `general-purpose`).
 pub struct AgentTool {
     registry: AgentRegistry,
     description: String,
     spawn_fn: Option<SpawnFn>,
+    skill_callbacks: Option<SkillCallbacks>,
 }
 
 impl AgentTool {
     pub fn new() -> Self {
+        Self::with_skill_callbacks(None)
+    }
+
+    /// Create an `AgentTool` that can register inherited `skill` tools for general-purpose spawns.
+    pub fn with_skill_callbacks(skill_callbacks: Option<SkillCallbacks>) -> Self {
         let registry = AgentRegistry::builtin();
         let description = format!(
             "{}\n{}",
@@ -41,6 +53,7 @@ impl AgentTool {
             registry,
             description,
             spawn_fn: None,
+            skill_callbacks,
         }
     }
 
@@ -91,7 +104,7 @@ impl AgentTool {
         }
     }
 
-    fn register_explore_tools(sub: &mut LlmSession, specs: &[ToolSpec]) {
+    fn register_read_only_tools(sub: &mut LlmSession, specs: &[ToolSpec]) {
         for spec in specs {
             match spec.function.name.as_str() {
                 "grep" => sub.register_tool(Box::new(crate::GrepTool::new())),
@@ -104,6 +117,56 @@ impl AgentTool {
                 }
                 _ => {}
             }
+        }
+    }
+
+    fn register_general_purpose_tools(
+        sub: &mut LlmSession,
+        specs: &[ToolSpec],
+        skill_callbacks: &Option<SkillCallbacks>,
+    ) {
+        for spec in specs {
+            match spec.function.name.as_str() {
+                "grep" => sub.register_tool(Box::new(crate::GrepTool::new())),
+                "glob" => sub.register_tool(Box::new(crate::GlobTool::new())),
+                "read_file" => sub.register_tool(Box::new(crate::ReadFileTool::new())),
+                "write_file" => sub.register_tool(Box::new(crate::WriteFileTool::new())),
+                "edit_file" => sub.register_tool(Box::new(crate::EditFileTool::new())),
+                "bash" => {
+                    let mut bash = crate::bash::BashTool::new();
+                    bash.set_cancellation_token(sub.cancellation_token_arc());
+                    sub.register_tool(Box::new(bash));
+                }
+                "skill" => {
+                    if let Some((lookup, list)) = skill_callbacks {
+                        sub.register_tool(Box::new(crate::SkillTool::new(
+                            Box::new({
+                                let lookup = Arc::clone(lookup);
+                                move |name| lookup(name)
+                            }),
+                            Box::new({
+                                let list = Arc::clone(list);
+                                move || list()
+                            }),
+                        )));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn register_tools_for_definition(
+        &self,
+        sub: &mut LlmSession,
+        def: &AgentDefinition,
+        specs: &[ToolSpec],
+    ) {
+        match def.subagent_type.as_str() {
+            "general-purpose" => {
+                Self::register_general_purpose_tools(sub, specs, &self.skill_callbacks)
+            }
+            _ => Self::register_read_only_tools(sub, specs),
         }
     }
 }
@@ -124,7 +187,7 @@ impl Tool for AgentTool {
     }
 
     fn parameters(&self) -> serde_json::Value {
-        prompt::parameters()
+        prompt::parameters(&self.registry.subagent_types())
     }
 
     fn execute(&self, _args: serde_json::Value) -> ToolResult {
@@ -142,9 +205,10 @@ impl Tool for AgentTool {
                 Err(err) => return err,
             };
 
-            if self.registry.resolve(subagent_type).is_err() {
-                return ToolResult::error(format!("Unknown subagent_type: {subagent_type}"));
-            }
+            let def = match self.registry.resolve(subagent_type) {
+                Ok(def) => def.clone(),
+                Err(err) => return ToolResult::error(err),
+            };
 
             if let Some(spawn_fn) = &self.spawn_fn {
                 let result = match spawn_fn(session, subagent_type, prompt).await {
@@ -157,7 +221,7 @@ impl Tool for AgentTool {
             let registry = self.registry.clone();
             let result =
                 match spawn_builtin(session, &registry, subagent_type, prompt, |sub, specs| {
-                    Self::register_explore_tools(sub, specs)
+                    self.register_tools_for_definition(sub, &def, specs);
                 })
                 .await
                 {
@@ -181,9 +245,24 @@ mod tests {
     }
 
     #[test]
-    fn description_includes_explore_builtin() {
+    fn description_includes_all_builtins() {
         let tool = AgentTool::new();
         assert!(tool.description().contains("explore"));
+        assert!(tool.description().contains("plan"));
+        assert!(tool.description().contains("general-purpose"));
         assert!(tool.description().contains("read-only"));
+    }
+
+    #[test]
+    fn parameters_enum_lists_all_builtins() {
+        let tool = AgentTool::new();
+        let params = tool.parameters();
+        let enum_values = params["properties"]["subagent_type"]["enum"]
+            .as_array()
+            .expect("subagent_type enum");
+        let names: Vec<_> = enum_values.iter().filter_map(|v| v.as_str()).collect();
+        assert!(names.contains(&"explore"));
+        assert!(names.contains(&"plan"));
+        assert!(names.contains(&"general-purpose"));
     }
 }

--- a/crates/aish-tools/src/agent_tool/prompt.rs
+++ b/crates/aish-tools/src/agent_tool/prompt.rs
@@ -5,7 +5,7 @@ Spawn a synchronous sub-agent to handle an isolated sub-task. Only the final con
 is returned to the parent session; intermediate tool output stays in the sub-session.\n\n\
 Available subagent types:";
 
-pub fn parameters() -> serde_json::Value {
+pub fn parameters(subagent_types: &[String]) -> serde_json::Value {
     serde_json::json!({
         "type": "object",
         "properties": {
@@ -19,7 +19,7 @@ pub fn parameters() -> serde_json::Value {
             },
             "subagent_type": {
                 "type": "string",
-                "enum": ["explore"],
+                "enum": subagent_types,
                 "description": "Built-in sub-agent type to spawn"
             }
         },

--- a/crates/aish-tools/src/lib.rs
+++ b/crates/aish-tools/src/lib.rs
@@ -20,7 +20,7 @@ pub mod agent_tool {
     mod agent_tool;
     mod prompt;
 
-    pub use self::agent_tool::{AgentTool, SpawnFn};
+    pub use self::agent_tool::{AgentTool, SkillCallbacks, SpawnFn};
 }
 
 pub mod ask_user {

--- a/crates/aish-tools/tests/agent_tool_test.rs
+++ b/crates/aish-tools/tests/agent_tool_test.rs
@@ -57,7 +57,7 @@ async fn test_agent_tool_unknown_subagent_type_errors() {
             serde_json::json!({
                 "description": "plan task",
                 "prompt": "make a plan",
-                "subagent_type": "plan"
+                "subagent_type": "troubleshoot"
             }),
             &session,
         )


### PR DESCRIPTION
## Summary
- Add `plan` and `general-purpose` to `AgentRegistry` with allowlist/denylist tool strategies
- Extend `resolve_tools_for_agent` for all three Phase 1 built-ins (plan excludes plan_mode tools; general-purpose inherits skill when parent has it)
- Update `Agent` tool description/schema enum with embedded whenToUse; wire skill callbacks in shell for general-purpose spawns

## Test plan
- [x] `cargo test -p aish-llm agents::`
- [x] `cargo test -p aish-tools agent_tool`
- [x] `make format-check && make lint`
- [ ] `make ci-check` (full workspace; aish-pty completion_query timing test may flake)

Closes #332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for more built-in sub-agent types, including planning and general-purpose options.
  * Agent tool selection now adapts to the available capabilities of the parent session, including skill-aware behavior.

* **Bug Fixes**
  * Improved tool filtering so sub-agents only receive compatible tools.
  * General-purpose sub-agents now avoid restricted tools while preserving access to allowed ones.
  * Updated shell setup so skill information is loaded before agent tools are registered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->