### PR TITLE
feat(subagent): show indented spawn progress in shell TUI

### DIFF
--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -349,6 +349,9 @@ shell:
     prefix_diagnose: "  └─ 🔧 Diagnose-Tool"
     done_diagnose: "  └─ ✅ Diagnose abgeschlossen"
 
+  sub_agent:
+    thinking: "Denkt nach"
+
 security:
   sandbox_off_action:
     allow: "Direkt erlauben"

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -654,6 +654,9 @@ shell:
     prefix_diagnose: "  └─ 🔧 Diagnose tool"
     done_diagnose: "  └─ ✅ Diagnosis done"
 
+  sub_agent:
+    thinking: "Thinking"
+
 security:
   sandbox_off_action:
     allow: "Allow"

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -349,6 +349,9 @@ shell:
     prefix_diagnose: "  └─ 🔧 Herramienta de diagnóstico"
     done_diagnose: "  └─ ✅ Diagnóstico completado"
 
+  sub_agent:
+    thinking: "Pensando"
+
 security:
   sandbox_off_action:
     allow: "Permitir directamente"

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -349,6 +349,9 @@ shell:
     prefix_diagnose: "  └─ 🔧 Outil de diagnostic"
     done_diagnose: "  └─ ✅ Diagnostic termine"
 
+  sub_agent:
+    thinking: "Reflexion"
+
 security:
   sandbox_off_action:
     allow: "Autoriser directement"

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -349,6 +349,9 @@ shell:
     prefix_diagnose: "  └─ 🔧 診断ツール"
     done_diagnose: "  └─ ✅ 診断完了"
 
+  sub_agent:
+    thinking: "考え中"
+
 security:
   sandbox_off_action:
     allow: "そのまま許可"

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -654,6 +654,9 @@ shell:
     prefix_diagnose: "  └─ 🔧 诊断工具"
     done_diagnose: "  └─ ✅ 诊断完成"
 
+  sub_agent:
+    thinking: "思考中"
+
 security:
   sandbox_off_action:
     allow: "直接放行"

