### PR TITLE
revert(pty): drop CodeRabbit review fixes from #348 (regression)

### DIFF
--- a/crates/aish-cli/src/main.rs
+++ b/crates/aish-cli/src/main.rs
@@ -1594,7 +1594,6 @@ impl OscScanner {
         let prefix = b"\x1b]5151;";
 
         while i < buf.len() {
-            // Check for OSC 5151 prefix at this position
             if i + prefix.len() <= buf.len() && &buf[i..i + prefix.len()] == prefix {
                 // Found OSC 5151 start, find terminator
                 let op_start = i + prefix.len();
@@ -1614,17 +1613,10 @@ impl OscScanner {
                     commands.push(op);
                     i = end + term_len;
                 } else {
-                    // Incomplete payload — save for next chunk
+                    // Incomplete — save for next chunk
                     self.pending = buf[i..].to_vec();
                     break;
                 }
-            } else if buf[i] == 0x1b && i + prefix.len() > buf.len() {
-                // Partial prefix at buffer end: the ESC byte and possibly a
-                // few following bytes could be the start of an OSC 5151
-                // sequence split across chunks. Save them for next time
-                // instead of emitting as clean output.
-                self.pending = buf[i..].to_vec();
-                break;
             } else {
                 clean.push(buf[i]);
                 i += 1;

--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -354,7 +354,6 @@ shell:
     seconds_ago: "vor {seconds}s"
     minutes_ago: "vor {minutes}min"
     hours_ago: "vor {hours}h"
-    days_ago: "vor {days}T"
 
   ask_user:
     default_title: "Benutzereingabe erforderlich"

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -566,7 +566,6 @@ shell:
     seconds_ago: "{seconds}s ago"
     minutes_ago: "{minutes}min ago"
     hours_ago: "{hours}h ago"
-    days_ago: "{days}d ago"
 
   panel:
     history_title: "Output History ({count} records)"

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -164,7 +164,7 @@ shell:
     diagnose: "Diagnóstico de solo lectura del último comando fallido"
     status: "Mostrar estado del entorno del sistema"
     live_sessions: "Listar sesiones PTY activas"
-    kill_live_sessions: "Terminar sesión(es) PTY por ID"
+    kill_live_sessions: "Terminar sesion(es) PTY por ID"
 
   feedback:
     select_type: "Seleccionar tipo de comentario"
@@ -330,8 +330,8 @@ shell:
     panel_title: "Sesiones PTY Activas"
     search_placeholder: "Buscar..."
     panel_footer: "↑/↓ navegar · Enter seleccionar · Esc cancelar"
-    create_new: "Crear nueva sesión"
-    already_current: "Ya en esta sesión."
+    create_new: "Crear nueva sesion"
+    already_current: "Ya en esta sesion."
     started_label: "iniciado: {age}"
     current_tag: "[actual]"
 
@@ -346,15 +346,14 @@ shell:
     kill_done: "hecho"
     kill_failed: "fallo: {error}"
     not_found: "Sesion '{id}' no encontrada."
-    is_current: "{id} es la sesión actual — use 'exit' para salir."
+    is_current: "{id} es la sesion actual — use 'exit' para salir."
     summary: "{killed} terminadas, {failed} fallaron."
-    all_terminated: "{count} sesión(es) terminada(s)."
+    all_terminated: "{count} sesion(es) terminada(s)."
 
   time:
     seconds_ago: "hace {seconds}s"
     minutes_ago: "hace {minutes}min"
     hours_ago: "hace {hours}h"
-    days_ago: "hace {days}d"
 
   ask_user:
     default_title: "Se requiere entrada del usuario"

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -354,7 +354,6 @@ shell:
     seconds_ago: "il y a {seconds}s"
     minutes_ago: "il y a {minutes}min"
     hours_ago: "il y a {hours}h"
-    days_ago: "il y a {days}j"
 
   ask_user:
     default_title: "Saisie utilisateur requise"

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -354,7 +354,6 @@ shell:
     seconds_ago: "{seconds}秒前"
     minutes_ago: "{minutes}分前"
     hours_ago: "{hours}時間前"
-    days_ago: "{days}日前"
 
   ask_user:
     default_title: "ユーザー入力が必要です"

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -566,7 +566,6 @@ shell:
     seconds_ago: "{seconds}秒前"
     minutes_ago: "{minutes}分钟前"
     hours_ago: "{hours}小时前"
-    days_ago: "{days}天前"
 
   panel:
     history_title: "输出历史（{count} 条记录）"

--- a/crates/aish-pty/src/daemon.rs
+++ b/crates/aish-pty/src/daemon.rs
@@ -933,35 +933,18 @@ pub fn run_pty_daemon_shell(
             }
             let child_pid = child.as_raw() as u32;
 
-            // Bind listener.
-            // On any error below, kill the forked child and close master_pty
-            // to avoid leaking a process and an fd.
+            // Bind listener
             if let Some(parent) = socket_path.parent() {
                 let _ = std::fs::create_dir_all(parent);
             }
             let _ = std::fs::remove_file(socket_path);
-            let listener = match UnixListener::bind(socket_path) {
-                Ok(l) => l,
-                Err(e) => {
-                    let _ = nix::sys::signal::kill(child, Some(nix::sys::signal::Signal::SIGTERM));
-                    // SAFETY: [Category 8 — FFI] close master_pty — valid fd
-                    // from openpty, not owned by OwnedFd.
-                    unsafe {
-                        libc::close(master_pty);
-                    }
-                    return Err(AishError::Pty(format!("bind socket: {e}")));
-                }
-            };
+            let listener = UnixListener::bind(socket_path)
+                .map_err(|e| AishError::Pty(format!("bind socket: {e}")))?;
             use std::os::unix::fs::PermissionsExt;
             let _ = std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(0o600));
-            if let Err(e) = listener.set_nonblocking(true) {
-                let _ = nix::sys::signal::kill(child, Some(nix::sys::signal::Signal::SIGTERM));
-                // SAFETY: [Category 8 — FFI] close master_pty — valid fd.
-                unsafe {
-                    libc::close(master_pty);
-                }
-                return Err(AishError::Pty(format!("listener nonblocking: {e}")));
-            }
+            listener
+                .set_nonblocking(true)
+                .map_err(|e| AishError::Pty(format!("listener nonblocking: {e}")))?;
 
             let session_info = DaemonSessionInfo {
                 session_id: session_id.to_string(),
@@ -1101,18 +1084,7 @@ pub fn run_pty_daemon_shell(
                                         }
                                         match frame.frame_type {
                                             TYPE_INPUT => {
-                                                // Write to PTY master, retry on EAGAIN.
-                                                // NOTE: On EAGAIN we sleep 1ms and retry
-                                                // in-place. This briefly blocks the select
-                                                // loop, but user keystrokes are tiny (1-16
-                                                // bytes) and the PTY kernel buffer is
-                                                // typically 4KB+, so EAGAIN only fires on
-                                                // very large pastes — a rare case where a
-                                                // few ms of blocking is acceptable. A full
-                                                // fix would queue unwritten bytes and retry
-                                                // when select reports master_pty writable,
-                                                // but that adds significant complexity for
-                                                // a marginal edge case.
+                                                // Write to PTY master, retry on EAGAIN
                                                 let data = &frame.payload;
                                                 let mut written = 0;
                                                 while written < data.len() {
@@ -1163,6 +1135,18 @@ pub fn run_pty_daemon_shell(
                                                 }
                                             }
                                             TYPE_DETACH => remove = true,
+                                            TYPE_KILL_SESSION => {
+                                                let _ = nix::sys::signal::kill(
+                                                    child,
+                                                    Some(nix::sys::signal::Signal::SIGTERM),
+                                                );
+                                                std::thread::sleep(Duration::from_millis(200));
+                                                let _ = nix::sys::signal::kill(
+                                                    child,
+                                                    Some(nix::sys::signal::Signal::SIGKILL),
+                                                );
+                                                child_exited = true;
+                                            }
                                             _ => {}
                                         }
                                     }

--- a/crates/aish-pty/src/scrollback.rs
+++ b/crates/aish-pty/src/scrollback.rs
@@ -43,24 +43,13 @@ impl ScrollbackBuffer {
     }
 
     /// Append raw PTY output bytes. Overwrites oldest data when full.
-    ///
-    /// Copies data in contiguous chunks (up to the wrap point, then the
-    /// remainder) rather than per-byte, to reduce overhead on the daemon's
-    /// hot PTY-output path.
     pub fn push(&mut self, data: &[u8]) {
-        if data.is_empty() {
-            return;
-        }
-        let mut remaining = data;
-        while !remaining.is_empty() {
-            let chunk_end = self.write_pos + remaining.len().min(self.capacity);
-            let copy_len = chunk_end.min(self.capacity) - self.write_pos;
-            self.buf[self.write_pos..self.write_pos + copy_len]
-                .copy_from_slice(&remaining[..copy_len]);
-            self.write_pos = (self.write_pos + copy_len) % self.capacity;
-            let new_len = self.len.saturating_add(copy_len).min(self.capacity);
-            self.len = new_len;
-            remaining = &remaining[copy_len..];
+        for &byte in data {
+            self.buf[self.write_pos] = byte;
+            self.write_pos = (self.write_pos + 1) % self.capacity;
+            if self.len < self.capacity {
+                self.len += 1;
+            }
         }
     }
 

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -2705,7 +2705,11 @@ impl AishShell {
                     .as_ref()
                     .map(|c| c == &s.session_id || s.session_id.starts_with(c))
                     .unwrap_or(false);
-                let cwd_display = cwd_display(&s.cwd, &home);
+                let cwd_display = if !home.is_empty() && s.cwd.starts_with(&home) {
+                    format!("~{}", &s.cwd[home.len()..])
+                } else {
+                    s.cwd.clone()
+                };
                 let age_str = format_age(now.saturating_sub(s.started_at));
                 let detail = if is_current {
                     format!(
@@ -2816,7 +2820,11 @@ impl AishShell {
                 .as_ref()
                 .map(|c| c == &s.session_id || s.session_id.starts_with(c))
                 .unwrap_or(false);
-            let cwd_display = cwd_display(&s.cwd, &home);
+            let cwd_display = if !home.is_empty() && s.cwd.starts_with(&home) {
+                format!("~{}", &s.cwd[home.len()..])
+            } else {
+                s.cwd.clone()
+            };
             let age_str = format_age(now.saturating_sub(s.started_at));
             let current = if is_current {
                 format!("  \x1b[32m{}\x1b[0m", t("shell.live_sessions.current_tag"))
@@ -6680,15 +6688,6 @@ fn emit_osc(op: &str) {
 }
 
 /// Format a duration in seconds as a localized "N s/min/h ago" string.
-/// Render a cwd path with the home directory abbreviated to `~`.
-fn cwd_display(cwd: &str, home: &str) -> String {
-    if !home.is_empty() && cwd.starts_with(home) {
-        format!("~{}", &cwd[home.len()..])
-    } else {
-        cwd.to_string()
-    }
-}
-
 fn format_age(secs: u64) -> String {
     use aish_i18n::t_with_args;
     let mut args = std::collections::HashMap::new();
@@ -6698,12 +6697,9 @@ fn format_age(secs: u64) -> String {
     } else if secs < 3600 {
         args.insert("minutes".to_string(), (secs / 60).to_string());
         t_with_args("shell.time.minutes_ago", &args)
-    } else if secs < 86400 {
+    } else {
         args.insert("hours".to_string(), (secs / 3600).to_string());
         t_with_args("shell.time.hours_ago", &args)
-    } else {
-        args.insert("days".to_string(), (secs / 86400).to_string());
-        t_with_args("shell.time.days_ago", &args)
     }
 }
 


### PR DESCRIPTION
## Summary

Reverts the `fix: address CodeRabbit review comments` portion that was squashed into #348 (`3d289e2`). The original commit is `51b58ea` on `feat/pty-daemon-attach`.

## Why

After #348 landed, two regressions showed up at the prompt:

1. **`;` backspace regression** — typing `;abc`, then backspacing to clear, leaves the spinner running and a stale ghost text gets repainted on the now-blank line, so it looks like the `;` "can't be fully deleted" and the typed text "disappears".
2. **`/` slash-command popup broken** — pressing `/` on an empty prompt enters the `SlashInputSession` but the ratatui inline viewport never finishes initializing (hangs at the DSR cursor-position query).

Bisecting the `feat/pty-daemon-attach` branch showed `51b58ea` as the offending commit. Reverting it on top of `upstream/main` (where #348 was squashed as `3d289e2`) restores the working behavior. `git revert` applied cleanly with no conflicts.

## What is reverted

- OscScanner partial-prefix handling in `aish-cli/main.rs`
- daemon.rs resource cleanup on socket bind failure + dead-code removal
- scrollback.rs push() slice optimization
- app.rs `format_age` days bucket + `cwd_display()` helper extraction
- locale strings (`days_ago`, missing accents in es-ES)

## Verification

- `git revert 51b58ea` applied with no conflicts on top of `upstream/main` (`e345a3e`)
- Revert diff is the exact inverse of `51b58ea` (+42 / -87 vs original +87 / -42)
- After revert, `;` backspace and `/` popup both behave correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of streamed terminal control sequences split across output chunks, preventing incomplete content from being displayed prematurely.
  - Improved live-session termination handling for more reliable cleanup.
  - Scrollback behavior remains consistent when receiving large amounts of terminal output.
  - Relative time displays now use hours instead of days for older activity.

- **Localization**
  - Updated Spanish live-session wording.
  - Refined relative-time translations across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->