### PR TITLE
feat(subagent): unify spawn termination semantics (Phase 1)

### DIFF
--- a/crates/aish-llm/src/agents/mod.rs
+++ b/crates/aish-llm/src/agents/mod.rs
@@ -5,13 +5,19 @@
 //! Issue #332: plan + general-purpose built-ins and tool filtering.
 
 mod mock_llm;
+mod outcome;
 mod registry;
 mod spawn;
 mod tool_loop;
 mod tools;
 
 pub use mock_llm::{mock_text_response, mock_tool_call_response};
+pub use outcome::{
+    extract_spawn_outcome, OutcomeConfig, SpawnOutcome, TerminationKind, INCOMPLETE_PREFIX,
+};
 pub use registry::{AgentDefinition, AgentRegistry, ToolStrategy};
-pub use spawn::{spawn, spawn_builtin, SpawnConfig, SpawnResult, GLOBAL_MAX_TURNS};
+pub use spawn::{
+    effective_max_turns, spawn, spawn_builtin, SpawnConfig, SpawnResult, GLOBAL_MAX_TURNS,
+};
 pub use tool_loop::{run_tool_loop_until_done, LoopOutcome, LoopStatus, ToolLoopConfig};
 pub use tools::{parent_has_skill_tool, resolve_tool_names_for_agent, resolve_tools_for_agent};

