### PR TITLE
fix(subagent): inherit parent tools and abort on Ctrl+C

### DIFF
--- a/crates/aish-llm/src/agents/registry.rs
+++ b/crates/aish-llm/src/agents/registry.rs
@@ -117,6 +117,12 @@ impl AgentRegistry {
         lines.sort();
         lines.join("\n")
     }
+
+    /// Insert or replace a definition (tests / future dynamic agents).
+    #[cfg(test)]
+    pub fn insert_for_test(&mut self, def: AgentDefinition) {
+        self.agents.insert(def.subagent_type.clone(), def);
+    }
 }
 
 impl Default for AgentRegistry {

--- a/crates/aish-llm/src/agents/spawn.rs
+++ b/crates/aish-llm/src/agents/spawn.rs
@@ -89,14 +89,15 @@ where
 
 /// Spawn a built-in sub-agent from `parent`.
 ///
-/// `register_tools` receives the sub-session and filtered parent tool specs; it must
-/// register concrete tool implementations on the sub-session.
+/// Filtered parent tools are inherited by shared handle (`Arc`) so the sub-session
+/// tool set matches [`resolve_tools_for_agent`] — no per-type re-registration.
+/// `configure` may still adjust the sub-session (e.g. mock LLM responses in tests).
 pub async fn spawn_builtin<F>(
     parent: &LlmSession,
     registry: &AgentRegistry,
     subagent_type: &str,
     prompt: &str,
-    register_tools: F,
+    configure: F,
 ) -> Result<SpawnResult, String>
 where
     F: FnOnce(&mut LlmSession, &[ToolSpec]),
@@ -105,6 +106,8 @@ where
     let parent_tools = parent.tool_specs();
     let parent_has_skill = parent_has_skill_tool(&parent_tools);
     let allowed_specs = resolve_tools_for_agent(def, &parent_tools, parent_has_skill);
+    let inherited_tools =
+        parent.shared_tools_by_names(allowed_specs.iter().map(|spec| spec.function.name.as_str()));
     let enforce_read_only_bash = matches!(def.tool_strategy, ToolStrategy::Allowlist(_));
     let max_turns = effective_max_turns(def.max_turns);
     let spawn_id = Uuid::new_v4().to_string();
@@ -126,7 +129,13 @@ where
                 enforce_read_only_bash,
             });
             install_sub_agent_event_proxy(sub, &agent_type, &spawn_id);
-            register_tools(sub, &allowed_specs);
+            for tool in &inherited_tools {
+                let registered = tool
+                    .for_sub_session(sub)
+                    .unwrap_or_else(|| Arc::clone(tool));
+                sub.register_shared_tool(registered);
+            }
+            configure(sub, &allowed_specs);
         },
     )
     .await;
