### PR TITLE
feat(skills): embed Builtin skills and load them at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -90,7 +90,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "uuid",
 ]
@@ -136,7 +136,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "tokio",
  "tracing",
@@ -186,7 +186,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
  "tracing",
  "uuid",
@@ -291,6 +291,7 @@ dependencies = [
  "dirs 5.0.1",
  "notify",
  "regex",
+ "rust-embed",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -509,6 +510,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bon"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,6 +720,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +745,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -822,6 +847,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,8 +943,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1326,6 +1371,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,6 +1492,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2294,7 +2361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2860,6 +2927,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
+dependencies = [
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
+dependencies = [
+ "globset",
+ "sha2 0.11.0",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,8 +3258,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3435,7 +3549,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -4082,7 +4196,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]

--- a/crates/aish-shell/src/ai_handler.rs
+++ b/crates/aish-shell/src/ai_handler.rs
@@ -11,7 +11,7 @@ use aish_llm::{ChatMessage, LlmCallbackResult, LlmSession, MessageContent, Tool}
 use aish_memory::MemoryManager;
 use aish_prompts::PromptManager;
 use aish_session::SessionContextMessage;
-use aish_skills::SkillManager;
+use aish_skills::SharedSkillManager;
 
 /// Shared handle for the memory manager, accessible from both AiHandler and tools.
 pub type SharedMemoryManager = Arc<Mutex<Option<MemoryManager>>>;
@@ -169,7 +169,7 @@ pub struct AiHandler {
     llm_session: LlmSession,
     context_manager: ContextManager,
     memory_manager: SharedMemoryManager,
-    skill_manager: SkillManager,
+    skill_manager: SharedSkillManager,
     memory_config: MemoryConfig,
     prompt_manager: PromptManager,
     token_store: crate::token_store::TokenUsageStore,
@@ -179,7 +179,7 @@ impl AiHandler {
     pub fn new(
         llm_session: LlmSession,
         memory_manager: SharedMemoryManager,
-        skill_manager: SkillManager,
+        skill_manager: SharedSkillManager,
         memory_config: MemoryConfig,
         max_llm_messages: usize,
         max_shell_messages: usize,
@@ -667,12 +667,13 @@ impl AiHandler {
     /// Extract @skill_name references and inject skill prefix.
     /// Example: "@grep do this" → "use grep skill to do this.\n\ndo this"
     fn inject_skill_prefix(&self, text: &str) -> String {
-        let available: Vec<String> = self
-            .skill_manager
+        let manager = self.skill_manager.lock().unwrap_or_else(|e| e.into_inner());
+        let available: Vec<String> = manager
             .list_skills()
             .iter()
             .map(|s| s.metadata.name.to_lowercase())
             .collect();
+        drop(manager);
 
         if available.is_empty() {
             return text.to_string();
@@ -776,23 +777,27 @@ impl AiHandler {
     /// Inject loaded skill descriptions into the context so the AI can use them.
     /// Uses stable injection — only updates when skills actually change.
     fn inject_skills(&mut self) {
-        let skills = self.skill_manager.list_skills();
-        if skills.is_empty() {
-            self.context_manager.inject_knowledge_stable("skills", "");
-            return;
-        }
-
-        let descriptions: Vec<String> = skills
-            .iter()
-            .map(|s| {
+        let content = {
+            let manager = self.skill_manager.lock().unwrap_or_else(|e| e.into_inner());
+            let skills = manager.list_skills();
+            if skills.is_empty() {
+                String::new()
+            } else {
+                let descriptions: Vec<String> = skills
+                    .iter()
+                    .map(|s| {
+                        format!(
+                            "## {}\n{}\nPath: {}",
+                            s.metadata.name, s.metadata.description, s.file_path
+                        )
+                    })
+                    .collect();
                 format!(
-                    "## {}\n{}\nPath: {}",
-                    s.metadata.name, s.metadata.description, s.file_path
+                    "<available-skills>\n{}\n</available-skills>",
+                    descriptions.join("\n\n")
                 )
-            })
-            .collect();
-        let text = descriptions.join("\n\n");
-        let content = format!("<available-skills>\n{}\n</available-skills>", text);
+            }
+        };
 
         self.context_manager
             .inject_knowledge_stable("skills", &content);

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -18,7 +18,7 @@ use aish_memory::MemoryManager;
 use aish_security::{load_policy, SecurityManager};
 use aish_session::{SessionContextMessage, SessionRecord, SessionStateSnapshot, SessionStore};
 use aish_skills::hotreload::SkillHotReloader;
-use aish_skills::SkillManager;
+use aish_skills::{SharedSkillManager, SkillManager};
 use aish_tools::ToolRegistry;
 use std::path::PathBuf;
 
@@ -37,6 +37,18 @@ use crate::types::ShellState;
 /// Format prompt + command as displayed after Enter (without trailing newline).
 fn format_user_submitted_line(prompt: &str, command: &str) -> String {
     format!("{prompt}{command}")
+}
+
+fn skill_to_tool_info(skill: &aish_skills::Skill) -> aish_tools::SkillInfo {
+    aish_tools::SkillInfo {
+        name: skill.metadata.name.clone(),
+        content: skill.content.clone(),
+        description: skill.metadata.description.clone(),
+        base_dir: skill.base_dir.clone(),
+        context: skill.metadata.context,
+        agent: skill.metadata.agent.clone(),
+        allowed_tools: skill.metadata.allowed_tools.clone(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -447,7 +459,7 @@ pub struct AishShell {
     audit_user: Option<String>,
     audit_host: Option<String>,
     current_remote_host: Arc<Mutex<Option<String>>>,
-    pub skill_manager: SkillManager,
+    pub skill_manager: SharedSkillManager,
     pub skill_hot_reloader: Option<SkillHotReloader>,
     pub memory_manager: SharedMemoryManager,
     pub version: String,
@@ -871,18 +883,25 @@ impl AishShell {
             }),
         );
         tool_registry.register(Box::new(memory_tool));
-        // Load skills (best-effort, before tool registration so SkillTool can use real data)
-        let mut skill_manager = SkillManager::new();
+        // Load skills (best-effort, before tool registration so SkillTool can use real data).
+        // Shared with AiHandler + hot-reload so Builtin/User precedence and live edits apply.
         // Skill/hook loading is gated by `enable_scripts`; when false the
         // directories are still known but nothing is loaded or hot-reloaded.
-        if config.enable_scripts {
-            let _ = skill_manager.load_all_skills();
-        }
-        let skill_count = skill_manager.list_skills().len();
+        let skill_manager: SharedSkillManager = Arc::new(Mutex::new(SkillManager::new()));
+        let skill_count = {
+            let mut manager = skill_manager.lock().unwrap_or_else(|e| e.into_inner());
+            if config.enable_scripts {
+                let _ = manager.load_all_skills();
+            }
+            manager.list_skills().len()
+        };
 
         // Start skill hot-reloader if skill directories exist
-        let skill_hot_reloader = {
-            let dirs = skill_manager.get_skill_dirs();
+        let skill_hot_reloader = if config.enable_scripts {
+            let dirs = skill_manager
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .get_skill_dirs();
             if dirs.is_empty() {
                 None
             } else {
@@ -890,32 +909,26 @@ impl AishShell {
                 reloader.start();
                 Some(reloader)
             }
+        } else {
+            None
         };
 
-        // Wire SkillTool with real callbacks that look up skills from the loaded manager
+        // Wire SkillTool to the live shared manager (no startup snapshot).
         let skill_tool = {
-            let skills_snapshot: std::collections::HashMap<String, aish_tools::SkillInfo> =
-                skill_manager
+            let lookup_manager = Arc::clone(&skill_manager);
+            let list_manager = Arc::clone(&skill_manager);
+            let lookup = Box::new(move |name: &str| {
+                let manager = lookup_manager.lock().unwrap_or_else(|e| e.into_inner());
+                manager.get_skill(name).map(skill_to_tool_info)
+            });
+            let list = Box::new(move || {
+                let manager = list_manager.lock().unwrap_or_else(|e| e.into_inner());
+                manager
                     .list_skills()
                     .iter()
-                    .map(|s| {
-                        (
-                            s.metadata.name.clone(),
-                            aish_tools::SkillInfo {
-                                name: s.metadata.name.clone(),
-                                content: s.content.clone(),
-                                description: s.metadata.description.clone(),
-                                base_dir: s.base_dir.clone(),
-                                context: s.metadata.context,
-                                agent: s.metadata.agent.clone(),
-                                allowed_tools: s.metadata.allowed_tools.clone(),
-                            },
-                        )
-                    })
-                    .collect();
-            let skill_names: Vec<String> = skills_snapshot.keys().cloned().collect();
-            let lookup = Box::new(move |name: &str| skills_snapshot.get(name).cloned());
-            let list = Box::new(move || skill_names.clone());
+                    .map(|skill| skill.metadata.name.clone())
+                    .collect()
+            });
             aish_tools::SkillTool::new(lookup, list)
         };
         tool_registry.register(Box::new(skill_tool));
@@ -1735,7 +1748,7 @@ impl AishShell {
         let ai_handler = AiHandler::new(
             llm_session,
             memory_manager.clone(),
-            skill_manager,
+            Arc::clone(&skill_manager),
             memory_config,
             config.max_llm_messages,
             config.max_shell_messages,
@@ -1784,10 +1797,6 @@ impl AishShell {
             *slot = Some(pty.clone());
         }
 
-        // Placeholder instances for struct fields.  The real subsystems live
-        // inside AiHandler which needs mutable access during each turn.
-        let shell_skill_manager = SkillManager::new();
-
         let secret_check_closure =
             Self::build_secret_check_closure(security_manager.secret_scanner().clone());
 
@@ -1815,7 +1824,7 @@ impl AishShell {
             audit_user,
             audit_host,
             current_remote_host: Arc::new(Mutex::new(None)),
-            skill_manager: shell_skill_manager,
+            skill_manager,
             skill_hot_reloader,
             memory_manager: memory_manager.clone(),
             version,
@@ -1978,9 +1987,12 @@ impl AishShell {
                 break;
             }
 
-            // Check for skill hot-reload changes
+            // Check for skill hot-reload changes (shared manager used by SkillTool / AiHandler)
             if let Some(ref reloader) = self.skill_hot_reloader {
-                let affected = reloader.apply_changes(&mut self.skill_manager);
+                let affected = {
+                    let mut manager = self.skill_manager.lock().unwrap_or_else(|e| e.into_inner());
+                    reloader.apply_changes(&mut manager)
+                };
                 if !affected.is_empty() {
                     for name in &affected {
                         tracing::info!("Skill '{}' hot-reloaded", name);
@@ -6011,29 +6023,16 @@ impl AishShell {
         let audit_session_uuid_cb = audit_session_uuid;
         let audit_user_cb = audit_user;
 
-        // Load skills snapshot for SSH sessions (same as local session).
+        // Load skills snapshot for SSH sessions (includes Builtin roots at connect time).
         let ssh_skills_snapshot: std::sync::Arc<
             std::collections::HashMap<String, aish_tools::SkillInfo>,
         > = {
-            let mut sm = aish_skills::SkillManager::new();
+            let mut sm = SkillManager::new();
             let _ = sm.load_all_skills();
             std::sync::Arc::new(
                 sm.list_skills()
                     .iter()
-                    .map(|s| {
-                        (
-                            s.metadata.name.clone(),
-                            aish_tools::SkillInfo {
-                                name: s.metadata.name.clone(),
-                                content: s.content.clone(),
-                                description: s.metadata.description.clone(),
-                                base_dir: s.base_dir.clone(),
-                                context: s.metadata.context,
-                                agent: s.metadata.agent.clone(),
-                                allowed_tools: s.metadata.allowed_tools.clone(),
-                            },
-                        )
-                    })
+                    .map(|s| (s.metadata.name.clone(), skill_to_tool_info(s)))
                     .collect(),
             )
         };

--- a/crates/aish-skills/Cargo.toml
+++ b/crates/aish-skills/Cargo.toml
@@ -12,6 +12,7 @@ tracing.workspace = true
 regex.workspace = true
 notify.workspace = true
 dirs.workspace = true
+rust-embed = { version = "8", features = ["include-exclude"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/aish-skills/src/bundled.rs
+++ b/crates/aish-skills/src/bundled.rs
@@ -1,0 +1,112 @@
+//! Product-bundled skills embedded in the binary.
+//!
+//! Packaged skills ship **inside the binary** via [`rust_embed`], then are
+//! materialized into an app-managed cache directory for script/path access.
+//! They are never owned by `~/.config/aish/skills` unless the user copies them.
+
+use std::fs;
+use std::path::PathBuf;
+
+use rust_embed::Embed;
+
+/// Skills tree from the aish repo (`aish/skills/`), embedded at compile time.
+#[derive(Embed)]
+#[folder = "../../skills/"]
+#[exclude = "**/.gitignore"]
+struct BundledSkills;
+
+/// Return the Builtin skills root to scan.
+///
+/// Resolution order:
+/// 1. `AISH_BUILTIN_SKILLS_DIR` — tests / explicit override
+/// 2. App cache: `$XDG_CACHE_HOME/aish/bundled-skills/<version>/` (materialized embed)
+pub fn bundled_skills_root() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("AISH_BUILTIN_SKILLS_DIR") {
+        let path = PathBuf::from(dir);
+        if path.is_dir() {
+            return Some(path);
+        }
+        tracing::warn!(
+            "AISH_BUILTIN_SKILLS_DIR={:?} is not a directory; falling back to embedded skills",
+            path
+        );
+    }
+
+    materialize_bundled_skills().ok()
+}
+
+/// Extract embedded skills into the versioned cache dir (idempotent).
+fn materialize_bundled_skills() -> aish_core::Result<PathBuf> {
+    let cache_root = dirs::cache_dir().ok_or_else(|| {
+        aish_core::AishError::Skill("cannot resolve cache directory for bundled skills".into())
+    })?;
+    let dest = cache_root
+        .join("aish")
+        .join("bundled-skills")
+        .join(env!("CARGO_PKG_VERSION"));
+    let marker = dest.join(".complete");
+
+    if marker.is_file() && dest.is_dir() {
+        return Ok(dest);
+    }
+
+    // Incomplete extract from a previous crash — start clean.
+    if dest.exists() {
+        let _ = fs::remove_dir_all(&dest);
+    }
+    fs::create_dir_all(&dest).map_err(|e| {
+        aish_core::AishError::Skill(format!(
+            "failed to create bundled skills cache {}: {}",
+            dest.display(),
+            e
+        ))
+    })?;
+
+    for file in BundledSkills::iter() {
+        let rel = file.as_ref();
+        let Some(data) = BundledSkills::get(rel) else {
+            continue;
+        };
+        let path = dest.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                aish_core::AishError::Skill(format!("failed to create {}: {}", parent.display(), e))
+            })?;
+        }
+        fs::write(&path, data.data.as_ref()).map_err(|e| {
+            aish_core::AishError::Skill(format!("failed to write {}: {}", path.display(), e))
+        })?;
+    }
+
+    fs::write(&marker, env!("CARGO_PKG_VERSION").as_bytes()).map_err(|e| {
+        aish_core::AishError::Skill(format!(
+            "failed to write bundled skills marker {}: {}",
+            marker.display(),
+            e
+        ))
+    })?;
+
+    tracing::debug!("materialized bundled skills at {}", dest.display());
+    Ok(dest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embed_contains_diagnose_system_lag() {
+        assert!(
+            BundledSkills::get("diagnose_system_lag/SKILL.md").is_some(),
+            "repo skills/ must be embedded"
+        );
+    }
+
+    #[test]
+    fn materialize_writes_skill_md() {
+        let root = materialize_bundled_skills().expect("materialize");
+        assert!(root.join("diagnose_system_lag/SKILL.md").is_file());
+        assert!(root.join(".complete").is_file());
+        assert!(root.components().any(|c| c.as_os_str() == "bundled-skills"));
+    }
+}

--- a/crates/aish-skills/src/hotreload.rs
+++ b/crates/aish-skills/src/hotreload.rs
@@ -96,37 +96,36 @@ impl SkillHotReloader {
 
     /// Apply pending changes to a [`SkillManager`].
     ///
-    /// For each changed path the method determines whether it is a create /
-    /// modify (reload) or a delete (remove), and calls the appropriate
-    /// manager method. Returns the list of skill names that were affected.
+    /// Reloads all skill roots so User/Claude/Builtin precedence stays correct
+    /// (e.g. deleting a User override restores the Builtin skill of the same name).
+    /// Returns skill names associated with changed `SKILL.md` paths when known.
     pub fn apply_changes(&self, manager: &mut SkillManager) -> Vec<String> {
         let paths = self.take_changes();
         let mut affected = Vec::new();
 
         for path in &paths {
             if is_skill_file(path) {
-                if path.exists() {
-                    // File was created or modified.
-                    match manager.reload_skill(path) {
-                        Ok(()) => {
-                            if let Some(skill) = manager.get_skill_by_path(path) {
-                                affected.push(skill.metadata.name.clone());
-                            }
-                        }
-                        Err(e) => {
-                            tracing::warn!("Failed to reload skill {:?}: {}", path, e);
-                        }
-                    }
-                } else {
-                    // File was deleted — remove by path lookup.
-                    if let Some(name) = manager.find_skill_name_by_path(path) {
-                        manager.remove_skill(&name);
-                        affected.push(name);
-                    }
+                if let Some(name) = manager.find_skill_name_by_path(path) {
+                    affected.push(name);
+                } else if let Some(name) = path
+                    .parent()
+                    .and_then(|parent| parent.file_name())
+                    .map(|name| name.to_string_lossy().into_owned())
+                {
+                    // Create/rename before the manager knows the path yet.
+                    affected.push(name);
                 }
             }
         }
 
+        if paths.iter().any(|path| is_skill_file(path)) {
+            if let Err(error) = manager.load_all_skills() {
+                tracing::warn!("Failed to reload skills after filesystem change: {}", error);
+            }
+        }
+
+        affected.sort();
+        affected.dedup();
         affected
     }
 }

--- a/crates/aish-skills/src/lib.rs
+++ b/crates/aish-skills/src/lib.rs
@@ -13,10 +13,11 @@
     clippy::too_many_arguments
 )]
 
+pub mod bundled;
 pub mod hotreload;
 pub mod manager;
 pub mod models;
 pub mod validator;
 
-pub use manager::SkillManager;
+pub use manager::{SharedSkillManager, SkillManager};
 pub use models::{Skill, SkillExecutionContext, SkillList, SkillMetadata};

--- a/crates/aish-skills/src/manager.rs
+++ b/crates/aish-skills/src/manager.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use aish_core::SkillSource;
 
@@ -8,6 +9,9 @@ use crate::models::*;
 
 /// Regex to extract YAML frontmatter from markdown files.
 const FRONTMATTER_REGEX: &str = r"(?s)^---\s*\n(.*?)\n---\s*\n";
+
+/// Shared skill cache used by the shell, hot-reloader, and `SkillTool` lookups.
+pub type SharedSkillManager = Arc<Mutex<SkillManager>>;
 
 /// Discovers, loads, and manages skill plugins from filesystem directories.
 pub struct SkillManager {
@@ -31,7 +35,13 @@ impl SkillManager {
         }
     }
 
-    /// Scan and return skill root directories in priority order: USER > CLAUDE.
+    /// Scan and return skill root directories in priority order:
+    /// `User` > `Claude` > `Builtin`.
+    ///
+    /// Builtin skills are **embedded in the binary** and materialized into an
+    /// app-managed cache. They are not read from `/usr/share` and are not owned
+    /// by the user config directory. A same-named User or Claude skill shadows
+    /// Builtin.
     pub fn scan_skill_roots(&self) -> Vec<(SkillSource, PathBuf)> {
         let mut roots = Vec::new();
 
@@ -50,6 +60,11 @@ impl SkillManager {
             roots.push((SkillSource::Claude, home.join(".claude").join("skills")));
         }
 
+        // 3. BUILTIN: product-embedded skills (lowest priority)
+        if let Some(path) = crate::bundled::bundled_skills_root() {
+            roots.push((SkillSource::Builtin, path));
+        }
+
         roots.into_iter().filter(|(_, p)| p.is_dir()).collect()
     }
 
@@ -58,10 +73,15 @@ impl SkillManager {
     /// Skills from higher-priority sources (listed first) shadow skills with
     /// the same name from lower-priority sources.
     pub fn load_all_skills(&mut self) -> aish_core::Result<()> {
+        self.load_from_roots(self.scan_skill_roots())
+    }
+
+    /// Load skills from an explicit root list (first-wins by name).
+    pub fn load_from_roots(&mut self, roots: Vec<(SkillSource, PathBuf)>) -> aish_core::Result<()> {
         let mut loaded_skills: HashMap<String, Skill> = HashMap::new();
         let mut skill_lists: Vec<SkillList> = Vec::new();
 
-        for (source, root_path) in self.scan_skill_roots() {
+        for (source, root_path) in roots {
             let skill_list = self.load_skills(source, &root_path)?;
             skill_lists.push(skill_list);
 
@@ -178,12 +198,15 @@ impl SkillManager {
         self.skills_version
     }
 
-    /// Return the list of skill root directories that should be watched.
+    /// Return skill root directories that should be watched for hot-reload.
+    ///
+    /// Builtin (embedded) skills are excluded — they change with the binary, not
+    /// via filesystem edits under the cache.
     pub fn get_skill_dirs(&self) -> Vec<PathBuf> {
         self.scan_skill_roots()
             .into_iter()
-            .filter(|(_, p)| p.is_dir())
-            .map(|(_, p)| p)
+            .filter(|(source, path)| *source != SkillSource::Builtin && path.is_dir())
+            .map(|(_, path)| path)
             .collect()
     }
 
@@ -314,6 +337,8 @@ fn rewrite_skill_paths(content: &str, skill_name: &str, base_dir: &str) -> Strin
         format!("~/.config/aish/skills/{}", skill_name),
         format!("$HOME/.claude/skills/{}", skill_name),
         format!("$HOME/.config/aish/skills/{}", skill_name),
+        format!("/usr/local/share/aish/skills/{}", skill_name),
+        format!("/usr/share/aish/skills/{}", skill_name),
     ];
     let mut result = content.to_string();
     for p in patterns {
@@ -351,6 +376,58 @@ fn replace_path_prefix(haystack: &str, needle: &str, replacement: &str) -> Strin
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn write_skill(dir: &Path, name: &str, description: &str, body: &str) {
+        let skill_dir = dir.join(name);
+        std::fs::create_dir_all(&skill_dir).expect("skill dir");
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: {description}\n---\n{body}\n"),
+        )
+        .expect("write skill");
+    }
+
+    #[test]
+    fn user_skill_shadows_builtin_of_same_name() {
+        let user = tempfile::tempdir().expect("user dir");
+        let builtin = tempfile::tempdir().expect("builtin dir");
+        write_skill(user.path(), "demo", "user copy", "from user");
+        write_skill(builtin.path(), "demo", "builtin copy", "from builtin");
+        write_skill(
+            builtin.path(),
+            "only-builtin",
+            "builtin only",
+            "builtin body",
+        );
+
+        let mut manager = SkillManager::new();
+        manager
+            .load_from_roots(vec![
+                (SkillSource::User, user.path().to_path_buf()),
+                (SkillSource::Builtin, builtin.path().to_path_buf()),
+            ])
+            .expect("load");
+
+        let demo = manager.get_skill("demo").expect("demo");
+        assert_eq!(demo.source, SkillSource::User);
+        assert!(demo.content.contains("from user"));
+        assert_eq!(
+            manager.get_skill("only-builtin").map(|s| s.source.clone()),
+            Some(SkillSource::Builtin)
+        );
+    }
+
+    #[test]
+    fn scan_includes_embedded_builtin_root() {
+        let roots = SkillManager::new().scan_skill_roots();
+        assert!(
+            roots
+                .iter()
+                .any(|(source, path)| *source == SkillSource::Builtin
+                    && path.join("diagnose_system_lag/SKILL.md").is_file()),
+            "Builtin root should materialize embedded skills: {roots:?}"
+        );
+    }
 
     #[test]
     fn reload_rejects_subagent_skill_without_agent() {


### PR DESCRIPTION
## Summary
- Embed repo `skills/` in the binary and materialize into an app-managed cache (`$XDG_CACHE_HOME/aish/bundled-skills/<version>/`) so packaged skills do not depend on seeding into the user config directory.
- Precedence: **User > `~/.claude/skills` > Builtin**.
- Share one `SkillManager` across shell / `AiHandler` / `SkillTool`; hot-reload re-merges roots (Builtin cache is not watched).
- Optional `AISH_BUILTIN_SKILLS_DIR` for tests/overrides.
- Does not change `seed-skills.sh` in this PR.

## Test plan
- [x] `make format-check && make lint`
- [x] `cargo test -p aish-skills`
- [ ] No user copy of a packaged skill → Builtin from embed/cache is invokable
- [ ] User `~/.config/aish/skills/<name>` → User content wins
- [ ] Upgrade aish version → new cache dir materializes updated embedded skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in skills bundled with the application.
  * Skills now support priority-based loading, allowing custom skills to override built-in ones.
  * Skill changes are shared across components and reflected through live lookups.
  * Improved skill hot-reloading for updates across multiple skill files.

* **Bug Fixes**
  * Updated skill path rewriting to support additional system installation locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->