--- a/crates/aish-llm/src/agents/outcome.rs
+++ b/crates/aish-llm/src/agents/outcome.rs
@@ -1,0 +1,180 @@
+//! Pure spawn outcome extraction (Seam C): map loop termination to status + text.
+
+use super::tool_loop::LoopStatus;
+
+/// Prefix prepended when max turns is reached (PRD §4.6).
+pub const INCOMPLETE_PREFIX: &str = "[incomplete: max turns reached]\n";
+
+/// Configuration for [`extract_spawn_outcome`].
+#[derive(Debug, Clone)]
+pub struct OutcomeConfig {
+    pub incomplete_prefix: String,
+}
+
+impl Default for OutcomeConfig {
+    fn default() -> Self {
+        Self {
+            incomplete_prefix: INCOMPLETE_PREFIX.to_string(),
+        }
+    }
+}
+
+/// Why the sub-agent loop stopped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TerminationKind {
+    /// Assistant responded with text and no tool calls (natural stop).
+    NaturalStop { assistant_text: String },
+    /// Turn budget exhausted while the assistant still had tool calls pending.
+    MaxTurnsReached { last_assistant_text: String },
+    /// Parent or sub-session cancel token fired.
+    Cancelled,
+    /// Unrecoverable LLM or runtime error.
+    Fatal,
+}
+
+/// Status + text returned to the parent via [`super::spawn::SpawnResult`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpawnOutcome {
+    pub status: LoopStatus,
+    pub text: String,
+}
+
+/// Map termination semantics to the parent-visible spawn outcome (PRD §4.6).
+pub fn extract_spawn_outcome(kind: TerminationKind, config: &OutcomeConfig) -> SpawnOutcome {
+    match kind {
+        TerminationKind::NaturalStop { assistant_text } => SpawnOutcome {
+            status: LoopStatus::Complete,
+            text: assistant_text,
+        },
+        TerminationKind::MaxTurnsReached {
+            last_assistant_text,
+        } => {
+            let text = if last_assistant_text.is_empty() {
+                config.incomplete_prefix.clone()
+            } else {
+                format!("{}{last_assistant_text}", config.incomplete_prefix)
+            };
+            SpawnOutcome {
+                status: LoopStatus::Incomplete,
+                text,
+            }
+        }
+        TerminationKind::Cancelled => SpawnOutcome {
+            status: LoopStatus::Cancelled,
+            text: String::new(),
+        },
+        TerminationKind::Fatal => SpawnOutcome {
+            status: LoopStatus::Fatal,
+            text: String::new(),
+        },
+    }
+}
+
+#[cfg(test)]
+fn extract_spawn_outcome_from_messages(
+    messages: &[crate::types::ChatMessage],
+    config: &OutcomeConfig,
+) -> Option<SpawnOutcome> {
+    let last_assistant = messages.iter().rev().find(|m| m.role == "assistant")?;
+    if last_assistant
+        .tool_calls
+        .as_ref()
+        .is_some_and(|tc| !tc.is_empty())
+    {
+        return None;
+    }
+    Some(extract_spawn_outcome(
+        TerminationKind::NaturalStop {
+            assistant_text: last_assistant.text_content().unwrap_or("").to_string(),
+        },
+        config,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ChatMessage, MessageContent, ToolCall};
+
+    fn config() -> OutcomeConfig {
+        OutcomeConfig::default()
+    }
+
+    #[test]
+    fn test_natural_stop_assistant_text_is_complete() {
+        let outcome = extract_spawn_outcome(
+            TerminationKind::NaturalStop {
+                assistant_text: "nginx at /etc/nginx".to_string(),
+            },
+            &config(),
+        );
+        assert_eq!(outcome.status, LoopStatus::Complete);
+        assert_eq!(outcome.text, "nginx at /etc/nginx");
+    }
+
+    #[test]
+    fn test_max_turns_incomplete_with_prefix_and_last_text() {
+        let outcome = extract_spawn_outcome(
+            TerminationKind::MaxTurnsReached {
+                last_assistant_text: "partial findings".to_string(),
+            },
+            &config(),
+        );
+        assert_eq!(outcome.status, LoopStatus::Incomplete);
+        assert_eq!(
+            outcome.text,
+            "[incomplete: max turns reached]\npartial findings"
+        );
+    }
+
+    #[test]
+    fn test_max_turns_incomplete_prefix_only_when_no_last_text() {
+        let outcome = extract_spawn_outcome(
+            TerminationKind::MaxTurnsReached {
+                last_assistant_text: String::new(),
+            },
+            &config(),
+        );
+        assert_eq!(outcome.status, LoopStatus::Incomplete);
+        assert_eq!(outcome.text, "[incomplete: max turns reached]\n");
+    }
+
+    #[test]
+    fn test_cancelled_maps_to_cancelled_status() {
+        let outcome = extract_spawn_outcome(TerminationKind::Cancelled, &config());
+        assert_eq!(outcome.status, LoopStatus::Cancelled);
+        assert!(outcome.text.is_empty());
+    }
+
+    #[test]
+    fn test_fatal_maps_to_fatal_status() {
+        let outcome = extract_spawn_outcome(TerminationKind::Fatal, &config());
+        assert_eq!(outcome.status, LoopStatus::Fatal);
+        assert!(outcome.text.is_empty());
+    }
+
+    #[test]
+    fn test_extract_from_messages_natural_stop() {
+        let mut assistant = ChatMessage::assistant("done");
+        assistant.content = Some(MessageContent::Text("done".to_string()));
+        let messages = vec![ChatMessage::user("task"), assistant];
+
+        let outcome =
+            extract_spawn_outcome_from_messages(&messages, &config()).expect("natural stop");
+        assert_eq!(outcome.status, LoopStatus::Complete);
+        assert_eq!(outcome.text, "done");
+    }
+
+    #[test]
+    fn test_extract_from_messages_returns_none_when_last_assistant_has_tool_calls() {
+        let mut assistant = ChatMessage::assistant("");
+        assistant.tool_calls = Some(vec![ToolCall {
+            id: "c1".to_string(),
+            name: "grep".to_string(),
+            arguments: "{}".to_string(),
+        }]);
+        let messages = vec![ChatMessage::user("task"), assistant];
+
+        assert!(extract_spawn_outcome_from_messages(&messages, &config()).is_none());
+    }
+}

--- a/crates/aish-llm/src/agents/spawn.rs
+++ b/crates/aish-llm/src/agents/spawn.rs
@@ -13,8 +13,13 @@ use super::registry::{AgentRegistry, ToolStrategy};
 use super::tool_loop::{run_tool_loop_until_done, LoopStatus, ToolLoopConfig};
 use super::tools::{parent_has_skill_tool, resolve_tools_for_agent};
 
-/// Global ceiling on sub-agent turns (applied via `min(def.max_turns, GLOBAL_MAX_TURNS)`).
+/// Global ceiling on sub-agent turns (applied via [`effective_max_turns`]).
 pub const GLOBAL_MAX_TURNS: u32 = 30;
+
+/// Apply the global turn ceiling to a built-in's configured limit.
+pub fn effective_max_turns(def_max_turns: u32) -> u32 {
+    def_max_turns.min(GLOBAL_MAX_TURNS)
+}
 
 /// Configuration for [`spawn`].
 #[derive(Debug, Clone)]
@@ -96,7 +101,7 @@ where
     let parent_has_skill = parent_has_skill_tool(&parent_tools);
     let allowed_specs = resolve_tools_for_agent(def, &parent_tools, parent_has_skill);
     let enforce_read_only_bash = matches!(def.tool_strategy, ToolStrategy::Allowlist(_));
-    let max_turns = def.max_turns.min(GLOBAL_MAX_TURNS);
+    let max_turns = effective_max_turns(def.max_turns);
     let spawn_id = Uuid::new_v4().to_string();
     let agent_type = def.subagent_type.clone();
     let system_prompt = def.system_prompt.clone();
@@ -170,6 +175,7 @@ async fn forward_cancellation(
 mod tests {
     use super::*;
     use crate::agents::{mock_text_response, mock_tool_call_response, AgentRegistry};
+    use crate::client::LlmResponse;
     use crate::types::Tool;
     use aish_context::ContextBudgetPolicy;
 
@@ -463,5 +469,190 @@ mod tests {
 
         let result = run.await;
         assert_eq!(result.status, LoopStatus::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn test_spawn_max_turns_returns_incomplete_with_last_text() {
+        let parent = LlmSession::new("http://localhost", "key", "model", None, None);
+
+        let result = spawn(
+            &parent,
+            "keep searching",
+            SpawnConfig {
+                max_turns: 1,
+                ..Default::default()
+            },
+            |sub| {
+                disable_context_budget(sub);
+                sub.set_test_chat_responses(vec![
+                    Ok(mock_tool_call_response(&[("c1", "grep", "{}")])),
+                    Ok(mock_text_response("should not reach")),
+                ]);
+                sub.register_tool(Box::new(MockTool::new("grep")));
+            },
+        )
+        .await;
+
+        assert_eq!(result.status, LoopStatus::Incomplete);
+        assert_eq!(result.text, "[incomplete: max turns reached]\n");
+    }
+
+    #[tokio::test]
+    async fn test_spawn_max_turns_includes_last_assistant_text() {
+        let parent = LlmSession::new("http://localhost", "key", "model", None, None);
+
+        struct TextThenToolMockTool {
+            name: String,
+        }
+
+        impl Tool for TextThenToolMockTool {
+            fn name(&self) -> &str {
+                &self.name
+            }
+
+            fn description(&self) -> &str {
+                "mock"
+            }
+
+            fn parameters(&self) -> serde_json::Value {
+                serde_json::json!({"type": "object", "properties": {}})
+            }
+
+            fn execute(&self, _args: serde_json::Value) -> crate::types::ToolResult {
+                crate::types::ToolResult::success("ok")
+            }
+        }
+
+        fn mock_tool_call_with_content(text: &str) -> LlmResponse {
+            LlmResponse::Json(serde_json::json!({
+                "choices": [{
+                    "message": {
+                        "content": text,
+                        "tool_calls": [{
+                            "id": "c1",
+                            "type": "function",
+                            "function": {
+                                "name": "grep",
+                                "arguments": "{}",
+                            }
+                        }],
+                    }
+                }]
+            }))
+        }
+
+        let result = spawn(
+            &parent,
+            "investigate",
+            SpawnConfig {
+                max_turns: 1,
+                ..Default::default()
+            },
+            |sub| {
+                disable_context_budget(sub);
+                sub.set_test_chat_responses(vec![Ok(mock_tool_call_with_content(
+                    "partial findings",
+                ))]);
+                sub.register_tool(Box::new(TextThenToolMockTool {
+                    name: "grep".to_string(),
+                }));
+            },
+        )
+        .await;
+
+        assert_eq!(result.status, LoopStatus::Incomplete);
+        assert_eq!(
+            result.text,
+            "[incomplete: max turns reached]\npartial findings"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_spawn_fatal_llm_error() {
+        use aish_core::AishError;
+
+        let parent = LlmSession::new("http://localhost", "key", "model", None, None);
+
+        let result = spawn(&parent, "task", SpawnConfig::default(), |sub| {
+            disable_context_budget(sub);
+            sub.set_test_chat_responses(vec![Err(AishError::Llm("upstream failure".into()))]);
+        })
+        .await;
+
+        assert_eq!(result.status, LoopStatus::Fatal);
+        assert!(result.text.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_spawn_builtin_plan_max_turns_is_twenty() {
+        let registry = AgentRegistry::builtin();
+        assert_eq!(registry.resolve("plan").expect("plan").max_turns, 20);
+    }
+
+    #[test]
+    fn test_effective_max_turns_applies_global_cap() {
+        use super::effective_max_turns;
+
+        assert_eq!(effective_max_turns(15), 15);
+        assert_eq!(effective_max_turns(20), 20);
+        assert_eq!(effective_max_turns(25), 25);
+        assert_eq!(effective_max_turns(35), GLOBAL_MAX_TURNS);
+    }
+
+    #[tokio::test]
+    async fn test_spawn_respects_global_max_turns_at_runtime() {
+        let parent = LlmSession::new("http://localhost", "key", "model", None, None);
+
+        let responses: Vec<_> = (0..GLOBAL_MAX_TURNS + 3)
+            .map(|i| Ok(mock_tool_call_response(&[(&format!("c{i}"), "grep", "{}")])))
+            .collect();
+
+        let result = spawn(
+            &parent,
+            "deep task",
+            SpawnConfig {
+                max_turns: effective_max_turns(100),
+                ..Default::default()
+            },
+            |sub| {
+                disable_context_budget(sub);
+                sub.set_test_chat_responses(responses);
+                sub.register_tool(Box::new(MockTool::new("grep")));
+            },
+        )
+        .await;
+
+        assert_eq!(result.status, LoopStatus::Incomplete);
+        assert!(result.text.starts_with("[incomplete: max turns reached]"));
+    }
+
+    #[tokio::test]
+    async fn test_spawn_builtin_max_turns_exhaustion() {
+        let mut parent = LlmSession::new("http://localhost", "key", "model", None, None);
+        parent.register_tool(Box::new(MockTool::new("grep")));
+
+        let registry = AgentRegistry::builtin();
+        let explore_turns = registry.resolve("explore").expect("explore").max_turns;
+
+        let responses: Vec<_> = (0..explore_turns + 2)
+            .map(|i| Ok(mock_tool_call_response(&[(&format!("c{i}"), "grep", "{}")])))
+            .collect();
+
+        let result = spawn_builtin(
+            &parent,
+            &registry,
+            "explore",
+            "deep search",
+            |sub, specs| {
+                disable_context_budget(sub);
+                sub.set_test_chat_responses(responses);
+                register_mock_from_specs(sub, specs);
+            },
+        )
+        .await
+        .expect("spawn should succeed");
+
+        assert_eq!(result.status, LoopStatus::Incomplete);
+        assert!(result.text.starts_with("[incomplete: max turns reached]"));
     }
 }

--- a/crates/aish-llm/src/agents/tool_loop.rs
+++ b/crates/aish-llm/src/agents/tool_loop.rs
@@ -6,6 +6,8 @@ use crate::streaming::{extract_message_text, StreamParser};
 use crate::types::{ChatMessage, MessageContent};
 use aish_core::AishError;
 
+use super::outcome::{extract_spawn_outcome, OutcomeConfig, TerminationKind, INCOMPLETE_PREFIX};
+
 /// Configuration for [`run_tool_loop_until_done`].
 #[derive(Debug, Clone)]
 pub struct ToolLoopConfig {
@@ -22,7 +24,15 @@ impl Default for ToolLoopConfig {
         Self {
             max_turns: 20,
             system_message: None,
-            incomplete_prefix: "[incomplete: max turns reached]\n".to_string(),
+            incomplete_prefix: INCOMPLETE_PREFIX.to_string(),
+        }
+    }
+}
+
+impl ToolLoopConfig {
+    fn outcome_config(&self) -> OutcomeConfig {
+        OutcomeConfig {
+            incomplete_prefix: self.incomplete_prefix.clone(),
         }
     }
 }
@@ -46,45 +56,27 @@ pub struct LoopOutcome {
 }
 
 impl LoopOutcome {
-    fn complete(text: String, new_messages: Vec<ChatMessage>) -> Self {
+    fn from_spawn_outcome(
+        outcome: super::outcome::SpawnOutcome,
+        new_messages: Vec<ChatMessage>,
+        error: Option<AishError>,
+    ) -> Self {
         Self {
-            status: LoopStatus::Complete,
-            text,
+            status: outcome.status,
+            text: outcome.text,
             new_messages,
-            error: None,
-        }
-    }
-
-    fn incomplete(prefix: &str, last_text: &str, new_messages: Vec<ChatMessage>) -> Self {
-        let text = if last_text.is_empty() {
-            prefix.to_string()
-        } else {
-            format!("{prefix}{last_text}")
-        };
-        Self {
-            status: LoopStatus::Incomplete,
-            text,
-            new_messages,
-            error: None,
+            error,
         }
     }
 
     pub fn cancelled() -> Self {
-        Self {
-            status: LoopStatus::Cancelled,
-            text: String::new(),
-            new_messages: Vec::new(),
-            error: Some(AishError::Cancelled),
-        }
+        let outcome = extract_spawn_outcome(TerminationKind::Cancelled, &OutcomeConfig::default());
+        Self::from_spawn_outcome(outcome, Vec::new(), Some(AishError::Cancelled))
     }
 
     fn fatal(error: AishError) -> Self {
-        Self {
-            status: LoopStatus::Fatal,
-            text: String::new(),
-            new_messages: Vec::new(),
-            error: Some(error),
-        }
+        let outcome = extract_spawn_outcome(TerminationKind::Fatal, &OutcomeConfig::default());
+        Self::from_spawn_outcome(outcome, Vec::new(), Some(error))
     }
 }
 
@@ -118,11 +110,13 @@ pub async fn run_tool_loop_until_done(
         }
 
         if iterations >= config.max_turns {
-            return LoopOutcome::incomplete(
-                &config.incomplete_prefix,
-                &last_assistant_text,
-                loop_messages,
+            let outcome = extract_spawn_outcome(
+                TerminationKind::MaxTurnsReached {
+                    last_assistant_text: last_assistant_text.clone(),
+                },
+                &config.outcome_config(),
             );
+            return LoopOutcome::from_spawn_outcome(outcome, loop_messages, None);
         }
         iterations += 1;
 
@@ -154,7 +148,13 @@ pub async fn run_tool_loop_until_done(
         }
 
         if tool_calls.is_empty() {
-            return LoopOutcome::complete(content.unwrap_or_default(), loop_messages);
+            let outcome = extract_spawn_outcome(
+                TerminationKind::NaturalStop {
+                    assistant_text: content.unwrap_or_default(),
+                },
+                &config.outcome_config(),
+            );
+            return LoopOutcome::from_spawn_outcome(outcome, loop_messages, None);
         }
 
         if let Some(text) = content {
@@ -310,6 +310,25 @@ mod tests {
 
         assert_eq!(outcome.status, LoopStatus::Incomplete);
         assert!(outcome.text.starts_with("[incomplete: max turns reached]"));
+    }
+
+    #[tokio::test]
+    async fn test_loop_fatal_on_llm_error() {
+        let mut session =
+            test_session_with_responses(vec![Err(AishError::Llm("rate limited".into()))]);
+        session.register_tool(Box::new(MockTool::new("grep", "out")));
+
+        let outcome = run_tool_loop_until_done(
+            &session,
+            &ChatMessage::user("task"),
+            &[],
+            &ToolLoopConfig::default(),
+        )
+        .await;
+
+        assert_eq!(outcome.status, LoopStatus::Fatal);
+        assert!(outcome.text.is_empty());
+        assert!(outcome.error.is_some());
     }
 
     #[tokio::test]

--- a/crates/aish-llm/src/lib.rs
+++ b/crates/aish-llm/src/lib.rs
@@ -36,9 +36,10 @@ pub mod usage;
 
 pub use agent::{AgentConfig, AgentStep, ReActAgent};
 pub use agents::{
-    parent_has_skill_tool, resolve_tool_names_for_agent, resolve_tools_for_agent,
-    run_tool_loop_until_done, spawn, spawn_builtin, AgentDefinition, AgentRegistry, LoopOutcome,
-    LoopStatus, SpawnConfig, SpawnResult, ToolLoopConfig, ToolStrategy, GLOBAL_MAX_TURNS,
+    effective_max_turns, parent_has_skill_tool, resolve_tool_names_for_agent,
+    resolve_tools_for_agent, run_tool_loop_until_done, spawn, spawn_builtin, AgentDefinition,
+    AgentRegistry, LoopOutcome, LoopStatus, SpawnConfig, SpawnResult, ToolLoopConfig, ToolStrategy,
+    GLOBAL_MAX_TURNS,
 };
 pub use api::{
     resolve_anthropic_messages_url, resolve_api_dialect, stream_simple,

--- a/crates/aish-llm/tests/agent_termination_guard.rs
+++ b/crates/aish-llm/tests/agent_termination_guard.rs
@@ -1,0 +1,43 @@
+//! Regression guards for sub-agent termination semantics (AC-7, AC-13).
+
+#[test]
+fn agents_modules_do_not_use_react_or_diagnose_agents() {
+    let spawn_src = include_str!("../src/agents/spawn.rs");
+    let tool_loop_src = include_str!("../src/agents/tool_loop.rs");
+    let outcome_src = include_str!("../src/agents/outcome.rs");
+    for (name, src) in [
+        ("spawn.rs", spawn_src),
+        ("tool_loop.rs", tool_loop_src),
+        ("outcome.rs", outcome_src),
+    ] {
+        assert!(
+            !src.contains("ReActAgent::"),
+            "{name} must not use ReActAgent (AC-7)"
+        );
+        assert!(
+            !src.contains("DiagnoseAgent::"),
+            "{name} must not use DiagnoseAgent (AC-7)"
+        );
+    }
+}
+
+#[test]
+fn agents_modules_do_not_persist_transcripts() {
+    let spawn_src = include_str!("../src/agents/spawn.rs");
+    let tool_loop_src = include_str!("../src/agents/tool_loop.rs");
+    let outcome_src = include_str!("../src/agents/outcome.rs");
+    for (name, src) in [
+        ("spawn.rs", spawn_src),
+        ("tool_loop.rs", tool_loop_src),
+        ("outcome.rs", outcome_src),
+    ] {
+        assert!(
+            !src.contains("write_transcript"),
+            "{name} must not persist sub-agent transcripts (AC-13)"
+        );
+        assert!(
+            !src.contains("std::fs::write"),
+            "{name} must not write files during spawn (AC-13)"
+        );
+    }
+}

--- a/crates/aish-tools/tests/agent_tool_test.rs
+++ b/crates/aish-tools/tests/agent_tool_test.rs
@@ -31,6 +31,32 @@ fn mock_spawn_cancelled<'a>(
     })
 }
 
+fn mock_spawn_incomplete<'a>(
+    _session: &'a aish_llm::LlmSession,
+    _ty: &'a str,
+    _prompt: &'a str,
+) -> Pin<Box<dyn Future<Output = Result<SpawnResult, String>> + Send + 'a>> {
+    Box::pin(async {
+        Ok(SpawnResult {
+            text: "[incomplete: max turns reached]\npartial conclusion".to_string(),
+            status: LoopStatus::Incomplete,
+        })
+    })
+}
+
+fn mock_spawn_fatal<'a>(
+    _session: &'a aish_llm::LlmSession,
+    _ty: &'a str,
+    _prompt: &'a str,
+) -> Pin<Box<dyn Future<Output = Result<SpawnResult, String>> + Send + 'a>> {
+    Box::pin(async {
+        Ok(SpawnResult {
+            text: String::new(),
+            status: LoopStatus::Fatal,
+        })
+    })
+}
+
 #[tokio::test]
 async fn test_agent_tool_missing_prompt_errors() {
     let tool = AgentTool::new();
@@ -109,5 +135,52 @@ async fn test_agent_tool_mock_spawn_cancelled_errors() {
             .and_then(|m| m.get("dispatch_status"))
             .and_then(|v| v.as_str()),
         Some("short_circuit")
+    );
+}
+
+#[tokio::test]
+async fn test_agent_tool_mock_spawn_incomplete_success_with_prefix() {
+    let spawn_fn: SpawnFn = Arc::new(mock_spawn_incomplete);
+    let tool = AgentTool::with_spawn_fn(spawn_fn);
+    let session = aish_llm::LlmSession::new("http://localhost", "key", "model", None, None);
+    let result = tool
+        .execute_async_in_session(
+            serde_json::json!({
+                "description": "long search",
+                "prompt": "search everything",
+                "subagent_type": "explore"
+            }),
+            &session,
+        )
+        .await;
+    assert!(result.ok);
+    assert!(result.output.starts_with("[incomplete: max turns reached]"));
+    assert!(result.output.contains("partial conclusion"));
+}
+
+#[tokio::test]
+async fn test_agent_tool_mock_spawn_fatal_errors() {
+    let spawn_fn: SpawnFn = Arc::new(mock_spawn_fatal);
+    let tool = AgentTool::with_spawn_fn(spawn_fn);
+    let session = aish_llm::LlmSession::new("http://localhost", "key", "model", None, None);
+    let result = tool
+        .execute_async_in_session(
+            serde_json::json!({
+                "description": "run task",
+                "prompt": "do work",
+                "subagent_type": "explore"
+            }),
+            &session,
+        )
+        .await;
+    assert!(!result.ok);
+    assert!(result.output.contains("failed"));
+    assert_eq!(
+        result
+            .meta
+            .as_ref()
+            .and_then(|m| m.get("reason"))
+            .and_then(|v| v.as_str()),
+        Some("sub_agent_fatal")
     );
 }


### PR DESCRIPTION
## Summary
- Add Seam C `extract_spawn_outcome` to map natural stop, max_turns, cancel, and fatal termination to `SpawnResult` text/status (PRD §4.6).
- Wire `tool_loop` through the outcome mapper; apply `effective_max_turns` global cap in `spawn_builtin`.
- Extend Seam C/E tests and `AgentTool` mapping tests for incomplete success and fatal/cancel tool errors.

## Test plan
- [x] `make ci-check`
- [x] Seam C unit tests (`outcome.rs`)
- [x] Seam E cancel cascade (`spawn.rs`)
- [x] AgentTool incomplete/fatal/cancel mapping (`agent_tool_test.rs`)
- [x] AC-7/AC-13 guard tests (`agent_termination_guard.rs`)

Closes #333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sub-agent runs now return clearer end states, including incomplete, cancelled, and fatal outcomes with more consistent text shown to users.
  * Added a shared turn-limit cap so sub-agents stop at the effective maximum instead of exceeding limits.

* **Bug Fixes**
  * Improved handling of max-turn exhaustion so partial results are preserved and marked as incomplete.
  * Better fatal-error reporting for tool-based agent runs.

* **Tests**
  * Expanded regression coverage for termination behavior, turn limits, and incomplete/fatal agent-tool results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->