@@ -161,10 +170,13 @@ async fn forward_cancellation(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agents::{mock_text_response, mock_tool_call_response, AgentRegistry};
+    use crate::agents::{
+        mock_text_response, mock_tool_call_response, AgentDefinition, AgentRegistry, ToolStrategy,
+    };
     use crate::client::LlmResponse;
     use crate::types::Tool;
     use aish_context::ContextBudgetPolicy;
+    use aish_core::AishError;
 
     fn disable_context_budget(session: &mut LlmSession) {
         session.set_context_budget_policy(ContextBudgetPolicy {
@@ -203,11 +215,19 @@ mod tests {
         }
     }
 
-    fn register_mock_from_specs(sub: &mut LlmSession, specs: &[ToolSpec]) {
+    fn configure_spawn_test(sub: &mut LlmSession, responses: Vec<Result<LlmResponse, AishError>>) {
         disable_context_budget(sub);
-        for spec in specs {
-            sub.register_tool(Box::new(MockTool::new(&spec.function.name)));
-        }
+        sub.set_test_chat_responses(responses);
+    }
+
+    fn sub_tool_names(sub: &LlmSession) -> Vec<String> {
+        let mut names: Vec<_> = sub
+            .tool_specs()
+            .into_iter()
+            .map(|s| s.function.name)
+            .collect();
+        names.sort();
+        names
     }
 
     #[tokio::test]
@@ -219,18 +239,24 @@ mod tests {
 
         let registry = AgentRegistry::builtin();
         let result = spawn_builtin(&parent, &registry, "explore", "find nginx", |sub, specs| {
-            sub.set_test_chat_responses(vec![
-                Ok(mock_tool_call_response(&[("c1", "grep", "{}")])),
-                Ok(mock_tool_call_response(&[("c2", "read_file", "{}")])),
-                Ok(mock_text_response("nginx at /etc/nginx")),
-            ]);
+            configure_spawn_test(
+                sub,
+                vec![
+                    Ok(mock_tool_call_response(&[("c1", "grep", "{}")])),
+                    Ok(mock_tool_call_response(&[("c2", "read_file", "{}")])),
+                    Ok(mock_text_response("nginx at /etc/nginx")),
+                ],
+            );
             assert!(specs
                 .iter()
                 .any(|spec| spec.function.name.as_str() == "read_file"));
             assert!(!specs
                 .iter()
                 .any(|spec| spec.function.name.as_str() == "write_file"));
-            register_mock_from_specs(sub, specs);
+            let names = sub_tool_names(sub);
+            assert!(names.contains(&"grep".to_string()));
+            assert!(names.contains(&"read_file".to_string()));
+            assert!(!names.contains(&"write_file".to_string()));
         })
         .await
         .expect("spawn_builtin should succeed");
@@ -249,9 +275,8 @@ mod tests {
         let specs_before = parent.tool_specs();
 
         let registry = AgentRegistry::builtin();
-        let _ = spawn_builtin(&parent, &registry, "explore", "task", |sub, specs| {
-            sub.set_test_chat_responses(vec![Ok(mock_text_response("done"))]);
-            register_mock_from_specs(sub, specs);
+        let _ = spawn_builtin(&parent, &registry, "explore", "task", |sub, _specs| {
+            configure_spawn_test(sub, vec![Ok(mock_text_response("done"))]);
         })
         .await
         .expect("spawn_builtin should succeed");
@@ -281,12 +306,12 @@ mod tests {
             "plan",
             "design rollout",
             |sub, specs| {
-                sub.set_test_chat_responses(vec![Ok(mock_text_response("rollout plan"))]);
+                configure_spawn_test(sub, vec![Ok(mock_text_response("rollout plan"))]);
                 let names: Vec<_> = specs.iter().map(|s| s.function.name.as_str()).collect();
                 assert!(names.contains(&"grep"));
                 assert!(!names.contains(&"write_file"));
                 assert!(!names.contains(&"enter_plan_mode"));
-                register_mock_from_specs(sub, specs);
+                assert_eq!(sub_tool_names(sub), vec!["grep".to_string()]);
             },
         )
         .await
@@ -297,10 +322,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_spawn_builtin_general_purpose_excludes_agent() {
+    async fn test_spawn_builtin_general_purpose_inherits_parent_pool_minus_agent() {
         let mut parent = LlmSession::new("http://localhost", "key", "model", None, None);
         parent.register_tool(Box::new(MockTool::new("bash")));
         parent.register_tool(Box::new(MockTool::new("read_file")));
+        parent.register_tool(Box::new(MockTool::new("WebFetch")));
+        parent.register_tool(Box::new(MockTool::new("skill")));
         parent.register_tool(Box::new(MockTool::new("Agent")));
 
         let registry = AgentRegistry::builtin();
@@ -310,12 +337,22 @@ mod tests {
             "general-purpose",
             "run sub task",
             |sub, specs| {
-                sub.set_test_chat_responses(vec![Ok(mock_text_response("sub task done"))]);
+                configure_spawn_test(sub, vec![Ok(mock_text_response("sub task done"))]);
                 let names: Vec<_> = specs.iter().map(|s| s.function.name.as_str()).collect();
                 assert!(names.contains(&"bash"));
                 assert!(names.contains(&"read_file"));
+                assert!(names.contains(&"WebFetch"));
+                assert!(names.contains(&"skill"));
                 assert!(!names.contains(&"Agent"));
-                register_mock_from_specs(sub, specs);
+                assert_eq!(
+                    sub_tool_names(sub),
+                    vec![
+                        "WebFetch".to_string(),
+                        "bash".to_string(),
+                        "read_file".to_string(),
+                        "skill".to_string(),
+                    ]
+                );
             },
         )
         .await
@@ -323,6 +360,105 @@ mod tests {
 
         assert_eq!(result.status, LoopStatus::Complete);
         assert_eq!(result.text, "sub task done");
+    }
+
+    #[tokio::test]
+    async fn test_spawn_builtin_allowlist_inherits_skill_when_in_specs() {
+        // Future built-ins (e.g. troubleshoot) may allowlist skill; inheritance
+        // must not depend on the general-purpose registration branch.
+        let mut parent = LlmSession::new("http://localhost", "key", "model", None, None);
+        parent.register_tool(Box::new(MockTool::new("bash")));
+        parent.register_tool(Box::new(MockTool::new("read_file")));
+        parent.register_tool(Box::new(MockTool::new("skill")));
+        parent.register_tool(Box::new(MockTool::new("write_file")));
+
+        let mut registry = AgentRegistry::builtin();
+        registry.insert_for_test(AgentDefinition {
+            subagent_type: "skill-readonly".to_string(),
+            when_to_use: "test".to_string(),
+            system_prompt: "test".to_string(),
+            max_turns: 5,
+            tool_strategy: ToolStrategy::Allowlist(vec![
+                "bash".to_string(),
+                "read_file".to_string(),
+                "skill".to_string(),
+            ]),
+        });
+
+        let result = spawn_builtin(
+            &parent,
+            &registry,
+            "skill-readonly",
+            "use skill",
+            |sub, specs| {
+                configure_spawn_test(sub, vec![Ok(mock_text_response("ok"))]);
+                let names: Vec<_> = specs.iter().map(|s| s.function.name.as_str()).collect();
+                assert!(names.contains(&"skill"));
+                assert!(!names.contains(&"write_file"));
+                assert_eq!(
+                    sub_tool_names(sub),
+                    vec![
+                        "bash".to_string(),
+                        "read_file".to_string(),
+                        "skill".to_string(),
+                    ]
+                );
+            },
+        )
+        .await
+        .expect("allowlist+skill spawn should succeed");
+
+        assert_eq!(result.status, LoopStatus::Complete);
+    }
+
+    #[tokio::test]
+    async fn test_spawn_builtin_invokes_for_sub_session_adapter() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        struct AdaptingTool {
+            adapted: Arc<AtomicBool>,
+        }
+
+        impl Tool for AdaptingTool {
+            fn name(&self) -> &str {
+                "grep"
+            }
+
+            fn description(&self) -> &str {
+                "mock"
+            }
+
+            fn parameters(&self) -> serde_json::Value {
+                serde_json::json!({"type": "object", "properties": {}})
+            }
+
+            fn execute(&self, _args: serde_json::Value) -> crate::types::ToolResult {
+                crate::types::ToolResult::success("ok")
+            }
+
+            fn for_sub_session(&self, _sub: &LlmSession) -> Option<Arc<dyn Tool>> {
+                self.adapted.store(true, Ordering::SeqCst);
+                Some(Arc::new(MockTool::new("grep")))
+            }
+        }
+
+        let adapted = Arc::new(AtomicBool::new(false));
+        let mut parent = LlmSession::new("http://localhost", "key", "model", None, None);
+        parent.register_tool(Box::new(AdaptingTool {
+            adapted: Arc::clone(&adapted),
+        }));
+
+        let registry = AgentRegistry::builtin();
+        let _ = spawn_builtin(&parent, &registry, "explore", "task", |sub, _specs| {
+            configure_spawn_test(sub, vec![Ok(mock_text_response("done"))]);
+        })
+        .await
+        .expect("spawn_builtin should succeed");
+
+        assert!(
+            adapted.load(Ordering::SeqCst),
+            "spawn_builtin must call Tool::for_sub_session when inheriting tools"
+        );
     }
 
     #[tokio::test]
@@ -630,10 +766,8 @@ mod tests {
             &registry,
             "explore",
             "deep search",
-            |sub, specs| {
-                disable_context_budget(sub);
-                sub.set_test_chat_responses(responses);
-                register_mock_from_specs(sub, specs);
+            |sub, _specs| {
+                configure_spawn_test(sub, responses);
             },
         )
         .await
@@ -661,13 +795,21 @@ mod tests {
         }));
 
         let registry = AgentRegistry::builtin();
-        let _ = spawn_builtin(&parent, &registry, "explore", "find nginx", |sub, specs| {
-            sub.set_test_chat_responses(vec![
-                Ok(mock_tool_call_response(&[("c1", "grep", "{}")])),
-                Ok(mock_text_response("done")),
-            ]);
-            register_mock_from_specs(sub, specs);
-        })
+        let _ = spawn_builtin(
+            &parent,
+            &registry,
+            "explore",
+            "find nginx",
+            |sub, _specs| {
+                configure_spawn_test(
+                    sub,
+                    vec![
+                        Ok(mock_tool_call_response(&[("c1", "grep", "{}")])),
+                        Ok(mock_text_response("done")),
+                    ],
+                );
+            },
+        )
         .await
         .expect("spawn_builtin should succeed");
 

--- a/crates/aish-llm/src/agents/tool_loop.rs
+++ b/crates/aish-llm/src/agents/tool_loop.rs
@@ -208,6 +208,11 @@ pub async fn run_tool_loop_until_done(
             let tool_msg = ChatMessage::tool_result(&tc.id, result.output);
             messages.push(tool_msg.clone());
             loop_messages.push(tool_msg);
+            // User Ctrl+C during a tool cancels the session token; stop before
+            // another LLM "thinking" turn invents a timeout story.
+            if session.cancellation_token().is_cancelled() {
+                return LoopOutcome::cancelled();
+            }
         }
     }
 }
@@ -382,5 +387,72 @@ mod tests {
         .await;
 
         assert_eq!(outcome.status, LoopStatus::Cancelled);
+    }
+
+    /// Simulates Ctrl+C during a tool: the tool cancels the session token.
+    /// The loop must abort before consuming another LLM turn (no invented
+    /// "timeout" follow-up from the model).
+    struct CancelSessionTool {
+        token: std::sync::Arc<crate::CancellationToken>,
+    }
+
+    impl Tool for CancelSessionTool {
+        fn name(&self) -> &str {
+            "bash"
+        }
+
+        fn description(&self) -> &str {
+            "mock cancel"
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {}})
+        }
+
+        fn execute(&self, _args: serde_json::Value) -> crate::types::ToolResult {
+            self.token.cancel();
+            crate::types::ToolResult {
+                ok: false,
+                output: "已中断".into(),
+                meta: Some(serde_json::json!({
+                    "dispatch_status": "short_circuit",
+                    "reason": "user_cancelled",
+                })),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_loop_stops_after_tool_cancels_session() {
+        let mut session = test_session_with_responses(vec![
+            Ok(mock_tool_call_response(&[(
+                "c1",
+                "bash",
+                r#"{"command":"sleep 90"}"#,
+            )])),
+            // Must not be consumed — would be the "continue thinking" turn.
+            Ok(mock_text_response(
+                "sleep was interrupted by built-in timeout",
+            )),
+        ]);
+        let token = session.cancellation_token_arc();
+        session.register_tool(Box::new(CancelSessionTool { token }));
+
+        let outcome = run_tool_loop_until_done(
+            &session,
+            &ChatMessage::user("sleep 90"),
+            &[],
+            &ToolLoopConfig {
+                max_turns: 5,
+                ..Default::default()
+            },
+        )
+        .await;
+
+        assert_eq!(outcome.status, LoopStatus::Cancelled);
+        assert!(
+            session.cancellation_token().is_cancelled(),
+            "session token must stay cancelled"
+        );
     }
 }

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -28,7 +28,7 @@ const COMPACT_SUMMARY_SYSTEM_PROMPT: &str = "You summarize old AI Shell context 
 pub struct LlmSession {
     stream_ctx: StreamContext,
     api_dialect: ApiDialect,
-    tools: HashMap<String, Box<dyn Tool>>,
+    tools: HashMap<String, Arc<dyn Tool>>,
     cancellation_token: Arc<CancellationToken>,
     event_callback: Option<Arc<dyn Fn(LlmEvent) -> Option<LlmCallbackResult> + Send + Sync>>,
     confirmation_callback: Option<Arc<dyn Fn(&PreflightSecurityContext) -> bool + Send + Sync>>,
@@ -125,7 +125,23 @@ impl LlmSession {
     }
 
     pub fn register_tool(&mut self, tool: Box<dyn Tool>) {
+        self.register_shared_tool(Arc::from(tool));
+    }
+
+    /// Register a shared tool handle (used when inheriting parent tools into a sub-session).
+    pub fn register_shared_tool(&mut self, tool: Arc<dyn Tool>) {
         self.tools.insert(tool.name().to_string(), tool);
+    }
+
+    /// Return shared handles for tools whose names appear in `names` (order preserved).
+    pub fn shared_tools_by_names<'a, I>(&self, names: I) -> Vec<Arc<dyn Tool>>
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
+        names
+            .into_iter()
+            .filter_map(|name| self.tools.get(name).cloned())
+            .collect()
     }
 
     pub fn set_event_callback(
@@ -604,7 +620,15 @@ impl LlmSession {
                                 timestamp: now_timestamp(),
                                 metadata: None,
                             });
-                            let text = if self.security_notice_callback.is_some() {
+                            // Sub-agent cancel is shown by the shell as `shell.interrupted`
+                            // (same as Ctrl+C); do not return the tool string as AI body.
+                            let suppress_body = result.meta.as_ref().is_some_and(|meta| {
+                                matches!(
+                                    meta.get("reason").and_then(|v| v.as_str()),
+                                    Some("sub_agent_cancelled") | Some("user_cancelled")
+                                )
+                            });
+                            let text = if self.security_notice_callback.is_some() || suppress_body {
                                 String::new()
                             } else {
                                 output
@@ -984,7 +1008,15 @@ impl LlmSession {
                                 timestamp: now_timestamp(),
                                 metadata: None,
                             });
-                            let text = if self.security_notice_callback.is_some() {
+                            // Sub-agent cancel is shown by the shell as `shell.interrupted`
+                            // (same as Ctrl+C); do not return the tool string as AI body.
+                            let suppress_body = result.meta.as_ref().is_some_and(|meta| {
+                                matches!(
+                                    meta.get("reason").and_then(|v| v.as_str()),
+                                    Some("sub_agent_cancelled") | Some("user_cancelled")
+                                )
+                            });
+                            let text = if self.security_notice_callback.is_some() || suppress_body {
                                 String::new()
                             } else {
                                 output

--- a/crates/aish-llm/src/types.rs
+++ b/crates/aish-llm/src/types.rs
@@ -590,6 +590,18 @@ pub trait Tool: Send + Sync {
         let _ = session;
         self.execute_async(args)
     }
+
+    /// Optionally adapt this tool when inheriting it into a sub-agent session.
+    ///
+    /// Return `Some` to register a sub-session-specific instance (e.g. bash rebound
+    /// to the child cancel token). Return `None` to share the parent handle as-is.
+    fn for_sub_session(
+        &self,
+        sub: &crate::session::LlmSession,
+    ) -> Option<std::sync::Arc<dyn Tool>> {
+        let _ = sub;
+        None
+    }
 }
 
 /// Token used to cancel an in-progress LLM request.

--- a/crates/aish-pty/src/executor.rs
+++ b/crates/aish-pty/src/executor.rs
@@ -506,6 +506,7 @@ impl PtyExecutor {
                         let data = &tmp[..n as usize];
                         // Check for Ctrl-C (0x03).
                         if data.contains(&0x03) {
+                            cancel_token.cancel_as_user_interrupt();
                             let _ = kill_pg(child_pid, Signal::SIGINT);
                         }
                         write_buf.extend_from_slice(data);

--- a/crates/aish-pty/src/persistent.rs
+++ b/crates/aish-pty/src/persistent.rs
@@ -954,7 +954,9 @@ impl PersistentPty {
                             // the loop breaks.
                             let _ = self.write_master(b"\x03");
                             if let Some(ref ct) = cancel_token {
-                                ct.cancel();
+                                // Mark as user interrupt so bash can abort the
+                                // LLM session — raw-mode Ctrl+C is 0x03, not SIGINT.
+                                ct.cancel_as_user_interrupt();
                             }
                             cancelled = true;
                             break 'select_loop;

--- a/crates/aish-pty/src/types.rs
+++ b/crates/aish-pty/src/types.rs
@@ -3,6 +3,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// Simple cancellation token backed by an atomic bool.
 pub struct CancelToken {
     cancelled: AtomicBool,
+    /// Set when cancellation came from a user Ctrl+C (0x03), not an external
+    /// timeout / session-cancel bridge.
+    user_interrupt: AtomicBool,
 }
 
 impl Default for CancelToken {
@@ -15,6 +18,7 @@ impl CancelToken {
     pub fn new() -> Self {
         Self {
             cancelled: AtomicBool::new(false),
+            user_interrupt: AtomicBool::new(false),
         }
     }
 
@@ -22,8 +26,18 @@ impl CancelToken {
         self.cancelled.store(true, Ordering::SeqCst);
     }
 
+    /// Cancel and mark as a user Ctrl+C interrupt.
+    pub fn cancel_as_user_interrupt(&self) {
+        self.user_interrupt.store(true, Ordering::SeqCst);
+        self.cancel();
+    }
+
     pub fn is_cancelled(&self) -> bool {
         self.cancelled.load(Ordering::SeqCst)
+    }
+
+    pub fn is_user_interrupt(&self) -> bool {
+        self.user_interrupt.load(Ordering::SeqCst)
     }
 }
 
@@ -106,6 +120,24 @@ impl CommandSubmission {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_cancel_as_user_interrupt_sets_both_flags() {
+        let token = CancelToken::new();
+        assert!(!token.is_cancelled());
+        assert!(!token.is_user_interrupt());
+        token.cancel_as_user_interrupt();
+        assert!(token.is_cancelled());
+        assert!(token.is_user_interrupt());
+    }
+
+    #[test]
+    fn test_plain_cancel_is_not_user_interrupt() {
+        let token = CancelToken::new();
+        token.cancel();
+        assert!(token.is_cancelled());
+        assert!(!token.is_user_interrupt());
+    }
 
     #[test]
     fn test_command_source_display() {

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -653,8 +653,8 @@ impl AishShell {
         )));
         tool_registry.register(Box::new(aish_tools::EnterPlanModeTool::new()));
         tool_registry.register(Box::new(aish_tools::ExitPlanModeTool::new()));
-        // AgentTool registration is deferred until after skill loading so general-purpose
-        // sub-agents can inherit skill callbacks when the parent session has skills.
+        // AgentTool is registered after skill loading so the parent session already
+        // has SkillTool when general-purpose / future built-ins inherit the tool pool.
 
         // System diagnose tool — needs session credentials to spawn sub-sessions.
         // The shared event callback holder allows setting the callback after
@@ -783,21 +783,12 @@ impl AishShell {
                     })
                     .collect();
             let skill_names: Vec<String> = skills_snapshot.keys().cloned().collect();
-            let agent_skills = skills_snapshot.clone();
-            let agent_skill_names = skill_names.clone();
-            let agent_lookup =
-                std::sync::Arc::new(move |name: &str| agent_skills.get(name).cloned())
-                    as std::sync::Arc<dyn Fn(&str) -> Option<aish_tools::SkillInfo> + Send + Sync>;
-            let agent_list = std::sync::Arc::new(move || agent_skill_names.clone())
-                as std::sync::Arc<dyn Fn() -> Vec<String> + Send + Sync>;
-            tool_registry.register(Box::new(aish_tools::AgentTool::with_skill_callbacks(Some(
-                (agent_lookup, agent_list),
-            ))));
             let lookup = Box::new(move |name: &str| skills_snapshot.get(name).cloned());
             let list = Box::new(move || skill_names.clone());
             aish_tools::SkillTool::new(lookup, list)
         };
         tool_registry.register(Box::new(skill_tool));
+        tool_registry.register(Box::new(aish_tools::AgentTool::new()));
 
         // Create SystemDiagnoseTool with skill callbacks wired from the loaded skills
         {
@@ -1361,7 +1352,7 @@ impl AishShell {
                         sub_agent_animation_ref.stop();
                         animation_ref.stop();
                         clear_reasoning();
-                        println!("\x1b[33m{}\x1b[0m", t("shell.command_cancelled"));
+                        // Outer AI handlers print `shell.interrupted` once; avoid a second line.
                     }
                     LlmEventType::ToolConfirmationRequired => {
                         // Handled by separate confirmation_callback
@@ -2027,7 +2018,11 @@ impl AishShell {
 
                     match result {
                         Ok(response) => {
-                            if !did_stream && !response.trim().is_empty() {
+                            if self.ai_handler.cancellation_token().is_cancelled() {
+                                // Agent short-circuit cancel returns Ok("") — show the same
+                                // user-facing line as Err(Cancelled).
+                                println!("\x1b[33m{}\x1b[0m", t("shell.interrupted"));
+                            } else if !did_stream && !response.trim().is_empty() {
                                 // Non-streaming fallback: print full response with formatting
                                 let mut sep_renderer = ShellRenderer::new();
                                 sep_renderer.set_shared_recorder(self.shared_recorder.clone());
@@ -2317,7 +2312,9 @@ impl AishShell {
                                 let did_stream = self.streamed_content.load(Ordering::SeqCst);
                                 match result {
                                     Ok(response) => {
-                                        if !did_stream && !response.trim().is_empty() {
+                                        if self.ai_handler.cancellation_token().is_cancelled() {
+                                            println!("\x1b[33m{}\x1b[0m", t("shell.interrupted"));
+                                        } else if !did_stream && !response.trim().is_empty() {
                                             let mut sep_renderer = ShellRenderer::new();
                                             sep_renderer
                                                 .set_shared_recorder(self.shared_recorder.clone());

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -2020,128 +2020,133 @@ impl AishShell {
                         Ok(response) => {
                             if self.ai_handler.cancellation_token().is_cancelled() {
                                 // Agent short-circuit cancel returns Ok("") — show the same
-                                // user-facing line as Err(Cancelled).
+                                // user-facing line as Err(Cancelled). Do not treat as success
+                                // (no plan approval / history-as-ok).
                                 println!("\x1b[33m{}\x1b[0m", t("shell.interrupted"));
-                            } else if !did_stream && !response.trim().is_empty() {
-                                // Non-streaming fallback: print full response with formatting
-                                let mut sep_renderer = ShellRenderer::new();
-                                sep_renderer.set_shared_recorder(self.shared_recorder.clone());
-                                sep_renderer.render_separator();
-                                print_md_with_recording(&response, &self.shared_recorder);
-                                sep_renderer.render_separator();
-                            } else if did_stream {
-                                // Streaming display already handled by event callback
-                                // No additional output needed here.
-                            }
+                            } else {
+                                if !did_stream && !response.trim().is_empty() {
+                                    // Non-streaming fallback: print full response with formatting
+                                    let mut sep_renderer = ShellRenderer::new();
+                                    sep_renderer.set_shared_recorder(self.shared_recorder.clone());
+                                    sep_renderer.render_separator();
+                                    print_md_with_recording(&response, &self.shared_recorder);
+                                    sep_renderer.render_separator();
+                                } else if did_stream {
+                                    // Streaming display already handled by event callback
+                                    // No additional output needed here.
+                                }
 
-                            self.persist_session_snapshot();
+                                self.persist_session_snapshot();
 
-                            // Check if plan mode was exited during this AI turn.
-                            // If exit_plan_mode tool was called, show plan approval UI.
-                            let plan_state = self.ai_handler.plan_state();
-                            if plan_state.phase == aish_core::PlanPhase::Normal
-                                && plan_state.plan_id.is_some()
-                            {
-                                if let Some(artifact_path) = plan_state.artifact_path.as_ref() {
-                                    // Plan was exited — read artifact and present for approval
-                                    let artifact_text =
-                                        aish_core::plan::read_artifact_text(artifact_path);
+                                // Check if plan mode was exited during this AI turn.
+                                // If exit_plan_mode tool was called, show plan approval UI.
+                                let plan_state = self.ai_handler.plan_state();
+                                if plan_state.phase == aish_core::PlanPhase::Normal
+                                    && plan_state.plan_id.is_some()
+                                {
+                                    if let Some(artifact_path) = plan_state.artifact_path.as_ref() {
+                                        // Plan was exited — read artifact and present for approval
+                                        let artifact_text =
+                                            aish_core::plan::read_artifact_text(artifact_path);
 
-                                    // Use the enhanced plan approval flow
-                                    use crate::wizard::plan_approval::{
-                                        PlanApprovalDecision, PlanApprovalFlow,
-                                    };
-                                    let decision = PlanApprovalFlow::review_plan(
-                                        &artifact_text,
-                                        plan_state.summary.as_deref(),
-                                        if plan_state.draft_revision > 0 {
-                                            Some(plan_state.draft_revision)
-                                        } else {
-                                            None
-                                        },
-                                    );
+                                        // Use the enhanced plan approval flow
+                                        use crate::wizard::plan_approval::{
+                                            PlanApprovalDecision, PlanApprovalFlow,
+                                        };
+                                        let decision = PlanApprovalFlow::review_plan(
+                                            &artifact_text,
+                                            plan_state.summary.as_deref(),
+                                            if plan_state.draft_revision > 0 {
+                                                Some(plan_state.draft_revision)
+                                            } else {
+                                                None
+                                            },
+                                        );
 
-                                    match decision {
-                                        PlanApprovalDecision::Approved => {
-                                            // Create approved snapshot and transition state
-                                            let mut state = self.ai_handler.plan_state();
-                                            if let Ok(_snapshot) =
-                                                aish_core::plan::create_approved_snapshot(
-                                                    &mut state,
-                                                )
-                                            {
-                                                println!(
-                                                    "\x1b[32m{}\x1b[0m",
-                                                    t("shell.plan_approved")
-                                                );
-                                                println!(
-                                                    "\x1b[2m  {}\x1b[0m",
-                                                    t_with_args(
-                                                        "shell.plan_approved_hint",
-                                                        &std::collections::HashMap::new()
+                                        match decision {
+                                            PlanApprovalDecision::Approved => {
+                                                // Create approved snapshot and transition state
+                                                let mut state = self.ai_handler.plan_state();
+                                                if let Ok(_snapshot) =
+                                                    aish_core::plan::create_approved_snapshot(
+                                                        &mut state,
                                                     )
-                                                );
+                                                {
+                                                    println!(
+                                                        "\x1b[32m{}\x1b[0m",
+                                                        t("shell.plan_approved")
+                                                    );
+                                                    println!(
+                                                        "\x1b[2m  {}\x1b[0m",
+                                                        t_with_args(
+                                                            "shell.plan_approved_hint",
+                                                            &std::collections::HashMap::new()
+                                                        )
+                                                    );
+                                                }
                                             }
-                                        }
-                                        PlanApprovalDecision::ChangesRequested { feedback } => {
-                                            // Keep in planning phase — re-enter plan mode with feedback
-                                            println!(
-                                                "\x1b[33m{}\x1b[0m",
-                                                t("shell.plan_changes_requested")
-                                            );
-
-                                            // Re-enter plan mode to let the AI revise
-                                            self.ai_handler.enter_plan_mode(&self.session_uuid);
-
-                                            // Set the approval status and feedback directly on the mutex
-                                            {
-                                                let plan_state_lock =
-                                                    self.ai_handler.plan_state_ptr();
-                                                let mut ps = plan_state_lock.lock().unwrap();
-                                                ps.approval_status =
-                                                    aish_core::PlanApprovalStatus::ChangesRequested;
-                                                ps.approval_feedback_summary =
-                                                    if feedback.is_empty() {
-                                                        None
-                                                    } else {
-                                                        Some(feedback.clone())
-                                                    };
-                                                // Bump revision since we're requesting changes
-                                                aish_core::plan::bump_draft_revision(&mut ps);
-                                                // Preserve the artifact path from the previous plan
-                                                ps.artifact_path = plan_state.artifact_path.clone();
-                                                ps.plan_id = plan_state.plan_id.clone();
-                                            }
-
-                                            // If feedback was provided, send it back to the AI
-                                            // by injecting it as context
-                                            if !feedback.is_empty() {
-                                                let feedback_msg = format!(
-                                                    "[Plan Review Feedback]\nThe user requested changes to the plan:\n{}\n\nPlease revise the plan accordingly and use exit_plan_mode when ready.",
-                                                    feedback
-                                                );
-                                                self.ai_handler.add_shell_context(&feedback_msg);
+                                            PlanApprovalDecision::ChangesRequested { feedback } => {
+                                                // Keep in planning phase — re-enter plan mode with feedback
                                                 println!(
-                                                    "\x1b[2m  {}\x1b[0m",
-                                                    t("shell.plan_feedback_sent")
+                                                    "\x1b[33m{}\x1b[0m",
+                                                    t("shell.plan_changes_requested")
+                                                );
+
+                                                // Re-enter plan mode to let the AI revise
+                                                self.ai_handler.enter_plan_mode(&self.session_uuid);
+
+                                                // Set the approval status and feedback directly on the mutex
+                                                {
+                                                    let plan_state_lock =
+                                                        self.ai_handler.plan_state_ptr();
+                                                    let mut ps = plan_state_lock.lock().unwrap();
+                                                    ps.approval_status =
+                                                    aish_core::PlanApprovalStatus::ChangesRequested;
+                                                    ps.approval_feedback_summary =
+                                                        if feedback.is_empty() {
+                                                            None
+                                                        } else {
+                                                            Some(feedback.clone())
+                                                        };
+                                                    // Bump revision since we're requesting changes
+                                                    aish_core::plan::bump_draft_revision(&mut ps);
+                                                    // Preserve the artifact path from the previous plan
+                                                    ps.artifact_path =
+                                                        plan_state.artifact_path.clone();
+                                                    ps.plan_id = plan_state.plan_id.clone();
+                                                }
+
+                                                // If feedback was provided, send it back to the AI
+                                                // by injecting it as context
+                                                if !feedback.is_empty() {
+                                                    let feedback_msg = format!(
+                                                        "[Plan Review Feedback]\nThe user requested changes to the plan:\n{}\n\nPlease revise the plan accordingly and use exit_plan_mode when ready.",
+                                                        feedback
+                                                    );
+                                                    self.ai_handler
+                                                        .add_shell_context(&feedback_msg);
+                                                    println!(
+                                                        "\x1b[2m  {}\x1b[0m",
+                                                        t("shell.plan_feedback_sent")
+                                                    );
+                                                }
+                                            }
+                                            PlanApprovalDecision::Cancelled => {
+                                                println!(
+                                                    "\x1b[33m{}\x1b[0m",
+                                                    t("shell.plan_review_cancelled")
+                                                );
+                                                println!(
+                                                    "\x1b[2m{}\x1b[0m",
+                                                    t("shell.plan_review_hint")
                                                 );
                                             }
-                                        }
-                                        PlanApprovalDecision::Cancelled => {
-                                            println!(
-                                                "\x1b[33m{}\x1b[0m",
-                                                t("shell.plan_review_cancelled")
-                                            );
-                                            println!(
-                                                "\x1b[2m{}\x1b[0m",
-                                                t("shell.plan_review_hint")
-                                            );
                                         }
                                     }
                                 }
-                            }
 
-                            self.record_history(input, 0);
+                                self.record_history(input, 0);
+                            }
                         }
                         Err(aish_core::AishError::Cancelled) => {
                             self.animation.stop();
@@ -2313,20 +2318,24 @@ impl AishShell {
                                 match result {
                                     Ok(response) => {
                                         if self.ai_handler.cancellation_token().is_cancelled() {
+                                            // Same as Err(Cancelled): do not persist/history as success.
                                             println!("\x1b[33m{}\x1b[0m", t("shell.interrupted"));
-                                        } else if !did_stream && !response.trim().is_empty() {
-                                            let mut sep_renderer = ShellRenderer::new();
-                                            sep_renderer
-                                                .set_shared_recorder(self.shared_recorder.clone());
-                                            sep_renderer.render_separator();
-                                            print_md_with_recording(
-                                                &response,
-                                                &self.shared_recorder,
-                                            );
-                                            sep_renderer.render_separator();
+                                        } else {
+                                            if !did_stream && !response.trim().is_empty() {
+                                                let mut sep_renderer = ShellRenderer::new();
+                                                sep_renderer.set_shared_recorder(
+                                                    self.shared_recorder.clone(),
+                                                );
+                                                sep_renderer.render_separator();
+                                                print_md_with_recording(
+                                                    &response,
+                                                    &self.shared_recorder,
+                                                );
+                                                sep_renderer.render_separator();
+                                            }
+                                            self.persist_session_snapshot();
+                                            self.record_history(input, 0);
                                         }
-                                        self.persist_session_snapshot();
-                                        self.record_history(input, 0);
                                     }
                                     Err(aish_core::AishError::Cancelled) => {
                                         self.animation.stop();

--- a/crates/aish-tools/src/agent_tool/agent_tool.rs
+++ b/crates/aish-tools/src/agent_tool/agent_tool.rs
@@ -5,8 +5,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use aish_llm::{
-    spawn_builtin, AgentDefinition, AgentRegistry, LlmSession, LoopStatus, SpawnResult, Tool,
-    ToolResult, ToolSpec,
+    spawn_builtin, AgentRegistry, LlmSession, LoopStatus, SpawnResult, Tool, ToolResult,
 };
 
 use super::prompt;
@@ -23,26 +22,15 @@ pub type SpawnFn = Arc<
         + Sync,
 >;
 
-/// Optional skill callbacks for `general-purpose` sub-agents.
-pub type SkillLookupFn = Arc<dyn Fn(&str) -> Option<crate::SkillInfo> + Send + Sync>;
-pub type SkillListFn = Arc<dyn Fn() -> Vec<String> + Send + Sync>;
-pub type SkillCallbacks = (SkillLookupFn, SkillListFn);
-
 /// Tool that spawns built-in sub-agents (`explore`, `plan`, `general-purpose`).
 pub struct AgentTool {
     registry: AgentRegistry,
     description: String,
     spawn_fn: Option<SpawnFn>,
-    skill_callbacks: Option<SkillCallbacks>,
 }
 
 impl AgentTool {
     pub fn new() -> Self {
-        Self::with_skill_callbacks(None)
-    }
-
-    /// Create an `AgentTool` that can register inherited `skill` tools for general-purpose spawns.
-    pub fn with_skill_callbacks(skill_callbacks: Option<SkillCallbacks>) -> Self {
         let registry = AgentRegistry::builtin();
         let description = format!(
             "{}\n{}\n\nAvailable subagent types:\n{}\n\n{}\n\n{}",
@@ -56,7 +44,6 @@ impl AgentTool {
             registry,
             description,
             spawn_fn: None,
-            skill_callbacks,
         }
     }
 
@@ -90,7 +77,9 @@ impl AgentTool {
         match result.status {
             LoopStatus::Complete | LoopStatus::Incomplete => ToolResult::success(result.text),
             LoopStatus::Cancelled => {
-                Self::short_circuit_error("Sub-agent cancelled", "sub_agent_cancelled")
+                // User-facing copy matches shell Ctrl+C (`shell.interrupted`);
+                // meta.reason stays machine-readable for short-circuit handling.
+                Self::short_circuit_error(aish_i18n::t("shell.interrupted"), "sub_agent_cancelled")
             }
             LoopStatus::Fatal => Self::short_circuit_error("Sub-agent failed", "sub_agent_fatal"),
         }
@@ -104,72 +93,6 @@ impl AgentTool {
                 "dispatch_status": "short_circuit",
                 "reason": reason,
             })),
-        }
-    }
-
-    fn register_read_only_tools(sub: &mut LlmSession, specs: &[ToolSpec]) {
-        for spec in specs {
-            match spec.function.name.as_str() {
-                "grep" => sub.register_tool(Box::new(crate::GrepTool::new())),
-                "glob" => sub.register_tool(Box::new(crate::GlobTool::new())),
-                "read_file" => sub.register_tool(Box::new(crate::ReadFileTool::new())),
-                "bash" => {
-                    let mut bash = crate::bash::BashTool::new();
-                    bash.set_cancellation_token(sub.cancellation_token_arc());
-                    sub.register_tool(Box::new(bash));
-                }
-                _ => {}
-            }
-        }
-    }
-
-    fn register_general_purpose_tools(
-        sub: &mut LlmSession,
-        specs: &[ToolSpec],
-        skill_callbacks: &Option<SkillCallbacks>,
-    ) {
-        for spec in specs {
-            match spec.function.name.as_str() {
-                "grep" => sub.register_tool(Box::new(crate::GrepTool::new())),
-                "glob" => sub.register_tool(Box::new(crate::GlobTool::new())),
-                "read_file" => sub.register_tool(Box::new(crate::ReadFileTool::new())),
-                "write_file" => sub.register_tool(Box::new(crate::WriteFileTool::new())),
-                "edit_file" => sub.register_tool(Box::new(crate::EditFileTool::new())),
-                "bash" => {
-                    let mut bash = crate::bash::BashTool::new();
-                    bash.set_cancellation_token(sub.cancellation_token_arc());
-                    sub.register_tool(Box::new(bash));
-                }
-                "skill" => {
-                    if let Some((lookup, list)) = skill_callbacks {
-                        sub.register_tool(Box::new(crate::SkillTool::new(
-                            Box::new({
-                                let lookup = Arc::clone(lookup);
-                                move |name| lookup(name)
-                            }),
-                            Box::new({
-                                let list = Arc::clone(list);
-                                move || list()
-                            }),
-                        )));
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-
-    fn register_tools_for_definition(
-        &self,
-        sub: &mut LlmSession,
-        def: &AgentDefinition,
-        specs: &[ToolSpec],
-    ) {
-        match def.subagent_type.as_str() {
-            "general-purpose" => {
-                Self::register_general_purpose_tools(sub, specs, &self.skill_callbacks)
-            }
-            _ => Self::register_read_only_tools(sub, specs),
         }
     }
 }
@@ -208,29 +131,35 @@ impl Tool for AgentTool {
                 Err(err) => return err,
             };
 
-            let def = match self.registry.resolve(subagent_type) {
-                Ok(def) => def.clone(),
-                Err(err) => return ToolResult::error(err),
-            };
+            if let Err(err) = self.registry.resolve(subagent_type) {
+                return ToolResult::error(err);
+            }
 
             if let Some(spawn_fn) = &self.spawn_fn {
                 let result = match spawn_fn(session, subagent_type, prompt).await {
                     Ok(result) => result,
                     Err(err) => return ToolResult::error(err),
                 };
+                if result.status == LoopStatus::Cancelled {
+                    session.cancellation_token().cancel();
+                }
                 return Self::spawn_result_to_tool_result(result);
             }
 
             let registry = self.registry.clone();
             let result =
-                match spawn_builtin(session, &registry, subagent_type, prompt, |sub, specs| {
-                    self.register_tools_for_definition(sub, &def, specs);
-                })
-                .await
+                match spawn_builtin(session, &registry, subagent_type, prompt, |_sub, _specs| {})
+                    .await
                 {
                     Ok(result) => result,
                     Err(err) => return ToolResult::error(err),
                 };
+
+            if result.status == LoopStatus::Cancelled {
+                // Ensure the parent session is marked cancelled so the shell
+                // prints a single `已中断` even when Ctrl+C arrived as PTY 0x03.
+                session.cancellation_token().cancel();
+            }
 
             Self::spawn_result_to_tool_result(result)
         })

--- a/crates/aish-tools/src/bash/bash.rs
+++ b/crates/aish-tools/src/bash/bash.rs
@@ -284,6 +284,53 @@ impl BashTool {
         self.cancellation_token = Some(token);
     }
 
+    /// Build a sub-session bash that shares PTY/vault slots but uses `token` for cancel.
+    pub fn for_sub_session_token(&self, token: Arc<CancellationToken>) -> Self {
+        let mut bash = BashTool::new();
+        bash.set_cancellation_token(token);
+        bash.set_pty_slot(Arc::clone(&self.pty_slot));
+        bash.set_secret_vault(Arc::clone(&self.secret_vault));
+        bash
+    }
+
+    /// Test helper: shared cancel token currently wired into this tool, if any.
+    #[cfg(test)]
+    pub fn cancellation_token_for_test(&self) -> Option<Arc<CancellationToken>> {
+        self.cancellation_token.clone()
+    }
+
+    fn user_cancelled_result() -> ToolResult {
+        ToolResult {
+            ok: false,
+            output: aish_i18n::t("shell.interrupted"),
+            meta: Some(serde_json::json!({
+                "dispatch_status": "short_circuit",
+                "reason": "user_cancelled",
+            })),
+        }
+    }
+
+    /// After PTY/executor returns, map cancel-token state to a short-circuit
+    /// result. Raw-mode Ctrl+C sets `user_interrupt` on the PTY token only;
+    /// propagate that to the session token so tool loops abort.
+    fn outcome_if_cancelled(&self, cancel_token: &CancelToken) -> Option<ToolResult> {
+        if cancel_token.is_user_interrupt() {
+            if let Some(ref ct) = self.cancellation_token {
+                ct.cancel();
+            }
+            return Some(Self::user_cancelled_result());
+        }
+        if cancel_token.is_cancelled()
+            && self
+                .cancellation_token
+                .as_ref()
+                .is_some_and(|t| t.is_cancelled())
+        {
+            return Some(Self::user_cancelled_result());
+        }
+        None
+    }
+
     /// Set the shared PersistentPty slot for Ctrl+Z/bg/fg support.
     pub fn set_pty_slot(&mut self, slot: PtySlot) {
         self.pty_slot = slot;
@@ -366,6 +413,10 @@ impl BashTool {
         let result =
             pty.execute_command(command, command_timeout, Some(&cancel_token), interactive);
         done.store(true, Ordering::SeqCst);
+
+        if let Some(cancelled) = self.outcome_if_cancelled(&cancel_token) {
+            return cancelled;
+        }
 
         match result {
             Ok((output, exit_code, cwd)) => {
@@ -455,6 +506,10 @@ impl BashTool {
         let _interactive_guard = interactive.then(InteractiveInputGuard::acquire);
         let result = executor.execute_blocking(command, env_vars, &cancel_token);
         done.store(true, Ordering::SeqCst);
+
+        if let Some(cancelled) = self.outcome_if_cancelled(&cancel_token) {
+            return cancelled;
+        }
 
         match result {
             Ok(result) => {
@@ -565,6 +620,15 @@ impl Tool for BashTool {
 
         result
     }
+
+    fn for_sub_session(&self, sub: &aish_llm::LlmSession) -> Option<std::sync::Arc<dyn Tool>> {
+        // Sub-agents get a dedicated bash instance bound to the child cancel token
+        // (parent→child cascade still cancels via forward_cancellation → sub token).
+        // Share PTY/vault slots so remote/secret wiring from the parent still works.
+        Some(Arc::new(
+            self.for_sub_session_token(sub.cancellation_token_arc()),
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -577,6 +641,71 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+
+    #[test]
+    fn test_for_sub_session_token_binds_child_not_parent() {
+        let parent_token = Arc::new(CancellationToken::new());
+        let child_token = Arc::new(CancellationToken::new());
+        let mut parent_bash = BashTool::new();
+        parent_bash.set_cancellation_token(Arc::clone(&parent_token));
+
+        let child_bash = parent_bash.for_sub_session_token(Arc::clone(&child_token));
+        let bound = child_bash
+            .cancellation_token_for_test()
+            .expect("child bash should have a cancel token");
+        assert!(
+            Arc::ptr_eq(&bound, &child_token),
+            "sub-session bash must watch the child cancel token"
+        );
+        assert!(
+            !Arc::ptr_eq(&bound, &parent_token),
+            "sub-session bash must not keep the parent cancel token"
+        );
+    }
+
+    #[test]
+    fn test_user_interrupt_cancels_session_and_short_circuits() {
+        let session_token = Arc::new(CancellationToken::new());
+        let mut bash = BashTool::new();
+        bash.set_cancellation_token(Arc::clone(&session_token));
+
+        let pty_token = CancelToken::new();
+        pty_token.cancel_as_user_interrupt();
+
+        let result = bash
+            .outcome_if_cancelled(&pty_token)
+            .expect("user interrupt must short-circuit");
+        assert!(!result.ok);
+        assert_eq!(result.output, aish_i18n::t("shell.interrupted"));
+        assert_eq!(
+            result
+                .meta
+                .as_ref()
+                .and_then(|m| m.get("reason"))
+                .and_then(|v| v.as_str()),
+            Some("user_cancelled")
+        );
+        assert!(
+            session_token.is_cancelled(),
+            "session token must be cancelled so tool loops abort"
+        );
+    }
+
+    #[test]
+    fn test_timeout_cancel_without_session_cancel_does_not_short_circuit() {
+        let session_token = Arc::new(CancellationToken::new());
+        let mut bash = BashTool::new();
+        bash.set_cancellation_token(Arc::clone(&session_token));
+
+        let pty_token = CancelToken::new();
+        pty_token.cancel(); // timeout / plain cancel, not Ctrl+C
+
+        assert!(bash.outcome_if_cancelled(&pty_token).is_none());
+        assert!(
+            !session_token.is_cancelled(),
+            "timeout must not cancel the LLM session"
+        );
+    }
 
     #[test]
     fn test_needs_interactive_sudo() {

--- a/crates/aish-tools/src/bash/bash.rs
+++ b/crates/aish-tools/src/bash/bash.rs
@@ -414,15 +414,20 @@ impl BashTool {
             pty.execute_command(command, command_timeout, Some(&cancel_token), interactive);
         done.store(true, Ordering::SeqCst);
 
+        // Sync cwd even on cancel — e.g. `cd /tmp; sleep 90` then Ctrl+C must
+        // leave the process (and later shell sync) on /tmp, not the old cwd.
+        if let Ok((_, _, cwd)) = &result {
+            if !cwd.is_empty() {
+                let _ = std::env::set_current_dir(cwd);
+            }
+        }
+
         if let Some(cancelled) = self.outcome_if_cancelled(&cancel_token) {
             return cancelled;
         }
 
         match result {
-            Ok((output, exit_code, cwd)) => {
-                if !cwd.is_empty() {
-                    let _ = std::env::set_current_dir(&cwd);
-                }
+            Ok((output, exit_code, _cwd)) => {
                 let raw_line_count = output.lines().count();
                 let session_uuid = uuid::Uuid::new_v4().to_string();
                 let cwd = std::env::current_dir()

--- a/crates/aish-tools/src/lib.rs
+++ b/crates/aish-tools/src/lib.rs
@@ -20,7 +20,7 @@ pub mod agent_tool {
     mod agent_tool;
     mod prompt;
 
-    pub use self::agent_tool::{AgentTool, SkillCallbacks, SpawnFn};
+    pub use self::agent_tool::{AgentTool, SpawnFn};
 }
 
 pub mod ask_user {

--- a/crates/aish-tools/tests/agent_tool_test.rs
+++ b/crates/aish-tools/tests/agent_tool_test.rs
@@ -116,6 +116,10 @@ async fn test_agent_tool_mock_spawn_cancelled_errors() {
     let spawn_fn: SpawnFn = Arc::new(mock_spawn_cancelled);
     let tool = AgentTool::with_spawn_fn(spawn_fn);
     let session = aish_llm::LlmSession::new("http://localhost", "key", "model", None, None);
+    assert!(
+        !session.cancellation_token().is_cancelled(),
+        "precondition: parent session starts uncancelled"
+    );
     let result = tool
         .execute_async_in_session(
             serde_json::json!({
@@ -127,7 +131,7 @@ async fn test_agent_tool_mock_spawn_cancelled_errors() {
         )
         .await;
     assert!(!result.ok);
-    assert!(result.output.contains("cancelled"));
+    assert_eq!(result.output, aish_i18n::t("shell.interrupted"));
     assert_eq!(
         result
             .meta
@@ -135,6 +139,18 @@ async fn test_agent_tool_mock_spawn_cancelled_errors() {
             .and_then(|m| m.get("dispatch_status"))
             .and_then(|v| v.as_str()),
         Some("short_circuit")
+    );
+    assert_eq!(
+        result
+            .meta
+            .as_ref()
+            .and_then(|m| m.get("reason"))
+            .and_then(|v| v.as_str()),
+        Some("sub_agent_cancelled")
+    );
+    assert!(
+        session.cancellation_token().is_cancelled(),
+        "Cancelled spawn must cancel the parent session so the shell prints one interrupt line"
     );
 }
 


### PR DESCRIPTION
## Summary
- Spawn inherits filtered parent `Tool` Arcs (Claude Code–style) instead of re-registering per-type factories, so allowlist agents keep skill/WebFetch when present and bash binds the child cancel token.
- Raw-mode Ctrl+C (`0x03`) marks PTY cancel as user interrupt; bash cancels the session and short-circuits, the tool loop stops before another LLM turn, and the shell prints a single `已中断`.

## Test plan
- [ ] `cargo test -p aish-tools --lib -- test_user_interrupt_cancels_session`
- [ ] `cargo test -p aish-tools --test agent_tool_test`
- [ ] `cargo test -p aish-llm --lib -- test_loop_stops_after_tool_cancels`
- [ ] Manual: `;必须用 Agent(subagent_type=explore) 委派。子 agent 只用 bash 执行：sleep 90。` → wait for `🔧 bash (sleep 90)` → Ctrl+C once → expect one `已中断`, no further explore/main “timeout” narrative

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sub-agents now automatically inherit the parent session’s permitted tools, with support for tools to customize what gets created for sub-sessions.
  * Tools can run in sub-agent sessions while preserving shared resources like PTYs and secrets.
* **Bug Fixes**
  * Tool execution loops now stop immediately when cancellation occurs during a tool run.
  * Ctrl+C is now treated as a user interruption consistently, producing consistent “interrupted/cancelled” outcomes without extra follow-up processing.
* **Improvements**
  * Cancellation messaging is now localized to avoid duplicate or hard-coded text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->