### PR TITLE
feat(shell): centralized theme system, display polish and session management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
  "libc",
  "nix 0.29.0",
  "open",
+ "parking_lot",
  "ratatui",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ unicode-width = { version = "0.2", features = ["cjk"] }
 # System
 nix = { version = "0.29", features = ["term", "process", "signal", "fs", "ioctl", "poll", "user"] }
 libc = "0.2"
+parking_lot = "0.12"
 
 # Database
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/crates/aish-cli/src/main.rs
+++ b/crates/aish-cli/src/main.rs
@@ -45,6 +45,10 @@ struct Cli {
     #[arg(long)]
     config: Option<String>,
 
+    /// Continue: attach to an existing live session or pick from a list
+    #[arg(short = 'c', long = "continue")]
+    continue_session: bool,
+
     #[arg(long, hide = true)]
     sandbox_daemon: bool,
 
@@ -80,14 +84,9 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Run the AI Shell (default) — attaches to existing PTY session or creates new
+    /// Run the AI Shell — creates a new PTY session by default.
+    /// Use --continue/-c to attach to an existing live session.
     Run,
-
-    /// Start a new PTY session (like `tmux new`)
-    New,
-
-    /// Rename a live PTY session interactively
-    RenameLiveSessions,
 
     /// Kill PTY session(s) by ID prefix. Supports multiple IDs and `all`.
     Kill {
@@ -290,47 +289,53 @@ fn main() {
         config.api_base = api_base;
     }
 
-    match cli.command.unwrap_or(Commands::Run) {
-        Commands::Run => run_shell(config),
-        Commands::New => run_shell_new(config),
-        Commands::RenameLiveSessions => rename_live_sessions(),
-        Commands::Kill { ids } => kill_session_by_id(&ids),
-        Commands::KillAll => kill_session_by_id(&["all".to_string()]),
-        Commands::Resume { session_id } => run_shell_resume(config, &session_id),
-        Commands::Info => show_info(&config),
-        Commands::Setup => {
+    match cli.command {
+        // `aish` or `aish run`: start a fresh shell by default.
+        // Use --continue/-c to attach to an existing live session.
+        None | Some(Commands::Run) => {
+            if cli.continue_session {
+                run_shell_continue(config);
+            } else {
+                run_shell_new(config);
+            }
+        }
+        Some(Commands::Kill { ids }) => kill_session_by_id(&ids),
+        Some(Commands::KillAll) => kill_session_by_id(&["all".to_string()]),
+        Some(Commands::Resume { session_id }) => run_shell_resume(config, &session_id),
+        Some(Commands::Info) => show_info(&config),
+        Some(Commands::Setup) => {
             if !run_setup(&mut config) {
                 std::process::exit(1);
             }
         }
-        Commands::ModelsUsage => show_models_usage(&config),
-        Commands::CheckToolSupport {
+        Some(Commands::ModelsUsage) => show_models_usage(&config),
+        Some(Commands::CheckToolSupport {
             model,
             api_base,
             api_key,
-        } => check_tool_support(&config, model, api_base, api_key),
-        Commands::CheckLangfuse {
+        }) => check_tool_support(&config, model, api_base, api_key),
+        Some(Commands::CheckLangfuse {
             public_key,
             secret_key,
             host,
-        } => check_langfuse(&config, public_key, secret_key, host),
-        Commands::Update {
+        }) => check_langfuse(&config, public_key, secret_key, host),
+        Some(Commands::Update {
             check_only,
             pre_release,
-        } => {
+        }) => {
             update::run_update(check_only, pre_release);
         }
-        Commands::Uninstall { purge } => {
+        Some(Commands::Uninstall { purge }) => {
             uninstall::run_uninstall(purge);
         }
-        Commands::Doctor { fix } => {
+        Some(Commands::Doctor { fix }) => {
             let doctor = aish_shell::doctor::Doctor::new();
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
                 doctor.run(fix).await;
             });
         }
-        Commands::ModelsAuth {
+        Some(Commands::ModelsAuth {
             provider,
             model,
             set_default,
@@ -339,7 +344,7 @@ fn main() {
             open_browser,
             callback_port,
             config: auth_config,
-        } => {
+        }) => {
             let mut cfg = load_config(auth_config.as_deref());
             models_auth::run_models_auth(
                 &mut cfg,
@@ -459,43 +464,24 @@ fn spawn_pty_daemon(
     .into())
 }
 
-fn run_shell(config: aish_config::ConfigModel) {
-    let pty_daemon_enabled = config.pty_daemon_enabled
+/// Whether PTY daemon mode is active: enabled in config *and* not
+/// suppressed by `AISH_PTY_DAEMON=0` (set inside daemon children to
+/// prevent infinite recursion).
+fn is_daemon_mode(config: &aish_config::ConfigModel) -> bool {
+    config.pty_daemon_enabled
         && std::env::var("AISH_PTY_DAEMON")
             .map(|v| v != "0" && v != "false" && v != "no")
-            .unwrap_or(true);
+            .unwrap_or(true)
+}
 
-    if !pty_daemon_enabled {
-        run_shell_normal(config);
-        return;
-    }
-
-    let mut sessions = aish_pty::discover_sessions();
-    sessions.sort_by_key(|s| std::cmp::Reverse(s.started_at));
-
-    if !sessions.is_empty() {
-        match show_session_picker(&sessions) {
-            SessionAction::Attach(idx) => {
-                let s = &sessions[idx];
-                eprintln!(
-                    "\x1b[32m[aish] Attaching to session {}\x1b[0m",
-                    &s.session_id[..8.min(s.session_id.len())]
-                );
-                if run_pty_raw_attach(&s.socket_path.to_string_lossy(), &s.session_id) {
-                    return;
-                }
-                eprintln!("\x1b[33m[aish] Attach failed.\x1b[0m");
-            }
-            SessionAction::New => {}
-            SessionAction::Cancel => return,
-        }
-    }
-
+/// Spawn a fresh PTY daemon session from the current executable and
+/// attach to it.  Returns `true` on successful attach (caller returns),
+/// `false` if spawning or attaching failed (caller falls back).
+fn spawn_daemon_and_attach(config: &aish_config::ConfigModel) -> bool {
     let cwd = std::env::current_dir()
         .unwrap_or_default()
         .to_string_lossy()
         .to_string();
-    eprintln!("\x1b[32m[aish] Starting new PTY daemon session...\x1b[0m");
     match spawn_pty_daemon(
         &cwd,
         if config.model.is_empty() {
@@ -509,84 +495,131 @@ fn run_shell(config: aish_config::ConfigModel) {
             Some(config.api_base.as_str())
         },
     ) {
-        Ok(info) => {
-            if run_pty_raw_attach(&info.socket_path.to_string_lossy(), &info.session_id) {
-                return;
-            }
+        Ok(info) => run_pty_raw_attach(&info.socket_path.to_string_lossy(), &info.session_id),
+        Err(e) => {
+            eprintln!("\x1b[33m[aish] PTY daemon failed: {}\x1b[0m", e);
+            false
         }
-        Err(e) => eprintln!("\x1b[33m[aish] PTY daemon failed: {}\x1b[0m", e),
     }
-    eprintln!("\x1b[33m[aish] Falling back to standalone shell.\x1b[0m");
-    run_shell_normal(config);
+}
+
+fn run_shell_continue(config: aish_config::ConfigModel) {
+    if !is_daemon_mode(&config) {
+        run_shell_normal(config);
+        return;
+    }
+
+    let sessions = aish_pty::discover_sessions();
+
+    if !sessions.is_empty() {
+        match show_session_picker(sessions) {
+            SessionAction::Attach(s) => {
+                let short = &s.session_id[..8.min(s.session_id.len())];
+                eprintln!("\x1b[32m[aish] Attaching to session {short}\x1b[0m");
+                if run_pty_raw_attach(&s.socket_path.to_string_lossy(), &s.session_id) {
+                    return;
+                }
+                eprintln!("\x1b[33m[aish] Attach failed.\x1b[0m");
+            }
+            SessionAction::New => {}
+            SessionAction::Cancel => return,
+        }
+    }
+
+    if !spawn_daemon_and_attach(&config) {
+        eprintln!("\x1b[33m[aish] Falling back to standalone shell.\x1b[0m");
+        run_shell_normal(config);
+    }
 }
 
 enum SessionAction {
-    Attach(usize),
+    Attach(aish_pty::DaemonSessionInfo),
     New,
     Cancel,
 }
 
-/// Interactive session picker using arrow-key navigation.
-fn show_session_picker(sessions: &[aish_pty::DaemonSessionInfo]) -> SessionAction {
+/// Interactive session picker with inline rename support. Arrow keys move,
+/// Enter attaches to the highlighted session, Ctrl+E renames it (then re-shows
+/// the refreshed list), and Esc cancels. "Create new session" spawns a fresh
+/// daemon. Owns the session list so renames can refresh it between rounds.
+fn show_session_picker(initial_sessions: Vec<aish_pty::DaemonSessionInfo>) -> SessionAction {
     use aish_ui::{
         PanelOutcome, PanelRuntime, SearchSelectItem, SearchSelectOutcome, SearchSelectPanel,
     };
 
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+    let mut sessions = initial_sessions;
+    sessions.sort_by_key(|s| std::cmp::Reverse(s.started_at));
 
-    let mut items: Vec<SearchSelectItem> = sessions
-        .iter()
-        .enumerate()
-        .map(|(i, s)| {
-            let cwd_display = display_cwd(&s.cwd);
-            let age_str = format_duration(now.saturating_sub(s.started_at));
-            let short_id = &s.session_id[..8.min(s.session_id.len())];
-            let name = s.name.as_deref().unwrap_or("");
-            // Label shows name (if set) or short_id, followed by cwd.
-            let label = if !name.is_empty() {
-                format!("{}  {}", name, cwd_display)
-            } else {
-                format!("{}  {}", short_id, cwd_display)
-            };
-            // Search text includes both name and short_id so users can
-            // search by either.
-            let search_text = format!("{} {} {}", name, short_id, cwd_display);
-            SearchSelectItem::new(format!("session:{}", i), label)
-                .with_detail(format!("started: {}", age_str))
-                .with_search_text(search_text)
-        })
-        .collect();
+    loop {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
 
-    // "Create new" is the default (last item, pre-selected)
-    items.push(SearchSelectItem::new(
-        "new",
-        "Create new session".to_string(),
-    ));
-
-    let panel = SearchSelectPanel::new("Select PTY Session", "Type to search sessions...", items)
-        .with_footer(
-            "↑↓ navigate · Enter select · Esc cancel · Run 'aish kill <id>' to terminate a session",
-        )
-        .with_selected_value(Some("new"));
-
-    match PanelRuntime::new().run(panel) {
-        Ok(PanelOutcome::Submitted(SearchSelectOutcome::Selected(value))) => {
-            if value == "new" {
-                SessionAction::New
-            } else if let Some(idx_str) = value.strip_prefix("session:") {
-                match idx_str.parse::<usize>() {
-                    Ok(idx) if idx < sessions.len() => SessionAction::Attach(idx),
-                    _ => SessionAction::New,
+        let mut items: Vec<SearchSelectItem> = sessions
+            .iter()
+            .enumerate()
+            .map(|(i, s)| {
+                let cwd_display = display_cwd(&s.cwd);
+                let age_str = format_duration(now.saturating_sub(s.started_at));
+                let short_id = &s.session_id[..8.min(s.session_id.len())];
+                let name = s.name.as_deref().unwrap_or("");
+                // Label is the short id + cwd; a custom name (if any) is the
+                // bold green highlight prefix so it stands out at a glance.
+                let label = format!("{short_id}  {cwd_display}");
+                let search_text = format!("{name} {short_id} {cwd_display}");
+                let mut item = SearchSelectItem::new(format!("session:{i}"), label)
+                    .with_detail(format!("started: {age_str}"))
+                    .with_search_text(search_text);
+                if !name.is_empty() {
+                    item = item.with_highlight(name);
                 }
-            } else {
-                SessionAction::New
+                item
+            })
+            .collect();
+
+        // "Create new" is the last item and the default selection.
+        items.push(SearchSelectItem::new(
+            "new",
+            "Create new session".to_string(),
+        ));
+
+        let panel =
+            SearchSelectPanel::new("Select PTY Session", "Type to search sessions...", items)
+                .with_footer(
+                    "↑↓ navigate · Enter select · Ctrl+E rename · Esc cancel · Run 'aish kill <id>' to terminate a session",
+                )
+                .with_selected_value(Some("new"));
+
+        match PanelRuntime::new().run(panel) {
+            Ok(PanelOutcome::Submitted(SearchSelectOutcome::Selected(value))) => {
+                if value == "new" {
+                    return SessionAction::New;
+                }
+                if let Some(idx) = index_from_value(&value, sessions.len()) {
+                    return SessionAction::Attach(sessions[idx].clone());
+                }
+                return SessionAction::New;
             }
+            Ok(PanelOutcome::Submitted(SearchSelectOutcome::Rename(value))) => {
+                if let Some(idx) = index_from_value(&value, sessions.len()) {
+                    rename_session_interactive(&sessions[idx]);
+                }
+                // Refresh so the new name shows up, then re-show the picker.
+                sessions = aish_pty::discover_sessions();
+                sessions.sort_by_key(|s| std::cmp::Reverse(s.started_at));
+                continue;
+            }
+            _ => return SessionAction::Cancel,
         }
-        _ => SessionAction::Cancel,
     }
+}
+
+/// Parse a picker item value like "session:3" into a bounded index.
+fn index_from_value(value: &str, len: usize) -> Option<usize> {
+    let idx_str = value.strip_prefix("session:")?;
+    let idx: usize = idx_str.parse().ok()?;
+    (idx < len).then_some(idx)
 }
 /// Run the normal (non-daemon) AishShell.
 fn run_shell_normal(mut config: aish_config::ConfigModel) {
@@ -619,94 +652,21 @@ fn run_shell_normal(mut config: aish_config::ConfigModel) {
     }
 }
 
-/// Interactively rename a live PTY session. With active sessions, opens an
-/// interactive panel: select a session to rename it (Enter), Esc to cancel.
-/// Without active sessions, prints a hint and exits.
-fn rename_live_sessions() {
-    let sessions = aish_pty::discover_sessions();
-    if sessions.is_empty() {
-        println!("No active PTY sessions.");
-        println!("Run 'aish' to start one.");
-        return;
-    }
+/// Open a text-input panel to rename a live session. Returns `true` when the
+/// name was written to disk (so callers can refresh their session list).
+fn rename_session_interactive(session: &aish_pty::DaemonSessionInfo) -> bool {
+    use aish_ui::{ChoiceOutcome, ChoicePanel, PanelOutcome, PanelRuntime};
 
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-
-    // Build the session selection panel.
-    use aish_ui::{
-        ChoiceOutcome, ChoicePanel, PanelOutcome, PanelRuntime, SearchSelectItem,
-        SearchSelectOutcome, SearchSelectPanel,
-    };
-
-    let items: Vec<SearchSelectItem> = sessions
-        .iter()
-        .enumerate()
-        .map(|(i, s)| {
-            let cwd_display = display_cwd(&s.cwd);
-            let age_str = format_duration(now.saturating_sub(s.started_at));
-            let short_id = &s.session_id[..8.min(s.session_id.len())];
-            let mut item = SearchSelectItem::new(
-                format!("session:{}", i),
-                format!("{}  {}", short_id, cwd_display),
-            )
-            .with_detail(format!("started: {}", age_str));
-            if let Some(n) = &s.name {
-                if !n.is_empty() {
-                    item = item.with_badge(n.clone());
-                }
-            }
-            item
-        })
-        .collect();
-
-    let panel = SearchSelectPanel::new(
-        "Live PTY Sessions",
-        "Select a session to rename (Enter) · Esc to cancel",
-        items,
-    )
-    .with_footer("↑↓ navigate · Enter rename · Esc cancel");
-
-    let selected = match PanelRuntime::new().run(panel) {
-        Ok(PanelOutcome::Submitted(SearchSelectOutcome::Selected(value))) => value,
-        _ => {
-            // User cancelled; fall back to printing the plain list.
-            print_session_list(&sessions, now);
-            return;
-        }
-    };
-
-    let idx = match selected.strip_prefix("session:") {
-        Some(s) => match s.parse::<usize>() {
-            Ok(n) if n < sessions.len() => n,
-            _ => {
-                print_session_list(&sessions, now);
-                return;
-            }
-        },
-        None => {
-            print_session_list(&sessions, now);
-            return;
-        }
-    };
-
-    let session = &sessions[idx];
     let short_id = &session.session_id[..8.min(session.session_id.len())];
     let current = session.name.as_deref().unwrap_or("");
 
-    // Second step: enter a new name via ChoicePanel custom input.
-    let rename_panel = ChoicePanel::new(
-        format!("Rename session {}", short_id),
-        format!(
-            "Current name: {}",
-            if current.is_empty() {
-                "(none)"
-            } else {
-                current
-            }
-        ),
+    let panel = ChoicePanel::new(
+        format!("Rename session {short_id}"),
+        if current.is_empty() {
+            "Current name: (none)".to_string()
+        } else {
+            format!("Current name: {current}")
+        },
         Vec::new(),
     )
     .with_custom_label("Enter new name (empty to clear)")
@@ -714,54 +674,25 @@ fn rename_live_sessions() {
     .with_allow_empty_custom_input(true)
     .with_footer("Type a name | Enter save | Esc cancel");
 
-    match PanelRuntime::new().run(rename_panel) {
+    match PanelRuntime::new().run(panel) {
         Ok(PanelOutcome::Submitted(ChoiceOutcome::CustomInput(name))) => {
             match aish_pty::rename_session(&session.session_id, &name) {
                 Ok(()) => {
                     if name.trim().is_empty() {
-                        println!("Cleared name for session {}.", short_id);
+                        println!("Cleared name for session {short_id}.");
                     } else {
-                        println!("Renamed session {} → \"{}\".", short_id, name.trim());
+                        println!("Renamed session {short_id} → \"{}\".", name.trim());
                     }
+                    true
                 }
-                Err(e) => eprintln!("\x1b[31mFailed to rename: {}\x1b[0m", e),
+                Err(e) => {
+                    eprintln!("\x1b[31mFailed to rename: {e}\x1b[0m");
+                    false
+                }
             }
         }
-        _ => {
-            // Cancelled or selected an empty list item — just print the list.
-        }
+        _ => false,
     }
-
-    // Re-discover so the printed list reflects the rename we just performed.
-    let refreshed = aish_pty::discover_sessions();
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    print_session_list(&refreshed, now);
-}
-
-/// Print the session list in plain (non-interactive) form.
-fn print_session_list(sessions: &[aish_pty::DaemonSessionInfo], now: u64) {
-    println!("Active PTY sessions:\n");
-    for s in sessions {
-        let cwd_display = display_cwd(&s.cwd);
-        let age = format_duration(now.saturating_sub(s.started_at));
-        let model = s.model.as_deref().unwrap_or("");
-        let label = session_label(s);
-        println!(
-            "  {label}  cwd: {cwd:<20}  started: {age}{model}",
-            label = label,
-            cwd = cwd_display,
-            age = age,
-            model = if model.is_empty() {
-                String::new()
-            } else {
-                format!("  {}", model)
-            }
-        );
-    }
-    println!("\n{} session(s) total", sessions.len());
 }
 
 fn kill_session_by_id(ids: &[String]) {
@@ -862,41 +793,24 @@ fn display_cwd(cwd: &str) -> String {
 fn session_label(s: &aish_pty::DaemonSessionInfo) -> String {
     let short_id = &s.session_id[..8.min(s.session_id.len())];
     match &s.name {
-        Some(n) if !n.is_empty() => format!("{} ({})", n, short_id),
-        _ => short_id.to_string(),
+        // Bold green name + dim short id, so custom names stand out at a glance.
+        Some(n) if !n.is_empty() => {
+            format!("\x1b[1;32m{n}\x1b[0m \x1b[2m({short_id})\x1b[0m")
+        }
+        _ => format!("\x1b[2m{short_id}\x1b[0m"),
     }
 }
 
 fn run_shell_new(config: aish_config::ConfigModel) {
-    let cwd = std::env::current_dir()
-        .unwrap_or_default()
-        .to_string_lossy()
-        .to_string();
-    eprintln!("\x1b[32m[aish] Creating new PTY daemon session...\x1b[0m");
-    match spawn_pty_daemon(
-        &cwd,
-        if config.model.is_empty() {
-            None
-        } else {
-            Some(config.model.as_str())
-        },
-        if config.api_base.is_empty() {
-            None
-        } else {
-            Some(config.api_base.as_str())
-        },
-    ) {
-        Ok(info) => {
-            if run_pty_raw_attach(&info.socket_path.to_string_lossy(), &info.session_id) {
-                return;
-            }
-        }
-        Err(e) => {
-            eprintln!("\x1b[33m[aish] PTY daemon failed: {}\x1b[0m", e);
-        }
+    if !is_daemon_mode(&config) {
+        run_shell_normal(config);
+        return;
     }
-    eprintln!("\x1b[33m[aish] Falling back to normal shell.\x1b[0m");
-    run_shell_normal(config);
+
+    if !spawn_daemon_and_attach(&config) {
+        eprintln!("\x1b[33m[aish] Falling back to standalone shell.\x1b[0m");
+        run_shell_normal(config);
+    }
 }
 
 fn run_shell_resume(config: aish_config::ConfigModel, session_id: &str) {
@@ -1218,14 +1132,6 @@ fn run_pty_raw_attach(socket_path: &str, session_id: &str) -> bool {
     // buffered scrollback.
     let mut skip_osc_commands = false;
 
-    // SAFETY: [Category 8 — FFI] `write()` to stdout_fd — a single short
-    // message. `stdout_fd` is stdout (valid). The byte slice is a static
-    // literal; `.as_ptr()` is valid for its lifetime.
-    unsafe {
-        let msg = b"\r\n\x1b[32m[aish] Attached (Ctrl+Q to detach)\x1b[0m\r\n";
-        libc::write(stdout_fd, msg.as_ptr() as *const _, msg.len());
-    }
-
     // Flush scrollback immediately. The attach handshake consumed all
     // scrollback bytes from the socket into `pending_events`, so the
     // kernel socket buffer is now empty. Without this explicit drain,
@@ -1272,6 +1178,10 @@ fn run_pty_raw_attach(socket_path: &str, session_id: &str) -> bool {
     }
 
     let mut stdin_buf = [0u8; 1024];
+    // True when the inner shell sent ShellExiting (user typed `exit`/`logout`).
+    // Distinguishes a true detach (Ctrl+Q — session still alive) from a shell
+    // exit (session is dying, nothing to reattach to).
+    let mut shell_exited = false;
 
     loop {
         let socket_fd = backend.readable_fds()[0];
@@ -1329,6 +1239,14 @@ fn run_pty_raw_attach(socket_path: &str, session_id: &str) -> bool {
                     if qpos > 0 {
                         let _ = backend.write_input(&data[..qpos]);
                     }
+                    // Ctrl+Q detaches. Restore cooked terminal mode and, when
+                    // the current session is still unnamed, prompt for a note
+                    // so it stays identifiable in `aish -c`.
+                    // SAFETY: tcsetattr restores `orig_termios` saved at attach.
+                    unsafe {
+                        libc::tcsetattr(stdin_fd, libc::TCSANOW, &orig_termios);
+                    }
+                    ctrl_q_detach_nudge(session_id);
                     break;
                 }
                 if data.len() == 1 && data[0] == 0x04 {
@@ -1382,6 +1300,7 @@ fn run_pty_raw_attach(socket_path: &str, session_id: &str) -> bool {
                                 if matches!(evt, aish_pty::BackendControlEvent::ShellExiting { .. })
                                 {
                                     should_exit = true;
+                                    shell_exited = true;
                                 }
                             }
                         }
@@ -1448,8 +1367,49 @@ fn run_pty_raw_attach(socket_path: &str, session_id: &str) -> bool {
     unsafe {
         libc::tcsetattr(stdin_fd, libc::TCSANOW, &orig_termios);
     }
-    eprintln!("\x1b[32m[aish] Detached. Run `aish` to reattach.\x1b[0m");
+    // Only show the reattach hint when the session is actually still alive
+    // (Ctrl+Q/Ctrl+D detach). When the inner shell typed `exit`, the daemon
+    // sends EXIT_NOTICE which sets running=false — nothing to reattach to.
+    if !shell_exited && backend.is_running() {
+        eprintln!("\x1b[32m[aish] {}\x1b[0m", aish_i18n::t("cli.detach_hint"));
+    }
     true
+}
+
+/// Ctrl+Q detach nudge: when the current session has no user note, prompt for
+/// one so it stays identifiable in `aish -c` after detach. Enter saves &
+/// detaches; Esc (or an empty submit) detaches without naming. The caller
+/// must restore cooked terminal mode first so the panel can render.
+fn ctrl_q_detach_nudge(session_id: &str) {
+    use aish_i18n::t;
+    use aish_ui::{ChoiceOutcome, ChoicePanel, PanelOutcome, PanelRuntime};
+
+    let needs_note = aish_pty::discover_sessions()
+        .into_iter()
+        .find(|s| s.session_id == session_id)
+        .map(|s| s.name.as_deref().unwrap_or("").trim().is_empty())
+        .unwrap_or(false);
+    if !needs_note {
+        return;
+    }
+
+    let panel = ChoicePanel::new(
+        t("shell.live_sessions.exit_no_note_title"),
+        t("shell.live_sessions.exit_no_note_hint"),
+        Vec::new(),
+    )
+    .with_custom_label(t("shell.live_sessions.rename_input_label"))
+    .with_allow_cancel(true)
+    .with_allow_empty_custom_input(true)
+    .with_footer(t("shell.live_sessions.exit_no_note_footer"));
+
+    if let Ok(PanelOutcome::Submitted(ChoiceOutcome::CustomInput(name))) =
+        PanelRuntime::new().run(panel)
+    {
+        if !name.trim().is_empty() {
+            let _ = aish_pty::rename_session(session_id, &name);
+        }
+    }
 }
 
 /// Result of OSC action handling.

--- a/crates/aish-cli/src/main.rs
+++ b/crates/aish-cli/src/main.rs
@@ -569,8 +569,16 @@ fn show_session_picker(initial_sessions: Vec<aish_pty::DaemonSessionInfo>) -> Se
                 let label = format!("{short_id}  {cwd_display}");
                 let search_text = format!("{name} {short_id} {cwd_display}");
                 let mut item = SearchSelectItem::new(format!("session:{i}"), label)
-                    .with_detail(format!("started: {age_str}"))
-                    .with_search_text(search_text);
+                    .with_detail(aish_i18n::t_with_args(
+                        "shell.live_sessions.started_label",
+                        &{
+                            let mut a = std::collections::HashMap::new();
+                            a.insert("age".to_string(), age_str);
+                            a
+                        },
+                    ))
+                    .with_search_text(search_text)
+                    .with_renamable();
                 if !name.is_empty() {
                     item = item.with_highlight(name);
                 }
@@ -581,15 +589,16 @@ fn show_session_picker(initial_sessions: Vec<aish_pty::DaemonSessionInfo>) -> Se
         // "Create new" is the last item and the default selection.
         items.push(SearchSelectItem::new(
             "new",
-            "Create new session".to_string(),
+            aish_i18n::t("shell.live_sessions.create_new"),
         ));
 
-        let panel =
-            SearchSelectPanel::new("Select PTY Session", "Type to search sessions...", items)
-                .with_footer(
-                    "↑↓ navigate · Enter select · Ctrl+E rename · Esc cancel · Run 'aish kill <id>' to terminate a session",
-                )
-                .with_selected_value(Some("new"));
+        let panel = SearchSelectPanel::new(
+            aish_i18n::t("shell.live_sessions.panel_title"),
+            aish_i18n::t("shell.live_sessions.search_placeholder"),
+            items,
+        )
+        .with_footer(aish_i18n::t("shell.live_sessions.panel_footer"))
+        .with_selected_value(Some("new"));
 
         match PanelRuntime::new().run(panel) {
             Ok(PanelOutcome::Submitted(SearchSelectOutcome::Selected(value))) => {
@@ -661,32 +670,62 @@ fn rename_session_interactive(session: &aish_pty::DaemonSessionInfo) -> bool {
     let current = session.name.as_deref().unwrap_or("");
 
     let panel = ChoicePanel::new(
-        format!("Rename session {short_id}"),
+        aish_i18n::t_with_args("shell.live_sessions.rename_title", &{
+            let mut a = std::collections::HashMap::new();
+            a.insert("id".to_string(), short_id.to_string());
+            a
+        }),
         if current.is_empty() {
-            "Current name: (none)".to_string()
+            aish_i18n::t("shell.live_sessions.rename_current_none")
         } else {
-            format!("Current name: {current}")
+            aish_i18n::t_with_args("shell.live_sessions.rename_current_set", &{
+                let mut a = std::collections::HashMap::new();
+                a.insert("name".to_string(), current.to_string());
+                a
+            })
         },
         Vec::new(),
     )
-    .with_custom_label("Enter new name (empty to clear)")
+    .with_custom_label(aish_i18n::t("shell.live_sessions.rename_input_label"))
     .with_allow_cancel(true)
     .with_allow_empty_custom_input(true)
-    .with_footer("Type a name | Enter save | Esc cancel");
+    .with_footer(aish_i18n::t("shell.live_sessions.rename_input_footer"));
 
     match PanelRuntime::new().run(panel) {
         Ok(PanelOutcome::Submitted(ChoiceOutcome::CustomInput(name))) => {
             match aish_pty::rename_session(&session.session_id, &name) {
                 Ok(()) => {
                     if name.trim().is_empty() {
-                        println!("Cleared name for session {short_id}.");
+                        println!(
+                            "{}",
+                            aish_i18n::t_with_args("shell.live_sessions.rename_cleared", &{
+                                let mut a = std::collections::HashMap::new();
+                                a.insert("id".to_string(), short_id.to_string());
+                                a
+                            })
+                        );
                     } else {
-                        println!("Renamed session {short_id} → \"{}\".", name.trim());
+                        println!(
+                            "{}",
+                            aish_i18n::t_with_args("shell.live_sessions.rename_done", &{
+                                let mut a = std::collections::HashMap::new();
+                                a.insert("id".to_string(), short_id.to_string());
+                                a.insert("name".to_string(), name.trim().to_string());
+                                a
+                            })
+                        );
                     }
                     true
                 }
                 Err(e) => {
-                    eprintln!("\x1b[31mFailed to rename: {e}\x1b[0m");
+                    eprintln!(
+                        "{}",
+                        aish_i18n::t_with_args("shell.live_sessions.rename_failed", &{
+                            let mut a = std::collections::HashMap::new();
+                            a.insert("err".to_string(), e.to_string());
+                            a
+                        })
+                    );
                     false
                 }
             }

--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -6,6 +6,7 @@ cli:
   check_langfuse_command_help: "Langfuse-Konfiguration prüfen"
   setup_command_help: "Interaktive Einrichtung ausführen und beenden"
   check_tool_support_command_help: "Live-Prüfung der Tool-Call-Unterstützung debuggen"
+  detach_hint: "Getrennt. `aish -c` ausfuehren, um wieder zu verbinden."
   resume_failed: "Sitzung konnte nicht fortgesetzt werden: {error}"
 
   option:
@@ -234,6 +235,7 @@ shell:
     choice_prompt: "Ihre Auswahl (Standard: n): "
 
   exit_goodbye: "Shell wird beendet. Auf Wiedersehen!"
+  exit_daemon_hint: "※ Tipp: Strg+Q zum Trennen (Sitzung bleibt aktiv), dann aish -c zum Neuverbinden"
   command_cancelled: "Befehl abgebrochen"
   error_correction:
     press_semicolon_hint: "Die Befehlsausführung ist fehlgeschlagen. ; für Schnellreparatur oder /diagnose für Diagnose."
@@ -309,7 +311,7 @@ shell:
     iteration_limit_title: "⏸ Tool-Aufruf-Limit erreicht"
     iteration_continue_prompt: "Fortfahren? [Y/n]"
   resume:
-    exit_command: "Fortsetzen mit: aish resume {session_id}"
+    exit_command: "KI-Kontext fortsetzen: aish resume {session_id}"
     usage: "Verwendung: /resume [session_id]"
     session_store_unavailable: "Sitzungsspeicher ist nicht verfügbar."
     no_sessions: "Keine früheren Sitzungen gefunden."
@@ -331,11 +333,22 @@ shell:
     none_active: "Keine aktiven PTY-Sitzungen."
     panel_title: "Aktive PTY-Sitzungen"
     search_placeholder: "Suchen..."
-    panel_footer: "↑/↓ navigieren · Enter wählen · Esc abbrechen"
+    panel_footer: "↑/↓ navigieren · Enter wählen · Ctrl+E umbenennen · Esc abbrechen"
     create_new: "Neue Sitzung erstellen"
     already_current: "Bereits in dieser Sitzung."
     started_label: "gestartet: {age}"
     current_tag: "[aktuell]"
+    rename_title: "Sitzung {id} umbenennen"
+    rename_current_none: "Aktueller Name: (keiner)"
+    rename_current_set: "Aktueller Name: {name}"
+    rename_input_label: "Neuen Namen eingeben (leer zum Loeschen)"
+    rename_input_footer: "Namen eingeben | Enter speichern | Esc abbrechen"
+    rename_done: "Sitzung {id} → \"{name}\" umbenannt"
+    rename_cleared: "Name fuer Sitzung {id} geloescht"
+    rename_failed: "Umbenennen fehlgeschlagen: {err}"
+    exit_no_note_title: "Vor dem Beenden einen Namen hinzufuegen?"
+    exit_no_note_hint: "Diese Sitzung hat keinen Namen — unbenannte Sitzungen sind nach dem Trennen schwer zu unterscheiden."
+    exit_no_note_footer: "Enter speichern & beenden · Esc ohne beenden"
 
   kill_live_sessions:
     daemon_disabled: "PTY-Daemon ist deaktiviert. In config.yaml aktivieren:"
@@ -512,6 +525,11 @@ help:
       - Priorität: CLI-Argumente > Umgebungsvariablen (`AISH_MODEL`, `AISH_API_KEY`, `AISH_API_BASE`) > Konfigurationsdatei
       - `/setup` oder `aish setup` für interaktive Konfiguration
 
+      ## Sitzungsverwaltung
+      - `aish -c` — an eine aktive Sitzung anhaengen (oder aus Liste waehlen)
+      - `Ctrl+Q` — aktuelle Sitzung trennen (laeuft im Hintergrund); mit `aish -c` wieder verbinden
+      - `Ctrl+E` — markierte Sitzung im Auswahlmenue umbenennen
+
       ## Tastenkombinationen
       | Taste | Aktion |
       |-------|--------|
@@ -519,6 +537,8 @@ help:
       | `Ctrl+D` | Shell beenden |
       | `Shift+Tab` / `F2` | Planmodus umschalten |
       | `Ctrl+O` | Ausgabeverlauf durchsuchen |
+      | `Ctrl+Q` | Sitzung trennen (mit `aish -c` verbinden) |
+      | `Ctrl+E` | Sitzung umbenennen (im Auswahlmenue) |
       | `/` in leerer Zeile | Slash-Befehlsauswahl |
 
       ## Hilfeseiten
@@ -700,6 +720,13 @@ help:
         | `Ctrl+D` | Shell beenden |
         | `Ctrl+O` | Ausgabeverlauf durchsuchen |
         | `Esc` | Aktuelle Eingabe abbrechen |
+
+        ## Sitzungsverwaltung
+
+        | Taste | Aktion |
+        |-------|--------|
+        | `Ctrl+Q` | Sitzung trennen (bleibt aktiv; mit `aish -c` verbinden) |
+        | `Ctrl+E` | Markierte Sitzung umbenennen (im Auswahlmenue) |
 
         ## Moduswechsel
 

--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -346,9 +346,9 @@ shell:
     rename_done: "Sitzung {id} → \"{name}\" umbenannt"
     rename_cleared: "Name fuer Sitzung {id} geloescht"
     rename_failed: "Umbenennen fehlgeschlagen: {err}"
-    exit_no_note_title: "Vor dem Beenden einen Namen hinzufuegen?"
+    exit_no_note_title: "Notiz vor dem Trennen hinzufuegen?"
     exit_no_note_hint: "Diese Sitzung hat keinen Namen — unbenannte Sitzungen sind nach dem Trennen schwer zu unterscheiden."
-    exit_no_note_footer: "Enter speichern & beenden · Esc ohne beenden"
+    exit_no_note_footer: "Enter speichern & trennen · Esc ohne Namen trennen"
 
   kill_live_sessions:
     daemon_disabled: "PTY-Daemon ist deaktiviert. In config.yaml aktivieren:"

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -557,9 +557,9 @@ shell:
     rename_done: "Renamed {id} → \"{name}\""
     rename_cleared: "Cleared name for {id}"
     rename_failed: "Failed to rename: {err}"
-    exit_no_note_title: "Add a note before exiting?"
+    exit_no_note_title: "Add a note before detaching?"
     exit_no_note_hint: "This session has no note — unnamed sessions are hard to tell apart after detach."
-    exit_no_note_footer: "Enter save & exit · Esc exit without"
+    exit_no_note_footer: "Enter save & detach · Esc detach without naming"
 
   kill_live_sessions:
     daemon_disabled: "PTY daemon is disabled. Enable it in config.yaml:"

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -6,6 +6,7 @@ cli:
   check_langfuse_command_help: "Check Langfuse configuration"
   setup_command_help: "Run interactive setup and exit"
   check_tool_support_command_help: "Debug live tool-call support check"
+  detach_hint: "Detached. Run `aish -c` to reattach."
 
   models_auth_title: "Models Auth: {provider}"
   models_auth_relogin_hint: "Re-sign in or rotate credentials. First-time setup runs auth inside `aish setup`."
@@ -434,6 +435,7 @@ shell:
   ctrl_c_again: "Ctrl+C again within 1s to exit"
   exiting: "Exiting..."
   exit_goodbye: "Exiting shell. Goodbye!"
+  exit_daemon_hint: "※ Tip: Press Ctrl+Q to detach (keeps session alive), then aish -c to reconnect"
 
   # Confirm dialog
   confirm_dialog_title: "Tool Execution"
@@ -520,7 +522,7 @@ shell:
     iteration_continue_prompt: "Continue? [Y/n]"
 
   resume:
-    exit_command: "Resume with: aish resume {session_id}"
+    exit_command: "Resume AI context: aish resume {session_id}"
     usage: "Usage: /resume [session_id]"
     session_store_unavailable: "Session store is not available."
     no_sessions: "No previous sessions found."
@@ -542,11 +544,22 @@ shell:
     none_active: "No active PTY sessions."
     panel_title: "Live PTY Sessions"
     search_placeholder: "Search..."
-    panel_footer: "Up/Down navigate · Enter select · Esc cancel"
+    panel_footer: "Up/Down navigate · Enter select · Ctrl+E rename · Esc cancel"
     create_new: "Create new session"
     already_current: "Already in this session."
     started_label: "started: {age}"
     current_tag: "[current]"
+    rename_title: "Rename session {id}"
+    rename_current_none: "Current name: (none)"
+    rename_current_set: "Current name: {name}"
+    rename_input_label: "Enter new name (empty to clear)"
+    rename_input_footer: "Type a name | Enter save | Esc cancel"
+    rename_done: "Renamed {id} → \"{name}\""
+    rename_cleared: "Cleared name for {id}"
+    rename_failed: "Failed to rename: {err}"
+    exit_no_note_title: "Add a note before exiting?"
+    exit_no_note_hint: "This session has no note — unnamed sessions are hard to tell apart after detach."
+    exit_no_note_footer: "Enter save & exit · Esc exit without"
 
   kill_live_sessions:
     daemon_disabled: "PTY daemon is disabled. Enable it in config.yaml:"
@@ -921,6 +934,11 @@ help:
       - CLI args > env vars (`AISH_MODEL`, `AISH_API_KEY`, `AISH_API_BASE`) > config file
       - Run `/setup` or `aish setup` for interactive configuration
 
+      ## Session Management
+      - `aish -c` — attach to an existing live session (or pick from a list)
+      - `Ctrl+Q` — detach the current session (keeps running in background); reconnect with `aish -c`
+      - `Ctrl+E` — rename the highlighted session in the picker
+
       ## Keyboard Shortcuts
       | Key | Action |
       |-----|--------|
@@ -928,6 +946,8 @@ help:
       | `Ctrl+D` | Exit shell |
       | `Shift+Tab` / `F2` | Toggle plan mode |
       | `Ctrl+O` | Browse output history |
+      | `Ctrl+Q` | Detach session (reconnect with `aish -c`) |
+      | `Ctrl+E` | Rename session (in picker) |
       | `/` on empty line | Slash command picker |
 
       ## Help Pages
@@ -1110,6 +1130,13 @@ help:
         | `Ctrl+D` | Exit shell |
         | `Ctrl+O` | Browse output history |
         | `Esc` | Cancel current input |
+
+        ## Session Management
+
+        | Key | Action |
+        |-----|--------|
+        | `Ctrl+Q` | Detach session (keeps it alive; reconnect with `aish -c`) |
+        | `Ctrl+E` | Rename highlighted session (in picker) |
 
         ## Mode Switching
 

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -6,6 +6,7 @@ cli:
   check_langfuse_command_help: "Comprobar la configuración de Langfuse"
   setup_command_help: "Ejecutar la configuración interactiva y salir"
   check_tool_support_command_help: "Depurar la comprobación en vivo de soporte de llamadas a herramientas"
+  detach_hint: "Sesión desconectada. Ejecuta `aish -c` para reconectar."
   resume_failed: "No se pudo reanudar la sesión: {error}"
 
   option:
@@ -234,6 +235,7 @@ shell:
     choice_prompt: "Tu elección (predeterminado: n): "
 
   exit_goodbye: "Saliendo del shell. ¡Adiós!"
+  exit_daemon_hint: "※ Consejo: Pulsa Ctrl+Q para desconectar (sesión activa), luego aish -c para reconectar"
   command_cancelled: "Comando cancelado"
   error_correction:
     press_semicolon_hint: "La ejecución del comando falló. ; para corrección rápida o /diagnose para diagnóstico."
@@ -309,7 +311,7 @@ shell:
     iteration_limit_title: "⏸ Límite de llamadas a herramientas alcanzado"
     iteration_continue_prompt: "¿Continuar? [Y/n]"
   resume:
-    exit_command: "Reanudar con: aish resume {session_id}"
+    exit_command: "Reanudar contexto de IA: aish resume {session_id}"
     usage: "Uso: /resume [session_id]"
     session_store_unavailable: "El almacén de sesiones no está disponible."
     no_sessions: "No se encontraron sesiones anteriores."
@@ -331,11 +333,22 @@ shell:
     none_active: "No hay sesiones PTY activas."
     panel_title: "Sesiones PTY Activas"
     search_placeholder: "Buscar..."
-    panel_footer: "↑/↓ navegar · Enter seleccionar · Esc cancelar"
+    panel_footer: "↑/↓ navegar · Enter seleccionar · Ctrl+E renombrar · Esc cancelar"
     create_new: "Crear nueva sesion"
     already_current: "Ya en esta sesion."
     started_label: "iniciado: {age}"
     current_tag: "[actual]"
+    rename_title: "Renombrar sesion {id}"
+    rename_current_none: "Nombre actual: (ninguno)"
+    rename_current_set: "Nombre actual: {name}"
+    rename_input_label: "Ingrese nuevo nombre (vacio para borrar)"
+    rename_input_footer: "Escriba un nombre | Enter guardar | Esc cancelar"
+    rename_done: "Sesion {id} renombrada → \"{name}\""
+    rename_cleared: "Nombre borrado para la sesion {id}"
+    rename_failed: "Error al renombrar: {err}"
+    exit_no_note_title: "¿Agregar una nota antes de salir?"
+    exit_no_note_hint: "Esta sesion no tiene nota — las sesiones sin nombre son dificiles de distinguir tras desconectar."
+    exit_no_note_footer: "Enter guardar y salir · Esc salir sin guardar"
 
   kill_live_sessions:
     daemon_disabled: "Demonio PTY deshabilitado. Habilitar en config.yaml:"
@@ -512,6 +525,11 @@ help:
       - Prioridad: argumentos CLI > variables de entorno (`AISH_MODEL`, `AISH_API_KEY`, `AISH_API_BASE`) > archivo de config
       - Ejecuta `/setup` o `aish setup` para configuración interactiva
 
+      ## Gestión de sesiones
+      - `aish -c` — conectar a una sesión activa (o elegir de una lista)
+      - `Ctrl+Q` — desconectar la sesión actual (sigue en segundo plano); reconectar con `aish -c`
+      - `Ctrl+E` — renombrar la sesión seleccionada en el selector
+
       ## Atajos de teclado
       | Tecla | Acción |
       |-------|--------|
@@ -519,6 +537,8 @@ help:
       | `Ctrl+D` | Salir del shell |
       | `Shift+Tab` / `F2` | Alternar modo plan |
       | `Ctrl+O` | Navegar historial de salida |
+      | `Ctrl+Q` | Desconectar sesión (reconectar con `aish -c`) |
+      | `Ctrl+E` | Renombrar sesión (en selector) |
       | `/` en línea vacía | Selector de comandos slash |
 
       ## Páginas de ayuda
@@ -700,6 +720,13 @@ help:
         | `Ctrl+D` | Salir del shell |
         | `Ctrl+O` | Explorar historial de salida |
         | `Esc` | Cancelar entrada actual |
+
+        ## Gestión de sesiones
+
+        | Tecla | Acción |
+        |-------|--------|
+        | `Ctrl+Q` | Desconectar sesión (sigue activa; reconectar con `aish -c`) |
+        | `Ctrl+E` | Renombrar sesión seleccionada (en selector) |
 
         ## Cambio de modo
 

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -346,9 +346,9 @@ shell:
     rename_done: "Sesion {id} renombrada → \"{name}\""
     rename_cleared: "Nombre borrado para la sesion {id}"
     rename_failed: "Error al renombrar: {err}"
-    exit_no_note_title: "¿Agregar una nota antes de salir?"
+    exit_no_note_title: "¿Añadir una nota antes de desconectar?"
     exit_no_note_hint: "Esta sesion no tiene nota — las sesiones sin nombre son dificiles de distinguir tras desconectar."
-    exit_no_note_footer: "Enter guardar y salir · Esc salir sin guardar"
+    exit_no_note_footer: "Enter guardar y desconectar · Esc desconectar sin nombre"
 
   kill_live_sessions:
     daemon_disabled: "Demonio PTY deshabilitado. Habilitar en config.yaml:"

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -346,9 +346,9 @@ shell:
     rename_done: "Session {id} renommee → \"{name}\""
     rename_cleared: "Nom efface pour la session {id}"
     rename_failed: "Echec du renommage : {err}"
-    exit_no_note_title: "Ajouter une note avant de quitter ?"
+    exit_no_note_title: "Ajouter une note avant de détacher ?"
     exit_no_note_hint: "Cette session n'a pas de note — les sessions sans nom sont difficiles a distinguer apres déconnexion."
-    exit_no_note_footer: "Enter enregistrer & quitter · Esc quitter sans"
+    exit_no_note_footer: "Enter enregistrer & détacher · Esc détacher sans nommer"
 
   kill_live_sessions:
     daemon_disabled: "Daemon PTY desactive. Activer dans config.yaml :"

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -6,6 +6,7 @@ cli:
   check_langfuse_command_help: "Verifier la configuration de Langfuse"
   setup_command_help: "Executer la configuration interactive et quitter"
   check_tool_support_command_help: "Depanner la verification en direct de la prise en charge des appels d'outils"
+  detach_hint: "Session détachée. Lancez `aish -c` pour vous reconnecter."
   resume_failed: "Echec de la reprise de session : {error}"
 
   option:
@@ -234,6 +235,7 @@ shell:
     choice_prompt: "Votre choix (par defaut : n) : "
 
   exit_goodbye: "Fermeture du shell. Au revoir !"
+  exit_daemon_hint: "※ Astuce : Ctrl+Q pour détacher (session active), puis aish -c pour se reconnecter"
   command_cancelled: "Commande annulee"
   error_correction:
     press_semicolon_hint: "L'execution de la commande a echoue. ; pour correction rapide ou /diagnose pour diagnostic."
@@ -309,7 +311,7 @@ shell:
     iteration_limit_title: "⏸ Limite d'appels d'outils atteinte"
     iteration_continue_prompt: "Continuer ? [Y/n]"
   resume:
-    exit_command: "Reprendre avec : aish resume {session_id}"
+    exit_command: "Reprendre le contexte IA : aish resume {session_id}"
     usage: "Utilisation : /resume [session_id]"
     session_store_unavailable: "Le stockage des sessions n'est pas disponible."
     no_sessions: "Aucune session precedente trouvee."
@@ -331,11 +333,22 @@ shell:
     none_active: "Aucune session PTY active."
     panel_title: "Sessions PTY Actives"
     search_placeholder: "Rechercher..."
-    panel_footer: "↑/↓ naviguer · Enter selectionner · Esc annuler"
+    panel_footer: "↑/↓ naviguer · Enter selectionner · Ctrl+E renommer · Esc annuler"
     create_new: "Creer une nouvelle session"
     already_current: "Deja dans cette session."
     started_label: "demarre: {age}"
     current_tag: "[actuel]"
+    rename_title: "Renommer la session {id}"
+    rename_current_none: "Nom actuel : (aucun)"
+    rename_current_set: "Nom actuel : {name}"
+    rename_input_label: "Entrez un nouveau nom (vide pour effacer)"
+    rename_input_footer: "Tapez un nom | Enter enregistrer | Esc annuler"
+    rename_done: "Session {id} renommee → \"{name}\""
+    rename_cleared: "Nom efface pour la session {id}"
+    rename_failed: "Echec du renommage : {err}"
+    exit_no_note_title: "Ajouter une note avant de quitter ?"
+    exit_no_note_hint: "Cette session n'a pas de note — les sessions sans nom sont difficiles a distinguer apres déconnexion."
+    exit_no_note_footer: "Enter enregistrer & quitter · Esc quitter sans"
 
   kill_live_sessions:
     daemon_disabled: "Daemon PTY desactive. Activer dans config.yaml :"
@@ -512,6 +525,11 @@ help:
       - Priorité : arguments CLI > variables d'environnement (`AISH_MODEL`, `AISH_API_KEY`, `AISH_API_BASE`) > fichier de config
       - Exécutez `/setup` ou `aish setup` pour la configuration interactive
 
+      ## Gestion des sessions
+      - `aish -c` — se connecter à une session active (ou choisir dans une liste)
+      - `Ctrl+Q` — détacher la session courante (continue en arrière-plan) ; reconnecter avec `aish -c`
+      - `Ctrl+E` — renommer la session sélectionnée dans le sélecteur
+
       ## Raccourcis clavier
       | Touche | Action |
       |--------|--------|
@@ -519,6 +537,8 @@ help:
       | `Ctrl+D` | Quitter le shell |
       | `Shift+Tab` / `F2` | Basculer le mode plan |
       | `Ctrl+O` | Parcourir l'historique de sortie |
+      | `Ctrl+Q` | Détacher la session (reconnecter avec `aish -c`) |
+      | `Ctrl+E` | Renommer la session (dans le sélecteur) |
       | `/` sur ligne vide | Sélecteur de commandes slash |
 
       ## Pages d'aide
@@ -700,6 +720,13 @@ help:
         | `Ctrl+D` | Quitter le shell |
         | `Ctrl+O` | Parcourir l'historique de sortie |
         | `Échap` | Annuler la saisie en cours |
+
+        ## Gestion des sessions
+
+        | Touche | Action |
+        |--------|--------|
+        | `Ctrl+Q` | Détacher la session (reste active ; reconnecter avec `aish -c`) |
+        | `Ctrl+E` | Renommer la session sélectionnée (dans le sélecteur) |
 
         ## Changement de mode
 

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -6,6 +6,7 @@ cli:
   check_langfuse_command_help: "Langfuse の設定を確認します"
   setup_command_help: "対話式セットアップを実行して終了します"
   check_tool_support_command_help: "ツール呼び出しのライブ検証をデバッグします"
+  detach_hint: "セッションを切り離しました。`aish -c` で再接続できます。"
   resume_failed: "セッションの復元に失敗しました: {error}"
 
   option:
@@ -234,6 +235,7 @@ shell:
     choice_prompt: "選択してください（既定: n）: "
 
   exit_goodbye: "シェルを終了します。さようなら！"
+  exit_daemon_hint: "※ ヒント: Ctrl+Q でセッションを切り離し（バックグラウンド継続）、aish -c で再接続"
   command_cancelled: "コマンドをキャンセルしました"
   error_correction:
     press_semicolon_hint: "コマンド実行に失敗しました。; でクイック修正、または /diagnose で診断。"
@@ -309,7 +311,7 @@ shell:
     iteration_limit_title: "⏸ ツール呼び出し上限に達しました"
     iteration_continue_prompt: "続行しますか？[Y/n]"
   resume:
-    exit_command: "復元するには: aish resume {session_id}"
+    exit_command: "AIコンテキストを復元: aish resume {session_id}"
     usage: "使い方: /resume [session_id]"
     session_store_unavailable: "セッションストアを利用できません。"
     no_sessions: "以前のセッションは見つかりませんでした。"
@@ -331,11 +333,22 @@ shell:
     none_active: "アクティブなPTYセッションがありません。"
     panel_title: "アクティブPTYセッション"
     search_placeholder: "検索..."
-    panel_footer: "↑/↓ 移動 · Enter 選択 · Esc キャンセル"
+    panel_footer: "↑/↓ 移動 · Enter 選択 · Ctrl+E 名前変更 · Esc キャンセル"
     create_new: "新規セッション作成"
     already_current: "現在のセッションです。"
     started_label: "開始: {age}"
     current_tag: "[現在]"
+    rename_title: "セッション {id} の名前を変更"
+    rename_current_none: "現在の名前: (なし)"
+    rename_current_set: "現在の名前: {name}"
+    rename_input_label: "新しい名前を入力(空でクリア)"
+    rename_input_footer: "名前を入力 | Enter 保存 | Esc キャンセル"
+    rename_done: "セッション {id} を \"{name}\" に変更しました"
+    rename_cleared: "セッション {id} の名前をクリアしました"
+    rename_failed: "名前変更に失敗: {err}"
+    exit_no_note_title: "終了前にメモを追加しますか？"
+    exit_no_note_hint: "このセッションにはメモがありません。名前のないセッションは切断後に見分けがつきません。"
+    exit_no_note_footer: "Enter 保存して終了 · Esc そのまま終了"
 
   kill_live_sessions:
     daemon_disabled: "PTYデーモンが無効です。config.yaml で有効にしてください："
@@ -512,6 +525,11 @@ help:
       - 優先度：コマンドライン引数 > 環境変数（`AISH_MODEL`、`AISH_API_KEY`、`AISH_API_BASE`） > 設定ファイル
       - `/setup` または `aish setup` でインタラクティブに設定
 
+      ## セッション管理
+      - `aish -c` — 既存のライブセッションに接続（またはリストから選択）
+      - `Ctrl+Q` — 現在のセッションを切り離す（バックグラウンドで継続）；`aish -c` で再接続
+      - `Ctrl+E` — ピッカーで選択中のセッションの名前を変更
+
       ## キーボードショートカット
       | キー | 操作 |
       |------|------|
@@ -519,6 +537,8 @@ help:
       | `Ctrl+D` | シェルを終了 |
       | `Shift+Tab` / `F2` | プランモード切替 |
       | `Ctrl+O` | 出力履歴を閲覧 |
+      | `Ctrl+Q` | セッションを切り離す（`aish -c` で再接続） |
+      | `Ctrl+E` | セッションの名前を変更（ピッカー内） |
       | 空行で `/` | スラッシュコマンドピッカー |
 
       ## ヘルプページ
@@ -700,6 +720,13 @@ help:
         | `Ctrl+D` | シェルを終了 |
         | `Ctrl+O` | 出力履歴を参照 |
         | `Esc` | 現在の入力をキャンセル |
+
+        ## セッション管理
+
+        | キー | 操作 |
+        |------|------|
+        | `Ctrl+Q` | セッションを切り離す（継続実行；`aish -c` で再接続） |
+        | `Ctrl+E` | 選択中のセッションの名前を変更（ピッカー内） |
 
         ## モード切替
 

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -346,9 +346,9 @@ shell:
     rename_done: "セッション {id} を \"{name}\" に変更しました"
     rename_cleared: "セッション {id} の名前をクリアしました"
     rename_failed: "名前変更に失敗: {err}"
-    exit_no_note_title: "終了前にメモを追加しますか？"
+    exit_no_note_title: "切り離し前にメモを追加しますか？"
     exit_no_note_hint: "このセッションにはメモがありません。名前のないセッションは切断後に見分けがつきません。"
-    exit_no_note_footer: "Enter 保存して終了 · Esc そのまま終了"
+    exit_no_note_footer: "Enter 保存して切り離し · Esc 名前なしで切り離し"
 
   kill_live_sessions:
     daemon_disabled: "PTYデーモンが無効です。config.yaml で有効にしてください："

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -557,9 +557,9 @@ shell:
     rename_done: "已重命名会话 {id} → \"{name}\""
     rename_cleared: "已清除会话 {id} 的名称"
     rename_failed: "重命名失败：{err}"
-    exit_no_note_title: "退出前添加备注？"
+    exit_no_note_title: "分离前添加备注？"
     exit_no_note_hint: "当前会话没有备注——脱离后未命名会话难以辨认。"
-    exit_no_note_footer: "Enter 保存并退出 · Esc 直接退出"
+    exit_no_note_footer: "Enter 保存并分离 · Esc 不命名分离"
 
   kill_live_sessions:
     daemon_disabled: "PTY 守护进程未启用，请在 config.yaml 中开启："

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -6,6 +6,7 @@ cli:
   check_langfuse_command_help: "检查 Langfuse 配置"
   setup_command_help: "运行交互式配置并退出"
   check_tool_support_command_help: "调试 tool-call 在线验证"
+  detach_hint: "已脱离会话。运行 `aish -c` 重新连接。"
 
   models_auth_title: "模型认证: {provider}"
   models_auth_relogin_hint: "用于重新登录或轮换凭证。首次配置请在 `aish setup` 向导内完成认证。"
@@ -434,6 +435,7 @@ shell:
   ctrl_c_again: "1 秒内再次按 Ctrl+C 退出"
   exiting: "正在退出..."
   exit_goodbye: "正在退出 Shell。再见！"
+  exit_daemon_hint: "※ 可用 Ctrl+Q 分离会话（保持后台运行），之后用 aish -c 重连"
 
   # 确认对话框
   confirm_dialog_title: "工具执行"
@@ -520,7 +522,7 @@ shell:
     iteration_continue_prompt: "是否继续？[Y/n]"
 
   resume:
-    exit_command: "恢复会话: aish resume {session_id}"
+    exit_command: "恢复 AI 上下文: aish resume {session_id}"
     usage: "用法: /resume [session_id]"
     session_store_unavailable: "会话存储不可用。"
     no_sessions: "未找到历史会话。"
@@ -542,11 +544,22 @@ shell:
     none_active: "没有活跃的 PTY 会话。"
     panel_title: "活跃 PTY 会话"
     search_placeholder: "搜索..."
-    panel_footer: "↑/↓ 导航 · Enter 选择 · Esc 取消"
+    panel_footer: "↑/↓ 导航 · Enter 选择 · Ctrl+E 重命名 · Esc 取消"
     create_new: "创建新会话"
     already_current: "已在当前会话中。"
     started_label: "启动于: {age}"
     current_tag: "[当前]"
+    rename_title: "重命名会话 {id}"
+    rename_current_none: "当前名称：（无）"
+    rename_current_set: "当前名称：{name}"
+    rename_input_label: "输入新名称（留空清除）"
+    rename_input_footer: "输入名称 | Enter 保存 | Esc 取消"
+    rename_done: "已重命名会话 {id} → \"{name}\""
+    rename_cleared: "已清除会话 {id} 的名称"
+    rename_failed: "重命名失败：{err}"
+    exit_no_note_title: "退出前添加备注？"
+    exit_no_note_hint: "当前会话没有备注——脱离后未命名会话难以辨认。"
+    exit_no_note_footer: "Enter 保存并退出 · Esc 直接退出"
 
   kill_live_sessions:
     daemon_disabled: "PTY 守护进程未启用，请在 config.yaml 中开启："
@@ -920,6 +933,11 @@ help:
       - 优先级：命令行参数 > 环境变量（`AISH_MODEL`、`AISH_API_KEY`、`AISH_API_BASE`） > 配置文件
       - 运行 `/setup` 或 `aish setup` 进行交互式配置
 
+      ## 会话管理
+      - `aish -c` — 连接到已有的活动会话（或从列表选择）
+      - `Ctrl+Q` — 分离当前会话（后台保持运行）；用 `aish -c` 重新连接
+      - `Ctrl+E` — 在选择器中重命名选中的会话
+
       ## 快捷键
       | 按键 | 功能 |
       |------|------|
@@ -927,6 +945,8 @@ help:
       | `Ctrl+D` | 退出 Shell |
       | `Shift+Tab` / `F2` | 切换计划模式 |
       | `Ctrl+O` | 浏览输出历史 |
+      | `Ctrl+Q` | 分离会话（用 `aish -c` 重连） |
+      | `Ctrl+E` | 重命名会话（选择器中） |
       | 空行按 `/` | 斜杠命令选择器 |
 
       ## 帮助页面
@@ -1108,6 +1128,13 @@ help:
         | `Ctrl+D` | 退出 Shell |
         | `Ctrl+O` | 浏览输出历史 |
         | `Esc` | 取消当前输入 |
+
+        ## 会话管理
+
+        | 按键 | 操作 |
+        |------|------|
+        | `Ctrl+Q` | 分离会话（保持运行；用 `aish -c` 重连） |
+        | `Ctrl+E` | 重命名选中会话（选择器中） |
 
         ## 模式切换
 

--- a/crates/aish-llm/src/client.rs
+++ b/crates/aish-llm/src/client.rs
@@ -167,6 +167,13 @@ impl LlmClient {
             "stream": stream,
         });
 
+        // Request usage data in the final SSE chunk when streaming.
+        // Most OpenAI-compatible APIs (OpenAI, Zhipu, DeepSeek, etc.) support
+        // this; unknown fields are ignored by compliant servers.
+        if stream {
+            body["stream_options"] = serde_json::json!({"include_usage": true});
+        }
+
         if let Some(temp) = temperature {
             body["temperature"] = serde_json::json!(temp);
         }

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -836,9 +836,8 @@ impl LlmSession {
                                         let (events, chunk_usage) =
                                             StreamParser::parse_sse_chunk(line);
                                         if let Some(u) = chunk_usage {
-                                            stream_prompt_tokens += u.prompt_tokens;
-                                            stream_completion_tokens += u.completion_tokens;
-                                            self.record_usage(u);
+                                            stream_prompt_tokens = u.prompt_tokens;
+                                            stream_completion_tokens = u.completion_tokens;
                                         }
                                         for event in events {
                                             match event {
@@ -952,6 +951,17 @@ impl LlmSession {
                                 return Err(AishError::Llm(format!("Stream error: {}", e)));
                             }
                         }
+                    }
+
+                    // Record usage once after the stream completes. The final
+                    // chunk carries cumulative totals — assigning (not +=)
+                    // avoids double-counting if a non-compliant server sends
+                    // usage in multiple chunks.
+                    if stream_prompt_tokens > 0 || stream_completion_tokens > 0 {
+                        self.record_usage(crate::usage::TokenUsage {
+                            prompt_tokens: stream_prompt_tokens,
+                            completion_tokens: stream_completion_tokens,
+                        });
                     }
 
                     // End reasoning if it was started

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -79,6 +79,10 @@ pub struct LlmSession {
     plan_state: Arc<Mutex<PlanModeState>>,
     /// Cumulative token usage statistics for this session.
     token_stats: std::sync::Mutex<crate::usage::TokenStats>,
+    /// Locally estimated prompt tokens from the last API call's message list.
+    /// Updated every iteration — reflects actual context window consumption
+    /// regardless of whether the API reports prompt_tokens in streaming mode.
+    last_prompt_estimate: std::sync::atomic::AtomicU64,
     /// Per-session tool execution policy (read-only bash enforcement, etc.).
     tool_execution_policy: crate::tool_context::ToolExecutionPolicy,
     /// True for sessions created via [`Self::create_subsession`].
@@ -137,6 +141,7 @@ impl LlmSession {
             compact_consecutive_failures: std::sync::Mutex::new(0),
             plan_state: Arc::new(Mutex::new(PlanModeState::default())),
             token_stats: std::sync::Mutex::new(crate::usage::TokenStats::default()),
+            last_prompt_estimate: std::sync::atomic::AtomicU64::new(0),
             tool_execution_policy: crate::tool_context::ToolExecutionPolicy::default(),
             is_sub_agent: false,
             #[cfg(test)]
@@ -324,6 +329,12 @@ impl LlmSession {
     /// Get a reference to the plan state (for external coordination).
     pub fn plan_state(&self) -> Arc<Mutex<PlanModeState>> {
         Arc::clone(&self.plan_state)
+    }
+
+    /// Return the locally estimated prompt token count from the last API call.
+    pub fn last_prompt_estimate(&self) -> u64 {
+        self.last_prompt_estimate
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Return a snapshot of cumulative token usage statistics.
@@ -575,6 +586,12 @@ impl LlmSession {
             iterations += 1;
 
             messages = self.prepare_messages_for_send(messages).await;
+
+            // Estimate prompt tokens locally for the context bar.
+            // This works even when the streaming API doesn't report prompt_tokens.
+            let estimate = estimate_chat_tokens(&messages, &self.context_budget_policy);
+            self.last_prompt_estimate
+                .store(estimate as u64, std::sync::atomic::Ordering::Relaxed);
 
             // Emit generation start BEFORE the API call so the display layer
             // can show a thinking animation while the request is in flight.
@@ -1423,6 +1440,7 @@ impl LlmSession {
             compact_consecutive_failures: std::sync::Mutex::new(0),
             plan_state: Arc::new(Mutex::new(PlanModeState::default())),
             token_stats: std::sync::Mutex::new(crate::usage::TokenStats::default()),
+            last_prompt_estimate: std::sync::atomic::AtomicU64::new(0),
             tool_execution_policy: self.tool_execution_policy,
             is_sub_agent: true,
             #[cfg(test)]

--- a/crates/aish-llm/src/streaming.rs
+++ b/crates/aish-llm/src/streaming.rs
@@ -97,29 +97,24 @@ impl StreamParser {
             Ok(v) => v,
             Err(_) => return (Vec::new(), None),
         };
-
-        // Check for usage data in the top-level response (present in final streaming chunk)
+        // Extract usage from top-level "usage" field if present.
+        // With stream_options.include_usage=true, the final chunk carries
+        // usage alongside (or instead of) choices.
         let mut extracted_usage = None;
-        if let Some(choice) = json
-            .get("choices")
-            .and_then(|c| c.as_array())
-            .and_then(|a| a.first())
-        {
-            if choice.get("finish_reason").is_some() {
-                let usage = TokenUsage::from_response_json(&json);
-                if usage.prompt_tokens > 0 || usage.completion_tokens > 0 {
-                    extracted_usage = Some(usage);
-                }
-            }
+        let top_usage = TokenUsage::from_response_json(&json);
+        if top_usage.prompt_tokens > 0 || top_usage.completion_tokens > 0 {
+            extracted_usage = Some(top_usage);
         }
 
         let choices = match json.get("choices").and_then(|c| c.as_array()) {
-            Some(c) => c,
-            None => return (Vec::new(), None),
+            Some(c) if !c.is_empty() => c,
+            // Empty or missing choices — return usage if we found it
+            // (APIs may send a usage-only final chunk).
+            _ => return (Vec::new(), extracted_usage),
         };
         let choice = match choices.first() {
             Some(c) => c,
-            None => return (Vec::new(), None),
+            None => return (Vec::new(), extracted_usage),
         };
 
         let delta = choice.get("delta");
@@ -129,7 +124,7 @@ impl StreamParser {
         if let Some(content) = extract_message_text(delta.and_then(|d| d.get("content"))) {
             if !content.is_empty() {
                 events.push(SseEvent::ContentDelta(content.to_string()));
-                return (events, None);
+                return (events, extracted_usage);
             }
         }
 
@@ -140,7 +135,7 @@ impl StreamParser {
         {
             if !reasoning.is_empty() {
                 events.push(SseEvent::ReasoningDelta(reasoning.to_string()));
-                return (events, None);
+                return (events, extracted_usage);
             }
         }
 
@@ -175,7 +170,7 @@ impl StreamParser {
                 });
             }
             if !events.is_empty() {
-                return (events, None);
+                return (events, extracted_usage);
             }
         }
 
@@ -185,7 +180,7 @@ impl StreamParser {
             return (events, extracted_usage);
         }
 
-        (Vec::new(), None)
+        (Vec::new(), extracted_usage)
     }
 }
 
@@ -261,6 +256,74 @@ mod tests {
         assert_eq!(events.len(), 1);
         match &events[0] {
             SseEvent::ContentDelta(text) => assert_eq!(text, "总结已生成"),
+            other => panic!("unexpected event: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_sse_chunk_extracts_usage_from_empty_choices_final_chunk() {
+        // Regression test: when stream_options.include_usage is true, OpenAI emits
+        // a final chunk carrying `usage` alongside an EMPTY `choices: []` array.
+        // The parser must surface the usage instead of dropping it with the
+        // empty choices (the original bug returned None here).
+        let line = r#"data: {"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":50,"total_tokens":150}}"#;
+
+        let (events, usage) = StreamParser::parse_sse_chunk(line);
+        // Empty choices produce no stream events.
+        assert!(
+            events.is_empty(),
+            "expected no events for empty-choices chunk"
+        );
+        // ...but the usage must still be propagated.
+        let usage = usage.expect("usage must be extracted from empty-choices final chunk");
+        assert_eq!(usage.prompt_tokens, 100);
+        assert_eq!(usage.completion_tokens, 50);
+    }
+
+    #[test]
+    fn parse_sse_chunk_extracts_usage_alongside_finish_event() {
+        // Usage may arrive on the same chunk that carries a finish_reason with
+        // non-empty choices. Both the Finish event and the usage must be returned.
+        let line = r#"data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":200,"completion_tokens":80,"total_tokens":280}}"#;
+
+        let (events, usage) = StreamParser::parse_sse_chunk(line);
+        let usage = usage.expect("usage must be extracted from finish chunk");
+        assert_eq!(usage.prompt_tokens, 200);
+        assert_eq!(usage.completion_tokens, 80);
+
+        // The finish event must still be emitted alongside the usage.
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            SseEvent::Finish(reason) => assert_eq!(reason, "stop"),
+            other => panic!("unexpected event: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_sse_chunk_returns_no_usage_for_content_delta() {
+        // A mid-stream content delta carries no usage field; the parser must
+        // report None so callers do not record phantom zero-token usage.
+        let line = r#"data: {"choices":[{"index":0,"delta":{"content":"hello"}}]}"#;
+
+        let (events, usage) = StreamParser::parse_sse_chunk(line);
+        assert!(usage.is_none(), "content delta must not report usage");
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            SseEvent::ContentDelta(text) => assert_eq!(text, "hello"),
+            other => panic!("unexpected event: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_sse_chunk_done_marker_carries_no_usage() {
+        // The terminal [DONE] sentinel never carries usage; None is expected.
+        let line = "data: [DONE]";
+
+        let (events, usage) = StreamParser::parse_sse_chunk(line);
+        assert!(usage.is_none(), "[DONE] marker must not report usage");
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            SseEvent::Done => {}
             other => panic!("unexpected event: {:?}", other),
         }
     }

--- a/crates/aish-llm/src/usage.rs
+++ b/crates/aish-llm/src/usage.rs
@@ -46,6 +46,9 @@ pub struct TokenStats {
     pub total_input: u64,
     pub total_output: u64,
     pub request_count: u64,
+    /// Prompt tokens from the most recent API call — the actual context
+    /// window consumption at the current conversation depth.
+    pub last_prompt_tokens: u64,
 }
 
 impl TokenStats {
@@ -53,6 +56,7 @@ impl TokenStats {
     pub fn record(&mut self, usage: TokenUsage) {
         self.total_input += usage.prompt_tokens;
         self.total_output += usage.completion_tokens;
+        self.last_prompt_tokens = usage.prompt_tokens;
         self.request_count += 1;
     }
 

--- a/crates/aish-shell/Cargo.toml
+++ b/crates/aish-shell/Cargo.toml
@@ -46,6 +46,7 @@ nix.workspace = true
 libc.workspace = true
 open = "5"
 cliclack = "0.5.4"
+parking_lot.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/aish-shell/src/ai_handler.rs
+++ b/crates/aish-shell/src/ai_handler.rs
@@ -335,6 +335,21 @@ impl AiHandler {
         self.token_store.stats()
     }
 
+    /// Return cumulative token usage for the current session (not persisted store).
+    pub fn session_token_stats(&self) -> aish_llm::TokenStats {
+        self.llm_session.token_stats()
+    }
+
+    /// Return locally estimated prompt tokens from the last API call.
+    pub fn last_prompt_estimate(&self) -> u64 {
+        self.llm_session.last_prompt_estimate()
+    }
+
+    /// Return current context budget state (estimated tokens, pressure, %).
+    pub fn context_budget_state(&self) -> aish_context::ContextBudgetState {
+        self.context_manager.budget_state()
+    }
+
     /// Persist token usage delta from the current session to disk.
     pub fn persist_token_usage(&mut self) {
         let stats = self.llm_session.token_stats();
@@ -451,21 +466,30 @@ impl AiHandler {
             for img in &extracted.attached {
                 if img.size_bytes >= 1024 {
                     eprintln!(
-                        "\x1b[2m📎 Attached image: {} ({:.1} KB)\x1b[0m",
-                        img.filename,
-                        img.size_bytes as f64 / 1024.0
+                        "{}",
+                        crate::theme::faint(&format!(
+                            "📎 Attached image: {} ({:.1} KB)",
+                            img.filename,
+                            img.size_bytes as f64 / 1024.0
+                        ))
                     );
                 } else {
                     eprintln!(
-                        "\x1b[2m📎 Attached image: {} ({} B)\x1b[0m",
-                        img.filename, img.size_bytes
+                        "{}",
+                        crate::theme::faint(&format!(
+                            "📎 Attached image: {} ({} B)",
+                            img.filename, img.size_bytes
+                        ))
                     );
                 }
             }
             if extracted.attached.len() > 1 {
                 eprintln!(
-                    "\x1b[2m📎 {} images attached\x1b[0m",
-                    extracted.attached.len()
+                    "{}",
+                    crate::theme::faint(&format!(
+                        "📎 {} images attached",
+                        extracted.attached.len()
+                    ))
                 );
             }
         }
@@ -1199,8 +1223,8 @@ pub(crate) fn print_failure_diagnose_report(result: &FailureDiagnoseParseResult)
     use aish_i18n::t;
     if result.outcome == DiagnoseParseOutcome::FormatError {
         println!(
-            "\x1b[33m{}\x1b[0m",
-            t("shell.failure_diagnose.parse_format_error")
+            "{}",
+            crate::theme::warning(&t("shell.failure_diagnose.parse_format_error"))
         );
         return;
     }
@@ -1208,8 +1232,8 @@ pub(crate) fn print_failure_diagnose_report(result: &FailureDiagnoseParseResult)
     println!("{}", t("shell.failure_diagnose.report_title"));
     if result.outcome == DiagnoseParseOutcome::ProseFallback {
         println!(
-            "\x1b[33m{}\x1b[0m",
-            t("shell.failure_diagnose.parse_prose_fallback")
+            "{}",
+            crate::theme::warning(&t("shell.failure_diagnose.parse_prose_fallback"))
         );
     }
     println!(

--- a/crates/aish-shell/src/animation.rs
+++ b/crates/aish-shell/src/animation.rs
@@ -1,10 +1,12 @@
 use std::io::{self, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use richrs::spinner::Spinner;
+use crate::theme;
 
 /// Thread-safe animation wrapper that displays a spinner with elapsed time
 /// in a background thread.
@@ -24,7 +26,7 @@ impl SharedAnimation {
         }
     }
 
-    /// Start a spinner with the given label text.
+    /// Start a shimmer animation with the given label text.
     pub fn start(&self, text: &str) {
         self.stop();
 
@@ -37,40 +39,52 @@ impl SharedAnimation {
         let handle = thread::Builder::new()
             .name("aish-animation".into())
             .spawn(move || {
-                let mut spinner = Spinner::new("dots").expect("dots spinner should exist");
-
                 // Hide cursor
                 print!("\x1b[?25l");
                 let _ = io::stdout().flush();
 
                 while active.load(Ordering::SeqCst) {
-                    let frame = spinner.next_frame();
+                    // Auto-stop when a tool needs interactive terminal input
+                    // (sudo password, ssh, vim, etc.) so the prompt is visible.
+                    if aish_tools::bash::interactive_input_active() {
+                        break;
+                    }
                     let elapsed = start_time.elapsed().as_secs_f64();
+                    let time_ms = start_time.elapsed().as_millis() as u64;
+                    let shimmered = theme::shimmer_text(&text, time_ms);
                     if elapsed > 0.1 {
                         print!(
-                            "\r\x1b[K\x1b[34m{} {} ... {:.1}s\x1b[0m",
-                            frame, text, elapsed
+                            "\r\x1b[K{} {}",
+                            shimmered,
+                            theme::dim(&format!("{:.1}s", elapsed))
                         );
                     } else {
-                        print!("\r\x1b[K\x1b[34m{} {}\x1b[0m", frame, text);
+                        print!("\r\x1b[K{}", shimmered);
                     }
                     let _ = io::stdout().flush();
-                    thread::sleep(Duration::from_millis(150));
+                    for _ in 0..10 {
+                        if !active.load(Ordering::SeqCst)
+                            || aish_tools::bash::interactive_input_active()
+                        {
+                            break;
+                        }
+                        thread::sleep(Duration::from_millis(5));
+                    }
                 }
 
-                // Clear spinner line and restore cursor
+                // Clear animation line and restore cursor
                 print!("\r\x1b[2K\x1b[?25h");
                 let _ = io::stdout().flush();
             })
             .ok();
 
-        *self.handle.lock().unwrap() = handle;
+        *self.handle.lock() = handle;
     }
 
-    /// Stop the spinner and clear the line.
+    /// Stop the animation and clear the line.
     pub fn stop(&self) {
         self.active.store(false, Ordering::SeqCst);
-        if let Some(h) = self.handle.lock().unwrap().take() {
+        if let Some(h) = self.handle.lock().take() {
             let _ = h.join();
         }
     }
@@ -88,10 +102,10 @@ impl Drop for SharedAnimation {
     }
 }
 
-/// Spinner for sub-agent thinking lines (`  └─ explore · ⠇ 思考中 ... 2.1s`).
+/// Shimmer animation for sub-agent thinking lines (`  └─ explore · 思考中 2.1s`).
 ///
-/// Separate from [`SharedAnimation`] so the main-loop spinner can stay off while
-/// sub-agent progress remains visibly alive.
+/// Separate from [`SharedAnimation`] so the main-loop animation can stay off
+/// while sub-agent progress remains visibly alive.
 pub struct SubAgentThinkingAnimation {
     active: Arc<AtomicBool>,
     handle: Mutex<Option<thread::JoinHandle<()>>>,
@@ -105,37 +119,44 @@ impl SubAgentThinkingAnimation {
         }
     }
 
-    /// Animate `prefix` + spinner + `label` on a single dimmed line.
+    /// Animate `prefix` (dimmed) + shimmer sweep on `label`.
     pub fn start(&self, prefix: &str, label: &str) {
         self.stop();
 
         let active = self.active.clone();
         active.store(true, Ordering::SeqCst);
 
-        let prefix = prefix.to_string();
+        let prefix = theme::dim(prefix);
         let label = label.to_string();
         let start_time = Instant::now();
 
         let handle = thread::Builder::new()
             .name("aish-subagent-animation".into())
             .spawn(move || {
-                let mut spinner = Spinner::new("dots").expect("dots spinner should exist");
                 print!("\x1b[?25l");
                 let _ = io::stdout().flush();
 
                 while active.load(Ordering::SeqCst) {
-                    let frame = spinner.next_frame();
                     let elapsed = start_time.elapsed().as_secs_f64();
+                    let time_ms = start_time.elapsed().as_millis() as u64;
+                    let shimmered = theme::shimmer_text(&label, time_ms);
                     if elapsed > 0.1 {
                         print!(
-                            "\r\x1b[K\x1b[2m{}{} {} ... {:.1}s\x1b[0m",
-                            prefix, frame, label, elapsed
+                            "\r\x1b[K{}{} {}",
+                            prefix,
+                            shimmered,
+                            theme::dim(&format!("{:.1}s", elapsed))
                         );
                     } else {
-                        print!("\r\x1b[K\x1b[2m{}{} {}\x1b[0m", prefix, frame, label);
+                        print!("\r\x1b[K{}{}", prefix, shimmered);
                     }
                     let _ = io::stdout().flush();
-                    thread::sleep(Duration::from_millis(150));
+                    for _ in 0..10 {
+                        if !active.load(Ordering::SeqCst) {
+                            break;
+                        }
+                        thread::sleep(Duration::from_millis(5));
+                    }
                 }
 
                 print!("\r\x1b[2K\x1b[?25h");
@@ -143,12 +164,12 @@ impl SubAgentThinkingAnimation {
             })
             .ok();
 
-        *self.handle.lock().unwrap() = handle;
+        *self.handle.lock() = handle;
     }
 
     pub fn stop(&self) {
         self.active.store(false, Ordering::SeqCst);
-        if let Some(h) = self.handle.lock().unwrap().take() {
+        if let Some(h) = self.handle.lock().take() {
             let _ = h.join();
         }
     }

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -3122,7 +3122,8 @@ impl AishShell {
                             "\u{25cf}".to_string()
                         } else {
                             "\u{25cb}".to_string()
-                        });
+                        })
+                        .with_renamable();
                     if !name.is_empty() {
                         item = item.with_highlight(name);
                     }

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -1249,27 +1249,27 @@ impl AishShell {
                             // Snapshot old file content for write_file/edit_file
                             // so we can render a colored diff at ToolExecutionEnd.
                             if name == "write_file" || name == "edit_file" {
-                                if let Some(path) = event
+                                let path = event
                                     .data
                                     .get("tool_args")
                                     .and_then(|a| a.get("path"))
-                                    .and_then(|p| p.as_str())
-                                {
-                                    // Snapshot old content for diff rendering at tool end.
-                                    // Always assign (None on failure/oversize) so a failed
-                                    // read cannot leave a stale snapshot from a prior call.
-                                    *file_edit_snapshot_ref.lock() =
-                                        match std::fs::read_to_string(path) {
-                                            Ok(c) if c.len() <= 64 * 1024 => {
-                                                Some((path.to_string(), c))
-                                            }
-                                            Ok(_) => None,
-                                            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                                                Some((path.to_string(), String::new()))
-                                            }
-                                            Err(_) => None,
-                                        };
-                                }
+                                    .and_then(|p| p.as_str());
+                                // Always reset the snapshot slot: Some on
+                                // success / new-file, None on failure or when
+                                // the tool call lacks a path argument.
+                                *file_edit_snapshot_ref.lock() = match path {
+                                    Some(path) => match std::fs::read_to_string(path) {
+                                        Ok(c) if c.len() <= 64 * 1024 => {
+                                            Some((path.to_string(), c))
+                                        }
+                                        Ok(_) => None,
+                                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                                            Some((path.to_string(), String::new()))
+                                        }
+                                        Err(_) => None,
+                                    },
+                                    None => None,
+                                };
                             }
                             // Ensure we're on a fresh line after content streaming
                             if content_started_flag.load(Ordering::SeqCst) {

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -31,6 +31,7 @@ use crate::prompt;
 use crate::readline::ShellReadline;
 use crate::renderer::ShellRenderer;
 use crate::resume_selector::{select_resume_session, ResumeSessionItem};
+use crate::theme;
 use crate::types::ShellState;
 
 /// Format prompt + command as displayed after Enter (without trailing newline).
@@ -71,8 +72,6 @@ async fn poll_cancelled(token: *const CancellationToken) {
     }
 }
 
-/// Braille spinner frames used in the reasoning overlay.
-const DOTS_FRAMES: &[&str] = &["⠁", "⠂", "⠄", "⡀", "⢀", "⠠", "⠐", "⠈"];
 const RESUME_LIST_LIMIT: usize = 20;
 
 const SSH_CONTEXT_CAP: usize = 40;
@@ -456,7 +455,7 @@ impl AishShell {
     /// Display a yellow InputGuard warning and ask y/N confirmation.
     /// Returns `true` if the user explicitly confirms (y/yes).
     fn confirm_action(reason: &str, prompt_label: &str) -> bool {
-        eprintln!("\x1b[33m{}\x1b[0m", reason);
+        eprintln!("{}", theme::warning(reason));
         print!("{} [y/N] ", prompt_label);
         let _ = std::io::stdout().flush();
 
@@ -523,7 +522,7 @@ impl AishShell {
         let verdict = self.input_guard.check(input, context);
         match &verdict {
             aish_security::input_guard::InputVerdict::Block { .. } => {
-                eprintln!("\x1b[31m{}\x1b[0m", verdict.format_display());
+                eprintln!("{}", theme::error(&verdict.format_display()));
                 if record_on_block {
                     self.record_history(input, 1);
                 }
@@ -591,7 +590,7 @@ impl AishShell {
         match choice {
             crate::tui::SecretDialogChoice::Abort => {
                 let aborted = t("shell.security.secret.aborted");
-                println!("\x1b[33m{}\x1b[0m", aborted);
+                println!("{}", theme::warning(&aborted));
                 false
             }
             crate::tui::SecretDialogChoice::Redact => {
@@ -601,7 +600,7 @@ impl AishShell {
                     let mut rargs = std::collections::HashMap::new();
                     rargs.insert("count".to_string(), count.to_string());
                     let msg = t_with_args("shell.security.secret.redacted", &rargs);
-                    println!("\x1b[33m{}\x1b[0m", msg);
+                    println!("{}", theme::warning(&msg));
                     *question = redacted;
                 }
                 true
@@ -918,6 +917,11 @@ impl AishShell {
         // Shared history of collapsed bash outputs for Ctrl+O browsing.
         let expand_history = Arc::new(Mutex::new(crate::expand_history::ExpandHistory::new()));
         let expand_history_ref = expand_history.clone();
+        // Snapshot of (file_path, old_content) captured at ToolExecutionStart
+        // for write_file/edit_file, used to render a colored diff at end.
+        let file_edit_snapshot: Arc<parking_lot::Mutex<Option<(String, String)>>> =
+            Arc::new(parking_lot::Mutex::new(None));
+        let file_edit_snapshot_ref = file_edit_snapshot.clone();
 
         // Set global Ctrl+O live handler for bash output viewing during
         // PTY command execution.
@@ -1015,8 +1019,11 @@ impl AishShell {
                             let mut ttft_args = std::collections::HashMap::new();
                             ttft_args.insert("time".to_string(), format!("{:.1}", ttft));
                             println!(
-                                "\x1b[2m{}\x1b[0m",
-                                aish_i18n::t_with_args("shell.thinking_time", &ttft_args)
+                                "{}",
+                                theme::faint(&aish_i18n::t_with_args(
+                                    "shell.thinking_time",
+                                    &ttft_args
+                                ))
                             );
                         }
                         *thinking_start_ref.lock().unwrap() = None;
@@ -1031,7 +1038,7 @@ impl AishShell {
                         animation_ref.stop();
                         if !compaction_notice_shown_ref.swap(true, Ordering::SeqCst) {
                             if let Some(message) = context_compaction_notice(&event) {
-                                println!("\x1b[2m{}\x1b[0m", message);
+                                println!("{}", theme::faint(&message));
                             }
                         }
                     }
@@ -1098,11 +1105,12 @@ impl AishShell {
                                 if !content_started_flag.load(Ordering::SeqCst) {
                                     content_started_flag.store(true, Ordering::SeqCst);
                                     renderer_ref.lock().unwrap().render_separator();
+                                    let ai_prefix = theme::muted("🤖 ");
                                     crate::recorder::shared_record_output(
                                         &shared_recorder_cb,
-                                        "\x1b[1;90m🤖 ",
+                                        &ai_prefix,
                                     );
-                                    print!("\x1b[1;90m🤖 ");
+                                    print!("{}", ai_prefix);
                                 }
                                 // Accumulate delta and print raw text
                                 renderer_ref.lock().unwrap().append_delta(delta);
@@ -1143,7 +1151,11 @@ impl AishShell {
                                     .saturating_sub(4);
 
                                 let frame = reasoning_frame_ref.fetch_add(1, Ordering::SeqCst);
-                                let spinner = DOTS_FRAMES[frame % DOTS_FRAMES.len()];
+                                let spinner = crate::theme::spinner_frame(
+                                    crate::theme::SPINNER_STATUS,
+                                    frame,
+                                );
+                                let spinner = crate::theme::accent(spinner);
 
                                 // Elapsed time for header
                                 let elapsed_str = thinking_start_ref
@@ -1179,18 +1191,15 @@ impl AishShell {
 
                                 // Header line
                                 if display_lines.is_empty() {
-                                    print!(
-                                        "\r\x1b[K\x1b[90m{}{}...\x1b[0m\n",
-                                        spinner, elapsed_str
-                                    );
+                                    print!("\r\x1b[K{}{}...\n", spinner, elapsed_str);
                                 } else {
-                                    print!("\r\x1b[K\x1b[90m{}{}\x1b[0m\n", spinner, elapsed_str);
+                                    print!("\r\x1b[K{}{}\n", spinner, elapsed_str);
                                 }
 
                                 // Content lines
                                 for line in &display_lines {
                                     let truncated = truncate_display_width(line.trim(), max_cols);
-                                    print!("\r\x1b[K\x1b[90m{}\x1b[0m\n", truncated);
+                                    print!("\r\x1b[K{}\n", crate::theme::muted(&truncated));
                                 }
 
                                 // Clear leftover lines from previous larger display
@@ -1237,6 +1246,31 @@ impl AishShell {
                                 .get("tool_args")
                                 .map(|a| format_tool_args_for_display(name, a))
                                 .unwrap_or_default();
+                            // Snapshot old file content for write_file/edit_file
+                            // so we can render a colored diff at ToolExecutionEnd.
+                            if name == "write_file" || name == "edit_file" {
+                                if let Some(path) = event
+                                    .data
+                                    .get("tool_args")
+                                    .and_then(|a| a.get("path"))
+                                    .and_then(|p| p.as_str())
+                                {
+                                    // Snapshot old content for diff rendering at tool end.
+                                    // Always assign (None on failure/oversize) so a failed
+                                    // read cannot leave a stale snapshot from a prior call.
+                                    *file_edit_snapshot_ref.lock() =
+                                        match std::fs::read_to_string(path) {
+                                            Ok(c) if c.len() <= 64 * 1024 => {
+                                                Some((path.to_string(), c))
+                                            }
+                                            Ok(_) => None,
+                                            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                                                Some((path.to_string(), String::new()))
+                                            }
+                                            Err(_) => None,
+                                        };
+                                }
+                            }
                             // Ensure we're on a fresh line after content streaming
                             if content_started_flag.load(Ordering::SeqCst) {
                                 println!();
@@ -1250,10 +1284,11 @@ impl AishShell {
                                     )
                                 } else {
                                     format!(
-                                        "\x1b[36m{}: {} ({})\x1b[0m",
-                                        t("shell.tool.prefix"),
-                                        name,
-                                        args_preview
+                                        "{} {} {} {}",
+                                        theme::dim(theme::TOOL_BOX_TOP),
+                                        theme::accent(theme::TOOL_PREFIX),
+                                        theme::accent(name),
+                                        theme::muted(&format!("({})", args_preview))
                                     )
                                 };
                             crate::recorder::shared_record_output(
@@ -1262,12 +1297,38 @@ impl AishShell {
                             );
                             println!("{}", tool_line);
                             let _ = io::stdout().flush();
+                            // Start progress spinner for non-interactive tools.
+                            // Skip animation when the tool needs interactive
+                            // terminal input (sudo password, ssh, TUI apps) —
+                            // the spinner's \r\x1b[K would erase the prompt.
+                            let is_interactive_tool = matches!(name, "ask_user" | "resolve");
+                            let bash_needs_tty = name == "bash"
+                                && event
+                                    .data
+                                    .get("tool_args")
+                                    .and_then(|a| a.get("command"))
+                                    .and_then(|c| c.as_str())
+                                    .is_some_and(aish_tools::bash::command_needs_interactive);
+                            if crate::llm_event_ui::sub_agent_context(&event).is_none()
+                                && !react_agent_llm_event(&event)
+                                && !is_interactive_tool
+                                && !bash_needs_tty
+                            {
+                                animation_ref.start(&theme::tool_status_label(name));
+                            }
                         }
                     }
                     LlmEventType::ToolExecutionEnd => {
                         if crate::llm_event_ui::is_parent_agent_spawn_tool_event(&event) {
                             sub_agent_ui_active_ref.store(false, Ordering::SeqCst);
                         }
+                        // Stop progress spinner started at ToolExecutionStart.
+                        animation_ref.stop();
+                        let tool_ok = event
+                            .data
+                            .get("ok")
+                            .and_then(|b| b.as_bool())
+                            .unwrap_or(true);
                         if let Some(preview) =
                             event.data.get("output_preview").and_then(|p| p.as_str())
                         {
@@ -1297,13 +1358,23 @@ impl AishShell {
                                         .and_then(|v| v.as_u64())
                                         .unwrap_or_else(|| content.lines().count() as u64)
                                         as usize;
+                                    let rail = theme::dim(theme::TOOL_BOX_MID);
                                     let collapsed = collapse_display_lines(&content, 2);
-                                    let mut preview_ansi = format!("\x1b[2m{}\x1b[0m", collapsed);
+                                    let mut preview_ansi = collapsed
+                                        .lines()
+                                        .map(|l| format!("{}   {}", rail, theme::dim(l)))
+                                        .collect::<Vec<_>>()
+                                        .join("\n");
                                     if total_lines > 2 {
                                         let hidden = total_lines - 2;
+                                        let ctrl_o = theme::bold(&theme::accent("Ctrl+O"));
                                         preview_ansi.push_str(&format!(
-                                            "\x1b[2m\n  ... {} lines hidden ─── \x1b[1;36mCtrl+O\x1b[0m\x1b[2m to expand ...\x1b[0m",
-                                            hidden
+                                            "\n{}   {}{} lines hidden ─── {}{}",
+                                            rail,
+                                            theme::dim("... "),
+                                            hidden,
+                                            ctrl_o,
+                                            theme::dim(" to expand ...")
                                         ));
                                     }
                                     preview_ansi.push('\n');
@@ -1347,6 +1418,60 @@ impl AishShell {
                                 }
                             }
                         }
+                        // Render colored diff for write_file/edit_file tools.
+                        // Only consume the snapshot when this End event matches
+                        // a write_file/edit_file call — otherwise leave it for
+                        // the paired End event of the tool that stored it.
+                        let end_tool = event
+                            .data
+                            .get("tool_name")
+                            .and_then(|n| n.as_str())
+                            .unwrap_or("");
+                        if end_tool == "write_file" || end_tool == "edit_file" {
+                            let diff_snapshot = file_edit_snapshot_ref.lock().take();
+                            if let Some((path, old_content)) = diff_snapshot {
+                                if let Ok(new_content) = std::fs::read_to_string(&path) {
+                                    if new_content.len() <= 64 * 1024 {
+                                        let diff =
+                                            theme::render_diff(&old_content, &new_content, 20);
+                                        if !diff.is_empty() {
+                                            let rail = theme::dim(theme::TOOL_BOX_MID);
+                                            let diff_ansi: String = diff
+                                                .lines()
+                                                .map(|l| format!("{}   {}", rail, l))
+                                                .collect::<Vec<_>>()
+                                                .join("\n");
+                                            println!("{}", diff_ansi);
+                                            let _ = io::stdout().flush();
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        // Always print completion indicator with box bottom corner.
+                        {
+                            let status_line = if tool_ok {
+                                format!(
+                                    "{} {} {}",
+                                    theme::dim(theme::TOOL_BOX_BOT),
+                                    theme::success(theme::ICON_SUCCESS),
+                                    theme::dim("done")
+                                )
+                            } else {
+                                format!(
+                                    "{} {} {}",
+                                    theme::dim(theme::TOOL_BOX_BOT),
+                                    theme::error(theme::ICON_ERROR),
+                                    theme::dim("failed")
+                                )
+                            };
+                            crate::recorder::shared_record_output(
+                                &shared_recorder_cb,
+                                &format!("{}\n", status_line),
+                            );
+                            println!("{}", status_line);
+                            let _ = io::stdout().flush();
+                        }
                     }
                     LlmEventType::Error => {
                         sub_agent_animation_ref.stop();
@@ -1363,7 +1488,7 @@ impl AishShell {
                             args.insert("error".to_string(), error_msg.to_string());
                             t_with_args("shell.error.llm_error_message", &args)
                         };
-                        eprintln!("\x1b[31m{}\x1b[0m", msg);
+                        eprintln!("{}", theme::error(&msg));
                     }
                     LlmEventType::Cancelled => {
                         sub_agent_animation_ref.stop();
@@ -1381,7 +1506,7 @@ impl AishShell {
                             .and_then(|p| p.as_str())
                             .unwrap_or("");
                         if !prompt_text.is_empty() {
-                            println!("\x1b[36m{}\x1b[0m", prompt_text);
+                            println!("{}", theme::accent(prompt_text));
                         }
                     }
                 }
@@ -1401,24 +1526,21 @@ impl AishShell {
             let inner_width = width.saturating_sub(4).max(20);
             let border = "─".repeat(inner_width);
             println!();
-            println!("\x1b[33m╭{}╮\x1b[0m", border);
-            print_panel_line(
-                "\x1b[1;33m ⚠  Security Confirmation Required\x1b[0m",
-                inner_width,
-            );
+            println!("{}", theme::warning(&format!("╭{}╮", border)));
+            let sec_title = theme::bold(&theme::warning(" ⚠  Security Confirmation Required"));
+            print_panel_line(&sec_title, inner_width);
             print_panel_line("", inner_width);
+            let tool_label = theme::bold(&theme::accent(&t("shell.confirm_dialog_tool")));
             print_panel_line(
-                &format!(
-                    "  \x1b[1;36m{}\x1b[0m   {}",
-                    t("shell.confirm_dialog_tool"),
-                    ctx.tool_name
-                ),
+                &format!("  {}   {}", tool_label, ctx.tool_name),
                 inner_width,
             );
             let reason_lines = wrap_text(&ctx.message, width.saturating_sub(14));
+            let reason_label = theme::bold(&theme::accent("Reason:"));
             print_panel_line(
                 &format!(
-                    "  \x1b[1;36mReason:\x1b[0m {}",
+                    "  {} {}",
+                    reason_label,
                     reason_lines.lines().next().unwrap_or("")
                 ),
                 inner_width,
@@ -1428,10 +1550,10 @@ impl AishShell {
             }
             print_panel_line("", inner_width);
             print_panel_line(
-                &format!("  \x1b[36m{}\x1b[0m", t("shell.confirm_dialog_question")),
+                &format!("  {}", theme::accent(&t("shell.confirm_dialog_question"))),
                 inner_width,
             );
-            println!("\x1b[33m╰{}╯\x1b[0m", border);
+            println!("{}", theme::warning(&format!("╰{}╯", border)));
             print!("  ");
             let _ = std::io::stdout().flush();
 
@@ -1463,14 +1585,11 @@ impl AishShell {
                 let inner_width = width.saturating_sub(4).max(20);
                 let border = "─".repeat(inner_width);
                 println!();
-                println!("\x1b[33m╭{}╮\x1b[0m", border);
-                print_panel_line(
-                    &format!(
-                        "\x1b[1;33m {}\x1b[0m",
-                        aish_i18n::t("shell.session.iteration_limit_title")
-                    ),
-                    inner_width,
-                );
+                println!("{}", theme::warning(&format!("╭{}╮", border)));
+                let iter_title = theme::bold(&theme::warning(&aish_i18n::t(
+                    "shell.session.iteration_limit_title",
+                )));
+                print_panel_line(&format!(" {}", iter_title), inner_width);
                 print_panel_line("", inner_width);
                 print_panel_line(
                     &format!(
@@ -1486,12 +1605,12 @@ impl AishShell {
                 print_panel_line("", inner_width);
                 print_panel_line(
                     &format!(
-                        "  \x1b[36m{}\x1b[0m",
-                        aish_i18n::t("shell.session.iteration_continue_prompt")
+                        "  {}",
+                        theme::accent(&aish_i18n::t("shell.session.iteration_continue_prompt"))
                     ),
                     inner_width,
                 );
-                println!("\x1b[33m╰{}╯\x1b[0m", border);
+                println!("{}", theme::warning(&format!("╰{}╯", border)));
                 print!("  ");
                 let _ = std::io::stdout().flush();
 
@@ -1787,11 +1906,14 @@ impl AishShell {
                         let new_phase = self.ai_handler.toggle_plan_mode(&self.session_uuid);
                         match new_phase {
                             aish_core::PlanPhase::Planning => {
-                                println!("\x1b[1;33m{}\x1b[0m", t("shell.plan_mode_enabled"));
-                                println!("\x1b[2m{}\x1b[0m", t("shell.plan_mode_hint"));
+                                println!(
+                                    "{}",
+                                    theme::bold(&theme::warning(&t("shell.plan_mode_enabled")))
+                                );
+                                println!("{}", theme::faint(&t("shell.plan_mode_hint")));
                             }
                             aish_core::PlanPhase::Normal => {
-                                println!("\x1b[33m{}\x1b[0m", t("shell.plan_mode_disabled"));
+                                println!("{}", theme::warning(&t("shell.plan_mode_disabled")));
                             }
                         }
                         continue;
@@ -1890,9 +2012,9 @@ impl AishShell {
                                         Some(corrected) => {
                                             // Display corrected command and description
                                             let corrected_line = format!(
-                                                "{} \x1b[1;36m{}\x1b[0m",
+                                                "{} {}",
                                                 t("shell.error_correction.corrected_command_title"),
-                                                corrected
+                                                theme::accent(&theme::bold(corrected))
                                             );
                                             println!("{}", corrected_line);
                                             crate::recorder::shared_record_output(
@@ -1910,9 +2032,9 @@ impl AishShell {
                                             }
                                             // Ask user confirmation: Y/n
                                             let prompt = format!(
-                                                "{}\x1b[1;36m{}\x1b[0m{}",
+                                                "{}{}{}",
                                                 t("shell.error_correction.confirm_execute_prefix"),
-                                                corrected,
+                                                theme::accent(&theme::bold(corrected)),
                                                 t("shell.error_correction.confirm_execute_suffix")
                                             );
                                             print!("{}", prompt);
@@ -1945,10 +2067,10 @@ impl AishShell {
                                         }
                                         None => {
                                             // No valid command, show description if available
-                                            let warn_line = format!(
-                                                "\x1b[33m\u{26a0} {}\x1b[0m",
+                                            let warn_line = theme::warning(&format!(
+                                                "\u{26a0} {}",
                                                 t("shell.error_correction.no_valid_command")
-                                            );
+                                            ));
                                             println!("{}", warn_line);
                                             crate::recorder::shared_record_output(
                                                 &self.shared_recorder,
@@ -1969,8 +2091,10 @@ impl AishShell {
                                                 }
                                             }
                                             let hint_line = format!(
-                                                "   \x1b[36m{}\x1b[0m",
-                                                t("shell.error_correction.retry_hint")
+                                                "   {}",
+                                                theme::accent(&t(
+                                                    "shell.error_correction.retry_hint"
+                                                ))
                                             );
                                             println!("{}", hint_line);
                                             crate::recorder::shared_record_output(
@@ -1984,9 +2108,9 @@ impl AishShell {
                                     self.animation.stop();
                                     crate::recorder::shared_record_output(
                                         &self.shared_recorder,
-                                        "\x1b[33mInterrupted\x1b[0m\r\n",
+                                        &format!("{}\r\n", theme::warning("Interrupted")),
                                     );
-                                    println!("\x1b[33mInterrupted\x1b[0m");
+                                    println!("{}", theme::warning("Interrupted"));
                                 }
                                 Err(e) => {
                                     self.animation.stop();
@@ -1996,7 +2120,7 @@ impl AishShell {
                                     if !matches!(e, aish_core::AishError::Llm(_)) {
                                         let msg = t("shell.error.llm_error_message")
                                             .replace("{error}", &e.to_string());
-                                        eprintln!("\x1b[31m{}\x1b[0m", msg);
+                                        eprintln!("{}", theme::error(&msg));
                                     }
                                 }
                             }
@@ -2032,6 +2156,8 @@ impl AishShell {
                         CrosstermEscWatcher::start(self.ai_handler.cancellation_token_arc());
                     let token_ptr =
                         self.ai_handler.cancellation_token() as *const CancellationToken;
+                    let token_stats_before = self.ai_handler.session_token_stats();
+                    let ai_start = std::time::Instant::now();
                     let result = runtime.block_on(async {
                         tokio::select! {
                             r = self.ai_handler.handle_question(&question) => r,
@@ -2040,6 +2166,7 @@ impl AishShell {
                             }
                         }
                     });
+                    let ai_elapsed = ai_start.elapsed().as_secs_f64();
                     esc_watcher.stop();
                     Self::restore_ai_sigint_handler(old_sigint);
                     self.sync_state_from_pty_cwd();
@@ -2052,7 +2179,7 @@ impl AishShell {
                                 // Agent short-circuit cancel returns Ok("") — show the same
                                 // user-facing line as Err(Cancelled). Do not treat as success
                                 // (no plan approval / history-as-ok).
-                                println!("\x1b[33m{}\x1b[0m", t("shell.interrupted"));
+                                println!("{}", theme::warning(&t("shell.interrupted")));
                             } else {
                                 if !did_stream && !response.trim().is_empty() {
                                     // Non-streaming fallback: print full response with formatting
@@ -2064,6 +2191,38 @@ impl AishShell {
                                 } else if did_stream {
                                     // Streaming display already handled by event callback
                                     // No additional output needed here.
+                                }
+
+                                // Print response metadata footer (tokens + context usage).
+                                {
+                                    let stats = self.ai_handler.session_token_stats();
+                                    let delta_in = stats
+                                        .total_input
+                                        .saturating_sub(token_stats_before.total_input);
+                                    let delta_out = stats
+                                        .total_output
+                                        .saturating_sub(token_stats_before.total_output);
+                                    let budget = self.ai_handler.context_budget_state();
+                                    let prompt_est = self.ai_handler.last_prompt_estimate();
+                                    let ctx_percent = if budget.effective_context_window > 0 {
+                                        (prompt_est * 100 / budget.effective_context_window as u64)
+                                            .min(100) as u8
+                                    } else {
+                                        0
+                                    };
+                                    let footer = theme::response_footer(
+                                        &self.config.model,
+                                        delta_in,
+                                        delta_out,
+                                        ctx_percent,
+                                        Some(ai_elapsed),
+                                    );
+                                    crate::recorder::shared_record_output(
+                                        &self.shared_recorder,
+                                        &format!("{}\n", footer),
+                                    );
+                                    println!("{}", footer);
+                                    let _ = std::io::stdout().flush();
                                 }
 
                                 self.persist_session_snapshot();
@@ -2103,23 +2262,25 @@ impl AishShell {
                                                     )
                                                 {
                                                     println!(
-                                                        "\x1b[32m{}\x1b[0m",
-                                                        t("shell.plan_approved")
+                                                        "{}",
+                                                        theme::success(&t("shell.plan_approved"))
                                                     );
                                                     println!(
-                                                        "\x1b[2m  {}\x1b[0m",
-                                                        t_with_args(
+                                                        "  {}",
+                                                        theme::faint(&t_with_args(
                                                             "shell.plan_approved_hint",
                                                             &std::collections::HashMap::new()
-                                                        )
+                                                        ))
                                                     );
                                                 }
                                             }
                                             PlanApprovalDecision::ChangesRequested { feedback } => {
                                                 // Keep in planning phase — re-enter plan mode with feedback
                                                 println!(
-                                                    "\x1b[33m{}\x1b[0m",
-                                                    t("shell.plan_changes_requested")
+                                                    "{}",
+                                                    theme::warning(&t(
+                                                        "shell.plan_changes_requested"
+                                                    ))
                                                 );
 
                                                 // Re-enter plan mode to let the AI revise
@@ -2156,19 +2317,23 @@ impl AishShell {
                                                     self.ai_handler
                                                         .add_shell_context(&feedback_msg);
                                                     println!(
-                                                        "\x1b[2m  {}\x1b[0m",
-                                                        t("shell.plan_feedback_sent")
+                                                        "  {}",
+                                                        theme::faint(&t(
+                                                            "shell.plan_feedback_sent"
+                                                        ))
                                                     );
                                                 }
                                             }
                                             PlanApprovalDecision::Cancelled => {
                                                 println!(
-                                                    "\x1b[33m{}\x1b[0m",
-                                                    t("shell.plan_review_cancelled")
+                                                    "{}",
+                                                    theme::warning(&t(
+                                                        "shell.plan_review_cancelled"
+                                                    ))
                                                 );
                                                 println!(
-                                                    "\x1b[2m{}\x1b[0m",
-                                                    t("shell.plan_review_hint")
+                                                    "{}",
+                                                    theme::faint(&t("shell.plan_review_hint"))
                                                 );
                                             }
                                         }
@@ -2180,7 +2345,7 @@ impl AishShell {
                         }
                         Err(aish_core::AishError::Cancelled) => {
                             self.animation.stop();
-                            println!("\x1b[33m{}\x1b[0m", t("shell.interrupted"));
+                            println!("{}", theme::warning(&t("shell.interrupted")));
                         }
                         Err(e) => {
                             // Errors are already displayed via the LlmEventType::Error
@@ -2188,7 +2353,7 @@ impl AishShell {
                             if !matches!(e, aish_core::AishError::Llm(_)) {
                                 let msg = t("shell.error.llm_error_message")
                                     .replace("{error}", &e.to_string());
-                                eprintln!("\x1b[31m{}\x1b[0m", msg);
+                                eprintln!("{}", theme::error(&msg));
                             }
                             self.record_history(input, 1);
                         }
@@ -2349,7 +2514,7 @@ impl AishShell {
                                     Ok(response) => {
                                         if self.ai_handler.cancellation_token().is_cancelled() {
                                             // Same as Err(Cancelled): do not persist/history as success.
-                                            println!("\x1b[33m{}\x1b[0m", t("shell.interrupted"));
+                                            println!("{}", theme::warning(&t("shell.interrupted")));
                                         } else {
                                             if !did_stream && !response.trim().is_empty() {
                                                 let mut sep_renderer = ShellRenderer::new();
@@ -2369,13 +2534,13 @@ impl AishShell {
                                     }
                                     Err(aish_core::AishError::Cancelled) => {
                                         self.animation.stop();
-                                        println!("\x1b[33m{}\x1b[0m", t("shell.interrupted"));
+                                        println!("{}", theme::warning(&t("shell.interrupted")));
                                     }
                                     Err(e) => {
                                         if !matches!(e, aish_core::AishError::Llm(_)) {
                                             let msg = t("shell.error.llm_error_message")
                                                 .replace("{error}", &e.to_string());
-                                            eprintln!("\x1b[31m{}\x1b[0m", msg);
+                                            eprintln!("{}", theme::error(&msg));
                                         }
                                     }
                                 }
@@ -2423,12 +2588,12 @@ impl AishShell {
                 let _ = rec.flush();
                 *guard = None;
                 println!(
-                    "\x1b[33m{}\x1b[0m",
-                    t_with_args("shell.record.auto_saved", &{
+                    "{}",
+                    theme::warning(&t_with_args("shell.record.auto_saved", &{
                         let mut args = std::collections::HashMap::new();
                         args.insert("path".to_string(), path.display().to_string());
                         args
-                    })
+                    }))
                 );
             }
         }
@@ -2441,6 +2606,13 @@ impl AishShell {
                 args
             })
         );
+        // In daemon mode, remind the user about Ctrl+Q detach + aish -c reconnect.
+        if std::env::var("AISH_DAEMON_MODE")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+        {
+            println!("{}", crate::theme::dim(&t("shell.exit_daemon_hint")));
+        }
 
         drop(rl);
         self.shutdown();
@@ -2524,9 +2696,9 @@ impl AishShell {
         self.state.can_correct_error = exit_code != 0 && exit_code != 130;
         if exit_code != 0 && exit_code != 130 {
             let hint = t("shell.error_correction.press_semicolon_hint");
-            let hint_str = format!("\x1b[2m\x1b[37m<{}>\x1b[0m\n", hint);
+            let hint_str = format!("{}\n", theme::muted(&format!("<{}>", hint)));
             crate::recorder::shared_record_output(&self.shared_recorder, &hint_str);
-            eprintln!("\x1b[2m\x1b[37m<{}>\x1b[0m", hint);
+            eprintln!("{}", theme::muted(&format!("<{}>", hint)));
         }
     }
 
@@ -2874,20 +3046,17 @@ impl AishShell {
     }
 
     /// List all live PTY daemon sessions with interactive selection.
+    /// Enter switches/attaches, Ctrl+E renames the highlighted session (then
+    /// re-shows the refreshed list), Esc cancels.
     fn handle_live_sessions_command(&self) {
         use aish_i18n::{t, t_with_args};
 
         if !self.config.pty_daemon_enabled {
             eprintln!(
-                "\x1b[33m{}\x1b[0m",
-                t("shell.live_sessions.daemon_disabled")
+                "{}",
+                theme::warning(&t("shell.live_sessions.daemon_disabled"))
             );
             eprintln!("{}", t("shell.live_sessions.daemon_disabled_hint"));
-            return;
-        }
-        let sessions = aish_pty::discover_sessions();
-        if sessions.is_empty() {
-            println!("{}", t("shell.live_sessions.none_active"));
             return;
         }
 
@@ -2895,92 +3064,185 @@ impl AishShell {
         let home = dirs::home_dir()
             .map(|h| h.to_string_lossy().to_string())
             .unwrap_or_default();
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
 
-        let mut items: Vec<aish_ui::SearchSelectItem> = sessions
-            .iter()
-            .enumerate()
-            .map(|(i, s)| {
-                let short = &s.session_id[..8.min(s.session_id.len())];
-                let name = s.name.as_deref().unwrap_or("");
-                let is_current = current_id
-                    .as_ref()
-                    .map(|c| c == &s.session_id || s.session_id.starts_with(c))
-                    .unwrap_or(false);
-                let cwd_display = if !home.is_empty() && s.cwd.starts_with(&home) {
-                    format!("~{}", &s.cwd[home.len()..])
-                } else {
-                    s.cwd.clone()
-                };
-                let age_str = format_age(now.saturating_sub(s.started_at));
-                let detail = if is_current {
-                    format!(
-                        "{} {}",
-                        t_with_args("shell.live_sessions.started_label", &age_args(age_str)),
-                        t("shell.live_sessions.current_tag")
-                    )
-                } else {
-                    t_with_args("shell.live_sessions.started_label", &age_args(age_str))
-                };
-                // Label shows name (if set) or short_id, followed by cwd.
-                let label = if !name.is_empty() {
-                    format!("{} {}", name, cwd_display)
-                } else {
-                    format!("{} {}", short, cwd_display)
-                };
-                // Search text includes name + short_id + cwd so users can
-                // search by any of them.
-                let search_text = format!("{} {} {}", name, short, cwd_display);
-                aish_ui::SearchSelectItem::new(format!("session:{}", i), label)
-                    .with_detail(detail)
-                    .with_search_text(search_text)
-                    .with_badge(if is_current {
-                        "\u{25cf}".to_string()
-                    } else {
-                        "\u{25cb}".to_string()
-                    })
-            })
-            .collect();
-
-        items.push(aish_ui::SearchSelectItem::new(
-            "new",
-            t("shell.live_sessions.create_new").to_string(),
-        ));
-
-        let panel = aish_ui::SearchSelectPanel::new(
-            t("shell.live_sessions.panel_title"),
-            t("shell.live_sessions.search_placeholder"),
-            items,
-        )
-        .with_footer(t("shell.live_sessions.panel_footer"));
-
-        if let Ok(aish_ui::PanelOutcome::Submitted(aish_ui::SearchSelectOutcome::Selected(value))) =
-            aish_ui::PanelRuntime::new().run(panel)
-        {
-            if value == "new" {
-                emit_osc("new");
+        loop {
+            let sessions = aish_pty::discover_sessions();
+            if sessions.is_empty() {
+                println!("{}", t("shell.live_sessions.none_active"));
                 return;
             }
-            if let Some(idx_str) = value.strip_prefix("session:") {
-                if let Ok(idx) = idx_str.parse::<usize>() {
-                    if idx < sessions.len() {
-                        let s = &sessions[idx];
-                        let is_current = current_id
-                            .as_ref()
-                            .map(|c| c == &s.session_id)
-                            .unwrap_or(false);
-                        if is_current {
-                            println!("{}", t("shell.live_sessions.already_current"));
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+
+            // Value of the current session's picker row, used to drive the
+            // animated shimmer sweep on that row.
+            let current_value = current_id.as_ref().and_then(|c| {
+                sessions
+                    .iter()
+                    .enumerate()
+                    .find(|(_, s)| c == &s.session_id || s.session_id.starts_with(c))
+                    .map(|(i, _)| format!("session:{i}"))
+            });
+
+            let mut items: Vec<aish_ui::SearchSelectItem> = sessions
+                .iter()
+                .enumerate()
+                .map(|(i, s)| {
+                    let short = &s.session_id[..8.min(s.session_id.len())];
+                    let name = s.name.as_deref().unwrap_or("");
+                    let is_current = current_id
+                        .as_ref()
+                        .map(|c| c == &s.session_id || s.session_id.starts_with(c))
+                        .unwrap_or(false);
+                    let cwd_display = if !home.is_empty() && s.cwd.starts_with(&home) {
+                        format!("~{}", &s.cwd[home.len()..])
+                    } else {
+                        s.cwd.clone()
+                    };
+                    let age_str = format_age(now.saturating_sub(s.started_at));
+                    let detail = if is_current {
+                        format!(
+                            "{} {}",
+                            t_with_args("shell.live_sessions.started_label", &age_args(age_str)),
+                            t("shell.live_sessions.current_tag")
+                        )
+                    } else {
+                        t_with_args("shell.live_sessions.started_label", &age_args(age_str))
+                    };
+                    // Label is short id + cwd; a custom name (if any) is the
+                    // bold green highlight prefix so it stands out at a glance.
+                    let label = format!("{short} {cwd_display}");
+                    let search_text = format!("{name} {short} {cwd_display}");
+                    let mut item = aish_ui::SearchSelectItem::new(format!("session:{}", i), label)
+                        .with_detail(detail)
+                        .with_search_text(search_text)
+                        .with_badge(if is_current {
+                            "\u{25cf}".to_string()
                         } else {
-                            emit_osc(&format!(
-                                "switch:{}",
-                                &s.session_id[..8.min(s.session_id.len())]
-                            ));
+                            "\u{25cb}".to_string()
+                        });
+                    if !name.is_empty() {
+                        item = item.with_highlight(name);
+                    }
+                    item
+                })
+                .collect();
+
+            items.push(aish_ui::SearchSelectItem::new(
+                "new",
+                t("shell.live_sessions.create_new").to_string(),
+            ));
+
+            let panel = aish_ui::SearchSelectPanel::new(
+                t("shell.live_sessions.panel_title"),
+                t("shell.live_sessions.search_placeholder"),
+                items,
+            )
+            .with_footer(t("shell.live_sessions.panel_footer"))
+            .with_shimmer(current_value.as_deref());
+
+            match aish_ui::PanelRuntime::new().run(panel) {
+                Ok(aish_ui::PanelOutcome::Submitted(aish_ui::SearchSelectOutcome::Selected(
+                    value,
+                ))) => {
+                    if value == "new" {
+                        emit_osc("new");
+                        return;
+                    }
+                    if let Some(idx_str) = value.strip_prefix("session:") {
+                        if let Ok(idx) = idx_str.parse::<usize>() {
+                            if idx < sessions.len() {
+                                let s = &sessions[idx];
+                                let is_current = current_id
+                                    .as_ref()
+                                    .map(|c| c == &s.session_id)
+                                    .unwrap_or(false);
+                                if is_current {
+                                    println!("{}", t("shell.live_sessions.already_current"));
+                                } else {
+                                    emit_osc(&format!(
+                                        "switch:{}",
+                                        &s.session_id[..8.min(s.session_id.len())]
+                                    ));
+                                }
+                            }
                         }
                     }
+                    return;
+                }
+                Ok(aish_ui::PanelOutcome::Submitted(aish_ui::SearchSelectOutcome::Rename(
+                    value,
+                ))) => {
+                    if let Some(idx_str) = value.strip_prefix("session:") {
+                        if let Ok(idx) = idx_str.parse::<usize>() {
+                            if idx < sessions.len() {
+                                self.rename_live_session_interactive(&sessions[idx]);
+                            }
+                        }
+                    }
+                    // Refresh so the new name shows up, then re-show the picker.
+                    continue;
+                }
+                _ => return,
+            }
+        }
+    }
+
+    /// Open a text-input panel to rename a live session in place. Used by the
+    /// `/live_sessions` picker (Ctrl+E).
+    fn rename_live_session_interactive(&self, session: &aish_pty::DaemonSessionInfo) {
+        use aish_i18n::{t, t_with_args};
+        use aish_ui::{ChoiceOutcome, ChoicePanel, PanelOutcome, PanelRuntime};
+        use std::collections::HashMap;
+
+        let short = &session.session_id[..8.min(session.session_id.len())];
+        let current = session.name.as_deref().unwrap_or("");
+        let mut id_args = HashMap::new();
+        id_args.insert("id".to_string(), short.to_string());
+
+        let question = if current.is_empty() {
+            t("shell.live_sessions.rename_current_none")
+        } else {
+            let mut a = HashMap::new();
+            a.insert("name".to_string(), current.to_string());
+            t_with_args("shell.live_sessions.rename_current_set", &a)
+        };
+
+        let panel = ChoicePanel::new(
+            t_with_args("shell.live_sessions.rename_title", &id_args),
+            question,
+            Vec::new(),
+        )
+        .with_custom_label(t("shell.live_sessions.rename_input_label"))
+        .with_allow_cancel(true)
+        .with_allow_empty_custom_input(true)
+        .with_footer(t("shell.live_sessions.rename_input_footer"));
+
+        if let Ok(PanelOutcome::Submitted(ChoiceOutcome::CustomInput(name))) =
+            PanelRuntime::new().run(panel)
+        {
+            match aish_pty::rename_session(&session.session_id, &name) {
+                Ok(()) => {
+                    if name.trim().is_empty() {
+                        println!(
+                            "{}",
+                            t_with_args("shell.live_sessions.rename_cleared", &id_args)
+                        );
+                    } else {
+                        let mut a = id_args.clone();
+                        a.insert("name".to_string(), name.trim().to_string());
+                        println!("{}", t_with_args("shell.live_sessions.rename_done", &a));
+                    }
+                }
+                Err(e) => {
+                    let mut a = id_args.clone();
+                    a.insert("err".to_string(), e.to_string());
+                    eprintln!(
+                        "{}",
+                        theme::error(&t_with_args("shell.live_sessions.rename_failed", &a))
+                    );
                 }
             }
         }
@@ -2996,8 +3258,8 @@ impl AishShell {
 
         if !self.config.pty_daemon_enabled {
             eprintln!(
-                "\x1b[33m{}\x1b[0m",
-                t("shell.kill_live_sessions.daemon_disabled")
+                "{}",
+                theme::warning(&t("shell.kill_live_sessions.daemon_disabled"))
             );
             eprintln!("{}", t("shell.kill_live_sessions.daemon_disabled_hint"));
             return;
@@ -3032,7 +3294,10 @@ impl AishShell {
             };
             let age_str = format_age(now.saturating_sub(s.started_at));
             let current = if is_current {
-                format!("  \x1b[32m{}\x1b[0m", t("shell.live_sessions.current_tag"))
+                format!(
+                    "  {}",
+                    theme::success(&t("shell.live_sessions.current_tag"))
+                )
             } else {
                 String::new()
             };
@@ -3050,15 +3315,15 @@ impl AishShell {
         // No args: list sessions so the user can pick an ID.
         if parts.len() < 2 {
             println!(
-                "\x1b[1m{}\x1b[0m",
-                t("shell.kill_live_sessions.list_header")
+                "{}",
+                theme::bold(&t("shell.kill_live_sessions.list_header"))
             );
             for s in &sessions {
                 println!("{}", format_session_line(s));
             }
             println!(
-                "\n\x1b[2m{}\x1b[0m",
-                t("shell.kill_live_sessions.usage_hint")
+                "\n{}",
+                theme::faint(&t("shell.kill_live_sessions.usage_hint"))
             );
             return;
         }
@@ -3088,14 +3353,20 @@ impl AishShell {
                 );
                 match aish_pty::kill_session(&s.socket_path) {
                     Ok(()) => {
-                        println!("\x1b[32m{}\x1b[0m", t("shell.kill_live_sessions.kill_done"))
+                        println!(
+                            "{}",
+                            theme::success(&t("shell.kill_live_sessions.kill_done"))
+                        )
                     }
                     Err(e) => {
                         let mut err_args = std::collections::HashMap::new();
                         err_args.insert("error".to_string(), e.to_string());
                         println!(
-                            "\x1b[31m{}\x1b[0m",
-                            t_with_args("shell.kill_live_sessions.kill_failed", &err_args)
+                            "{}",
+                            theme::error(&t_with_args(
+                                "shell.kill_live_sessions.kill_failed",
+                                &err_args
+                            ))
                         );
                     }
                 }
@@ -3130,8 +3401,11 @@ impl AishShell {
                         let mut cur_args = std::collections::HashMap::new();
                         cur_args.insert("id".to_string(), short.to_string());
                         eprintln!(
-                            "\x1b[33m{}\x1b[0m",
-                            t_with_args("shell.kill_live_sessions.is_current", &cur_args)
+                            "{}",
+                            theme::warning(&t_with_args(
+                                "shell.kill_live_sessions.is_current",
+                                &cur_args
+                            ))
                         );
                         errors += 1;
                         continue;
@@ -3144,15 +3418,21 @@ impl AishShell {
                     );
                     match aish_pty::kill_session(&s.socket_path) {
                         Ok(()) => {
-                            println!("\x1b[32m{}\x1b[0m", t("shell.kill_live_sessions.kill_done"));
+                            println!(
+                                "{}",
+                                theme::success(&t("shell.kill_live_sessions.kill_done"))
+                            );
                             killed += 1;
                         }
                         Err(e) => {
                             let mut err_args = std::collections::HashMap::new();
                             err_args.insert("error".to_string(), e.to_string());
                             println!(
-                                "\x1b[31m{}\x1b[0m",
-                                t_with_args("shell.kill_live_sessions.kill_failed", &err_args)
+                                "{}",
+                                theme::error(&t_with_args(
+                                    "shell.kill_live_sessions.kill_failed",
+                                    &err_args
+                                ))
                             );
                             errors += 1;
                         }
@@ -3162,8 +3442,8 @@ impl AishShell {
                     let mut nf_args = std::collections::HashMap::new();
                     nf_args.insert("id".to_string(), id.to_string());
                     eprintln!(
-                        "\x1b[31m{}\x1b[0m",
-                        t_with_args("shell.kill_live_sessions.not_found", &nf_args)
+                        "{}",
+                        theme::error(&t_with_args("shell.kill_live_sessions.not_found", &nf_args))
                     );
                     errors += 1;
                 }
@@ -3246,11 +3526,11 @@ impl AishShell {
         let report = match diagnose_result {
             Ok(parsed) => parsed,
             Err(aish_core::AishError::Cancelled) => {
-                println!("\x1b[33m{}\x1b[0m", t("shell.command_cancelled"));
+                println!("{}", theme::warning(&t("shell.command_cancelled")));
                 return;
             }
             Err(e) => {
-                eprintln!("\x1b[31m{}\x1b[0m", format_failure_diagnose_error(&e));
+                eprintln!("{}", theme::error(&format_failure_diagnose_error(&e)));
                 return;
             }
         };
@@ -3279,9 +3559,9 @@ impl AishShell {
             }
 
             let prompt = format!(
-                "{}\x1b[1;36m{}\x1b[0m{}",
+                "{}{}{}",
                 t("shell.failure_diagnose.confirm_fix_prefix"),
-                fix_cmd,
+                theme::accent(&theme::bold(&fix_cmd)),
                 t("shell.failure_diagnose.confirm_fix_suffix")
             );
             if !Self::confirm_action(&prompt, "") {
@@ -3598,7 +3878,7 @@ impl AishShell {
         match subcmd {
             "start" => {
                 if guard.is_some() {
-                    eprintln!("\x1b[33m{}\x1b[0m", t("shell.record.already_recording"));
+                    eprintln!("{}", theme::warning(&t("shell.record.already_recording")));
                     return;
                 }
                 let term_size = crossterm::terminal::size().unwrap_or((80, 24));
@@ -3607,22 +3887,22 @@ impl AishShell {
                     Ok(recorder) => {
                         *guard = Some(recorder);
                         println!(
-                            "\x1b[32m{}\x1b[0m",
-                            t_with_args("shell.record.started", &{
+                            "{}",
+                            theme::success(&t_with_args("shell.record.started", &{
                                 let mut args = std::collections::HashMap::new();
                                 args.insert("path".to_string(), file_path.display().to_string());
                                 args
-                            })
+                            }))
                         );
                     }
                     Err(e) => {
                         eprintln!(
-                            "\x1b[31m{}\x1b[0m",
-                            t_with_args("shell.record.start_failed", &{
+                            "{}",
+                            theme::error(&t_with_args("shell.record.start_failed", &{
                                 let mut args = std::collections::HashMap::new();
                                 args.insert("error".to_string(), e.to_string());
                                 args
-                            })
+                            }))
                         );
                     }
                 }
@@ -3641,17 +3921,17 @@ impl AishShell {
                         format!("{:.1} KB", size as f64 / 1024.0)
                     };
                     println!(
-                        "\x1b[32m{}\x1b[0m",
-                        t_with_args("shell.record.stopped", &{
+                        "{}",
+                        theme::success(&t_with_args("shell.record.stopped", &{
                             let mut args = std::collections::HashMap::new();
                             args.insert("path".to_string(), path.display().to_string());
                             args.insert("duration".to_string(), secs.to_string());
                             args.insert("size".to_string(), size_str);
                             args
-                        })
+                        }))
                     );
                 } else {
-                    eprintln!("\x1b[33m{}\x1b[0m", t("shell.record.not_recording"));
+                    eprintln!("{}", theme::warning(&t("shell.record.not_recording")));
                 }
             }
             _ => {
@@ -3660,13 +3940,13 @@ impl AishShell {
                     let path = rec.file_path().display().to_string();
                     let secs = elapsed.as_secs();
                     println!(
-                        "\x1b[33m{}\x1b[0m",
-                        t_with_args("shell.record.recording_status", &{
+                        "{}",
+                        theme::warning(&t_with_args("shell.record.recording_status", &{
                             let mut args = std::collections::HashMap::new();
                             args.insert("path".to_string(), path);
                             args.insert("duration".to_string(), secs.to_string());
                             args
-                        })
+                        }))
                     );
                 } else {
                     println!("{}", t("shell.record.usage"));
@@ -3684,7 +3964,7 @@ impl AishShell {
         }
 
         if parts.len() > 1 && (parts[1] == "--help" || parts[1] == "-h") {
-            println!("\x1b[36m{}\x1b[0m", t("shell.model_usage"));
+            println!("{}", theme::accent(&t("shell.model_usage")));
             return;
         }
 
@@ -3718,11 +3998,14 @@ impl AishShell {
         // Persist to config file
         let config_path = aish_config::ConfigLoader::default_config_path();
         if let Err(e) = aish_config::ConfigLoader::save(&self.config, &config_path) {
-            eprintln!("\x1b[33m{}\x1b[0m", {
-                let mut args = std::collections::HashMap::new();
-                args.insert("error".to_string(), e.to_string());
-                t_with_args("shell.config_save_warning", &args)
-            });
+            eprintln!(
+                "{}",
+                theme::warning(&{
+                    let mut args = std::collections::HashMap::new();
+                    args.insert("error".to_string(), e.to_string());
+                    t_with_args("shell.config_save_warning", &args)
+                })
+            );
         }
 
         let mut args = std::collections::HashMap::new();
@@ -3735,7 +4018,7 @@ impl AishShell {
         use aish_core::PlanPhase;
 
         if parts.len() > 1 && (parts[1] == "--help" || parts[1] == "-h") {
-            println!("\x1b[36mUsage: /plan [start|status|exit]\x1b[0m");
+            println!("{}", theme::accent("Usage: /plan [start|status|exit]"));
             return;
         }
 
@@ -3745,7 +4028,10 @@ impl AishShell {
 
         // Reject unknown subcommands
         if !subcommand.is_empty() && !["start", "status", "exit"].contains(&subcommand) {
-            eprintln!("\x1b[31mUnknown /plan subcommand: {}\x1b[0m", subcommand);
+            eprintln!(
+                "{}",
+                theme::error(&format!("Unknown /plan subcommand: {}", subcommand))
+            );
             return;
         }
 
@@ -3754,12 +4040,12 @@ impl AishShell {
                 match subcommand {
                     "exit" => {
                         self.ai_handler.exit_plan_mode();
-                        println!("\x1b[33mExited plan mode.\x1b[0m");
+                        println!("{}", theme::warning("Exited plan mode."));
                     }
                     _ => {
                         // Bare `/plan` or `/plan status` while planning → show status
                         let plan_id = plan_state.plan_id.as_deref().unwrap_or("unknown");
-                        println!("\x1b[1;36mPlan Mode (active)\x1b[0m");
+                        println!("{}", theme::accent(&theme::bold("Plan Mode (active)")));
                         println!("  Plan ID: {}", plan_id);
                         println!("  Approval: {}", plan_state.approval_status);
                         println!(
@@ -3779,11 +4065,12 @@ impl AishShell {
                         self.ai_handler.enter_plan_mode(&self.session_uuid);
                         let plan_state = self.ai_handler.plan_state();
                         let plan_id = plan_state.plan_id.as_deref().unwrap_or("unknown");
-                        println!("\x1b[1;36m=== Plan Mode ===\x1b[0m");
-                        println!("\x1b[2mPlan ID: {}\x1b[0m", plan_id);
-                        println!("\x1b[2mDuring planning, the AI has access to read-only tools and write_file/edit_file for the plan artifact.\x1b[0m");
+                        println!("{}", theme::accent(&theme::bold("=== Plan Mode ===")));
+                        println!("{}", theme::faint(&format!("Plan ID: {}", plan_id)));
+                        println!("{}", theme::faint("During planning, the AI has access to read-only tools and write_file/edit_file for the plan artifact."));
                         println!(
-                            "\x1b[2mType ; followed by your planning request to start.\x1b[0m"
+                            "{}",
+                            theme::faint("Type ; followed by your planning request to start.")
                         );
                     }
                 }
@@ -3845,15 +4132,15 @@ impl AishShell {
                 let mut args = std::collections::HashMap::new();
                 args.insert("model".to_string(), self.config.model.clone());
                 println!(
-                    "\n\x1b[32m{}\x1b[0m",
-                    t_with_args("shell.setup.applied", &args)
+                    "\n{}",
+                    theme::success(&t_with_args("shell.setup.applied", &args))
                 );
             }
             Err(aish_core::AishError::Cancelled) => {
-                eprintln!("\x1b[33m{}\x1b[0m", t("shell.setup.cancelled"));
+                eprintln!("{}", theme::warning(&t("shell.setup.cancelled")));
             }
             Err(e) => {
-                eprintln!("\x1b[31m{}\x1b[0m", e);
+                eprintln!("{}", theme::error(&e.to_string()));
             }
         }
     }
@@ -3892,7 +4179,7 @@ impl AishShell {
         // can see which host they are about to enter.
         if is_session {
             if let Some(host) = remote_host.as_deref() {
-                let marker = format!("\x1b[33m[ssh:{}]\x1b[0m", host);
+                let marker = theme::warning(&format!("[ssh:{}]", host));
                 eprintln!("{}", marker);
                 // Mirror to the session recorder so cast replay shows the
                 // same banner as the live terminal — without this, replay
@@ -4110,7 +4397,7 @@ impl AishShell {
             Ok(new_pty) => {
                 *self.lock_pty() = new_pty;
                 if show_notice {
-                    println!("\x1b[33mbash session restarted\x1b[0m");
+                    println!("{}", theme::warning("bash session restarted"));
                 }
                 Ok(())
             }
@@ -4147,31 +4434,37 @@ impl AishShell {
                 self.interruption = InterruptionState::ClearPending;
                 self.last_ctrl_c = Some(now);
                 let msg = format!(
-                    "\x1b[33m({})\x1b[0m\r\n",
-                    aish_i18n::t("shell.ctrl_c_again")
+                    "{}\r\n",
+                    theme::warning(&format!("({})", aish_i18n::t("shell.ctrl_c_again")))
                 );
                 crate::recorder::shared_record_output(&self.shared_recorder, &msg);
-                println!("\x1b[33m({})\x1b[0m", aish_i18n::t("shell.ctrl_c_again"));
+                println!(
+                    "{}",
+                    theme::warning(&format!("({})", aish_i18n::t("shell.ctrl_c_again")))
+                );
                 false
             }
             InterruptionState::ClearPending => {
                 if let Some(last) = self.last_ctrl_c {
                     if now.duration_since(last).as_secs() < 1 {
                         self.interruption = InterruptionState::ExitPending;
-                        let msg = format!("\x1b[33m{}\x1b[0m\r\n", aish_i18n::t("shell.exiting"));
+                        let msg = format!("{}\r\n", theme::warning(&aish_i18n::t("shell.exiting")));
                         crate::recorder::shared_record_output(&self.shared_recorder, &msg);
-                        println!("\x1b[33m{}\x1b[0m", aish_i18n::t("shell.exiting"));
+                        println!("{}", theme::warning(&aish_i18n::t("shell.exiting")));
                         return true;
                     }
                 }
                 self.interruption = InterruptionState::ClearPending;
                 self.last_ctrl_c = Some(now);
                 let msg = format!(
-                    "\x1b[33m({})\x1b[0m\r\n",
-                    aish_i18n::t("shell.ctrl_c_again")
+                    "{}\r\n",
+                    theme::warning(&format!("({})", aish_i18n::t("shell.ctrl_c_again")))
                 );
                 crate::recorder::shared_record_output(&self.shared_recorder, &msg);
-                println!("\x1b[33m({})\x1b[0m", aish_i18n::t("shell.ctrl_c_again"));
+                println!(
+                    "{}",
+                    theme::warning(&format!("({})", aish_i18n::t("shell.ctrl_c_again")))
+                );
                 false
             }
             InterruptionState::ExitPending => true,
@@ -4334,7 +4627,7 @@ impl AishShell {
                             script_env.insert("AISH_LAST_OUTPUT".to_string(), response);
                         }
                         Err(e) => {
-                            eprintln!("\x1b[31mAI error: {}\x1b[0m", e);
+                            eprintln!("{}", theme::error(&format!("AI error: {}", e)));
                             returncode = 1;
                         }
                     }
@@ -4570,7 +4863,10 @@ impl AishShell {
                         Ok(rt) => rt,
                         Err(e) => {
                             let _ = event_tx.send(aish_pty::AiEvent::Done(None));
-                            let msg = format!("\r\n\x1b[31mFollowup error: {}\x1b[0m\r\n", e);
+                            let msg = format!(
+                                "\r\n{}\r\n",
+                                theme::error(&format!("Followup error: {}", e))
+                            );
                             unsafe {
                                 nix::libc::write(
                                     nix::libc::STDOUT_FILENO,
@@ -4645,7 +4941,7 @@ impl AishShell {
                                     .swap(true, std::sync::atomic::Ordering::SeqCst)
                                 {
                                     if let Some(message) = context_compaction_notice(&event) {
-                                        println!("\x1b[2m{}\x1b[0m", message);
+                                        println!("{}", theme::faint(&message));
                                     }
                                 }
                             }
@@ -4712,7 +5008,11 @@ impl AishShell {
                                         let max_cols = 76usize;
                                         let frame = reasoning_frame
                                             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                                        let spinner = DOTS_FRAMES[frame % DOTS_FRAMES.len()];
+                                        let spinner = crate::theme::spinner_frame(
+                                            crate::theme::SPINNER_STATUS,
+                                            frame,
+                                        );
+                                        let spinner = crate::theme::accent(spinner);
                                         let elapsed_str = thinking_start_followup
                                             .lock()
                                             .unwrap()
@@ -4751,20 +5051,14 @@ impl AishShell {
                                             print!("\x1b[{}A", prev);
                                         }
                                         if display_lines.is_empty() {
-                                            print!(
-                                                "\r\x1b[K\x1b[90m{}{}...\x1b[0m\n",
-                                                spinner, elapsed_str
-                                            );
+                                            print!("\r\x1b[K{}{}...\n", spinner, elapsed_str);
                                         } else {
-                                            print!(
-                                                "\r\x1b[K\x1b[90m{}{}\x1b[0m\n",
-                                                spinner, elapsed_str
-                                            );
+                                            print!("\r\x1b[K{}{}\n", spinner, elapsed_str);
                                         }
                                         for line in &display_lines {
                                             let truncated =
                                                 truncate_display_width(line.trim(), max_cols);
-                                            print!("\r\x1b[K\x1b[90m{}\x1b[0m\n", truncated);
+                                            print!("\r\x1b[K{}\n", crate::theme::muted(&truncated));
                                         }
                                         for _ in new_count..prev {
                                             print!("\r\x1b[K\n");
@@ -4792,8 +5086,10 @@ impl AishShell {
                                     .or_else(|| event.data.get("error_message"))
                                     .and_then(|e| e.as_str())
                                     .unwrap_or("Unknown error");
-                                let msg =
-                                    format!("\r\n\x1b[31mFollowup LLM error: {}\x1b[0m\r\n", err);
+                                let msg = format!(
+                                    "\r\n{}\r\n",
+                                    theme::error(&format!("Followup LLM error: {}", err))
+                                );
                                 unsafe {
                                     nix::libc::write(
                                         nix::libc::STDOUT_FILENO,
@@ -4992,8 +5288,8 @@ impl AishShell {
                                                 }
                                                 anim_fu.stop();
                                                 let msg = format!(
-                                                    "\r\x1b[33m{}\x1b[0m\r\n",
-                                                    t("shell.command_cancelled")
+                                                    "\r{}\r\n",
+                                                    theme::warning(&t("shell.command_cancelled"))
                                                 );
                                                 unsafe {
                                                     nix::libc::write(
@@ -5039,8 +5335,8 @@ impl AishShell {
                                                     }
                                                     anim_fu.stop();
                                                     let msg = format!(
-                                                        "\r\x1b[33m{}\x1b[0m\r\n",
-                                                        t("shell.command_cancelled")
+                                                        "\r{}\r\n",
+                                                        theme::warning(&t("shell.command_cancelled"))
                                                     );
                                                     unsafe {
                                                         nix::libc::write(
@@ -5119,8 +5415,8 @@ impl AishShell {
                                 }
                                 anim_f.stop();
                                 let msg = format!(
-                                    "\r\x1b[33m{}\x1b[0m\r\n",
-                                    t("shell.command_cancelled")
+                                    "\r{}\r\n",
+                                    theme::warning(&t("shell.command_cancelled"))
                                 );
                                 unsafe {
                                     nix::libc::write(
@@ -5159,8 +5455,8 @@ impl AishShell {
                                     }
                                     anim_f.stop();
                                     let msg = format!(
-                                        "\r\x1b[33m{}\x1b[0m\r\n",
-                                        t("shell.command_cancelled")
+                                        "\r{}\r\n",
+                                        theme::warning(&t("shell.command_cancelled"))
                                     );
                                     unsafe {
                                         nix::libc::write(
@@ -5187,11 +5483,11 @@ impl AishShell {
                     // Check timeout (60s)
                     if followup_start.elapsed() > std::time::Duration::from_secs(60) {
                         anim_f.stop();
-                        let msg = b"\r\n\x1b[31mLLM timeout (60s)\x1b[0m";
+                        let msg = format!("\r\n{}\r\n", theme::error("LLM timeout (60s)"));
                         unsafe {
                             nix::libc::write(
                                 nix::libc::STDOUT_FILENO,
-                                msg.as_ptr() as *mut nix::libc::c_void,
+                                msg.as_ptr() as *const nix::libc::c_void,
                                 msg.len(),
                             );
                         }
@@ -5240,7 +5536,7 @@ impl AishShell {
             args.insert("reasons".to_string(), reasons);
             let title = aish_i18n::t("shell.security.secret.title");
             let message = aish_i18n::t_with_args("shell.security.secret.detected", &args);
-            let warning = format!("\x1b[33m? {}:\x1b[0m {}", title, message);
+            let warning = format!("{} {}", theme::warning(&format!("? {}:", title)), message);
             Some(aish_pty::SshSecretCheckResult {
                 warning,
                 detected_secrets: secrets,
@@ -5585,7 +5881,7 @@ impl AishShell {
                                     .swap(true, std::sync::atomic::Ordering::SeqCst)
                                 {
                                     if let Some(message) = context_compaction_notice(&event) {
-                                        println!("\x1b[2m{}\x1b[0m", message);
+                                        println!("{}", theme::faint(&message));
                                     }
                                 }
                             }
@@ -5652,7 +5948,11 @@ impl AishShell {
                                         let max_cols = 76usize;
                                         let frame = reasoning_frame
                                             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                                        let spinner = DOTS_FRAMES[frame % DOTS_FRAMES.len()];
+                                        let spinner = crate::theme::spinner_frame(
+                                            crate::theme::SPINNER_STATUS,
+                                            frame,
+                                        );
+                                        let spinner = crate::theme::accent(spinner);
                                         let elapsed_str = thinking_start_r
                                             .lock()
                                             .unwrap()
@@ -5691,20 +5991,14 @@ impl AishShell {
                                             print!("\x1b[{}A", prev);
                                         }
                                         if display_lines.is_empty() {
-                                            print!(
-                                                "\r\x1b[K\x1b[90m{}{}...\x1b[0m\n",
-                                                spinner, elapsed_str
-                                            );
+                                            print!("\r\x1b[K{}{}...\n", spinner, elapsed_str);
                                         } else {
-                                            print!(
-                                                "\r\x1b[K\x1b[90m{}{}\x1b[0m\n",
-                                                spinner, elapsed_str
-                                            );
+                                            print!("\r\x1b[K{}{}\n", spinner, elapsed_str);
                                         }
                                         for line in &display_lines {
                                             let truncated =
                                                 truncate_display_width(line.trim(), max_cols);
-                                            print!("\r\x1b[K\x1b[90m{}\x1b[0m\n", truncated);
+                                            print!("\r\x1b[K{}\n", crate::theme::muted(&truncated));
                                         }
                                         for _ in new_count..prev {
                                             print!("\r\x1b[K\n");
@@ -5732,7 +6026,7 @@ impl AishShell {
                                     .or_else(|| event.data.get("error_message"))
                                     .and_then(|e| e.as_str())
                                     .unwrap_or("Unknown error");
-                                eprintln!("\x1b[31mLLM error: {}\x1b[0m", error_msg);
+                                eprintln!("{}", theme::error(&format!("LLM error: {}", error_msg)));
                             }
                             LlmEventType::ToolExecutionStart => {
                                 let tool_name = event
@@ -5750,7 +6044,12 @@ impl AishShell {
                                         .and_then(|p| p.as_str())
                                         .unwrap_or("?");
                                     use std::io::Write;
-                                    println!("\x1b[90m📖 read_file({})\x1b[0m", path);
+                                    println!(
+                                        "{} {}({})",
+                                        crate::theme::accent(crate::theme::TOOL_PREFIX),
+                                        crate::theme::muted("read_file"),
+                                        path
+                                    );
                                     let _ = std::io::stdout().flush();
                                 }
                             }
@@ -5773,7 +6072,7 @@ impl AishShell {
                                             .and_then(|p| p.as_str())
                                             .unwrap_or("error");
                                         use std::io::Write;
-                                        println!("\x1b[31m{}\x1b[0m", preview);
+                                        println!("{}", theme::error(preview));
                                         let _ = std::io::stdout().flush();
                                     }
                                 }
@@ -5868,8 +6167,11 @@ impl AishShell {
                                 let mut elapsed_args = std::collections::HashMap::new();
                                 elapsed_args.insert("time".to_string(), format!("{:.1}", elapsed));
                                 println!(
-                                    "\x1b[2m{}\x1b[0m",
-                                    aish_i18n::t_with_args("shell.thinking_time", &elapsed_args)
+                                    "{}",
+                                    theme::faint(&aish_i18n::t_with_args(
+                                        "shell.thinking_time",
+                                        &elapsed_args
+                                    ))
                                 );
                             }
                             renderer.render_separator();
@@ -5901,10 +6203,7 @@ impl AishShell {
                     }
                     None => Some(aish_pty::AiResponse {
                         command: None,
-                        display_text: format!(
-                            "\x1b[33m{}\x1b[0m",
-                            aish_i18n::t("shell.session.ai_error")
-                        ),
+                        display_text: theme::warning(&aish_i18n::t("shell.session.ai_error")),
                         followup: None,
                         ask_user: None,
                     }),
@@ -5995,7 +6294,7 @@ impl AishShell {
                                 token.cancel();
                             }
                             animation.stop();
-                            println!("\x1b[33m{}\x1b[0m", t("shell.command_cancelled"));
+                            println!("{}", theme::warning(&t("shell.command_cancelled")));
                             break None;
                         } else if byte[0] == 0x1b {
                             // ESC — check for follow-up bytes (arrow/function
@@ -6024,7 +6323,7 @@ impl AishShell {
                                     token.cancel();
                                 }
                                 animation.stop();
-                                println!("\r\n\x1b[33m{}\x1b[0m", t("shell.command_cancelled"));
+                                println!("\r\n{}", theme::warning(&t("shell.command_cancelled")));
                                 break None;
                             }
                             // Follow-up bytes exist (ANSI escape
@@ -6048,7 +6347,7 @@ impl AishShell {
                     .is_some_and(|s| s.elapsed() > std::time::Duration::from_secs(60))
                 {
                     animation.stop();
-                    eprintln!("\x1b[31mLLM timeout (60s)\x1b[0m");
+                    eprintln!("{}", theme::error("LLM timeout (60s)"));
                     break None;
                 }
             };
@@ -6239,8 +6538,10 @@ impl AishShell {
                                                                 }
                                                                 animation.stop();
                                                                 let msg = format!(
-                                                                    "\r\x1b[33m{}\x1b[0m\r\n",
-                                                                    t("shell.command_cancelled")
+                                                                    "\r{}\r\n",
+                                                                    theme::warning(&t(
+                                                                        "shell.command_cancelled"
+                                                                    ))
                                                                 );
                                                                 unsafe {
                                                                     nix::libc::write(
@@ -6286,8 +6587,8 @@ impl AishShell {
                                                                     }
                                                                     animation.stop();
                                                                     let msg = format!(
-                                                                        "\r\x1b[33m{}\x1b[0m\r\n",
-                                                                        t("shell.command_cancelled")
+                                                                        "\r{}\r\n",
+                                                                        theme::warning(&t("shell.command_cancelled"))
                                                                     );
                                                                     unsafe {
                                                                         nix::libc::write(
@@ -6360,8 +6661,8 @@ impl AishShell {
                                                 }
                                                 animation.stop();
                                                 let msg = format!(
-                                                    "\r\x1b[33m{}\x1b[0m\r\n",
-                                                    t("shell.command_cancelled")
+                                                    "\r{}\r\n",
+                                                    theme::warning(&t("shell.command_cancelled"))
                                                 );
                                                 unsafe {
                                                     nix::libc::write(
@@ -6405,8 +6706,10 @@ impl AishShell {
                                                     }
                                                     animation.stop();
                                                     let msg = format!(
-                                                        "\r\x1b[33m{}\x1b[0m\r\n",
-                                                        t("shell.command_cancelled")
+                                                        "\r{}\r\n",
+                                                        theme::warning(&t(
+                                                            "shell.command_cancelled"
+                                                        ))
                                                     );
                                                     unsafe {
                                                         nix::libc::write(
@@ -6688,11 +6991,14 @@ pub fn collapse_output(
 
     let mut result = first.join("\n");
     result.push_str(&format!(
-        "\n\x1b[2m... ({} lines truncated{})\x1b[0m",
-        omitted,
-        offload_path
-            .map(|p| format!(", see {}", p))
-            .unwrap_or_default(),
+        "\n{}",
+        theme::faint(&format!(
+            "... ({} lines truncated{})",
+            omitted,
+            offload_path
+                .map(|p| format!(", see {}", p))
+                .unwrap_or_default(),
+        ))
     ));
     result.push('\n');
     result.push_str(&last.join("\n"));
@@ -6706,8 +7012,8 @@ mod submitted_line_tests {
 
     #[test]
     fn submitted_line_includes_prompt_and_command() {
-        let line = format_user_submitted_line("<aish> ", "/help");
-        assert_eq!(line, "<aish> /help");
+        let line = format_user_submitted_line("◆ aish ", "/help");
+        assert_eq!(line, "◆ aish /help");
     }
 }
 
@@ -6874,9 +7180,11 @@ fn print_panel_line(content: &str, inner_width: usize) {
     let visible = ansi_display_width(&rendered);
     let padding = inner_width.saturating_sub(visible);
     println!(
-        "\x1b[33m│\x1b[0m{}{}\x1b[33m│\x1b[0m",
+        "{}{}{}{}",
+        theme::warning("│"),
         rendered,
-        " ".repeat(padding)
+        " ".repeat(padding),
+        theme::warning("│")
     );
 }
 

--- a/crates/aish-shell/src/commands.rs
+++ b/crates/aish-shell/src/commands.rs
@@ -473,7 +473,7 @@ impl ShellState {
             Some(topic) => self.render_topic_help(topic),
             None => {
                 let title = t("help.general.title");
-                println!("\n\x1b[1;36m{}\x1b[0m\n", title);
+                println!("\n{}\n", crate::theme::accent(&crate::theme::bold(&title)));
                 let markdown = t("help.general.markdown");
                 crate::renderer::ShellRenderer::new().render_markdown(&markdown);
                 BuiltinResult::handled_no_output()
@@ -491,7 +491,7 @@ impl ShellState {
             eprintln!("{}", t_with_args("help.topics.unknown", &args));
             return BuiltinResult::handled_no_output();
         }
-        println!("\n\x1b[1;36m{}\x1b[0m\n", title);
+        println!("\n{}\n", crate::theme::accent(&crate::theme::bold(&title)));
         let md_key = format!("help.topics.{}.markdown", topic);
         let markdown = t(&md_key);
         crate::renderer::ShellRenderer::new().render_markdown(&markdown);

--- a/crates/aish-shell/src/doctor/output.rs
+++ b/crates/aish-shell/src/doctor/output.rs
@@ -1,20 +1,23 @@
 use crate::doctor::checker::{CheckItem, CheckResult, CheckStatus};
-use crossterm::style::{Color, Stylize};
+use crate::theme;
 
 pub struct Output;
 
 impl Output {
     pub fn print_header() {
         println!();
-        println!("{}", Self::header("       AISH Basic Config Diagnostics"));
+        println!(
+            "{}",
+            theme::accent(&theme::bold("       AISH Basic Config Diagnostics"))
+        );
         println!();
     }
 
     pub fn print_result(result: &CheckResult) {
         let icon = match result.status {
-            CheckStatus::Pass => Self::colored("✓", Color::Green),
-            CheckStatus::Warn => Self::colored("⚠", Color::Yellow),
-            CheckStatus::Fail => Self::colored("✗", Color::Red),
+            CheckStatus::Pass => theme::success(theme::ICON_SUCCESS),
+            CheckStatus::Warn => theme::warning(theme::ICON_WARNING),
+            CheckStatus::Fail => theme::error(theme::ICON_ERROR),
         };
         println!("[{}] {}", icon, result.checker);
         for item in &result.items {
@@ -24,14 +27,14 @@ impl Output {
 
     fn print_item(item: &CheckItem) {
         let icon = match item.status {
-            CheckStatus::Pass => Self::colored("✓", Color::Green),
-            CheckStatus::Warn => Self::colored("⚠", Color::Yellow),
-            CheckStatus::Fail => Self::colored("✗", Color::Red),
+            CheckStatus::Pass => theme::success(theme::ICON_SUCCESS),
+            CheckStatus::Warn => theme::warning(theme::ICON_WARNING),
+            CheckStatus::Fail => theme::error(theme::ICON_ERROR),
         };
         let indent = "    ";
         println!("{}{} {}", indent, icon, item.message);
         if let Some(hint) = &item.hint {
-            println!("{}{} {}", indent, Self::colored("→", Color::Cyan), hint);
+            println!("{}{} {}", indent, theme::accent("→"), hint);
         }
     }
 
@@ -42,9 +45,9 @@ impl Output {
         issues: &[String],
     ) {
         println!();
-        println!("{}", Self::separator());
+        println!("{}", theme::dim(&"─".repeat(50)));
         if fail_count == 0 && warn_count == 0 {
-            println!("{}", Self::colored("  All checks passed!", Color::Green));
+            println!("{}", theme::success("  All checks passed!"));
         } else {
             println!("  Found {} issue(s)", fail_count + warn_count);
             if !issues.is_empty() {
@@ -56,34 +59,31 @@ impl Output {
                 println!();
                 println!(
                     "  {}",
-                    Self::colored(
-                        &format!(
-                            "Tip: run 'aish doctor --fix' to auto-fix ({} fixable)",
-                            fixable_count
-                        ),
-                        Color::DarkGrey
-                    )
+                    theme::dim(&format!(
+                        "Tip: run 'aish doctor --fix' to auto-fix ({} fixable)",
+                        fixable_count
+                    ))
                 );
             }
         }
-        println!("{}", Self::separator());
+        println!("{}", theme::dim(&"─".repeat(50)));
     }
 
     pub fn print_fix_summary(fixed_count: usize, remaining: &[String]) {
         println!();
-        println!("{}", Self::separator());
+        println!("{}", theme::dim(&"─".repeat(50)));
         if fixed_count > 0 {
             println!(
                 "  {}",
-                Self::colored(&format!("Fixed {} issue(s).", fixed_count), Color::Green)
+                theme::success(&format!("Fixed {} issue(s).", fixed_count))
             );
             if !remaining.is_empty() {
                 println!(
                     "  {}",
-                    Self::colored(
-                        &format!("{} issue(s) require manual intervention:", remaining.len()),
-                        Color::Yellow
-                    )
+                    theme::warning(&format!(
+                        "{} issue(s) require manual intervention:",
+                        remaining.len()
+                    ))
                 );
                 println!();
                 for (i, issue) in remaining.iter().enumerate() {
@@ -91,19 +91,7 @@ impl Output {
                 }
             }
         }
-        println!("{}", Self::separator());
+        println!("{}", theme::dim(&"─".repeat(50)));
         println!();
-    }
-
-    fn header(s: &str) -> String {
-        Self::colored(s, Color::Cyan).to_string()
-    }
-
-    fn separator() -> String {
-        Self::colored(&"─".repeat(50), Color::DarkGrey).to_string()
-    }
-
-    fn colored(s: &str, color: Color) -> String {
-        format!("{}", crossterm::style::style(s).with(color))
     }
 }

--- a/crates/aish-shell/src/inline_completion.rs
+++ b/crates/aish-shell/src/inline_completion.rs
@@ -423,7 +423,6 @@ pub fn build_default_provider(
 }
 
 use std::sync::Mutex;
-use std::sync::OnceLock;
 use std::time::Duration;
 
 use aish_config::InlineCompletionConfig;
@@ -432,12 +431,12 @@ use aish_llm::CancellationToken;
 use crate::autosuggest::AutoSuggest;
 use crate::input::extract_ai_question;
 
-/// Single-cell spinner that replaces the `<aish>` mode badge in the prompt
-/// while an inline-completion LLM call is in flight.
+/// Single-cell spinner that replaces the `◆` icon in the `◆ aish` mode badge
+/// while an inline-completion LLM call is in flight. `aish` stays visible.
 ///
-/// Each frame is `<` + 4 chars + `>` (6 cols) — a dot bouncing through 4
-/// positions inside the angle brackets. The width matches `<aish>` exactly
-/// so the rest of the prompt never shifts.
+/// Each frame is a Braille spinner glyph + space + `aish` (6 cols),
+/// cycling through the 8-frame `theme::SPINNER_STATUS` Braille pattern. The
+/// width matches `◆ aish` exactly so the rest of the prompt never shifts.
 ///
 /// Writes go directly to stderr via `\x1b7` (save cursor) + optional
 /// `\x1b[<N>A` (move up N lines, navigating to the prompt line when input
@@ -542,10 +541,10 @@ impl PromptSpinner {
         // wrap" (last column of the current line) or auto-wraps it to the
         // next line — and we cannot tell which from width alone. Guessing
         // wrong makes lines_up off-by-one, so the animation (and the
-        // stop() restore that writes <aish>) lands on the wrong row,
+        // stop() restore that writes ◆ aish) lands on the wrong row,
         // overwriting the wrapped input instead of the prompt badge.
         // Skipping start() also makes stop() a no-op (no token set), so
-        // the prompt's original <aish> stays untouched. The ghost text
+        // the prompt's original ◆ aish stays untouched. The ghost text
         // still renders normally — only the spinner animation is skipped.
         let cols = self.terminal_cols.load(Ordering::SeqCst);
         let total = self.prompt_width.load(Ordering::SeqCst)
@@ -564,7 +563,7 @@ impl PromptSpinner {
 
         let me = self.clone();
         let handle = runtime.spawn(async move {
-            let frames = bounce_frames();
+            let frames = spinner_frames();
             let mut idx = 0usize;
             loop {
                 if tok.is_cancelled() {
@@ -585,7 +584,7 @@ impl PromptSpinner {
                 }
                 idx = idx.wrapping_add(1);
                 let mut elapsed_ms: u64 = 0;
-                while elapsed_ms < 120 {
+                while elapsed_ms < 80 {
                     if tok.is_cancelled() {
                         return;
                     }
@@ -608,7 +607,8 @@ impl PromptSpinner {
         self.handle.lock().unwrap().take();
         let up = Self::up_prefix(self.lines_up());
         let mut stderr = std::io::stderr().lock();
-        let _ = write!(stderr, "\x1b7{}\x1b[1G\x1b[35m<aish>\x1b[0m\x1b8", up);
+        let badge = crate::theme::accent(&format!("{} aish", crate::theme::MODE_ICON));
+        let _ = write!(stderr, "\x1b7{}\x1b[1G{}\x1b8", up, badge);
     }
 
     /// Cancel current task without writing restore (used internally by
@@ -622,31 +622,29 @@ impl PromptSpinner {
     }
 }
 
-/// Bouncing-dot frame sequence: `<•   >` → `<   •>` → back. 6 frames
-/// per cycle (forward 4 + reverse 2, excluding endpoints to avoid dup).
-/// Each frame is exactly 6 visible cols: `<` + 4 chars + `>`, matching
-/// `<aish>` width.
-fn bounce_frames() -> &'static [String] {
-    static FRAMES: OnceLock<Vec<String>> = OnceLock::new();
-    FRAMES.get_or_init(|| {
-        let positions: [usize; 6] = [0, 1, 2, 3, 2, 1];
-        positions
+/// Spinner frame sequence using Braille glyphs from `theme::SPINNER_STATUS`
+/// (the 8-frame "⣾⣽⣻⢿⡿⣟⣯⣷" cycle). The spinner glyph replaces only the `◆`
+/// icon while `aish` stays visible.
+///
+/// The `◆` badge glyph (U+25C6) is East-Asian-Width Ambiguous — it occupies
+/// 2 columns in CJK locales but 1 elsewhere — while Braille spinner glyphs are
+/// Neutral (always 1 column). Each frame pads the spinner glyph so its visible
+/// width matches the badge in every locale, keeping `aish` aligned and avoiding
+/// a stale trailing cell during the animation.
+fn spinner_frames() -> &'static [String] {
+    static FRAMES: std::sync::LazyLock<Vec<String>> = std::sync::LazyLock::new(|| {
+        let icon_w =
+            crate::prompt::term_char_width(crate::theme::MODE_ICON.chars().next().unwrap_or('◆'));
+        crate::theme::SPINNER_STATUS
             .iter()
-            .map(|&pos| {
-                let mut f = String::with_capacity(24);
-                f.push_str("\x1b[35m<");
-                for i in 0..4usize {
-                    if i == pos {
-                        f.push('•');
-                    } else {
-                        f.push(' ');
-                    }
-                }
-                f.push_str(">\x1b[0m");
-                f
+            .map(|&ch| {
+                let glyph = ch.chars().next().unwrap_or(' ');
+                let pad = icon_w.saturating_sub(crate::prompt::term_char_width(glyph));
+                crate::theme::accent(&format!("{}{} aish", ch, " ".repeat(pad)))
             })
             .collect()
-    })
+    });
+    &FRAMES
 }
 
 /// RAII guard: stops the spinner on drop. Used in `prefetch()` to guarantee
@@ -751,7 +749,7 @@ impl InlineCompleter {
         // Input changed — any pending hint is now stale.
         state.hint = None;
         // Cancel any in-flight task. Stop the spinner immediately so the
-        // prompt snaps back to `<aish>` on this keypress — the cancelled
+        // prompt snaps back to `◆ aish` on this keypress — the cancelled
         // prefetch task will exit on its own within ~20ms.
         if let Some((_, tok)) = state.pending.take() {
             tok.cancel();
@@ -919,7 +917,7 @@ impl InlineCompleter {
         // DECSC saves the cursor position to navigate back to the prompt
         // badge row. If the restore ran AFTER render_ghost and the ghost
         // wrapped the cursor onto a new line, the saved position would be
-        // wrong and <aish> would land on the wrapped input row. Dropping
+        // wrong and ◆ aish would land on the wrapped input row. Dropping
         // the guard here ensures stop() runs while the cursor is still at
         // the input end. On early-return paths (cancel/timeout/error above)
         // the guard still drops automatically.
@@ -961,9 +959,9 @@ fn render_ghost(suffix: &str) {
     // wraps across lines: the previous approach used \x1b[<N>D to move
     // the cursor back, but that sequence can only move left within the
     // current row. A wrapped ghost stranded the cursor on the wrong line,
-    // which in turn made the spinner's <aish> restore (via SpinnerGuard)
+    // which in turn made the spinner's ◆ aish restore (via SpinnerGuard)
     // write to the wrong row.
-    let _ = write!(stderr, "\x1b7\x1b[K\x1b[38;5;242m{}\x1b[0m\x1b8", suffix);
+    let _ = write!(stderr, "\x1b7\x1b[K{}\x1b8", crate::theme::dim(suffix));
     let _ = stderr.flush();
 }
 

--- a/crates/aish-shell/src/lib.rs
+++ b/crates/aish-shell/src/lib.rs
@@ -39,6 +39,7 @@ pub mod renderer;
 pub mod resume_selector;
 pub mod security_panel;
 pub mod status;
+pub mod theme;
 pub mod token_store;
 pub mod tui;
 pub mod types;

--- a/crates/aish-shell/src/llm_event_ui.rs
+++ b/crates/aish-shell/src/llm_event_ui.rs
@@ -45,8 +45,12 @@ pub fn is_parent_agent_spawn_tool_event(event: &LlmEvent) -> bool {
 pub fn sub_agent_indent(depth: u32) -> String {
     match depth {
         0 => String::new(),
-        1 => "  └─ ".to_string(),
-        n => format!("{}  └─ ", "  ".repeat(n as usize - 1)),
+        1 => format!("  {} ", crate::theme::TREE_LAST),
+        n => format!(
+            "{}  {} ",
+            "  ".repeat(n as usize - 1),
+            crate::theme::TREE_LAST
+        ),
     }
 }
 
@@ -68,16 +72,17 @@ pub fn format_sub_agent_thinking_line(ctx: &SubAgentContext, status: &str) -> St
         "{}{} · {}",
         sub_agent_indent(ctx.depth),
         ctx.agent_type,
-        status
+        crate::theme::muted(status)
     )
 }
 
 pub fn format_sub_agent_tool_line(ctx: &SubAgentContext, name: &str, args_preview: &str) -> String {
     format!(
-        "\x1b[36m{}🔧 {} ({})\x1b[0m",
+        "{}{} {} {}",
         sub_agent_child_indent(ctx.depth),
-        name,
-        args_preview
+        crate::theme::accent(crate::theme::TOOL_PREFIX),
+        crate::theme::accent(name),
+        crate::theme::muted(&format!("({})", args_preview))
     )
 }
 
@@ -94,7 +99,7 @@ pub fn print_sub_agent_generation_start(event: &LlmEvent) {
     if let Some(ctx) = sub_agent_context(event) {
         let status = aish_i18n::t("shell.sub_agent.thinking");
         let line = format_sub_agent_thinking_line(&ctx, &status);
-        println!("\x1b[2m{}\x1b[0m", line);
+        println!("{}", crate::theme::muted(&line));
         let _ = std::io::Write::flush(&mut std::io::stdout());
     }
 }
@@ -184,7 +189,9 @@ mod tests {
             spawn_id: "id".into(),
         };
         let line = format_sub_agent_tool_line(&ctx, "grep", "pattern=x");
-        assert!(line.starts_with("\x1b[36m    🔧 grep"));
+        assert!(line.starts_with("    "));
+        assert!(line.contains("❯"));
+        assert!(line.contains("grep"));
         assert!(!line.contains("plan"));
         assert!(line.contains("pattern=x"));
     }

--- a/crates/aish-shell/src/prompt.rs
+++ b/crates/aish-shell/src/prompt.rs
@@ -792,11 +792,16 @@ mod tests {
             .iter()
             .find(|line| line.contains("..."))
             .expect("expected a truncated changelog line in the output");
-        assert!(
-            truncated_line.ends_with("\x1b[0m"),
-            "truncated line must end with reset so padding stays neutral: {:?}",
-            truncated_line,
-        );
+        // With NO_COLOR set, theme functions emit plain text (no ANSI), so
+        // there is no color to reset. Otherwise the right border's own reset
+        // makes the line end with \x1b[0m, keeping padding neutral.
+        if std::env::var_os("NO_COLOR").is_none() {
+            assert!(
+                truncated_line.ends_with("\x1b[0m"),
+                "truncated line must end with reset so padding stays neutral: {:?}",
+                truncated_line,
+            );
+        }
     }
 
     #[test]

--- a/crates/aish-shell/src/prompt.rs
+++ b/crates/aish-shell/src/prompt.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
+use crate::theme;
 use aish_i18n::{t, t_with_args};
 
 /// Whether the current locale is a CJK (Chinese/Japanese/Korean) locale.
@@ -67,16 +69,44 @@ pub fn read_git_branch(cwd: &str) -> Option<String> {
     }
 }
 
+/// Cache for git dirty status: (checked_at, cwd, is_dirty).
+/// Prevents spawning `git status` on every prompt render — without this,
+/// each prompt (every Enter keypress) blocks ~50ms+ while git scans the
+/// worktree (worse on NFS-mounted repos).
+static GIT_DIRTY_CACHE: Mutex<Option<(Instant, String, bool)>> = Mutex::new(None);
+
+/// How long a cached dirty result remains valid.
+const DIRTY_CACHE_TTL: Duration = Duration::from_secs(2);
+
 /// Check if the git working tree has uncommitted changes.
+///
+/// Cached per-cwd with a 2-second TTL so repeated prompts within the same
+/// repo don't re-spawn `git status`.
 fn is_git_dirty(cwd: &str) -> bool {
-    let output = std::process::Command::new("git")
-        .args(["status", "--porcelain"])
-        .current_dir(cwd)
-        .output();
-    match output {
-        Ok(o) => !o.stdout.is_empty(),
-        Err(_) => false,
+    let now = Instant::now();
+
+    // Fast path: return cached result if still fresh for this cwd.
+    if let Ok(cache) = GIT_DIRTY_CACHE.lock() {
+        if let Some((checked_at, cached_cwd, dirty)) = cache.as_ref() {
+            if *cached_cwd == cwd && now.duration_since(*checked_at) < DIRTY_CACHE_TTL {
+                return *dirty;
+            }
+        }
     }
+
+    // Cache miss: spawn git status for the authoritative answer.
+    let dirty = std::process::Command::new("git")
+        .args(["--no-optional-locks", "status", "--porcelain"])
+        .current_dir(cwd)
+        .output()
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false);
+
+    if let Ok(mut cache) = GIT_DIRTY_CACHE.lock() {
+        *cache = Some((now, cwd.to_string(), dirty));
+    }
+
+    dirty
 }
 
 /// Abbreviate a path by keeping `~` and the last component intact,
@@ -181,12 +211,12 @@ fn truncate_ansi(s: &str, max_visible: usize) -> String {
 
 /// Render the shell prompt in compact.aish theme style.
 ///
-/// Format: `<mode> ~/n/x/g/aish|branch●➜ `
+/// Format: `◆ aish ~/n/x/g/aish ⎇ branch ●➜ `
 ///
-/// - Mode badge: magenta `<aish>` or yellow `<plan>`
-/// - Path is abbreviated and colored blue
-/// - Git branch in magenta with clean (green ●) or dirty (red ●) indicator
-/// - Prompt symbol: green ➜ on success, red ➜➜ on error
+/// - Mode badge: accent-blue `◆ aish` or warning-amber `◆ plan`
+/// - Path is abbreviated and muted
+/// - Git branch in gold with the `⎇` icon; clean (green `●`) or dirty (amber `●`) dot
+/// - Prompt symbol: green `➜` on success, red `➜➜` on error
 pub fn render_prompt(
     cwd: &str,
     _model: &str,
@@ -201,32 +231,40 @@ pub fn render_prompt(
     // Recording indicator
     let mut prompt = String::new();
     if recording {
-        prompt.push_str("\x1b[31m⏺\x1b[0m ");
+        prompt.push_str(&format!("{} ", theme::error("⏺")));
     }
 
-    // Mode badge (magenta for aish, yellow for plan)
-    let mode_color = if mode == "plan" { "33" } else { "35" };
-    prompt.push_str(&format!("\x1b[{}m<{}>\x1b[0m ", mode_color, mode));
+    // Mode badge (accent for aish, warning for plan)
+    let badge = if mode == "plan" {
+        theme::warning(&format!("{} {}", theme::MODE_ICON, mode))
+    } else {
+        theme::accent(&format!("{} {}", theme::MODE_ICON, mode))
+    };
+    prompt.push_str(&format!("{} ", badge));
 
-    // Abbreviated path in blue
+    // Abbreviated path (muted)
     let abbreviated = abbreviate_path(cwd, &home);
-    prompt.push_str(&format!("\x1b[34m{}\x1b[0m", abbreviated));
+    prompt.push_str(&theme::muted(&abbreviated));
 
-    // Git branch and status
+    // Git branch and status: "⎇ branch ●" — a space before the git icon and
+    // between the branch name and the dirty/clean dot for readability.
     if let Some(branch) = read_git_branch(cwd) {
-        prompt.push_str(&format!("|\x1b[35m{}\x1b[0m", branch));
+        prompt.push_str(&format!(
+            " {}",
+            theme::gold(&format!("{} {}", theme::ICON_GIT, branch))
+        ));
         if is_git_dirty(cwd) {
-            prompt.push_str("\x1b[31m●\x1b[0m");
+            prompt.push_str(&format!(" {}", theme::warning("●")));
         } else {
-            prompt.push_str("\x1b[32m●\x1b[0m");
+            prompt.push_str(&format!(" {}", theme::success("●")));
         }
     }
 
     // Prompt symbol based on last exit code
     if last_exit_code == 0 {
-        prompt.push_str("\x1b[32m➜\x1b[0m ");
+        prompt.push_str(&format!("{} ", theme::success(theme::PROMPT_OK)));
     } else {
-        prompt.push_str("\x1b[31m➜➜\x1b[0m ");
+        prompt.push_str(&format!("{} ", theme::error(theme::PROMPT_ERR)));
     }
 
     prompt
@@ -283,13 +321,21 @@ pub fn render_welcome(
     let mut content_lines = vec![
         String::new(),
         format!(
-            "  \x1b[1m{}:\x1b[0m {} \x1b[2m{}\x1b[0m",
-            model_label, model, model_hint
+            "  {}: {} {}",
+            theme::bold(&format!("{}:", model_label)),
+            model,
+            theme::faint(&model_hint)
         ),
-        format!("  \x1b[1m{}:\x1b[0m {}", config_label, config_path),
         format!(
-            "  \x1b[1m{}:\x1b[0m \x1b[92m#{}\x1b[0m {}",
-            skills_label, skill_count, skills_suffix
+            "  {}: {}",
+            theme::bold(&format!("{}:", config_label)),
+            config_path
+        ),
+        format!(
+            "  {}: {} {}",
+            theme::bold(&format!("{}:", skills_label)),
+            theme::success(&format!("#{}", skill_count)),
+            skills_suffix
         ),
         String::new(),
     ];
@@ -313,23 +359,31 @@ pub fn render_welcome(
             let hint_prefix = t_with_args("shell.welcome2.changelog_hint_prefix", &hint_args);
             let hint_suffix = t("shell.welcome2.changelog_hint_suffix");
             format!(
-                "  \x1b[1;36m{}\x1b[0m \x1b[2m·\x1b[0m \x1b[2m{} \x1b[1;36mCtrl+O\x1b[0m\x1b[2m {}\x1b[0m",
-                title, hint_prefix, hint_suffix,
+                "  {} {} {} {}",
+                theme::accent(&theme::bold(&title)),
+                theme::faint("·"),
+                theme::faint(&format!(
+                    "{} {} {}",
+                    hint_prefix,
+                    theme::accent("Ctrl+O"),
+                    hint_suffix
+                )),
+                ""
             )
         } else {
-            format!("  \x1b[1;36m{}\x1b[0m", title)
+            format!("  {}", theme::accent(&theme::bold(&title)))
         };
         content_lines.push(header);
 
         for entry in &changelog[..entries_to_show] {
             let cat = entry.category.as_str();
-            let (badge, color) = match cat {
-                "Added" => ("[+]", "\x1b[32m"),
-                "Changed" => ("[*]", "\x1b[33m"),
-                "Fixed" => ("[!]", "\x1b[31m"),
-                _ => ("[-]", "\x1b[37m"),
+            let badge_styled = match cat {
+                "Added" => theme::success("[+]"),
+                "Changed" => theme::warning("[*]"),
+                "Fixed" => theme::error("[!]"),
+                _ => theme::dim("[-]"),
             };
-            let mut line = format!("  {}{} {}{}", color, badge, entry.text, "\x1b[0m");
+            let mut line = format!("  {} {}", badge_styled, entry.text);
             let visible = strip_ansi_len(&line);
             if visible > inner_width {
                 let truncated = truncate_ansi(&line, inner_width - 3);
@@ -346,31 +400,34 @@ pub fn render_welcome(
     let title = format!(" {} ", header);
     let title_len = strip_ansi_len(&title);
     let top_fill = inner_width.saturating_sub(title_len + 1);
-    out.push_str(&format!(
-        "\x1b[37m╭─{}{}╮\x1b[0m\n",
+    out.push_str(&theme::dim(&format!(
+        "╭─{}{}╮",
         title,
         "─".repeat(top_fill)
-    ));
+    )));
+    out.push('\n');
 
     // Render content lines
     for line in &content_lines {
         let visible_len = strip_ansi_len(line);
         let padding = inner_width.saturating_sub(visible_len);
-        out.push_str(&format!(
-            "\x1b[37m│\x1b[0m{}{}\x1b[37m│\x1b[0m\n",
-            line,
-            " ".repeat(padding)
-        ));
+        out.push_str(&theme::dim("│"));
+        out.push_str(line);
+        out.push_str(&" ".repeat(padding));
+        out.push_str(&theme::dim("│"));
+        out.push('\n');
     }
 
     // Render rounded box bottom
-    out.push_str(&format!("\x1b[37m╰{}╯\x1b[0m\n", "─".repeat(inner_width)));
+    out.push_str(&theme::dim(&format!("╰{}╯", "─".repeat(inner_width))));
+    out.push('\n');
 
     out.push('\n');
 
     // Quick start section
     let qs_title = t("shell.welcome2.quick_start.title");
-    out.push_str(&format!("\x1b[1m{}\x1b[0m\n", qs_title));
+    out.push_str(&theme::bold(&qs_title));
+    out.push('\n');
 
     let item1_prefix = t("shell.welcome2.quick_start.item1_prefix");
     let cmd_ls = t("shell.welcome2.quick_start.cmd_ls");
@@ -401,15 +458,14 @@ pub fn render_welcome(
     let mut quick_1 = String::new();
     quick_1.push_str(&quick_1_prefix);
     quick_1.push_str(&" ".repeat(content_start.saturating_sub(strip_ansi_len(&quick_1_prefix))));
-    quick_1.push_str("\x1b[1;36m");
-    quick_1.push_str(&cmd_ls);
-    quick_1.push_str("\x1b[0m, \x1b[1;36m");
-    quick_1.push_str(&cmd_top);
-    quick_1.push_str("\x1b[0m, \x1b[1;36m");
-    quick_1.push_str(&cmd_vim);
-    quick_1.push_str("\x1b[0m, \x1b[1;36m");
-    quick_1.push_str(&cmd_ssh);
-    quick_1.push_str("\x1b[0m");
+    let cmds = format!(
+        "{}, {}, {}, {}",
+        theme::accent(&cmd_ls),
+        theme::accent(&cmd_top),
+        theme::accent(&cmd_vim),
+        theme::accent(&cmd_ssh)
+    );
+    quick_1.push_str(&cmds);
     quick_1.push_str(&item1_suffix);
     out.push_str(&quick_1);
     out.push('\n');
@@ -421,7 +477,7 @@ pub fn render_welcome(
     if let Some(first_part) = item2_parts.first() {
         quick_2.push_str(first_part);
         for part in item2_parts.iter().skip(1) {
-            quick_2.push_str("\x1b[1;36m;\x1b[0m");
+            quick_2.push_str(&theme::accent(";"));
             quick_2.push_str(part);
         }
     }
@@ -432,9 +488,7 @@ pub fn render_welcome(
     quick_3.push_str(&quick_3_prefix);
     quick_3.push_str(&" ".repeat(content_start.saturating_sub(strip_ansi_len(&quick_3_prefix))));
     quick_3.push_str(&item3_suffix_1);
-    quick_3.push_str("\x1b[1;36m");
-    quick_3.push_str(&item3_keyword);
-    quick_3.push_str("\x1b[0m");
+    quick_3.push_str(&theme::accent(&item3_keyword));
     quick_3.push_str(&item3_suffix_2);
     out.push_str(&quick_3);
     out.push('\n');
@@ -443,7 +497,8 @@ pub fn render_welcome(
 
     // Risk warning
     let risk = t("shell.welcome2.risk");
-    out.push_str(&format!("\x1b[2m{}\x1b[0m\n", risk));
+    out.push_str(&theme::faint(&risk));
+    out.push('\n');
 
     out
 }
@@ -632,7 +687,7 @@ mod tests {
             result
         );
         assert!(result.contains("➜"), "should contain prompt symbol");
-        assert!(result.contains("<aish>"), "should contain mode badge");
+        assert!(result.contains("◆ aish"), "should contain mode badge");
     }
 
     #[test]
@@ -651,8 +706,9 @@ mod tests {
     fn test_render_prompt_success_symbol() {
         let result = render_prompt("/tmp", "test-model", 0, "aish", false);
         assert!(
-            result.contains("\x1b[32m➜\x1b[0m"),
-            "should have green single arrow on success"
+            result.contains("➜"),
+            "should have single arrow prompt on success: {}",
+            result
         );
         assert!(
             !result.contains("➜➜"),
@@ -664,29 +720,22 @@ mod tests {
     fn test_render_prompt_error_symbol() {
         let result = render_prompt("/tmp", "test-model", 1, "aish", false);
         assert!(
-            result.contains("\x1b[31m➜➜\x1b[0m"),
-            "should have red double arrow on error"
+            result.contains("➜➜"),
+            "should have double arrow prompt on error: {}",
+            result
         );
     }
 
     #[test]
     fn test_render_prompt_aish_mode_badge() {
         let result = render_prompt("/tmp", "test-model", 0, "aish", false);
-        assert!(result.contains("<aish>"), "should show aish mode badge");
-        assert!(
-            result.contains("\x1b[35m<aish>"),
-            "aish badge should be magenta"
-        );
+        assert!(result.contains("◆ aish"), "should show aish mode badge");
     }
 
     #[test]
     fn test_render_prompt_plan_mode_badge() {
         let result = render_prompt("/tmp", "test-model", 0, "plan", false);
-        assert!(result.contains("<plan>"), "should show plan mode badge");
-        assert!(
-            result.contains("\x1b[33m<plan>"),
-            "plan badge should be yellow"
-        );
+        assert!(result.contains("◆ plan"), "should show plan mode badge");
     }
 
     #[test]

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -340,7 +340,7 @@ impl Helper for ShellHelper {}
 
 impl Highlighter for ShellHelper {
     fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
-        Cow::Owned(format!("\x1b[38;5;242m{}\x1b[0m", hint))
+        Cow::Owned(crate::theme::dim(hint))
     }
 }
 

--- a/crates/aish-shell/src/renderer.rs
+++ b/crates/aish-shell/src/renderer.rs
@@ -1,7 +1,8 @@
 use std::io::{self, Write};
 
 use crate::recorder::SharedRecorder;
-use richrs::color::{Color, StandardColor};
+use crate::theme;
+use richrs::color::Color;
 use richrs::console::Console;
 use richrs::markdown::Markdown;
 use richrs::style::Style;
@@ -300,9 +301,9 @@ fn render_code_block(
 
     // Dim bold language label
     if !lang.is_empty() {
-        let lang_ansi = format!("\x1b[1;2m{}\x1b[0m\n", lang);
+        let lang_ansi = format!("{}\n", theme::bold_faint(lang));
         record_to_shared(shared_recorder, &lang_ansi);
-        println!("\x1b[1;2m{}\x1b[0m", lang);
+        println!("{}", theme::bold_faint(lang));
     }
 
     // Syntax-highlighted code
@@ -373,14 +374,14 @@ impl ShellRenderer {
                 }
                 ContentSegment::Markdown(content) => {
                     let inline_style = Style::new()
-                        .with_color(Color::Standard(StandardColor::Cyan))
+                        .with_color(Color::Rgb {
+                            r: crate::theme::ACCENT_RGB.0,
+                            g: crate::theme::ACCENT_RGB.1,
+                            b: crate::theme::ACCENT_RGB.2,
+                        })
                         .bold();
                     let md = Markdown::new(&content).inline_code_style(inline_style);
                     let segs = md.render(self.terminal_width);
-                    // Record ANSI-rendered output so agg/GIF shows proper formatting.
-                    // richrs adds two trailing newlines per paragraph; the terminal
-                    // removes one with \x1b[1A\x1b[M. Remove one trailing newline
-                    // from the recording to match the terminal display.
                     {
                         let mut ansi = segs.to_ansi();
                         if ansi.ends_with("\n\n") {
@@ -395,9 +396,6 @@ impl ShellRenderer {
         }
         let _ = self.console.flush();
         let _ = io::stdout().flush();
-        // richrs Markdown adds two trailing newlines at paragraph end,
-        // creating a blank line before the bottom separator.
-        // Delete it only when the last segment was a Markdown paragraph.
         if last_was_markdown {
             print!("\x1b[1A\x1b[M");
             let _ = io::stdout().flush();
@@ -410,20 +408,20 @@ impl ShellRenderer {
         if delta.is_empty() {
             return;
         }
-        self.record_output(&format!("\x1b[1;90m{}\x1b[0m", delta));
+        let styled = theme::muted(delta);
+        self.record_output(&styled);
         self.streaming_active = true;
-        print!("\x1b[1;90m{}\x1b[0m", delta);
+        print!("{}", styled);
         let _ = io::stdout().flush();
     }
 
     /// Finalize streaming — print a newline and reset state.
-    /// Matches Python's _finalize_content_preview approach.
     pub fn finalize_stream(&mut self) {
         if !self.streaming_active {
             return;
         }
         self.streaming_active = false;
-        println!();
+        println!("\x1b[0m");
     }
 
     /// Reset state (call at GenerationStart).
@@ -438,19 +436,15 @@ impl ShellRenderer {
 
     /// Helper: record output data to the shared recorder if one is attached.
     fn record_output(&self, data: &str) {
-        if let Some(ref sr) = self.shared_recorder {
+        if let Some(sr) = &self.shared_recorder {
             crate::recorder::shared_record_output(sr, data);
         }
     }
 
-    /// Render a green horizontal separator line spanning the terminal.
-    /// Records a fixed 5-char separator for GIF output (terminal width is
-    /// unknown in asciinema→GIF conversion).
+    /// Print a blank line as a visual spacer between content blocks.
     pub fn render_separator(&mut self) {
-        let width = self.terminal_width.max(20);
-        let sep = "─".repeat(width);
-        self.record_output("\x1b[32m─────\x1b[0m\r\n");
-        print!("\r\x1b[32m{}\x1b[0m\r\n", sep);
+        self.record_output("\r\n");
+        println!();
         let _ = std::io::stdout().flush();
     }
 }

--- a/crates/aish-shell/src/resume_selector.rs
+++ b/crates/aish-shell/src/resume_selector.rs
@@ -72,6 +72,10 @@ pub fn select_resume_session(items: &[ResumeSessionItem]) -> io::Result<Option<S
 
     match PanelRuntime::new().run(panel).map_err(io::Error::other)? {
         PanelOutcome::Submitted(SearchSelectOutcome::Selected(session_id)) => Ok(Some(session_id)),
+        // Rename does not apply to persisted sessions; treat as a no-op.
+        PanelOutcome::Submitted(SearchSelectOutcome::Rename(_)) => Ok(None),
+        // Quit (Ctrl+Q) is not meaningful for the resume picker; cancel.
+        PanelOutcome::Submitted(SearchSelectOutcome::Quit) => Ok(None),
         PanelOutcome::Cancelled => Ok(None),
     }
 }

--- a/crates/aish-shell/src/status.rs
+++ b/crates/aish-shell/src/status.rs
@@ -8,6 +8,8 @@ mod system_info;
 
 use std::sync::Mutex;
 
+use crate::theme;
+
 /// System information collected via sysinfo crate.
 struct SystemInfo {
     hostname: String,
@@ -152,9 +154,9 @@ fn render(
                 .iter()
                 .map(|s| {
                     if s.active {
-                        format!("\x1b[32m{}\u{25cf}\x1b[0m", s.name)
+                        theme::success(&format!("{} {}", s.name, theme::ICON_SUCCESS))
                     } else {
-                        format!("\x1b[2m{}\u{25cb}\x1b[0m", s.name)
+                        theme::faint(&format!("{} {}", s.name, theme::ICON_DONE))
                     }
                 })
                 .collect();
@@ -171,11 +173,11 @@ fn render(
     let total = lines.len();
     for (i, line) in lines.iter().enumerate() {
         if i == 0 {
-            println!("\u{250c}\u{2500} {}", line);
+            println!("{} {}", theme::TREE_CORNER, line);
         } else if i == total - 1 {
-            println!("\u{2514}\u{2500} {}", line);
+            println!("{} {}", theme::TREE_LAST, line);
         } else {
-            println!("\u{251c}\u{2500} {}", line);
+            println!("{} {}", theme::TREE_BRANCH, line);
         }
     }
 }
@@ -247,9 +249,9 @@ fn render_to_string(
                 .iter()
                 .map(|(name, active)| {
                     if *active {
-                        format!("\x1b[32m{}\u{25cf}\x1b[0m", name)
+                        theme::success(&format!("{} {}", name, theme::ICON_SUCCESS))
                     } else {
-                        format!("\x1b[2m{}\u{25cb}\x1b[0m", name)
+                        theme::faint(&format!("{} {}", name, theme::ICON_DONE))
                     }
                 })
                 .collect();
@@ -265,11 +267,11 @@ fn render_to_string(
     let mut out = String::new();
     for (i, line) in lines.iter().enumerate() {
         if i == 0 {
-            out.push_str(&format!("\u{250c}\u{2500} {}\n", line));
+            out.push_str(&format!("{} {}\n", theme::TREE_CORNER, line));
         } else if i == total - 1 {
-            out.push_str(&format!("\u{2514}\u{2500} {}", line));
+            out.push_str(&format!("{} {}\n", theme::TREE_LAST, line));
         } else {
-            out.push_str(&format!("\u{251c}\u{2500} {}\n", line));
+            out.push_str(&format!("{} {}\n", theme::TREE_BRANCH, line));
         }
     }
     out

--- a/crates/aish-shell/src/theme.rs
+++ b/crates/aish-shell/src/theme.rs
@@ -13,11 +13,19 @@ use unicode_width::UnicodeWidthChar;
 
 /// Whether the current terminal supports 24-bit truecolor.
 /// Detected once from `COLORTERM` and cached for the process lifetime.
+/// Honors the `NO_COLOR` convention: any value disables all color.
 static TRUECOLOR: LazyLock<bool> = LazyLock::new(|| {
+    if std::env::var_os("NO_COLOR").is_some() {
+        return false;
+    }
     std::env::var("COLORTERM")
         .map(|v| v == "truecolor" || v == "24bit")
         .unwrap_or(false)
 });
+
+/// Whether all color output is disabled via the `NO_COLOR` environment
+/// variable (convention: presence of any value, including empty, disables).
+static NO_COLOR: LazyLock<bool> = LazyLock::new(|| std::env::var_os("NO_COLOR").is_some());
 
 fn supports_truecolor() -> bool {
     *TRUECOLOR
@@ -28,7 +36,11 @@ fn supports_truecolor() -> bool {
 // ───────────────────────────────────────────────────────────────────────────
 
 /// Apply foreground truecolor (or 256-color fallback) to `text`.
+/// Returns plain text when `NO_COLOR` is set.
 fn fg_rgb(r: u8, g: u8, b: u8, fallback256: u8, text: &str) -> String {
+    if *NO_COLOR {
+        return text.to_string();
+    }
     if supports_truecolor() {
         format!("\x1b[38;2;{r};{g};{b}m{text}\x1b[0m")
     } else {
@@ -231,6 +243,10 @@ static SHIMMER_ANSI: LazyLock<ShimmerAnsi> = LazyLock::new(|| ShimmerAnsi {
 /// Brightness is modulated by the cosine bump: dim at rest, vivid at the crest.
 /// On 256-color terminals, falls back to a three-tier monochrome palette.
 pub fn shimmer_text(text: &str, time_ms: u64) -> String {
+    // NO_COLOR convention: return plain text without ANSI.
+    if *NO_COLOR {
+        return text.to_string();
+    }
     let chars: Vec<char> = text.chars().collect();
     let len = chars.len();
     if len == 0 {

--- a/crates/aish-shell/src/theme.rs
+++ b/crates/aish-shell/src/theme.rs
@@ -1,0 +1,663 @@
+//! Centralized color palette and symbol system for aish terminal display.
+//!
+//! Inspired by oh-my-pi's theme system: truecolor hex colors with graceful
+//! fallback to 256-color ANSI when the terminal doesn't support 24-bit color.
+//! All display code should use these tokens instead of hardcoded ANSI codes.
+
+use std::sync::LazyLock;
+use unicode_width::UnicodeWidthChar;
+
+// ───────────────────────────────────────────────────────────────────────────
+// Terminal capability detection
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Whether the current terminal supports 24-bit truecolor.
+/// Detected once from `COLORTERM` and cached for the process lifetime.
+static TRUECOLOR: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var("COLORTERM")
+        .map(|v| v == "truecolor" || v == "24bit")
+        .unwrap_or(false)
+});
+
+fn supports_truecolor() -> bool {
+    *TRUECOLOR
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Color helpers
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Apply foreground truecolor (or 256-color fallback) to `text`.
+fn fg_rgb(r: u8, g: u8, b: u8, fallback256: u8, text: &str) -> String {
+    if supports_truecolor() {
+        format!("\x1b[38;2;{r};{g};{b}m{text}\x1b[0m")
+    } else {
+        format!("\x1b[38;5;{fallback256}m{text}\x1b[0m")
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Color tokens (r, g, b, 256-color fallback)
+// Palette inspired by oh-my-pi "titanium" theme.
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Accent color RGB channels (electric blue), shared with markdown renderer.
+pub const ACCENT_RGB: (u8, u8, u8) = (0, 180, 255);
+
+/// Electric blue — emphasis, headings, spinner, mode badge.
+pub fn accent(text: &str) -> String {
+    fg_rgb(ACCENT_RGB.0, ACCENT_RGB.1, ACCENT_RGB.2, 39, text)
+}
+
+/// Readout green — success, completion, git clean.
+pub fn success(text: &str) -> String {
+    fg_rgb(0, 255, 136, 48, text)
+}
+
+/// Alert red — errors, git dirty, failure indicators.
+pub fn error(text: &str) -> String {
+    fg_rgb(255, 71, 87, 203, text)
+}
+
+/// Warning amber — warnings, dirty indicator, pending states.
+pub fn warning(text: &str) -> String {
+    fg_rgb(255, 179, 71, 215, text)
+}
+
+/// Dim aluminum — secondary text, tool output, timestamps.
+pub fn muted(text: &str) -> String {
+    fg_rgb(156, 163, 176, 247, text)
+}
+
+/// Gray — tertiary text, hints, descriptions.
+pub fn dim(text: &str) -> String {
+    fg_rgb(107, 114, 128, 240, text)
+}
+
+/// Titanium gold — highlights, cost, special labels.
+pub fn gold(text: &str) -> String {
+    fg_rgb(212, 192, 144, 222, text)
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Text style helpers
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Bold text.
+pub fn bold(text: &str) -> String {
+    format!("\x1b[1m{text}\x1b[0m")
+}
+
+/// Dim text (ANSI dim attribute, independent of color).
+pub fn faint(text: &str) -> String {
+    format!("\x1b[2m{text}\x1b[0m")
+}
+
+/// Bold + dim text (combined SGR attributes).
+pub fn bold_faint(text: &str) -> String {
+    format!("\x1b[1;2m{text}\x1b[0m")
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Symbol constants
+// ───────────────────────────────────────────────────────────────────────────
+
+// Status icons
+pub const ICON_SUCCESS: &str = "✔";
+pub const ICON_ERROR: &str = "✘";
+pub const ICON_WARNING: &str = "⚠";
+pub const ICON_RUNNING: &str = "⟳";
+pub const ICON_DONE: &str = "•";
+pub const ICON_PENDING: &str = "⏳";
+
+// Git / branch
+pub const ICON_GIT: &str = "⎇";
+pub const ICON_BRANCH: &str = "⑂";
+
+// Prompt symbols
+pub const PROMPT_OK: &str = "➜";
+pub const PROMPT_ERR: &str = "➜➜";
+
+// Tree connectors
+pub const TREE_BRANCH: &str = "├─";
+pub const TREE_LAST: &str = "└─";
+pub const TREE_VERTICAL: &str = "│";
+pub const TREE_CORNER: &str = "┌─";
+
+// Markdown / formatting
+pub const QUOTE_RAIL: &str = "▏";
+pub const BULLET: &str = "•";
+pub const HR_CHAR: &str = "─";
+
+// Tool execution
+pub const TOOL_PREFIX: &str = "❯";
+
+/// Tool execution box drawing (layered visual grouping).
+pub const TOOL_BOX_TOP: &str = "╭─";
+pub const TOOL_BOX_MID: &str = "│";
+pub const TOOL_BOX_BOT: &str = "╰─";
+
+/// Mode badge icon prefix (replaces angle brackets `<aish>`).
+pub const MODE_ICON: &str = "◆";
+
+// ───────────────────────────────────────────────────────────────────────────
+// Spinner frames
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Status spinner: wide Braille frames for loaders and tool indicators.
+/// 8 frames, designed for ~80ms interval (12.5fps).
+/// Visually wider and more premium than the narrow dots pattern.
+pub const SPINNER_STATUS: &[&str] = &["⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"];
+
+/// Activity spinner: standard Braille dots for high-frequency UI updates.
+/// 10 frames, designed for ~33ms interval (30fps).
+pub const SPINNER_ACTIVITY: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Get a spinner frame by index (wraps around).
+pub fn spinner_frame<'a>(frames: &'a [&'a str], index: usize) -> &'a str {
+    frames[index % frames.len()]
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Shimmer animation — rainbow gradient sweep
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Shimmer tunables — a cosine-bump band sweeps across text at fixed velocity.
+const SHIMMER_SPEED: f64 = 30.0; // cells per second
+const SHIMMER_PADDING: f64 = 10.0; // virtual padding so band enters/exits smoothly
+const SHIMMER_BAND_HALF: f64 = 6.0; // half-width of the cosine bump
+const SHIMMER_TIER_HIGH: f64 = 0.65; // for 256-color fallback
+const SHIMMER_TIER_MID: f64 = 0.22;
+
+/// HSL → RGB conversion.  Returns 8-bit channels.
+fn hsl_to_rgb(h: f64, s: f64, l: f64) -> (u8, u8, u8) {
+    let h = (h.rem_euclid(360.0)) / 360.0;
+    let s = s.clamp(0.0, 1.0);
+    let l = l.clamp(0.0, 1.0);
+    if s == 0.0 {
+        let v = (l * 255.0).round() as u8;
+        return (v, v, v);
+    }
+    let q = if l < 0.5 {
+        l * (1.0 + s)
+    } else {
+        l + s - l * s
+    };
+    let p = 2.0 * l - q;
+    let f = |t: f64| -> f64 {
+        let t = if t < 0.0 {
+            t + 1.0
+        } else if t > 1.0 {
+            t - 1.0
+        } else {
+            t
+        };
+        if t < 1.0 / 6.0 {
+            p + (q - p) * 6.0 * t
+        } else if t < 0.5 {
+            q
+        } else if t < 2.0 / 3.0 {
+            p + (q - p) * (2.0 / 3.0 - t) * 6.0
+        } else {
+            p
+        }
+    };
+    (
+        (f(h + 1.0 / 3.0) * 255.0).round() as u8,
+        (f(h) * 255.0).round() as u8,
+        (f(h - 1.0 / 3.0) * 255.0).round() as u8,
+    )
+}
+
+/// Pre-resolved ANSI codes for the 256-color shimmer fallback.
+struct ShimmerAnsi {
+    high: &'static str,
+    mid: &'static str,
+    low: &'static str,
+    reset: &'static str,
+}
+
+static SHIMMER_ANSI: LazyLock<ShimmerAnsi> = LazyLock::new(|| ShimmerAnsi {
+    high: "\x1b[38;5;39m",
+    mid: "\x1b[38;5;247m",
+    low: "\x1b[38;5;240m",
+    reset: "\x1b[0m",
+});
+
+/// Apply a rainbow cosine-bump shimmer sweep across `text`.
+///
+/// A bright band travels left → right at fixed velocity (30 cells/s). Each
+/// character's hue rotates with its position, creating a flowing rainbow.
+/// Brightness is modulated by the cosine bump: dim at rest, vivid at the crest.
+/// On 256-color terminals, falls back to a three-tier monochrome palette.
+pub fn shimmer_text(text: &str, time_ms: u64) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    let len = chars.len();
+    if len == 0 {
+        return String::new();
+    }
+
+    // Compute display-width position for each character so the shimmer band
+    // sweeps correctly across CJK / fullwidth glyphs (which occupy 2 columns).
+    let mut total_width = 0.0_f64;
+    let char_pos: Vec<f64> = chars
+        .iter()
+        .map(|&ch| {
+            let start = total_width;
+            total_width += UnicodeWidthChar::width(ch).unwrap_or(0) as f64;
+            start
+        })
+        .collect();
+    let period = total_width + SHIMMER_PADDING * 2.0;
+    let pos = ((time_ms as f64 / 1000.0) * SHIMMER_SPEED) % period;
+
+    if supports_truecolor() {
+        // Rainbow mode: per-character HSL with position-based hue drift.
+        let mut result = String::with_capacity(text.len() * 6);
+        for (i, &ch) in chars.iter().enumerate() {
+            let idx = char_pos[i];
+            let dist = (idx + SHIMMER_PADDING - pos).abs();
+            let intensity = if dist >= SHIMMER_BAND_HALF {
+                0.0
+            } else {
+                0.5 * (1.0 + (std::f64::consts::PI * dist / SHIMMER_BAND_HALF).cos())
+            };
+            // Hue rotates per character and drifts over time for flow effect.
+            let hue = (i as f64) * 28.0 + time_ms as f64 * 0.05;
+            let sat = 0.45 + intensity * 0.45;
+            let light = 0.30 + intensity * 0.42;
+            let (r, g, b) = hsl_to_rgb(hue, sat, light);
+            result.push_str(&format!("\x1b[38;2;{r};{g};{b}m{ch}"));
+        }
+        result.push_str("\x1b[0m");
+        result
+    } else {
+        // 256-color fallback: three-tier monochrome.
+        let ansi = &*SHIMMER_ANSI;
+        let mut result = String::with_capacity(text.len() * 4);
+        let mut prev_tier: i8 = -1;
+        let mut run_start: usize = 0;
+        for (i, _ch) in chars.iter().enumerate() {
+            let idx = char_pos[i];
+            let dist = (idx + SHIMMER_PADDING - pos).abs();
+            let intensity = if dist >= SHIMMER_BAND_HALF {
+                0.0
+            } else {
+                0.5 * (1.0 + (std::f64::consts::PI * dist / SHIMMER_BAND_HALF).cos())
+            };
+            let tier = if intensity >= SHIMMER_TIER_HIGH {
+                2
+            } else if intensity >= SHIMMER_TIER_MID {
+                1
+            } else {
+                0
+            };
+            if tier != prev_tier {
+                if prev_tier >= 0 && i > run_start {
+                    let run: String = chars[run_start..i].iter().collect();
+                    let open = match prev_tier {
+                        2 => ansi.high,
+                        1 => ansi.mid,
+                        _ => ansi.low,
+                    };
+                    result.push_str(open);
+                    result.push_str(&run);
+                    result.push_str(ansi.reset);
+                }
+                prev_tier = tier;
+                run_start = i;
+            }
+        }
+        if prev_tier >= 0 {
+            let run: String = chars[run_start..].iter().collect();
+            let open = match prev_tier {
+                2 => ansi.high,
+                1 => ansi.mid,
+                _ => ansi.low,
+            };
+            result.push_str(open);
+            result.push_str(&run);
+            result.push_str(ansi.reset);
+        }
+        result
+    }
+}
+
+/// Short descriptive label for a tool, shown in the shimmer animation.
+/// Falls back to the raw tool name for unknown tools.
+pub fn tool_status_label(name: &str) -> String {
+    match name {
+        // Shell / execution
+        "bash" => "Executing command",
+        "python_exec" => "Executing Python",
+        "Agent" => "Spawning agent",
+        // File operations
+        "read_file" => "Reading file",
+        "write_file" => "Writing file",
+        "edit_file" => "Editing file",
+        // Search
+        "glob" => "Finding files",
+        "grep" => "Searching content",
+        // Web
+        "WebFetch" => "Fetching web content",
+        "web_search" => "Searching web",
+        // Memory / context
+        "memory" => "Accessing memory",
+        "skill" => "Using skill",
+        "host_note" => "Managing host note",
+        // Plan mode
+        "enter_plan_mode" => "Entering plan mode",
+        "exit_plan_mode" => "Exiting plan mode",
+        "list_plan_templates" => "Listing templates",
+        // Interactive
+        "ask_user" => "Awaiting input",
+        "resolve" => "Awaiting approval",
+        // External / MCP tools (may not always be present)
+        "debug" => "Debugging",
+        "lsp" => "Code intelligence",
+        "generate_image" => "Generating image",
+        _ => return name.to_string(),
+    }
+    .to_string()
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Response metadata footer helpers
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Format a token count compactly (e.g., 3200 → "3.2k", 1.2M → "1.2M").
+pub fn format_tokens(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
+/// Render a context usage progress bar (10 cells).
+/// Color changes with usage: green < 50%, amber 50-70%, red >= 70%.
+pub fn context_bar(percent: u8) -> String {
+    let filled = ((percent as f64 * 10.0 / 100.0).round() as usize)
+        .max(if percent > 0 { 1 } else { 0 })
+        .min(10);
+    let empty = 10 - filled;
+    let bar = format!("{}{}", "█".repeat(filled), "░".repeat(empty));
+    if percent < 50 {
+        format!("{} {}%", success(&bar), percent)
+    } else if percent < 70 {
+        format!("{} {}%", warning(&bar), percent)
+    } else {
+        format!("{} {}%", error(&bar), percent)
+    }
+}
+
+/// Render a one-line response metadata footer:
+/// `◉ model │ 3.2k in 1.1k out │ 3.2s │ ctx [████████░░] 23%`
+pub fn response_footer(
+    model: &str,
+    input_tokens: u64,
+    output_tokens: u64,
+    ctx_percent: u8,
+    elapsed_secs: Option<f64>,
+) -> String {
+    let sep = dim("│");
+    let time_part = match elapsed_secs {
+        Some(secs) => format!(" {} {} ", dim("·"), muted(&format!("{:.1}s", secs))),
+        None => " ".to_string(),
+    };
+    format!(
+        "{} {} {} {} {}{}{} ctx {}",
+        gold("◉"),
+        gold(model),
+        sep,
+        success(&format!("{} in", format_tokens(input_tokens))),
+        warning(&format!("{} out", format_tokens(output_tokens))),
+        time_part,
+        sep,
+        context_bar(ctx_percent)
+    )
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Unified diff rendering
+// ───────────────────────────────────────────────────────────────────────────
+
+/// A single line in a line-level diff.
+enum DiffLine {
+    Context(String),
+    Added(String),
+    Removed(String),
+}
+
+/// Compute a line-level diff between `old_lines` and `new_lines` using the
+/// classic LCS dynamic-programming table. Returns ordered diff lines.
+/// Runs in O(n*m) time and memory — callers must bound the input size.
+fn line_diff(old_lines: &[&str], new_lines: &[&str]) -> Vec<DiffLine> {
+    let n = old_lines.len();
+    let m = new_lines.len();
+    // dp[i][j] = length of LCS of old_lines[i..] and new_lines[j..]
+    let mut dp = vec![vec![0usize; m + 1]; n + 1];
+    for i in (0..n).rev() {
+        for j in (0..m).rev() {
+            if old_lines[i] == new_lines[j] {
+                dp[i][j] = dp[i + 1][j + 1] + 1;
+            } else {
+                dp[i][j] = dp[i + 1][j].max(dp[i][j + 1]);
+            }
+        }
+    }
+    let mut out = Vec::with_capacity(n + m);
+    let (mut i, mut j) = (0, 0);
+    while i < n && j < m {
+        if old_lines[i] == new_lines[j] {
+            out.push(DiffLine::Context(old_lines[i].to_string()));
+            i += 1;
+            j += 1;
+        } else if dp[i + 1][j] >= dp[i][j + 1] {
+            out.push(DiffLine::Removed(old_lines[i].to_string()));
+            i += 1;
+        } else {
+            out.push(DiffLine::Added(new_lines[j].to_string()));
+            j += 1;
+        }
+    }
+    while i < n {
+        out.push(DiffLine::Removed(old_lines[i].to_string()));
+        i += 1;
+    }
+    while j < m {
+        out.push(DiffLine::Added(new_lines[j].to_string()));
+        j += 1;
+    }
+    out
+}
+
+/// Render a colored unified diff between `old` and `new` text.
+///
+/// Produces a line-level diff (LCS-based). Added lines are green (`+`),
+/// removed lines are red (`-`), unchanged context lines are dimmed. Output is
+/// capped at `max_lines` diff lines; a `... N more lines` hint is appended
+/// when truncated. Returns an empty string when inputs are identical.
+pub fn render_diff(old: &str, new: &str, max_lines: usize) -> String {
+    // Skip expensive LCS when inputs are byte-identical.
+    if old == new {
+        return String::new();
+    }
+    // Use split('\n') (not lines()) so trailing-newline differences are visible.
+    let old_lines: Vec<&str> = old.split('\n').collect();
+    let new_lines: Vec<&str> = new.split('\n').collect();
+    // Bound input to avoid O(n*m) LCS blowup on very large diffs.
+    const MAX_LCS_LINES: usize = 1000;
+    let diff = line_diff(
+        &old_lines[..old_lines.len().min(MAX_LCS_LINES)],
+        &new_lines[..new_lines.len().min(MAX_LCS_LINES)],
+    );
+
+    let mut out = String::new();
+    let total = diff.len();
+    if total == 0 {
+        return out;
+    }
+    let shown = total.min(max_lines);
+    for line in diff.iter().take(shown) {
+        match line {
+            DiffLine::Context(s) => out.push_str(&format!("{}\n", muted(&format!("  {s}")))),
+            DiffLine::Added(s) => out.push_str(&format!("{}\n", success(&format!("+ {s}")))),
+            DiffLine::Removed(s) => out.push_str(&format!("{}\n", error(&format!("- {s}")))),
+        }
+    }
+    if total > shown {
+        out.push_str(&format!(
+            "{}\n",
+            dim(&format!("  ... {} more lines", total - shown))
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+mod diff_tests {
+    use super::*;
+
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::new();
+        let mut chars = s.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '\x1b' && chars.peek() == Some(&'[') {
+                // consume CSI sequence: ESC [ ... letter
+                chars.next();
+                for sc in chars.by_ref() {
+                    if sc.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn identical_inputs_produce_empty_diff() {
+        assert_eq!(render_diff("a\nb\n", "a\nb\n", 20), "");
+    }
+
+    #[test]
+    fn new_file_shows_all_additions() {
+        let d = strip_ansi(&render_diff("", "hello\nworld\n", 20));
+        assert!(d.contains("+ hello"));
+        assert!(d.contains("+ world"));
+        assert!(!d.contains("- "));
+    }
+
+    #[test]
+    fn edit_shows_addition_and_removal() {
+        let d = strip_ansi(&render_diff("old line\n", "new line\n", 20));
+        assert!(d.contains("- old line"));
+        assert!(d.contains("+ new line"));
+    }
+
+    #[test]
+    fn unchanged_lines_are_context() {
+        let d = strip_ansi(&render_diff("keep\nold\n", "keep\nnew\n", 20));
+        assert!(d.contains("  keep"));
+        assert!(d.contains("- old"));
+        assert!(d.contains("+ new"));
+    }
+
+    #[test]
+    fn truncation_hint_when_exceeding_max() {
+        let old = String::new();
+        let new: String = (0..50).map(|i| format!("line {i}\n")).collect();
+        let d = strip_ansi(&render_diff(&old, &new, 5));
+        assert!(d.contains("... 46 more lines"));
+    }
+
+    #[test]
+    fn trailing_newline_difference_is_visible() {
+        // With split('\n'), "a\n" → ["a", ""] vs "a" → ["a"].
+        // The removed empty line proves trailing-newline changes are surfaced.
+        let d = strip_ansi(&render_diff("a\n", "a", 20));
+        assert!(!d.is_empty(), "trailing newline diff must not be empty");
+    }
+
+    #[test]
+    fn format_tokens_boundaries() {
+        assert_eq!(format_tokens(0), "0");
+        assert_eq!(format_tokens(999), "999");
+        assert_eq!(format_tokens(1000), "1.0k");
+        assert_eq!(format_tokens(1500), "1.5k");
+        assert_eq!(format_tokens(999999), "1000.0k");
+        assert_eq!(format_tokens(1_000_000), "1.0M");
+        assert_eq!(format_tokens(1_500_000), "1.5M");
+    }
+
+    #[test]
+    fn context_bar_produces_output() {
+        // Verify context_bar produces a non-empty colored string for each tier.
+        assert!(!context_bar(10).is_empty()); // green tier (<50%)
+        assert!(!context_bar(55).is_empty()); // amber tier (50-70%)
+        assert!(!context_bar(80).is_empty()); // red tier (>=70%)
+    }
+
+    #[test]
+    fn context_bar_shows_at_least_one_cell_for_nonzero_percent() {
+        // Sub-10% percentages must show at least 1 filled cell, not all empty.
+        let bar6 = context_bar(6);
+        assert!(
+            bar6.contains('\u{2588}'),
+            "6% should have >=1 filled cell: {}",
+            bar6
+        );
+
+        let bar1 = context_bar(1);
+        assert!(
+            bar1.contains('\u{2588}'),
+            "1% should have >=1 filled cell: {}",
+            bar1
+        );
+
+        let bar0 = context_bar(0);
+        assert!(
+            !bar0.contains('\u{2588}'),
+            "0% should have 0 filled cells: {}",
+            bar0
+        );
+    }
+
+    #[test]
+    fn response_footer_without_elapsed_has_space_before_sep() {
+        let footer = strip_ansi(&response_footer("gpt-4", 1000, 500, 23, None));
+        assert!(
+            footer.contains("out │"),
+            "separator must have space before it when elapsed is None: {footer:?}"
+        );
+    }
+
+    #[test]
+    fn response_footer_with_elapsed_has_time_segment() {
+        let footer = strip_ansi(&response_footer("gpt-4", 1000, 500, 23, Some(1.5)));
+        assert!(
+            footer.contains("1.5s"),
+            "elapsed time must appear in footer: {footer:?}"
+        );
+    }
+
+    #[test]
+    fn shimmer_text_non_empty_for_ascii() {
+        let result = shimmer_text("hello world", 0);
+        assert!(!result.is_empty());
+        assert!(result.contains('h'));
+    }
+
+    #[test]
+    fn shimmer_text_non_empty_for_cjk() {
+        let result = shimmer_text("你好世界", 500);
+        assert!(!result.is_empty());
+        // Each CJK char should appear in the output.
+        assert!(result.contains('你'));
+    }
+}

--- a/crates/aish-shell/src/tui/ask_user.rs
+++ b/crates/aish-shell/src/tui/ask_user.rs
@@ -385,7 +385,7 @@ fn resolve_text_answer(
 }
 
 fn print_validation_error(error: &TextValidationError) {
-    println!("\x1b[31m{}\x1b[0m", error.message());
+    println!("{}", crate::theme::error(&error.message()));
 }
 
 #[cfg(test)]

--- a/crates/aish-shell/src/tui/inline_prompts.rs
+++ b/crates/aish-shell/src/tui/inline_prompts.rs
@@ -160,26 +160,42 @@ fn fallback_stdin_selection(
     allow_cancel: bool,
 ) -> DialogResult {
     // Print title
-    println!("\x1b[1m{}\x1b[0m", title);
+    println!("{}", crate::theme::bold(title));
     // Print question
-    println!("\x1b[36m{}\x1b[0m", question);
+    println!("{}", crate::theme::accent(question));
 
     // Print numbered options
     for (i, opt) in options.iter().enumerate() {
         if let Some(ref desc) = opt.description {
-            println!("  \x1b[33m{}.\x1b[0m {} - {}", i + 1, opt.label, desc);
+            println!(
+                "  {} {} - {}",
+                crate::theme::warning(&format!("{}.", i + 1)),
+                opt.label,
+                desc
+            );
         } else {
-            println!("  \x1b[33m{}.\x1b[0m {}", i + 1, opt.label);
+            println!(
+                "  {} {}",
+                crate::theme::warning(&format!("{}.", i + 1)),
+                opt.label
+            );
         }
     }
 
     // Custom input option
     if allow_custom {
-        println!("  \x1b[33m0.\x1b[0m \x1b[2m(type custom answer)\x1b[0m");
+        println!(
+            "  {} {}",
+            crate::theme::warning("0."),
+            crate::theme::faint("(type custom answer)")
+        );
     }
 
     if allow_cancel {
-        println!("  \x1b[2m(press Enter with empty input to cancel)\x1b[0m");
+        println!(
+            "  {}",
+            crate::theme::faint("(press Enter with empty input to cancel)")
+        );
     }
 
     print!("Your answer: ");

--- a/crates/aish-shell/src/wizard/mod.rs
+++ b/crates/aish-shell/src/wizard/mod.rs
@@ -376,8 +376,8 @@ impl SetupWizard {
             let mut args = std::collections::HashMap::new();
             args.insert("model".to_string(), normalized.clone());
             println!(
-                "  \x1b[2m{}\x1b[0m",
-                t_with_args("cli.setup.model_custom_saved_as", &args)
+                "  {}",
+                crate::theme::faint(&t_with_args("cli.setup.model_custom_saved_as", &args))
             );
         }
         self.selected_model = Some(normalized);

--- a/crates/aish-shell/src/wizard/plan_approval.rs
+++ b/crates/aish-shell/src/wizard/plan_approval.rs
@@ -5,6 +5,8 @@
 
 use std::io::{self, Write};
 
+use crate::theme;
+
 use super::plan_display::format_plan_for_display;
 
 /// User decision after reviewing a plan.
@@ -51,41 +53,55 @@ impl PlanApprovalFlow {
         let left_pad = header_pad / 2;
         let right_pad = header_pad - left_pad;
         println!(
-            "\x1b[1;33m\u{2550}{}\u{2550}\u{2550}{}\u{2550}\x1b[0m",
-            "\u{2550}".repeat(left_pad),
-            "\u{2550}".repeat(right_pad)
+            "{}",
+            theme::warning(&format!(
+                "\u{2550}{}\u{2550}\u{2550}{}\u{2550}",
+                "\u{2550}".repeat(left_pad),
+                "\u{2550}".repeat(right_pad)
+            ))
         );
         println!(
-            "\x1b[1;33m\u{2550}{}\u{2550}\u{2550}{}\u{2550}\x1b[0m",
-            " ".repeat(left_pad),
-            " ".repeat(right_pad)
+            "{}",
+            theme::warning(&format!(
+                "\u{2550}{}\u{2550}\u{2550}{}\u{2550}",
+                " ".repeat(left_pad),
+                " ".repeat(right_pad)
+            ))
         );
         // Center the header text
         println!(
-            "\x1b[1;33m\u{2550}\x1b[1m{}\x1b[1;33m\u{2550}\x1b[0m",
-            center_text(header_text, width)
+            "{}{}{}",
+            theme::warning("\u{2550}"),
+            theme::bold(&center_text(header_text, width)),
+            theme::warning("\u{2550}"),
         );
         println!(
-            "\x1b[1;33m\u{2550}{}\u{2550}\u{2550}{}\u{2550}\x1b[0m",
-            " ".repeat(left_pad),
-            " ".repeat(right_pad)
+            "{}",
+            theme::warning(&format!(
+                "\u{2550}{}\u{2550}\u{2550}{}\u{2550}",
+                " ".repeat(left_pad),
+                " ".repeat(right_pad)
+            ))
         );
         println!(
-            "\x1b[1;33m\u{2550}{}\u{2550}\u{2550}{}\u{2550}\x1b[0m",
-            "\u{2550}".repeat(left_pad),
-            "\u{2550}".repeat(right_pad)
+            "{}",
+            theme::warning(&format!(
+                "\u{2550}{}\u{2550}\u{2550}{}\u{2550}",
+                "\u{2550}".repeat(left_pad),
+                "\u{2550}".repeat(right_pad)
+            ))
         );
 
         // Summary line
         if let Some(s) = summary {
             if !s.is_empty() {
-                println!("\x1b[1m  Summary:\x1b[0m {}", s);
+                println!("{} {}", theme::bold("  Summary:"), s);
             }
         }
 
         // Revision number
         if let Some(rev) = revision {
-            println!("\x1b[2m  Revision: #{}\x1b[0m", rev);
+            println!("{}", theme::faint(&format!("  Revision: #{}", rev)));
         }
 
         println!();
@@ -101,15 +117,18 @@ impl PlanApprovalFlow {
 
         // Separator
         println!(
-            "\x1b[33m\u{2500}{}\x1b[0m",
-            "\u{2500}".repeat(width.saturating_sub(1))
+            "{}",
+            theme::warning(&format!(
+                "\u{2500}{}",
+                "\u{2500}".repeat(width.saturating_sub(1))
+            ))
         );
 
         // Options prompt
-        println!("\x1b[1m  Choose an action:\x1b[0m");
-        println!("    \x1b[32m[A]\x1b[0m Approve plan and proceed");
-        println!("    \x1b[33m[R]\x1b[0m Request changes to the plan");
-        println!("    \x1b[31m[C]\x1b[0m Cancel plan mode");
+        println!("{}", theme::bold("  Choose an action:"));
+        println!("    {} Approve plan and proceed", theme::success("[A]"));
+        println!("    {} Request changes to the plan", theme::warning("[R]"));
+        println!("    {} Cancel plan mode", theme::error("[C]"));
         print!("\n  Your choice: ");
         let _ = io::stdout().flush();
 
@@ -125,7 +144,10 @@ impl PlanApprovalFlow {
             "R" | "REQUEST" => {
                 // Prompt for feedback
                 println!();
-                println!("\x1b[1;33m  Please describe the changes you'd like:\x1b[0m");
+                println!(
+                    "{}",
+                    theme::bold(&theme::warning("  Please describe the changes you'd like:"))
+                );
                 print!("  > ");
                 let _ = io::stdout().flush();
 
@@ -138,7 +160,7 @@ impl PlanApprovalFlow {
                 let feedback = feedback.trim().to_string();
 
                 if feedback.is_empty() {
-                    println!("\x1b[2m  (No feedback provided)\x1b[0m");
+                    println!("{}", theme::faint("  (No feedback provided)"));
                 }
 
                 PlanApprovalDecision::ChangesRequested { feedback }
@@ -146,7 +168,10 @@ impl PlanApprovalFlow {
             "C" | "CANCEL" | "N" | "NO" | "" => PlanApprovalDecision::Cancelled,
             _ => {
                 // Unknown choice, treat as cancel
-                println!("\x1b[33m  Unknown option. Cancelling plan review.\x1b[0m");
+                println!(
+                    "{}",
+                    theme::warning("  Unknown option. Cancelling plan review.")
+                );
                 PlanApprovalDecision::Cancelled
             }
         }
@@ -163,10 +188,10 @@ fn center_text(text: &str, width: usize) -> String {
     let left = pad / 2;
     let right = pad - left;
     format!(
-        "{}{}\x1b[1;33m{}\x1b[0m",
+        "{}{}{}",
         " ".repeat(left),
         text,
-        " ".repeat(right)
+        theme::warning(&" ".repeat(right))
     )
 }
 

--- a/crates/aish-shell/src/wizard/plan_display.rs
+++ b/crates/aish-shell/src/wizard/plan_display.rs
@@ -1,22 +1,17 @@
 // Terminal formatting for plan markdown documents.
 //
-// Applies basic ANSI formatting to plan content for display in the
-// plan approval flow: bold headings, dim code blocks, bullet chars.
+// Applies theme-based formatting to plan content for display in the
+// plan approval flow: bold+accent headings, dim code blocks, bullet chars.
 
-/// ANSI escape codes for terminal formatting.
-const BOLD: &str = "\x1b[1m";
-const DIM: &str = "\x1b[2m";
-const CYAN: &str = "\x1b[36m";
-const RESET: &str = "\x1b[0m";
+use crate::theme;
 
 /// Format a plan markdown document for terminal display.
 ///
 /// Applies the following transformations:
-/// - `## Headings` → bold ANSI
+/// - `## Headings` → bold + accent color
 /// - `` ```code blocks``` `` → indented with dim color
 /// - `- bullet points` → bullet character
 /// - numbered items preserved as-is
-/// - reset ANSI at end
 pub fn format_plan_for_display(content: &str) -> String {
     let mut output = String::new();
     let mut in_code_block = false;
@@ -30,9 +25,9 @@ pub fn format_plan_for_display(content: &str) -> String {
                 in_code_block = false;
                 // Format buffered code lines
                 for code_line in code_buffer.lines() {
-                    output.push_str(&format!("{}  │ {}{}\n", DIM, code_line, RESET));
+                    output.push_str(&format!("{}\n", theme::dim(&format!("  │ {}", code_line))));
                 }
-                output.push_str(&format!("{}  └───{}\n", DIM, RESET));
+                output.push_str(&format!("{}\n", theme::dim("  └───")));
                 code_buffer.clear();
             } else {
                 // Start code block
@@ -41,9 +36,12 @@ pub fn format_plan_for_display(content: &str) -> String {
                 // Extract language hint if present
                 let lang = line.trim_start().trim_start_matches('`').trim();
                 if !lang.is_empty() {
-                    output.push_str(&format!("{}  ┌─── {} ───{}\n", DIM, lang, RESET));
+                    output.push_str(&format!(
+                        "{}\n",
+                        theme::dim(&format!("  ┌─── {} ───", lang))
+                    ));
                 } else {
-                    output.push_str(&format!("{}  ┌───{}\n", DIM, RESET));
+                    output.push_str(&format!("{}\n", theme::dim("  ┌───")));
                 }
             }
             continue;
@@ -59,10 +57,16 @@ pub fn format_plan_for_display(content: &str) -> String {
         let trimmed = line.trim();
         if trimmed.starts_with("### ") {
             let heading = trimmed.trim_start_matches('#').trim();
-            output.push_str(&format!("\n{}{}  {}{}\n\n", BOLD, CYAN, heading, RESET));
+            output.push_str(&format!(
+                "\n{}\n\n",
+                theme::bold(&theme::accent(&format!("  {}", heading)))
+            ));
         } else if trimmed.starts_with("## ") || trimmed.starts_with("# ") {
             let heading = trimmed.trim_start_matches('#').trim();
-            output.push_str(&format!("\n{}{}  {}{}\n", BOLD, CYAN, heading, RESET));
+            output.push_str(&format!(
+                "\n{}\n",
+                theme::bold(&theme::accent(&format!("  {}", heading)))
+            ));
         } else if trimmed.starts_with("- ") || trimmed.starts_with("* ") {
             // Convert markdown bullet markers to bullet character
             let item_text = &trimmed[2..];
@@ -73,11 +77,6 @@ pub fn format_plan_for_display(content: &str) -> String {
             output.push_str(line);
             output.push('\n');
         }
-    }
-
-    // Ensure ANSI reset at end
-    if !output.ends_with(&format!("{}\n", RESET)) && !output.ends_with(RESET) {
-        output.push_str(RESET);
     }
 
     output
@@ -95,9 +94,10 @@ mod tests {
         assert!(output.contains("Title"));
         assert!(output.contains("Section"));
         assert!(output.contains("Subsection"));
-        assert!(output.contains(BOLD));
-        assert!(output.contains(CYAN));
-        assert!(output.contains(RESET));
+        // Headings are indented with two spaces
+        assert!(output.contains("  Title"));
+        assert!(output.contains("  Section"));
+        assert!(output.contains("  Subsection"));
     }
 
     #[test]
@@ -118,7 +118,7 @@ mod tests {
 
         assert!(output.contains("rust"));
         assert!(output.contains("fn main() {}"));
-        assert!(output.contains(DIM));
+        assert!(output.contains("┌───"));
         assert!(output.contains('\u{2502}')); // │ box drawing
     }
 
@@ -134,8 +134,8 @@ mod tests {
     #[test]
     fn test_format_empty_input() {
         let output = format_plan_for_display("");
-        // Should contain at least the reset sequence
-        assert!(output.contains(RESET) || output.is_empty());
+        // Empty input yields empty output (no styling needed)
+        assert!(output.is_empty());
     }
 
     #[test]
@@ -176,7 +176,8 @@ echo "hello"
         assert!(output.contains("1. First step"));
         assert!(output.contains("echo"));
         assert!(output.contains('\u{2022}'));
-        assert!(output.contains(BOLD));
-        assert!(output.contains(RESET));
+        // Headings indented; code fence marker present
+        assert!(output.contains("  Plan"));
+        assert!(output.contains("┌───"));
     }
 }

--- a/crates/aish-tools/src/grep_tool/grep_tool.rs
+++ b/crates/aish-tools/src/grep_tool/grep_tool.rs
@@ -129,7 +129,13 @@ impl Tool for GrepTool {
                 };
                 if re.is_match(&line) {
                     let truncated = if line.len() > MAX_LINE_LENGTH {
-                        format!("{}...", &line[..MAX_LINE_LENGTH])
+                        let end = line
+                            .char_indices()
+                            .map(|(i, _)| i)
+                            .take_while(|&i| i <= MAX_LINE_LENGTH)
+                            .last()
+                            .unwrap_or(0);
+                        format!("{}...", &line[..end])
                     } else {
                         line
                     };

--- a/crates/aish-ui/src/runtime.rs
+++ b/crates/aish-ui/src/runtime.rs
@@ -13,6 +13,16 @@ pub trait PanelComponent {
     fn desired_height(&self, terminal_width: u16, terminal_height: u16) -> u16;
     fn render(&self, frame: &mut ratatui::Frame<'_>, area: Rect);
     fn handle_event(&mut self, event: event::Event) -> PanelEvent<Self::Output>;
+    /// Periodic redraw interval for animated panels. When `Some`, the runtime
+    /// polls for input with this timeout and, on timeout, calls [`tick`](Self::tick)
+    /// then redraws — enabling animations (e.g. a shimmer sweep). `None` (the
+    /// default) means the panel only redraws on input events.
+    fn tick_interval(&self) -> Option<Duration> {
+        None
+    }
+    /// Advance animation state by one tick. Called by the runtime whenever no
+    /// input arrives within [`tick_interval`](Self::tick_interval). Default no-op.
+    fn tick(&mut self) {}
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -61,7 +71,20 @@ impl PanelRuntime {
         let outcome = loop {
             terminal.draw(|frame| component.render(frame, frame.area()))?;
 
-            let event = event::read()?;
+            // Animated panels request a tick interval; block for at most that
+            // long so we redraw on timeout (advancing the animation) even
+            // without input. Non-animated panels block indefinitely on input.
+            let event = match component.tick_interval() {
+                Some(interval) => {
+                    if event::poll(interval)? {
+                        event::read()?
+                    } else {
+                        component.tick();
+                        continue;
+                    }
+                }
+                None => event::read()?,
+            };
             match component.handle_event(event) {
                 PanelEvent::Continue => continue,
                 PanelEvent::Submit(value) => break PanelOutcome::Submitted(value),

--- a/crates/aish-ui/src/select.rs
+++ b/crates/aish-ui/src/select.rs
@@ -34,6 +34,8 @@ pub struct SearchSelectItem {
     pub detail: Option<String>,
     pub badge: Option<String>,
     pub search_text: String,
+    /// Whether Ctrl+E rename is allowed for this item (default: false).
+    pub renamable: bool,
 }
 
 impl SearchSelectItem {
@@ -48,6 +50,7 @@ impl SearchSelectItem {
             detail: None,
             badge: None,
             search_text,
+            renamable: false,
         }
     }
 
@@ -72,6 +75,11 @@ impl SearchSelectItem {
 
     pub fn with_search_text(mut self, search_text: impl Into<String>) -> Self {
         self.search_text = search_text.into().to_lowercase();
+        self
+    }
+    /// Allow Ctrl+E rename for this item.
+    pub fn with_renamable(mut self) -> Self {
+        self.renamable = true;
         self
     }
 }
@@ -221,6 +229,9 @@ impl SearchSelectPanel {
         match entry {
             SelectEntry::Item(index) => {
                 let item = self.items.get(*index)?;
+                if !item.renamable {
+                    return None;
+                }
                 Some(SearchSelectOutcome::Rename(item.value.clone()))
             }
         }
@@ -860,8 +871,8 @@ mod tests {
             "Sessions",
             "Search",
             vec![
-                item("session:0", "Alpha", "session:0 alpha"),
-                item("session:1", "Beta", "session:1 beta"),
+                item("session:0", "Alpha", "session:0 alpha").with_renamable(),
+                item("session:1", "Beta", "session:1 beta").with_renamable(),
             ],
         );
 
@@ -886,6 +897,16 @@ mod tests {
         // Filter down to nothing, then Ctrl+E must not submit.
         panel.handle_event(key(KeyCode::Char('z')));
         assert!(panel.filtered_entries().is_empty());
+        assert_eq!(panel.handle_event(ctrl('e')), PanelEvent::Continue);
+    }
+    #[test]
+    fn ctrl_e_noop_for_non_renamable_item() {
+        let mut panel = SearchSelectPanel::new(
+            "Sessions",
+            "Search",
+            vec![item("session:0", "Alpha", "session:0 alpha")],
+        );
+        // renamable defaults to false → Ctrl+E must be a no-op.
         assert_eq!(panel.handle_event(ctrl('e')), PanelEvent::Continue);
     }
 

--- a/crates/aish-ui/src/select.rs
+++ b/crates/aish-ui/src/select.rs
@@ -6,7 +6,8 @@ use ratatui::{
     text::{Line, Span},
     widgets::Paragraph,
 };
-use unicode_width::UnicodeWidthStr;
+use std::time::Duration;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::{PanelComponent, PanelEvent};
 
@@ -16,10 +17,20 @@ const MIN_PANEL_HEIGHT: u16 = 6;
 const PANEL_PADDING_X: u16 = 2;
 const DESCRIPTION_INDENT: &str = "    ";
 
+// Shimmer sweep tunables (mirrors aish-shell's theme::shimmer_text): a cosine
+// bump band travels left→right across the highlighted row's text.
+const SHIMMER_SPEED: f64 = 30.0; // cells per second
+const SHIMMER_PADDING: f64 = 10.0; // virtual padding for smooth enter/exit
+const SHIMMER_BAND_HALF: f64 = 6.0; // half-width of the cosine bump
+const SHIMMER_TICK_MS: u64 = 33; // ~30fps animation tick
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SearchSelectItem {
     pub value: String,
     pub label: String,
+    /// Optional emphasized prefix rendered in bold accent color before the
+    /// label (e.g. a session's custom name), so it stands out at a glance.
+    pub highlight: Option<String>,
     pub detail: Option<String>,
     pub badge: Option<String>,
     pub search_text: String,
@@ -33,6 +44,7 @@ impl SearchSelectItem {
         Self {
             value,
             label,
+            highlight: None,
             detail: None,
             badge: None,
             search_text,
@@ -49,6 +61,15 @@ impl SearchSelectItem {
         self
     }
 
+    /// Set the emphasized prefix rendered in bold accent color before the
+    /// label. Used to make a key field (e.g. a custom session name) visually
+    /// distinct from the rest of the label.
+    pub fn with_highlight(mut self, highlight: impl Into<String>) -> Self {
+        let highlight = highlight.into();
+        self.highlight = (!highlight.trim().is_empty()).then_some(highlight);
+        self
+    }
+
     pub fn with_search_text(mut self, search_text: impl Into<String>) -> Self {
         self.search_text = search_text.into().to_lowercase();
         self
@@ -58,6 +79,10 @@ impl SearchSelectItem {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SearchSelectOutcome {
     Selected(String),
+    /// Rename the item carrying the given value (triggered by Ctrl+E).
+    Rename(String),
+    /// Exit the panel (triggered by Ctrl+Q). Callers decide exit semantics.
+    Quit,
 }
 
 /// Match when every whitespace-separated token in `query` is a substring of `search_text`.
@@ -83,6 +108,11 @@ pub struct SearchSelectPanel {
     query: String,
     selected: usize,
     max_visible_items: usize,
+    /// Value of the item whose row gets the animated shimmer sweep (the live
+    /// "current" session). `None` disables animation.
+    shimmer_value: Option<String>,
+    /// Animation clock in milliseconds, advanced one tick per redraw.
+    anim_ms: u64,
 }
 
 impl SearchSelectPanel {
@@ -102,11 +132,20 @@ impl SearchSelectPanel {
             query: String::new(),
             selected: 0,
             max_visible_items: DEFAULT_VISIBLE_ITEMS,
+            shimmer_value: None,
+            anim_ms: 0,
         }
     }
 
     pub fn with_footer(mut self, footer: impl Into<String>) -> Self {
         self.footer = Some(footer.into());
+        self
+    }
+
+    /// Mark the item with `value` as the "current" row that gets an animated
+    /// shimmer sweep. Pass `None` (or omit) for a static panel.
+    pub fn with_shimmer(mut self, value: Option<&str>) -> Self {
+        self.shimmer_value = value.map(|v| v.to_string());
         self
     }
 
@@ -170,6 +209,20 @@ impl SearchSelectPanel {
             SelectEntry::Item(index) => Some(SearchSelectOutcome::Selected(
                 self.items.get(*index)?.value.clone(),
             )),
+        }
+    }
+
+    /// Build a `Rename` outcome for the currently highlighted entry.
+    /// Returns `None` when no entry is highlighted (empty list), so callers
+    /// can treat Ctrl+E on an empty list as a no-op.
+    fn rename_current(&self) -> Option<SearchSelectOutcome> {
+        let entries = self.filtered_entries();
+        let entry = entries.get(self.selected)?;
+        match entry {
+            SelectEntry::Item(index) => {
+                let item = self.items.get(*index)?;
+                Some(SearchSelectOutcome::Rename(item.value.clone()))
+            }
         }
     }
 
@@ -281,6 +334,18 @@ impl PanelComponent for SearchSelectPanel {
         self.render_footer(frame, chunks[5]);
     }
 
+    fn tick_interval(&self) -> Option<Duration> {
+        // Only animate when a shimmer row is configured, so static panels
+        // still block on input (no busy redraw loop).
+        self.shimmer_value
+            .as_ref()
+            .map(|_| Duration::from_millis(SHIMMER_TICK_MS))
+    }
+
+    fn tick(&mut self) {
+        self.anim_ms = self.anim_ms.wrapping_add(SHIMMER_TICK_MS);
+    }
+
     fn handle_event(&mut self, event: Event) -> PanelEvent<Self::Output> {
         let Event::Key(key) = event else {
             return PanelEvent::Continue;
@@ -308,6 +373,13 @@ impl PanelComponent for SearchSelectPanel {
                 .select_current()
                 .map(PanelEvent::Submit)
                 .unwrap_or(PanelEvent::Continue),
+            KeyCode::Char('e') if key.modifiers.contains(KeyModifiers::CONTROL) => self
+                .rename_current()
+                .map(PanelEvent::Submit)
+                .unwrap_or(PanelEvent::Continue),
+            KeyCode::Char('q') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                PanelEvent::Submit(SearchSelectOutcome::Quit)
+            }
             KeyCode::Up => {
                 self.move_up(1);
                 PanelEvent::Continue
@@ -510,7 +582,32 @@ impl SearchSelectPanel {
             SelectEntry::Item(index) => {
                 let item = &self.items[index];
                 let mut spans = vec![Span::styled(marker, marker_style)];
-                spans.push(Span::styled(item.label.as_str(), label_style));
+                let is_shimmer = self
+                    .shimmer_value
+                    .as_deref()
+                    .is_some_and(|v| v == item.value);
+                if is_shimmer {
+                    // Animated rainbow sweep across the row's text.
+                    let text = match &item.highlight {
+                        Some(h) if !h.is_empty() => format!("{h}  {}", item.label),
+                        _ => item.label.clone(),
+                    };
+                    spans.extend(shimmer_spans(&text, self.anim_ms));
+                } else {
+                    if let Some(highlight) = &item.highlight {
+                        spans.push(Span::styled(
+                            highlight.as_str(),
+                            Style::default()
+                                // Accent electric blue — aish's signature colour
+                                // (matches theme::accent rgb 0,180,255), bold so
+                                // the note stands out from id + cwd.
+                                .fg(Color::Rgb(0, 180, 255))
+                                .add_modifier(Modifier::BOLD),
+                        ));
+                        spans.push(Span::raw("  "));
+                    }
+                    spans.push(Span::styled(item.label.as_str(), label_style));
+                }
                 if let Some(badge) = &item.badge {
                     spans.push(Span::styled(
                         format!(" {badge}"),
@@ -523,6 +620,89 @@ impl SearchSelectPanel {
             }
         }
     }
+}
+
+/// Build per-character ratatui spans with a cosine-bump rainbow sweep, the
+/// same algorithm as `aish_shell::theme::shimmer_text` but emitted as styled
+/// `Span`s (ratatui does not render raw ANSI). Each char gets its own
+/// `Color::Rgb` from an HSL hue that drifts with position and time, modulated
+/// by a travelling brightness bump.
+fn shimmer_spans(text: &str, time_ms: u64) -> Vec<Span<'static>> {
+    let chars: Vec<char> = text.chars().collect();
+    if chars.is_empty() {
+        return Vec::new();
+    }
+    let mut total_width = 0.0_f64;
+    let char_pos: Vec<f64> = chars
+        .iter()
+        .map(|&ch| {
+            let start = total_width;
+            total_width += UnicodeWidthChar::width(ch).unwrap_or(0) as f64;
+            start
+        })
+        .collect();
+    let period = total_width + SHIMMER_PADDING * 2.0;
+    let pos = ((time_ms as f64 / 1000.0) * SHIMMER_SPEED) % period;
+
+    chars
+        .iter()
+        .enumerate()
+        .map(|(i, &ch)| {
+            let idx = char_pos[i];
+            let dist = (idx + SHIMMER_PADDING - pos).abs();
+            let intensity = if dist >= SHIMMER_BAND_HALF {
+                0.0
+            } else {
+                0.5 * (1.0 + (std::f64::consts::PI * dist / SHIMMER_BAND_HALF).cos())
+            };
+            let hue = (i as f64) * 28.0 + time_ms as f64 * 0.05;
+            let sat = 0.45 + intensity * 0.45;
+            let light = 0.30 + intensity * 0.42;
+            let (r, g, b) = hsl_to_rgb(hue, sat, light);
+            Span::styled(ch.to_string(), Style::default().fg(Color::Rgb(r, g, b)))
+        })
+        .collect()
+}
+
+/// HSL → 8-bit RGB. Ported from `aish_shell::theme` so this crate stays
+/// independent of the shell layer.
+fn hsl_to_rgb(h: f64, s: f64, l: f64) -> (u8, u8, u8) {
+    let h = h.rem_euclid(360.0) / 360.0;
+    let s = s.clamp(0.0, 1.0);
+    let l = l.clamp(0.0, 1.0);
+    if s == 0.0 {
+        let v = (l * 255.0).round() as u8;
+        return (v, v, v);
+    }
+    let q = if l < 0.5 {
+        l * (1.0 + s)
+    } else {
+        l + s - l * s
+    };
+    let p = 2.0 * l - q;
+    let f = |t: f64| -> f64 {
+        let t = if t < 0.0 {
+            t + 1.0
+        } else if t > 1.0 {
+            t - 1.0
+        } else {
+            t
+        };
+        if t < 1.0 / 6.0 {
+            p + (q - p) * 6.0 * t
+        } else if t < 0.5 {
+            q
+        } else if t < 2.0 / 3.0 {
+            p + (q - p) * (2.0 / 3.0 - t) * 6.0
+        } else {
+            p
+        }
+    };
+    (
+        (f(h + 1.0 / 3.0) * 255.0).round() as u8,
+        (f(h) * 255.0).round() as u8,
+        (f(h - 1.0 / 3.0) * 255.0).round() as u8,
+    )
 }
 
 fn padded_area(area: Rect) -> Rect {
@@ -566,6 +746,10 @@ mod tests {
 
     fn key(code: KeyCode) -> Event {
         Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    fn ctrl(ch: char) -> Event {
+        Event::Key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::CONTROL))
     }
 
     #[test]
@@ -668,5 +852,79 @@ mod tests {
             required_panel.handle_event(key(KeyCode::Esc)),
             PanelEvent::Continue
         );
+    }
+
+    #[test]
+    fn ctrl_e_emits_rename_for_selected_item() {
+        let mut panel = SearchSelectPanel::new(
+            "Sessions",
+            "Search",
+            vec![
+                item("session:0", "Alpha", "session:0 alpha"),
+                item("session:1", "Beta", "session:1 beta"),
+            ],
+        );
+
+        // Default selection is the first item → Ctrl+E renames it.
+        assert_eq!(
+            panel.handle_event(ctrl('e')),
+            PanelEvent::Submit(SearchSelectOutcome::Rename("session:0".to_string()))
+        );
+
+        // Move down, then Ctrl+E renames the now-highlighted second item.
+        panel.handle_event(key(KeyCode::Down));
+        assert_eq!(
+            panel.handle_event(ctrl('e')),
+            PanelEvent::Submit(SearchSelectOutcome::Rename("session:1".to_string()))
+        );
+    }
+
+    #[test]
+    fn ctrl_e_on_empty_list_is_noop() {
+        let mut panel =
+            SearchSelectPanel::new("Sessions", "Search", vec![item("a", "Alpha", "a alpha")]);
+        // Filter down to nothing, then Ctrl+E must not submit.
+        panel.handle_event(key(KeyCode::Char('z')));
+        assert!(panel.filtered_entries().is_empty());
+        assert_eq!(panel.handle_event(ctrl('e')), PanelEvent::Continue);
+    }
+
+    #[test]
+    fn ctrl_q_emits_quit() {
+        let mut panel = SearchSelectPanel::new(
+            "Sessions",
+            "Search",
+            vec![item("session:0", "Alpha", "session:0 alpha")],
+        );
+        assert_eq!(
+            panel.handle_event(ctrl('q')),
+            PanelEvent::Submit(SearchSelectOutcome::Quit)
+        );
+    }
+
+    #[test]
+    fn shimmer_only_animates_when_configured() {
+        // No shimmer configured → no tick interval (static, blocks on input).
+        let panel =
+            SearchSelectPanel::new("Sessions", "Search", vec![item("a", "Alpha", "a alpha")]);
+        assert_eq!(panel.tick_interval(), None);
+
+        // Shimmer configured → tick interval present, tick advances the clock.
+        let mut panel = panel.with_shimmer(Some("a"));
+        assert_eq!(
+            panel.tick_interval(),
+            Some(std::time::Duration::from_millis(SHIMMER_TICK_MS))
+        );
+        assert_eq!(panel.anim_ms, 0);
+        panel.tick();
+        assert_eq!(panel.anim_ms, SHIMMER_TICK_MS);
+    }
+
+    #[test]
+    fn shimmer_spans_produces_one_span_per_char() {
+        let spans = shimmer_spans("abc", 0);
+        assert_eq!(spans.len(), 3);
+        // Empty input → no spans.
+        assert!(shimmer_spans("", 500).is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Optimize animation, prompt, tool execution, file-edit and token/context display across aish. Closes #358.

### Theme system (`crates/aish-shell/src/theme.rs`, new)
- Centralized color palette with **truecolor → 256-color graceful fallback** (auto-detected from `COLORTERM`)
- Honors the `NO_COLOR` environment convention (disables all ANSI color when set)
- Unified symbol/icon constants, spinner frames, shimmer rainbow animation
- LCS-based `render_diff` for file-edit display, `response_footer` (model · tokens · ctx bar · elapsed), `context_bar`

### Display migration
- All hardcoded ANSI color escapes across shell/ui/tools migrated to `theme::*` tokens
- Response metadata footer after each AI turn (input/output tokens, context usage bar, elapsed time)
- Inline file-edit diff rendering (old vs new content) for `write_file`/`edit_file`
- Markdown inline-code style uses shared `ACCENT_RGB` const

### Session management
- `aish -c` / `--continue`: attach to an existing live session (or pick from list)
- **Ctrl+E**: inline rename in session picker (persisted to session store; opt-in per item via `renamable` flag)
- **Ctrl+Q**: detach current session (keeps alive in background)
- Removed redundant `New` / `RenameLiveSessions` subcommands
- `--continue` is now top-level only (no longer pollutes subcommand `--help`)
- Session picker and rename dialog fully localized via `shell.live_sessions.*` i18n keys

### CodeRabbit review fixes
- Streaming `usage` extraction: record once after stream (not per-chunk) to avoid double-counting
- `file_edit_snapshot` always reset (None when path absent or read fails)
- `NO_COLOR` honored in all color helpers and shimmer
- Ctrl+E rename is opt-in (`renamable` flag) — resume picker and synthetic items no longer emit Rename
- `exit_no_note_*` strings corrected to "detach" terminology across all 6 locales

## User-visible Changes
- New themed prompt, spinner, and animation visuals (truecolor with 256-color fallback)
- Token/context/timing footer after each AI response
- File-edit operations now show a colored diff
- `aish -c` to reattach to a detached session; Ctrl+Q to detach; Ctrl+E to rename
- `/help` documents session management in all 6 locales

## Compatibility
- No breaking config changes. `parking_lot` added as workspace dependency.
- `-c/--continue` replaces the removed `New` and `RenameLiveSessions` subcommands.
- `NO_COLOR=1` now correctly disables ANSI color output.

## Testing
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- `cargo test --workspace` ✅ (all suites pass, 0 failures)

## Change Type
- [x] Feature (new theme system, session management)
- [x] Improvement (display polish, i18n)
- [x] Bug fix (streaming usage, snapshot reset, NO_COLOR)

## Scope
All changes are within `crates/` (aish-cli, aish-shell, aish-llm, aish-ui, aish-i18n, aish-tools) and workspace `Cargo.toml`/`Cargo.lock`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `aish -c` to reconnect to active shell/PTY sessions.
  * Improved live-session management: `Ctrl+Q` detaches (and can prompt for a note/name), `Ctrl+E` renames; richer session picker and labels.
  * Added shimmer animations in selection UIs, refreshed terminal spinner/overlay behavior, and unified diffs when editing/writing files.
* **Bug Fixes**
  * Improved streaming token-usage accounting (prevents double-counting) and prompt-token tracking.
  * Fixed truncation to avoid breaking non-ASCII text.
* **Documentation**
  * Expanded session-management and shortcut help across locales (including `Ctrl+Q`/`aish -c` guidance).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->