### PR TITLE
fix(web_fetch): decode HTML entities in single pass to prevent double-decoding

### DIFF
--- a/crates/aish-tools/src/web_fetch/utils.rs
+++ b/crates/aish-tools/src/web_fetch/utils.rs
@@ -403,9 +403,8 @@ fn decode_html_entities(input: &str) -> String {
     // turning `&amp;lt;` into `&lt;`, which was then decoded again into
     // `<` — corrupting the original content.
     static ENTITY_RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
-    let re = ENTITY_RE.get_or_init(|| {
-        Regex::new(r"&(?:amp|lt|gt|quot|apos|nbsp|#39);").expect("valid regex")
-    });
+    let re = ENTITY_RE
+        .get_or_init(|| Regex::new(r"&(?:amp|lt|gt|quot|apos|nbsp|#39);").expect("valid regex"));
     re.replace_all(input, |caps: &regex::Captures| match &caps[0] {
         "&amp;" => "&",
         "&lt;" => "<",

--- a/crates/aish-tools/src/web_fetch/utils.rs
+++ b/crates/aish-tools/src/web_fetch/utils.rs
@@ -396,14 +396,26 @@ fn regex_replace_all(input: &str, pattern: &str, replacement: &str) -> String {
 }
 
 fn decode_html_entities(input: &str) -> String {
-    input
-        .replace("&nbsp;", " ")
-        .replace("&amp;", "&")
-        .replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&quot;", "\"")
-        .replace("&#39;", "'")
-        .replace("&apos;", "'")
+    // Decode all entities in a single pass so that `&amp;lt;` (which
+    // represents the literal text `&lt;`) is not double-decoded into `<`.
+    //
+    // The previous chained `.replace()` approach decoded `&amp;` first,
+    // turning `&amp;lt;` into `&lt;`, which was then decoded again into
+    // `<` — corrupting the original content.
+    static ENTITY_RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    let re = ENTITY_RE.get_or_init(|| {
+        Regex::new(r"&(?:amp|lt|gt|quot|apos|nbsp|#39);").expect("valid regex")
+    });
+    re.replace_all(input, |caps: &regex::Captures| match &caps[0] {
+        "&amp;" => "&",
+        "&lt;" => "<",
+        "&gt;" => ">",
+        "&quot;" => "\"",
+        "&apos;" | "&#39;" => "'",
+        "&nbsp;" => " ",
+        _ => unreachable!(),
+    })
+    .to_string()
 }
 
 fn normalize_text_whitespace(input: &str) -> String {
@@ -529,5 +541,29 @@ mod tests {
         let prompt = make_secondary_model_prompt("content", "summarize", false);
         assert!(prompt.contains("125-character maximum"));
         assert!(prompt.contains("summarize"));
+    }
+
+    #[test]
+    fn decode_html_entities_basic() {
+        assert_eq!(decode_html_entities("&lt;"), "<");
+        assert_eq!(decode_html_entities("&gt;"), ">");
+        assert_eq!(decode_html_entities("&amp;"), "&");
+        assert_eq!(decode_html_entities("&quot;"), "\"");
+        assert_eq!(decode_html_entities("&#39;"), "'");
+        assert_eq!(decode_html_entities("&apos;"), "'");
+        assert_eq!(decode_html_entities("&nbsp;"), " ");
+    }
+
+    #[test]
+    fn decode_html_entities_no_double_decode() {
+        // `&amp;lt;` in HTML represents the literal text `&lt;`, not `<`.
+        // The old chained-replace approach decoded `&amp;` first,
+        // turning `&amp;lt;` into `&lt;`, then decoded `&lt;` into `<`.
+        // A single-pass decoder must leave `&amp;lt;` → `&lt;`.
+        assert_eq!(decode_html_entities("&amp;lt;"), "&lt;");
+        assert_eq!(decode_html_entities("&amp;gt;"), "&gt;");
+        assert_eq!(decode_html_entities("&amp;quot;"), "&quot;");
+        assert_eq!(decode_html_entities("&amp;#39;"), "&#39;");
+        assert_eq!(decode_html_entities("&amp;apos;"), "&apos;");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #355

The `decode_html_entities` function in `crates/aish-tools/src/web_fetch/utils.rs` used chained `.replace()` calls where `&amp;` was decoded **before** other entities (`&lt;`, `&gt;`, `&quot;`, etc.). This caused `&amp;lt;` — which represents the literal text `&lt;` in HTML — to be double-decoded into `<`, corrupting web content before it reaches the LLM.

## Root Cause

```rust
// Old (buggy):
fn decode_html_entities(input: &str) -> String {
    input
        .replace("&nbsp;", " ")
        .replace("&amp;", "&")   // decoded first!
        .replace("&lt;", "<")    // then re-decodes the result
        .replace("&gt;", ">")
        .replace("&quot;", "\"")
        .replace("&#39;", "'")
        .replace("&apos;", "'")
}
```

Processing `&amp;lt;`:
1. `&amp;` -> `&`, producing `&lt;`
2. `&lt;` -> `<`, producing `<` (wrong! should be `&lt;`)

## Fix

Replace the chained `.replace()` calls with a single-pass regex that matches all known entities at once and replaces each with its decoded character, preventing any chain reaction.

## Test Coverage

Added two new test cases:

- `decode_html_entities_basic` -- verifies each entity decodes correctly
- `decode_html_entities_no_double_decode` -- verifies `&amp;lt;` -> `&lt;` (not `<`), `&amp;gt;` -> `&gt;` (not `>`), etc.

All 7 tests in `web_fetch::utils::tests` pass.

```
test web_fetch::utils::tests::decode_html_entities_basic ... ok
test web_fetch::utils::tests::decode_html_entities_no_double_decode ... ok
test web_fetch::utils::tests::html_to_readable_text_removes_scripts_and_tags ... ok
test web_fetch::utils::tests::normalizes_http_to_https ... ok
test web_fetch::utils::tests::redirect_only_allows_same_origin_or_www_equivalent ... ok
test web_fetch::utils::tests::rejects_private_hosts ... ok
test web_fetch::utils::tests::secondary_prompt_includes_quote_restriction_for_unapproved_domains ... ok
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML entity decoding to avoid double-decoding encoded strings (e.g., `&amp;lt;` now stays as `&lt;` text).
  * Ensures correct conversion of common entities like `&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`/`&`#39`;`, and `&nbsp;`.
  * Expanded automated test coverage for basic decoding and “no double decode” scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->