--- a/crates/aish-llm/src/agents/event_metadata.rs
+++ b/crates/aish-llm/src/agents/event_metadata.rs
@@ -1,0 +1,111 @@
+//! Sub-agent event metadata enrichment for TUI observability (PRD §4.5).
+
+use aish_core::LlmEvent;
+use serde_json::{json, Value};
+
+/// Phase 1 fixed nesting depth (no nested sub-agents).
+pub const SUB_AGENT_DEPTH: u32 = 1;
+
+/// Merge sub-agent observability fields into an event's `data` payload.
+pub fn enrich_event_data_with_sub_agent_metadata(
+    data: Value,
+    agent_type: &str,
+    spawn_id: &str,
+) -> Value {
+    if let Some(obj) = data.as_object() {
+        let mut new_obj = obj.clone();
+        insert_sub_agent_metadata_fields(&mut new_obj, agent_type, spawn_id);
+        Value::Object(new_obj)
+    } else {
+        json!({
+            "source": "sub_agent",
+            "agent_type": agent_type,
+            "depth": SUB_AGENT_DEPTH,
+            "spawn_id": spawn_id,
+            "original_data": data,
+        })
+    }
+}
+
+fn insert_sub_agent_metadata_fields(
+    obj: &mut serde_json::Map<String, Value>,
+    agent_type: &str,
+    spawn_id: &str,
+) {
+    obj.insert("source".to_string(), json!("sub_agent"));
+    obj.insert("agent_type".to_string(), json!(agent_type));
+    obj.insert("depth".to_string(), json!(SUB_AGENT_DEPTH));
+    obj.insert("spawn_id".to_string(), json!(spawn_id));
+}
+
+/// Forward `event` to `parent_cb` with sub-agent metadata merged into `data`.
+pub fn forward_sub_agent_event(
+    parent_cb: &dyn Fn(LlmEvent) -> Option<crate::types::LlmCallbackResult>,
+    event: LlmEvent,
+    agent_type: &str,
+    spawn_id: &str,
+) -> Option<crate::types::LlmCallbackResult> {
+    parent_cb(LlmEvent {
+        event_type: event.event_type,
+        data: enrich_event_data_with_sub_agent_metadata(event.data, agent_type, spawn_id),
+        timestamp: event.timestamp,
+        metadata: event.metadata,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aish_core::LlmEventType;
+
+    #[test]
+    fn enrich_merges_into_object_data() {
+        let data = json!({"tool_name": "grep", "tool_args": {}});
+        let enriched = enrich_event_data_with_sub_agent_metadata(data, "explore", "uuid-1");
+
+        assert_eq!(enriched["source"], "sub_agent");
+        assert_eq!(enriched["agent_type"], "explore");
+        assert_eq!(enriched["depth"], SUB_AGENT_DEPTH);
+        assert_eq!(enriched["spawn_id"], "uuid-1");
+        assert_eq!(enriched["tool_name"], "grep");
+    }
+
+    #[test]
+    fn enrich_wraps_non_object_data() {
+        let data = json!("plain");
+        let enriched = enrich_event_data_with_sub_agent_metadata(data, "plan", "uuid-2");
+
+        assert_eq!(enriched["source"], "sub_agent");
+        assert_eq!(enriched["agent_type"], "plan");
+        assert_eq!(enriched["depth"], SUB_AGENT_DEPTH);
+        assert_eq!(enriched["spawn_id"], "uuid-2");
+        assert_eq!(enriched["original_data"], "plain");
+    }
+
+    #[test]
+    fn forward_sub_agent_event_preserves_event_type() {
+        let seen = std::sync::Mutex::new(None);
+        let cb = |event: LlmEvent| {
+            *seen.lock().unwrap() = Some(event);
+            None
+        };
+
+        forward_sub_agent_event(
+            &cb,
+            LlmEvent {
+                event_type: LlmEventType::ToolExecutionStart,
+                data: json!({"tool_name": "read_file"}),
+                timestamp: 1.0,
+                metadata: None,
+            },
+            "general-purpose",
+            "spawn-abc",
+        );
+
+        let event = seen.lock().unwrap().take().expect("callback invoked");
+        assert_eq!(event.event_type, LlmEventType::ToolExecutionStart);
+        assert_eq!(event.data["source"], "sub_agent");
+        assert_eq!(event.data["agent_type"], "general-purpose");
+        assert_eq!(event.data["spawn_id"], "spawn-abc");
+    }
+}

--- a/crates/aish-llm/src/agents/mod.rs
+++ b/crates/aish-llm/src/agents/mod.rs
@@ -4,6 +4,7 @@
 //! Issue #331: explore vertical slice — registry, tool filter, spawn_builtin.
 //! Issue #332: plan + general-purpose built-ins and tool filtering.
 
+mod event_metadata;
 mod mock_llm;
 mod outcome;
 mod registry;

--- a/crates/aish-llm/src/agents/spawn.rs
+++ b/crates/aish-llm/src/agents/spawn.rs
@@ -9,6 +9,7 @@ use crate::session::LlmSession;
 use crate::tool_context::ToolExecutionPolicy;
 use crate::types::{ChatMessage, LlmCallbackResult, ToolSpec};
 
+use super::event_metadata::forward_sub_agent_event;
 use super::registry::{AgentRegistry, ToolStrategy};
 use super::tool_loop::{run_tool_loop_until_done, LoopStatus, ToolLoopConfig};
 use super::tools::{parent_has_skill_tool, resolve_tools_for_agent};
@@ -135,28 +136,7 @@ fn install_sub_agent_event_proxy(sub: &mut LlmSession, agent_type: &str, spawn_i
 
     let proxy: Arc<dyn Fn(LlmEvent) -> Option<LlmCallbackResult> + Send + Sync> =
         Arc::new(move |event: LlmEvent| {
-            let modified_data = if let Some(obj) = event.data.as_object() {
-                let mut new_obj = obj.clone();
-                new_obj.insert("source".to_string(), serde_json::json!("sub_agent"));
-                new_obj.insert("agent_type".to_string(), serde_json::json!(agent_type));
-                new_obj.insert("depth".to_string(), serde_json::json!(1));
-                new_obj.insert("spawn_id".to_string(), serde_json::json!(spawn_id));
-                serde_json::Value::Object(new_obj)
-            } else {
-                serde_json::json!({
-                    "source": "sub_agent",
-                    "agent_type": agent_type,
-                    "depth": 1,
-                    "spawn_id": spawn_id,
-                    "original_data": event.data,
-                })
-            };
-            parent_cb(LlmEvent {
-                event_type: event.event_type,
-                data: modified_data,
-                timestamp: event.timestamp,
-                metadata: event.metadata,
-            })
+            forward_sub_agent_event(parent_cb.as_ref(), event, &agent_type, &spawn_id)
         });
     sub.set_event_callback(proxy);
 }
@@ -654,5 +634,76 @@ mod tests {
 
         assert_eq!(result.status, LoopStatus::Incomplete);
         assert!(result.text.starts_with("[incomplete: max turns reached]"));
+    }
+
+    #[tokio::test]
+    async fn test_spawn_builtin_forwards_sub_agent_metadata_on_events() {
+        use aish_core::LlmEventType;
+        use std::collections::HashSet;
+        use std::sync::{Arc, Mutex};
+        use uuid::Uuid;
+
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let captured_cb = captured.clone();
+
+        let mut parent = LlmSession::new("http://localhost", "key", "model", None, None);
+        parent.register_tool(Box::new(MockTool::new("grep")));
+        parent.set_event_callback(Arc::new(move |event| {
+            captured_cb.lock().unwrap().push(event);
+            None
+        }));
+
+        let registry = AgentRegistry::builtin();
+        let _ = spawn_builtin(&parent, &registry, "explore", "find nginx", |sub, specs| {
+            sub.set_test_chat_responses(vec![
+                Ok(mock_tool_call_response(&[("c1", "grep", "{}")])),
+                Ok(mock_text_response("done")),
+            ]);
+            register_mock_from_specs(sub, specs);
+        })
+        .await
+        .expect("spawn_builtin should succeed");
+
+        let events = captured.lock().unwrap();
+        let sub_events: Vec<_> = events
+            .iter()
+            .filter(|event| {
+                event.data.get("source").and_then(|value| value.as_str()) == Some("sub_agent")
+            })
+            .collect();
+
+        assert!(!sub_events.is_empty());
+        for event in &sub_events {
+            assert_eq!(
+                event
+                    .data
+                    .get("agent_type")
+                    .and_then(|value| value.as_str()),
+                Some("explore")
+            );
+            assert_eq!(
+                event.data.get("depth").and_then(|value| value.as_u64()),
+                Some(super::super::event_metadata::SUB_AGENT_DEPTH as u64)
+            );
+            let spawn_id = event
+                .data
+                .get("spawn_id")
+                .and_then(|value| value.as_str())
+                .expect("spawn_id");
+            assert!(Uuid::parse_str(spawn_id).is_ok(), "spawn_id must be a UUID");
+        }
+
+        let spawn_ids: HashSet<_> = sub_events
+            .iter()
+            .filter_map(|event| event.data.get("spawn_id").and_then(|value| value.as_str()))
+            .collect();
+        assert_eq!(spawn_ids.len(), 1);
+
+        assert!(sub_events
+            .iter()
+            .any(|event| event.event_type == LlmEventType::GenerationStart));
+        assert!(sub_events
+            .iter()
+            .any(|event| event.event_type == LlmEventType::ToolExecutionStart));
     }
 }

--- a/crates/aish-llm/src/agents/tool_loop.rs
+++ b/crates/aish-llm/src/agents/tool_loop.rs
@@ -1,5 +1,7 @@
 //! Reusable native tool calling loop for sub-agent spawn paths.
 
+use aish_core::{LlmEvent, LlmEventType};
+
 use crate::client::LlmResponse;
 use crate::session::LlmSession;
 use crate::streaming::{extract_message_text, StreamParser};
@@ -122,6 +124,13 @@ pub async fn run_tool_loop_until_done(
 
         messages = session.prepare_messages_for_send(messages).await;
 
+        session.emit_event(LlmEvent {
+            event_type: LlmEventType::GenerationStart,
+            data: serde_json::json!({}),
+            timestamp: now_timestamp(),
+            metadata: None,
+        });
+
         let response = match session
             .chat_completion_raw(
                 &messages,
@@ -133,8 +142,23 @@ pub async fn run_tool_loop_until_done(
             .await
         {
             Ok(r) => r,
-            Err(e) => return LoopOutcome::fatal(e),
+            Err(e) => {
+                session.emit_event(LlmEvent {
+                    event_type: LlmEventType::GenerationEnd,
+                    data: serde_json::json!({}),
+                    timestamp: now_timestamp(),
+                    metadata: None,
+                });
+                return LoopOutcome::fatal(e);
+            }
         };
+
+        session.emit_event(LlmEvent {
+            event_type: LlmEventType::GenerationEnd,
+            data: serde_json::json!({}),
+            timestamp: now_timestamp(),
+            metadata: None,
+        });
 
         let LlmResponse::Json(json) = response else {
             return LoopOutcome::fatal(AishError::Llm(
@@ -182,6 +206,13 @@ pub async fn run_tool_loop_until_done(
             loop_messages.push(tool_msg);
         }
     }
+}
+
+fn now_timestamp() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
 }
 
 #[cfg(test)]

--- a/crates/aish-shell/src/animation.rs
+++ b/crates/aish-shell/src/animation.rs
@@ -87,3 +87,81 @@ impl Drop for SharedAnimation {
         self.stop();
     }
 }
+
+/// Spinner for sub-agent thinking lines (`  └─ explore · ⠇ 思考中 ... 2.1s`).
+///
+/// Separate from [`SharedAnimation`] so the main-loop spinner can stay off while
+/// sub-agent progress remains visibly alive.
+pub struct SubAgentThinkingAnimation {
+    active: Arc<AtomicBool>,
+    handle: Mutex<Option<thread::JoinHandle<()>>>,
+}
+
+impl SubAgentThinkingAnimation {
+    pub fn new() -> Self {
+        Self {
+            active: Arc::new(AtomicBool::new(false)),
+            handle: Mutex::new(None),
+        }
+    }
+
+    /// Animate `prefix` + spinner + `label` on a single dimmed line.
+    pub fn start(&self, prefix: &str, label: &str) {
+        self.stop();
+
+        let active = self.active.clone();
+        active.store(true, Ordering::SeqCst);
+
+        let prefix = prefix.to_string();
+        let label = label.to_string();
+        let start_time = Instant::now();
+
+        let handle = thread::Builder::new()
+            .name("aish-subagent-animation".into())
+            .spawn(move || {
+                let mut spinner = Spinner::new("dots").expect("dots spinner should exist");
+                print!("\x1b[?25l");
+                let _ = io::stdout().flush();
+
+                while active.load(Ordering::SeqCst) {
+                    let frame = spinner.next_frame();
+                    let elapsed = start_time.elapsed().as_secs_f64();
+                    if elapsed > 0.1 {
+                        print!(
+                            "\r\x1b[K\x1b[2m{}{} {} ... {:.1}s\x1b[0m",
+                            prefix, frame, label, elapsed
+                        );
+                    } else {
+                        print!("\r\x1b[K\x1b[2m{}{} {}\x1b[0m", prefix, frame, label);
+                    }
+                    let _ = io::stdout().flush();
+                    thread::sleep(Duration::from_millis(150));
+                }
+
+                print!("\r\x1b[2K\x1b[?25h");
+                let _ = io::stdout().flush();
+            })
+            .ok();
+
+        *self.handle.lock().unwrap() = handle;
+    }
+
+    pub fn stop(&self) {
+        self.active.store(false, Ordering::SeqCst);
+        if let Some(h) = self.handle.lock().unwrap().take() {
+            let _ = h.join();
+        }
+    }
+}
+
+impl Default for SubAgentThinkingAnimation {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for SubAgentThinkingAnimation {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -1257,6 +1257,9 @@ impl AishShell {
                         }
                     }
                     LlmEventType::ToolExecutionEnd => {
+                        if crate::llm_event_ui::is_parent_agent_spawn_tool_event(&event) {
+                            sub_agent_ui_active_ref.store(false, Ordering::SeqCst);
+                        }
                         if let Some(preview) =
                             event.data.get("output_preview").and_then(|p| p.as_str())
                         {

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -23,7 +23,7 @@ use aish_tools::ToolRegistry;
 use std::path::PathBuf;
 
 use crate::ai_handler::{AiHandler, SharedMemoryManager};
-use crate::animation::SharedAnimation;
+use crate::animation::{SharedAnimation, SubAgentThinkingAnimation};
 use crate::environment;
 use crate::esc_watcher::CrosstermEscWatcher;
 use crate::input;
@@ -902,6 +902,10 @@ impl AishShell {
         let compaction_active_ref = compaction_active.clone();
         let compaction_notice_shown = Arc::new(AtomicBool::new(false));
         let compaction_notice_shown_ref = compaction_notice_shown.clone();
+        let sub_agent_ui_active = Arc::new(AtomicBool::new(false));
+        let sub_agent_ui_active_ref = sub_agent_ui_active.clone();
+        let sub_agent_animation = Arc::new(SubAgentThinkingAnimation::new());
+        let sub_agent_animation_ref = sub_agent_animation.clone();
 
         // Shared history of collapsed bash outputs for Ctrl+O browsing.
         let expand_history = Arc::new(Mutex::new(crate::expand_history::ExpandHistory::new()));
@@ -995,6 +999,8 @@ impl AishShell {
                     }
                     LlmEventType::OpEnd => {
                         // Operation ends — stop animation and show timing
+                        sub_agent_ui_active_ref.store(false, Ordering::SeqCst);
+                        sub_agent_animation_ref.stop();
                         animation_ref.stop();
                         let ttft = *ttft_value_ref.lock().unwrap();
                         if ttft >= 0.1 {
@@ -1022,6 +1028,17 @@ impl AishShell {
                         }
                     }
                     LlmEventType::GenerationStart if react_agent_llm_event(&event) => {}
+                    LlmEventType::GenerationStart
+                        if crate::llm_event_ui::sub_agent_llm_event(&event) =>
+                    {
+                        animation_ref.stop();
+                        clear_reasoning();
+                        if let Some(prefix) =
+                            crate::llm_event_ui::sub_agent_thinking_animation_prefix(&event)
+                        {
+                            sub_agent_animation_ref.start(&prefix, &t("shell.sub_agent.thinking"));
+                        }
+                    }
                     LlmEventType::GenerationStart => {
                         compaction_active_ref.store(false, Ordering::SeqCst);
                         animation_ref.stop();
@@ -1036,9 +1053,16 @@ impl AishShell {
                         reasoning_buf_ref.lock().unwrap().clear();
                         reasoning_frame_ref.store(0, Ordering::SeqCst);
                         renderer_ref.lock().unwrap().reset();
-                        animation_ref.start(&t("shell.status.thinking"));
+                        if !sub_agent_ui_active_ref.load(Ordering::SeqCst) {
+                            animation_ref.start(&t("shell.status.thinking"));
+                        }
                     }
                     LlmEventType::GenerationEnd if react_agent_llm_event(&event) => {}
+                    LlmEventType::GenerationEnd
+                        if crate::llm_event_ui::sub_agent_llm_event(&event) =>
+                    {
+                        sub_agent_animation_ref.stop();
+                    }
                     LlmEventType::GenerationEnd => {
                         animation_ref.stop();
                         clear_reasoning();
@@ -1047,6 +1071,8 @@ impl AishShell {
                             renderer_ref.lock().unwrap().finalize_stream();
                         }
                     }
+                    LlmEventType::ContentDelta
+                        if crate::llm_event_ui::sub_agent_llm_event(&event) => {}
                     LlmEventType::ContentDelta => {
                         if let Some(delta) = event.data.get("delta").and_then(|d| d.as_str()) {
                             if !delta.is_empty() {
@@ -1180,8 +1206,21 @@ impl AishShell {
                         reasoning_buf_ref.lock().unwrap().clear();
                     }
                     LlmEventType::ToolExecutionStart => {
-                        if let Some(name) = event.data.get("tool_name").and_then(|n| n.as_str()) {
-                            if !react_agent_llm_event(&event) {
+                        if crate::llm_event_ui::is_parent_agent_spawn_tool_event(&event) {
+                            sub_agent_ui_active_ref.store(true, Ordering::SeqCst);
+                            animation_ref.stop();
+                            sub_agent_animation_ref.stop();
+                            clear_reasoning();
+                        } else if let Some(name) =
+                            event.data.get("tool_name").and_then(|n| n.as_str())
+                        {
+                            let is_sub_agent =
+                                crate::llm_event_ui::sub_agent_context(&event).is_some();
+                            if is_sub_agent {
+                                sub_agent_animation_ref.stop();
+                                animation_ref.stop();
+                                clear_reasoning();
+                            } else if !react_agent_llm_event(&event) {
                                 animation_ref.stop();
                                 clear_reasoning();
                             }
@@ -1194,12 +1233,21 @@ impl AishShell {
                             if content_started_flag.load(Ordering::SeqCst) {
                                 println!();
                             }
-                            let tool_line = format!(
-                                "\x1b[36m{}: {} ({})\x1b[0m",
-                                t("shell.tool.prefix"),
-                                name,
-                                args_preview
-                            );
+                            let tool_line =
+                                if let Some(ctx) = crate::llm_event_ui::sub_agent_context(&event) {
+                                    crate::llm_event_ui::format_sub_agent_tool_line(
+                                        &ctx,
+                                        name,
+                                        &args_preview,
+                                    )
+                                } else {
+                                    format!(
+                                        "\x1b[36m{}: {} ({})\x1b[0m",
+                                        t("shell.tool.prefix"),
+                                        name,
+                                        args_preview
+                                    )
+                                };
                             crate::recorder::shared_record_output(
                                 &shared_recorder_cb,
                                 &format!("{}\n", tool_line),
@@ -1248,6 +1296,16 @@ impl AishShell {
                                         ));
                                     }
                                     preview_ansi.push('\n');
+                                    if let Some(ctx) =
+                                        crate::llm_event_ui::sub_agent_context(&event)
+                                    {
+                                        preview_ansi =
+                                            crate::llm_event_ui::indent_sub_agent_output_block(
+                                                &ctx,
+                                                preview_ansi.trim_end(),
+                                            );
+                                        preview_ansi.push('\n');
+                                    }
                                     crate::recorder::shared_record_output(
                                         &shared_recorder_cb,
                                         &preview_ansi,
@@ -1280,6 +1338,7 @@ impl AishShell {
                         }
                     }
                     LlmEventType::Error => {
+                        sub_agent_animation_ref.stop();
                         animation_ref.stop();
                         clear_reasoning();
                         let error_msg = event
@@ -1296,6 +1355,7 @@ impl AishShell {
                         eprintln!("\x1b[31m{}\x1b[0m", msg);
                     }
                     LlmEventType::Cancelled => {
+                        sub_agent_animation_ref.stop();
                         animation_ref.stop();
                         clear_reasoning();
                         println!("\x1b[33m{}\x1b[0m", t("shell.command_cancelled"));
@@ -4023,6 +4083,11 @@ impl AishShell {
                                 }
                             }
                             LlmEventType::GenerationStart if react_agent_llm_event(&event) => {}
+                            LlmEventType::GenerationStart
+                                if crate::llm_event_ui::sub_agent_llm_event(&event) =>
+                            {
+                                crate::llm_event_ui::print_sub_agent_generation_start(&event);
+                            }
                             LlmEventType::GenerationStart => {
                                 compaction_active.store(false, std::sync::atomic::Ordering::SeqCst);
                                 anim.stop();
@@ -4034,10 +4099,14 @@ impl AishShell {
                                 anim.start(&t("shell.status.thinking"));
                             }
                             LlmEventType::GenerationEnd if react_agent_llm_event(&event) => {}
+                            LlmEventType::GenerationEnd
+                                if crate::llm_event_ui::sub_agent_llm_event(&event) => {}
                             LlmEventType::GenerationEnd => {
                                 anim.stop();
                                 clear_reasoning();
                             }
+                            LlmEventType::ContentDelta
+                                if crate::llm_event_ui::sub_agent_llm_event(&event) => {}
                             LlmEventType::ContentDelta => {
                                 if let Some(delta) =
                                     event.data.get("delta").and_then(|d| d.as_str())
@@ -4932,6 +5001,11 @@ impl AishShell {
                                 }
                             }
                             LlmEventType::GenerationStart if react_agent_llm_event(&event) => {}
+                            LlmEventType::GenerationStart
+                                if crate::llm_event_ui::sub_agent_llm_event(&event) =>
+                            {
+                                crate::llm_event_ui::print_sub_agent_generation_start(&event);
+                            }
                             LlmEventType::GenerationStart => {
                                 compaction_active.store(false, std::sync::atomic::Ordering::SeqCst);
                                 anim.stop();
@@ -4943,10 +5017,14 @@ impl AishShell {
                                 anim.start(&t("shell.status.thinking"));
                             }
                             LlmEventType::GenerationEnd if react_agent_llm_event(&event) => {}
+                            LlmEventType::GenerationEnd
+                                if crate::llm_event_ui::sub_agent_llm_event(&event) => {}
                             LlmEventType::GenerationEnd => {
                                 anim.stop();
                                 clear_reasoning();
                             }
+                            LlmEventType::ContentDelta
+                                if crate::llm_event_ui::sub_agent_llm_event(&event) => {}
                             LlmEventType::ContentDelta => {
                                 if let Some(delta) =
                                     event.data.get("delta").and_then(|d| d.as_str())

--- a/crates/aish-shell/src/lib.rs
+++ b/crates/aish-shell/src/lib.rs
@@ -30,6 +30,7 @@ pub mod image;
 pub mod inline_completion;
 pub mod input;
 pub mod keyboard;
+pub mod llm_event_ui;
 pub mod nl_detect;
 pub mod prompt;
 pub mod readline;

--- a/crates/aish-shell/src/llm_event_ui.rs
+++ b/crates/aish-shell/src/llm_event_ui.rs
@@ -1,0 +1,204 @@
+//! Helpers for rendering sub-agent LLM events in the shell TUI (AC-11).
+
+use aish_core::LlmEvent;
+
+/// Parsed sub-agent metadata from an [`LlmEvent`] `data` payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubAgentContext {
+    pub agent_type: String,
+    pub depth: u32,
+    pub spawn_id: String,
+}
+
+pub fn event_data_source(event: &LlmEvent) -> Option<&str> {
+    event.data.get("source").and_then(|value| value.as_str())
+}
+
+pub fn sub_agent_context(event: &LlmEvent) -> Option<SubAgentContext> {
+    if event_data_source(event) != Some("sub_agent") {
+        return None;
+    }
+    Some(SubAgentContext {
+        agent_type: event.data.get("agent_type")?.as_str()?.to_string(),
+        depth: event.data.get("depth")?.as_u64()? as u32,
+        spawn_id: event.data.get("spawn_id")?.as_str()?.to_string(),
+    })
+}
+
+pub fn sub_agent_llm_event(event: &LlmEvent) -> bool {
+    sub_agent_context(event).is_some()
+}
+
+/// Parent-session `Agent` tool call that spawns a sub-agent — hide its tool banner;
+/// sub-agent indented events carry the visible progress instead.
+pub fn is_parent_agent_spawn_tool_event(event: &LlmEvent) -> bool {
+    if sub_agent_llm_event(event) {
+        return false;
+    }
+    matches!(
+        event.data.get("tool_name").and_then(|value| value.as_str()),
+        Some("Agent")
+    )
+}
+
+/// Branch indent for sub-agent status lines (`depth=1` → `  └─ `).
+pub fn sub_agent_indent(depth: u32) -> String {
+    match depth {
+        0 => String::new(),
+        1 => "  └─ ".to_string(),
+        n => format!("{}  └─ ", "  ".repeat(n as usize - 1)),
+    }
+}
+
+/// Child indent for tool/output lines under a branch (`depth=1` → four spaces).
+pub fn sub_agent_child_indent(depth: u32) -> String {
+    match depth {
+        0 => "  ".to_string(),
+        1 => "    ".to_string(),
+        n => format!("{}    ", "  ".repeat(n as usize)),
+    }
+}
+
+pub fn sub_agent_thinking_prefix(ctx: &SubAgentContext) -> String {
+    format!("{}{} · ", sub_agent_indent(ctx.depth), ctx.agent_type)
+}
+
+pub fn format_sub_agent_thinking_line(ctx: &SubAgentContext, status: &str) -> String {
+    format!(
+        "{}{} · {}",
+        sub_agent_indent(ctx.depth),
+        ctx.agent_type,
+        status
+    )
+}
+
+pub fn format_sub_agent_tool_line(ctx: &SubAgentContext, name: &str, args_preview: &str) -> String {
+    format!(
+        "\x1b[36m{}🔧 {} ({})\x1b[0m",
+        sub_agent_child_indent(ctx.depth),
+        name,
+        args_preview
+    )
+}
+
+pub fn indent_sub_agent_output_block(ctx: &SubAgentContext, block: &str) -> String {
+    let prefix = sub_agent_child_indent(ctx.depth);
+    block
+        .lines()
+        .map(|line| format!("{}{}", prefix, line))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn print_sub_agent_generation_start(event: &LlmEvent) {
+    if let Some(ctx) = sub_agent_context(event) {
+        let status = aish_i18n::t("shell.sub_agent.thinking");
+        let line = format_sub_agent_thinking_line(&ctx, &status);
+        println!("\x1b[2m{}\x1b[0m", line);
+        let _ = std::io::Write::flush(&mut std::io::stdout());
+    }
+}
+
+/// Prefix for [`crate::animation::SubAgentThinkingAnimation`].
+pub fn sub_agent_thinking_animation_prefix(event: &LlmEvent) -> Option<String> {
+    sub_agent_context(event).map(|ctx| sub_agent_thinking_prefix(&ctx))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aish_core::LlmEventType;
+
+    fn sub_agent_event(event_type: LlmEventType, extra: serde_json::Value) -> LlmEvent {
+        let mut data = serde_json::json!({
+            "source": "sub_agent",
+            "agent_type": "explore",
+            "depth": 1,
+            "spawn_id": "550e8400-e29b-41d4-a716-446655440000",
+        });
+        if let Some(obj) = extra.as_object() {
+            for (k, v) in obj {
+                data[k] = v.clone();
+            }
+        }
+        LlmEvent {
+            event_type,
+            data,
+            timestamp: 0.0,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn sub_agent_context_parses_metadata_fields() {
+        let event = sub_agent_event(LlmEventType::ToolExecutionStart, serde_json::json!({}));
+        let ctx = sub_agent_context(&event).expect("sub-agent context");
+        assert_eq!(ctx.agent_type, "explore");
+        assert_eq!(ctx.depth, 1);
+        assert_eq!(ctx.spawn_id, "550e8400-e29b-41d4-a716-446655440000");
+    }
+
+    #[test]
+    fn sub_agent_context_rejects_other_sources() {
+        let event = LlmEvent {
+            event_type: LlmEventType::ToolExecutionStart,
+            data: serde_json::json!({"source": "react_agent"}),
+            timestamp: 0.0,
+            metadata: None,
+        };
+        assert!(sub_agent_context(&event).is_none());
+    }
+
+    #[test]
+    fn is_parent_agent_spawn_tool_event_detects_parent_only() {
+        let parent = LlmEvent {
+            event_type: LlmEventType::ToolExecutionStart,
+            data: serde_json::json!({"tool_name": "Agent", "tool_args": {}}),
+            timestamp: 0.0,
+            metadata: None,
+        };
+        assert!(is_parent_agent_spawn_tool_event(&parent));
+
+        let sub = sub_agent_event(
+            LlmEventType::ToolExecutionStart,
+            serde_json::json!({"tool_name": "glob"}),
+        );
+        assert!(!is_parent_agent_spawn_tool_event(&sub));
+    }
+
+    #[test]
+    fn sub_agent_thinking_prefix_includes_branch_and_agent_type() {
+        let ctx = SubAgentContext {
+            agent_type: "explore".into(),
+            depth: 1,
+            spawn_id: "id".into(),
+        };
+        assert_eq!(sub_agent_thinking_prefix(&ctx), "  └─ explore · ");
+    }
+
+    #[test]
+    fn format_sub_agent_tool_line_uses_child_indent_without_agent_prefix() {
+        let ctx = SubAgentContext {
+            agent_type: "plan".into(),
+            depth: 1,
+            spawn_id: "id".into(),
+        };
+        let line = format_sub_agent_tool_line(&ctx, "grep", "pattern=x");
+        assert!(line.starts_with("\x1b[36m    🔧 grep"));
+        assert!(!line.contains("plan"));
+        assert!(line.contains("pattern=x"));
+    }
+
+    #[test]
+    fn indent_sub_agent_output_block_uses_child_indent() {
+        let ctx = SubAgentContext {
+            agent_type: "explore".into(),
+            depth: 1,
+            spawn_id: "id".into(),
+        };
+        let indented = indent_sub_agent_output_block(&ctx, "line1\nline2");
+        assert!(indented.starts_with("    line1"));
+        assert!(indented.contains("\n    line2"));
+        assert!(!indented.contains("└─"));
+    }
+}


### PR DESCRIPTION
## Summary

- Enrich sub-agent `LlmEvent` payloads with `source=sub_agent`, `agent_type`, `depth`, and `spawn_id` during spawn/tool-loop execution
- Render nested sub-agent progress in the shell TUI: hide the parent `Agent` tool banner, show an indented thinking spinner (`└─ explore · …`), and indent child tool/output lines
- Preserve `react_agent` diagnose behavior by exempting it from tool-start spinner teardown

Closes #334

## Test plan

- [x] `cargo test -p aish-llm sub_agent`
- [x] `cargo test -p aish-shell llm_event_ui`
- [x] `make format-check && make lint`
- [x] WeTTY manual: sub-agent explore spawn shows indented spinner/tool lines without parent Agent banner
- [x] WeTTY manual: system diagnose (`react_agent`) completes without stuck spinner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “sub-agent thinking” terminal indicator with localized labels across supported languages.
  * Enhanced sub-agent UI rendering with dedicated progress/spinner behavior and formatted sub-agent tool-call banners and indented outputs.
* **Bug Fixes**
  * Improved the reliability and consistency of sub-agent event handling during generation, tool execution, and streaming (reducing UI overlap with main output).
  * Sub-agent event context is preserved more accurately, leading to steadier display of related sub-agent state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->