### PR TITLE
feat(shell): interactive /setting panel for config editing

### DIFF
--- a/crates/aish-cli/src/main.rs
+++ b/crates/aish-cli/src/main.rs
@@ -185,14 +185,22 @@ enum Commands {
 }
 
 fn main() {
-    // Initialize logging
+    let cli = Cli::parse();
+
+    // Initialize logging. RUST_LOG wins; otherwise honor the selected
+    // config's `log_level` (best-effort early load). Passing the --config
+    // path here (not None) matters: load() runs an additive migration that
+    // rewrites the file when keys are missing, so load(None) would touch the
+    // DEFAULT path even when --config points elsewhere. Falls back to "warn".
+    let config_path = cli.config.as_deref().map(std::path::Path::new);
+    let log_level = aish_config::ConfigLoader::load(config_path)
+        .map(|c| c.log_level)
+        .unwrap_or_else(|_| "warn".to_string());
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(log_level)),
         )
         .init();
-
-    let cli = Cli::parse();
 
     if cli.sandbox_daemon {
         let socket_path = cli.sandbox_socket.as_deref().map(std::path::Path::new);

--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -155,6 +155,7 @@ shell:
     help: "Hilfeinformationen anzeigen"
     model: "KI-Modell anzeigen oder wechseln"
     setup: "Setup-Assistenten öffnen"
+    setting: "Interaktiven Einstellungsbereich öffnen"
     plan: "Planmodus steuern"
     token: "Token-Nutzung anzeigen"
     resume: "Vorherige Sitzung fortsetzen"
@@ -306,6 +307,197 @@ shell:
     no_config_manager: "Neukonfiguration nicht möglich: Konfigurationsmanager nicht verfügbar"
     cancelled: "Einrichtung abgebrochen; aktuelle Einstellungen werden beibehalten"
     applied: "Konfiguration aktualisiert, aktuelles Modell: {model}"
+
+  setting:
+    title: "Einstellungen"
+    search_entry: "Einstellungen suchen..."
+    search_desc: "Per Stichwort zu jeder Einstellung in allen Kategorien springen"
+    search_title: "Einstellungen suchen"
+    search_placeholder: "Tippen zum Filtern (Name / Beschreibung / Kategorie)"
+    search_footer: "↑/↓ bewegen · Tippen filtert · Enter bearbeiten · Esc zurück"
+    search_empty: "Keine passenden Einstellungen"
+    restart_summary: "{count} Änderung(en) werden nach Neustart wirksam"
+    subtitle: "Kategorie zum Konfigurieren wählen (Esc zum Beenden)"
+    select_setting: "Einstellung zum Bearbeiten wählen (Esc zurück)"
+    on: "an"
+    off: "aus"
+    not_set: "(nicht gesetzt)"
+    current_tag: "aktuell"
+    applied: "Gespeichert {label} = {value}"
+    applied_clear: "Gelöscht {label}"
+    invalid: "Ungültiger Wert: {error}"
+    restart_hint: "(wirksam nach Neustart)"
+    cat:
+      model: "Modell & Anbieter"
+      appearance: "Erscheinungsbild"
+      ai: "KI-Verhalten"
+      security: "Sicherheit"
+      context: "Kontext & Gedächtnis"
+      remote: "Remote-Prompt"
+      advanced: "Erweitert"
+    cat_desc:
+      model: "LLM-Modell, Endpoint und Zugangsdaten"
+      appearance: "Prompt-Symbol und Antwort-Sprache"
+      ai: "Completion, Kontext und Token-Verwaltung"
+      security: "Input Guard, Sandbox und Risikostufe"
+      context: "Gedächtnis-Recall, Compaction und Verlauf"
+      remote: "SSH/telnet-Prompt-Segmente"
+      advanced: "Logging, Tracing und PTY-Daemon"
+    k:
+      model:
+        label: "KI-Modell"
+        desc: "Modellname, der an den Anbieter gesendet wird, z. B. gpt-4o, glm-4.6, deepseek-chat"
+      api_base:
+        label: "API-Basis-URL"
+        desc: "OpenAI-kompatible Endpoint-URL für Chat-Completions"
+      api_key:
+        label: "API-Schlüssel"
+        desc: "Geheimschlüssel für den LLM-Anbieter (in config.yaml gespeichert)"
+      temperature:
+        label: "Temperatur"
+        desc: "Sampling-Zufälligkeit 0.0–2.0; höher = kreativer"
+      max_tokens:
+        label: "Max Tokens"
+        desc: "Token-Obergrenze für Antworten (leer = Anbieter-Standard)"
+      prompt_style:
+        label: "Prompt-Symbol"
+        desc: "Benutzerdefiniertes Prompt-Symbol (leer = Standardpfeil)"
+      output_language:
+        label: "Ausgabesprache"
+        desc: "Bevorzugte Sprache für KI-Antworten (zh-CN, en-US, ja-JP, de-DE, fr-FR, es-ES)"
+      auto_suggest:
+        label: "Auto-Suggest"
+        desc: "Verlaufsbasierte Auto-Suggest-Hinweise beim Tippen anzeigen"
+      inline_completion:
+        label: "Inline-Completion"
+        desc: "KI-Inline-Completion beim Tippen"
+      inline_debounce_ms:
+        label: "Inline-Debounce (ms)"
+        desc: "Verzögerung vor Auslösen der Inline-Completion nach Tippen-Stop"
+      inline_context_lines:
+        label: "Inline-Kontextzeilen"
+        desc: "Anzahl aktueller Shell-Zeilen, die als Kontext an Inline-Completion gesendet werden"
+      inline_max_tokens:
+        label: "Inline Max Tokens"
+        desc: "Token-Obergrenze für Inline-Completion-Antworten"
+      inline_min_input_chars:
+        label: "Inline Min Input Chars"
+        desc: "Mindestzeichen vor Auslösen der Inline-Completion"
+      inline_timeout_secs:
+        label: "Inline-Timeout (s)"
+        desc: "Sekunden Wartezeit auf Inline-Completion vor Abbruch"
+      inline_disable_thinking:
+        label: "Inline Disable Thinking"
+        desc: "Reasoning/Thinking-Tokens in Inline-Completion unterdrücken"
+      inline_enforce_json:
+        label: "Inline Enforce JSON"
+        desc: "Inline-Completion zwingen, striktes JSON zurückzugeben"
+      max_llm_messages:
+        label: "Max LLM-Messages"
+        desc: "Maximale Konversations-Turns im LLM-Verlauf"
+      enable_token_estimation:
+        label: "Token-Estimation aktivieren"
+        desc: "tiktoken zur Schätzung der Token-Anzahl für Kontext-Trimming verwenden"
+      input_guard_enabled:
+        label: "Input Guard"
+        desc: "Eingabe gegen gefährliche-Befehl-Regeln vorab prüfen"
+      enable_sandbox:
+        label: "Sandbox aktivieren"
+        desc: "Risikobefehle in einer Sandbox vorab ausführen, bevor sie erlaubt werden"
+      default_risk_level:
+        label: "Standard-Risikostufe"
+        desc: "Basis-Risikoeinstufung für unbekannte Befehle (low/medium/high)"
+      sandbox_off_action:
+        label: "Sandbox-Off-Aktion"
+        desc: "Verhalten, wenn Sandbox nicht verfügbar (allow/confirm/block)"
+      sandbox_timeout_seconds:
+        label: "Sandbox-Timeout (s)"
+        desc: "Sekunden bis zum Abbruch einer Sandbox-Vorabausführung"
+      memory_auto_recall:
+        label: "Memory Auto-Recall"
+        desc: "Relevante langfristige Erinnerungen automatisch in KI-Kontext einbringen"
+      memory_auto_retain:
+        label: "Memory Auto-Retain"
+        desc: "Nennenswerte Fakten automatisch ins langfristige Gedächtnis speichern"
+      context_auto_compact:
+        label: "Context Auto-Compact"
+        desc: "Konversation bei steigendem Kontextdruck automatisch kompaktieren"
+      compact_full_enabled:
+        label: "Full Compaction"
+        desc: "Vollständigen Compaction-Durchlauf aktivieren, der alte Turns zusammenfasst"
+      compact_context_window_tokens:
+        label: "Context-Window-Tokens"
+        desc: "Modell-Kontextfenstergröße für Compaction-Berechnung"
+      compact_micro_keep_recent:
+        label: "Micro-Compact Keep Recent"
+        desc: "Wörtlich erhaltene Turns bei Micro-Compaction"
+      compact_shell_keep_recent:
+        label: "Shell-Compact Keep Recent"
+        desc: "Shell-Befehls-Turns, die bei Shell-Compaction erhalten bleiben"
+      compact_summary_max_tokens:
+        label: "Compact-Summary Max Tokens"
+        desc: "Token-Obergrenze für die von Full Compaction erzeugte Zusammenfassung"
+      compact_max_consecutive_failures:
+        label: "Max aufeinanderfolgende Fehler"
+        desc: "Compaction-Fehler vor Fallback auf Trim"
+      compact_reserved_output_tokens:
+        label: "Reserved Output Tokens"
+        desc: "Für Modell-Antwort reservierte Tokens, vom Kontext-Budget abgezogen"
+      history_size:
+        label: "Verlaufsgröße"
+        desc: "Maximale Shell-Verlaufseinträge"
+      max_shell_messages:
+        label: "Max Shell-Messages"
+        desc: "Maximale Shell-Befehls-Turns im KI-Kontext"
+      context_token_budget:
+        label: "Kontext-Token-Budget"
+        desc: "Optionale harte Obergrenze für gesamte Kontext-Tokens (leer = unbegrenzt)"
+      enable_remote_git_prompt:
+        label: "Remote Git-Prompt"
+        desc: "git-Branch in Remote- (SSH/telnet) Bash-Prompts anzeigen"
+      remote_rich_prompt:
+        label: "Remote Rich-Prompt"
+        desc: "Mehrzeilige Remote-Prompts aktivieren (user@host, cwd, git)"
+      remote_show_venv:
+        label: "Remote Venv anzeigen"
+        desc: "Aktives Python-venv in Remote-Prompts anzeigen"
+      remote_show_container:
+        label: "Remote Container anzeigen"
+        desc: "Container/Runtime-Markierungen in Remote-Prompts anzeigen"
+      remote_show_kube:
+        label: "Remote Kube anzeigen"
+        desc: "Kubernetes-Kontext in Remote-Prompts anzeigen"
+      remote_danger_patterns:
+        label: "Remote Danger Patterns"
+        desc: "Hostname-Regexe, die Remote-PS1 als Gefahr markieren (kommagetrennt)"
+      enable_langfuse:
+        label: "Langfuse aktivieren"
+        desc: "Langfuse LLM-Observability-Tracing aktivieren"
+      langfuse_public_key:
+        label: "Langfuse Public Key"
+        desc: "Langfuse Public Key"
+      langfuse_secret_key:
+        label: "Langfuse Secret Key"
+        desc: "Langfuse Secret Key"
+      langfuse_host:
+        label: "Langfuse Host"
+        desc: "Langfuse Self-Host-Instanz-URL"
+      enable_scripts:
+        label: "Skripte aktivieren"
+        desc: ".aish-Skriptsystem und Lifecycle-Hooks aktivieren"
+      log_level:
+        label: "Log Level"
+        desc: "Tracing-Log-Detaillierungsgrad (error/warn/info/debug/trace)"
+      pty_daemon_enabled:
+        label: "PTY-Daemon"
+        desc: "PTY-Sitzungen über Verbindungsabbrüche hinweg via Hintergrund-Daemon erhalten"
+      codex_auth_path:
+        label: "Codex Auth Path"
+        desc: "Pfad zu OpenAI Codex/ChatGPT auth.json"
+      session_db_path:
+        label: "Session-DB-Pfad"
+        desc: "Benutzerdefinierter Sitzungs-Datenbankort (leer = Standard)"
+
   session:
     iteration_limit_reached: "{count} Tool-Aufruf-Iterationen abgeschlossen."
     iteration_limit_title: "⏸ Tool-Aufruf-Limit erreicht"
@@ -515,6 +707,7 @@ help:
       | `/quit` | AI Shell beenden |
       | `/model [Name]` | KI-Modell anzeigen oder wechseln |
       | `/setup` | API-Einstellungen neu konfigurieren |
+      | `/setting` | Interaktiven Einstellungsbereich öffnen |
       | `/plan [start\|status\|exit]` | Planmodus steuern |
       | `/token` | Token-Nutzung anzeigen (letzte 7 Tage) |
       | `/resume [id]` | Vorherige Sitzung fortsetzen |

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -354,6 +354,7 @@ shell:
     help: "Show help information"
     model: "Show or switch AI model"
     setup: "Open setup wizard"
+    setting: "Open interactive settings panel"
     plan: "Plan mode control"
     token: "Show token usage"
     resume: "Resume previous session"
@@ -671,6 +672,196 @@ shell:
     cancelled: "Setup cancelled, keeping current settings"
     applied: "Configuration updated, current model: {model}"
 
+  setting:
+    title: "Settings"
+    search_entry: "Search settings..."
+    search_desc: "Jump to any setting by keyword across all categories"
+    search_title: "Search settings"
+    search_placeholder: "Type to filter (name / description / category)"
+    search_footer: "Up/Down move  Type to filter  Enter edit  Esc back"
+    search_empty: "No matching settings"
+    restart_summary: "{count} change(s) will take effect after restart"
+    subtitle: "Choose a category to configure (Esc to exit)"
+    select_setting: "Select a setting to edit (Esc to go back)"
+    on: "on"
+    off: "off"
+    not_set: "(not set)"
+    current_tag: "current"
+    applied: "Saved {label} = {value}"
+    applied_clear: "Cleared {label}"
+    invalid: "Invalid value: {error}"
+    restart_hint: "(takes effect after restart)"
+    cat:
+      model: "Model & Provider"
+      appearance: "Appearance"
+      ai: "AI Behavior"
+      security: "Security"
+      context: "Context & Memory"
+      remote: "Remote Prompt"
+      advanced: "Advanced"
+    cat_desc:
+      model: "LLM model, endpoint and credentials"
+      appearance: "Prompt symbol and response language"
+      ai: "Completion, context and token handling"
+      security: "Input guard, sandbox and risk level"
+      context: "Memory recall, compaction and history"
+      remote: "SSH/telnet prompt segments"
+      advanced: "Logging, tracing and PTY daemon"
+    k:
+      model:
+        label: "AI Model"
+        desc: "Model name sent to the provider, e.g. gpt-4o, glm-4.6, deepseek-chat"
+      api_base:
+        label: "API Base URL"
+        desc: "OpenAI-compatible endpoint URL for chat completions"
+      api_key:
+        label: "API Key"
+        desc: "Secret key used to authenticate with the provider"
+      temperature:
+        label: "Temperature"
+        desc: "Sampling randomness, 0.0-2.0. Lower is more focused and deterministic"
+      max_tokens:
+        label: "Max Output Tokens"
+        desc: "Cap on response length. Blank = use the model default"
+      prompt_style:
+        label: "Prompt Symbol"
+        desc: "Character shown before the input cursor, e.g. ->, $, or an emoji (blank = default arrow)"
+      output_language:
+        label: "AI Response Language"
+        desc: "Language the AI replies in (overrides the terminal locale)"
+      auto_suggest:
+        label: "Auto-Suggest"
+        desc: "Show shell command suggestions while you type"
+      inline_completion:
+        label: "Inline AI Completion"
+        desc: "Gray ghost-text AI suggestions while typing an AI prompt"
+      max_llm_messages:
+        label: "Max AI Messages"
+        desc: "How many AI conversation turns to keep in context"
+      enable_token_estimation:
+        label: "Token Estimation"
+        desc: "Estimate token usage to trim context automatically"
+      input_guard_enabled:
+        label: "Input Guard"
+        desc: "Block dangerous input patterns before execution"
+      enable_sandbox:
+        label: "Sandbox"
+        desc: "Pre-run risky commands in an isolated sandbox (needs the systemd service)"
+      default_risk_level:
+        label: "Default Risk Level"
+        desc: "Baseline security threshold for command confirmation"
+      sandbox_off_action:
+        label: "Sandbox Fallback Action"
+        desc: "What to do when the sandbox is unavailable: allow, confirm, or block"
+      sandbox_timeout_seconds:
+        label: "Sandbox Timeout"
+        desc: "Seconds before a sandboxed pre-run is killed (1-300)"
+      memory_auto_recall:
+        label: "Memory Auto-Recall"
+        desc: "Inject relevant long-term memories into AI context"
+      memory_auto_retain:
+        label: "Memory Auto-Retain"
+        desc: "Automatically save important facts to long-term memory"
+      context_auto_compact:
+        label: "Context Auto-Compact"
+        desc: "Summarize old context when nearing the token limit"
+      history_size:
+        label: "History Size"
+        desc: "Maximum number of commands kept in shell history"
+      max_shell_messages:
+        label: "Max Shell Messages"
+        desc: "How many shell history entries to keep in AI context"
+      context_token_budget:
+        label: "Context Token Budget"
+        desc: "Hard cap on context tokens; blank = no limit"
+      enable_remote_git_prompt:
+        label: "Remote Git Prompt"
+        desc: "Show git branch in the prompt during SSH/telnet sessions"
+      remote_rich_prompt:
+        label: "Remote Rich Prompt"
+        desc: "Probe remote host for environment-aware prompt segments"
+      remote_show_venv:
+        label: "Remote Show Venv"
+        desc: "Show venv/conda name segment in the remote prompt"
+      remote_show_container:
+        label: "Remote Show Container"
+        desc: "Show container (docker/podman) segment in the remote prompt"
+      remote_show_kube:
+        label: "Remote Show Kube"
+        desc: "Show kube context segment in the remote prompt"
+      log_level:
+        label: "Log Level"
+        desc: "Verbosity of the log file"
+      enable_langfuse:
+        label: "Langfuse Tracing"
+        desc: "Send LLM traces to Langfuse for observability (needs keys)"
+      langfuse_public_key:
+        label: "Langfuse Public Key"
+        desc: "Project public key for LLM observability tracing"
+      langfuse_secret_key:
+        label: "Langfuse Secret Key"
+        desc: "Project secret key (masked on display)"
+      langfuse_host:
+        label: "Langfuse Host"
+        desc: "Langfuse server URL (self-hosted or cloud)"
+      enable_scripts:
+        label: "Skills & Hooks"
+        desc: "Load skill plugins and lifecycle hooks at startup"
+      pty_daemon_enabled:
+        label: "PTY Daemon"
+        desc: "Persist shell sessions across terminal disconnects"
+      inline_debounce_ms:
+        label: "Inline Debounce (ms)"
+        desc: "Delay after typing stops before requesting a ghost-text suggestion"
+      inline_context_lines:
+        label: "Inline Context Lines"
+        desc: "Recent shell-history lines sent as context for suggestions"
+      inline_max_tokens:
+        label: "Inline Max Tokens"
+        desc: "Hard cap on tokens for the suggested suffix"
+      inline_min_input_chars:
+        label: "Inline Min Input Chars"
+        desc: "Minimum characters before a suggestion is triggered"
+      inline_timeout_secs:
+        label: "Inline Timeout (s)"
+        desc: "Abandon a suggestion request after this many seconds"
+      inline_disable_thinking:
+        label: "Inline Disable Thinking"
+        desc: "Send flags to suppress chain-of-thought in suggestions"
+      inline_enforce_json:
+        label: "Inline Enforce JSON"
+        desc: "Force JSON-mode output for suggestions (some gateways return 400)"
+      compact_full_enabled:
+        label: "Full Compaction"
+        desc: "Allow full summary compaction when micro-compact isn't enough"
+      compact_context_window_tokens:
+        label: "Context Window Tokens"
+        desc: "Override the model context window size (blank = auto)"
+      compact_micro_keep_recent:
+        label: "Micro-compact Keep Recent"
+        desc: "Messages retained during a micro-compaction pass"
+      compact_shell_keep_recent:
+        label: "Shell Keep Recent"
+        desc: "Shell commands retained during context compaction"
+      compact_summary_max_tokens:
+        label: "Summary Max Tokens"
+        desc: "Maximum tokens for the generated compaction summary"
+      compact_max_consecutive_failures:
+        label: "Max Compact Failures"
+        desc: "Consecutive compaction failures before giving up"
+      compact_reserved_output_tokens:
+        label: "Reserved Output Tokens"
+        desc: "Tokens reserved for model output (blank = auto)"
+      remote_danger_patterns:
+        label: "Remote Danger Patterns"
+        desc: "Hostname regexes marking remote PS1 as danger (comma-separated)"
+      codex_auth_path:
+        label: "Codex Auth Path"
+        desc: "Path to OpenAI Codex/ChatGPT auth.json"
+      session_db_path:
+        label: "Session DB Path"
+        desc: "Custom session database location (blank = default)"
+
   ask_user:
     default_title: "User input required"
     default_hint: "[default: {value}]"
@@ -918,6 +1109,7 @@ help:
       | `/quit` | Exit AI Shell |
       | `/model [name]` | Show or switch AI model |
       | `/setup` | Reconfigure API settings |
+      | `/setting` | Open the interactive settings panel |
       | `/plan [start\|status\|exit]` | Plan mode control |
       | `/token` | Show token usage (last 7 days) |
       | `/resume [id]` | Resume a previous session |

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -155,6 +155,7 @@ shell:
     help: "Mostrar información de ayuda"
     model: "Mostrar o cambiar modelo de IA"
     setup: "Abrir asistente de configuración"
+    setting: "Abrir el panel de configuración interactivo"
     plan: "Control del modo plan"
     token: "Mostrar uso de tokens"
     resume: "Reanudar sesión anterior"
@@ -306,6 +307,197 @@ shell:
     no_config_manager: "No se puede reconfigurar: el gestor de configuración no está disponible"
     cancelled: "Configuración cancelada; se conservan los ajustes actuales"
     applied: "Configuración actualizada; modelo actual: {model}"
+
+  setting:
+    title: "Ajustes"
+    search_entry: "Buscar ajustes..."
+    search_desc: "Salta a cualquier ajuste por palabra clave en todas las categorías"
+    search_title: "Buscar ajustes"
+    search_placeholder: "Escribe para filtrar (nombre / descripción / categoría)"
+    search_footer: "↑/↓ mover  Escribe para filtrar  Enter editar  Esc volver"
+    search_empty: "No hay ajustes coincidentes"
+    restart_summary: "{count} cambio(s) se aplicarán tras reiniciar"
+    subtitle: "Elige una categoría para configurar (Esc para salir)"
+    select_setting: "Selecciona un ajuste para editar (Esc para volver)"
+    on: "activado"
+    off: "desactivado"
+    not_set: "(sin definir)"
+    current_tag: "actual"
+    applied: "Guardado {label} = {value}"
+    applied_clear: "Borrado {label}"
+    invalid: "Valor no válido: {error}"
+    restart_hint: "(se aplica tras reiniciar)"
+    cat:
+      model: "Modelo y proveedor"
+      appearance: "Apariencia"
+      ai: "Comportamiento de IA"
+      security: "Seguridad"
+      context: "Contexto y memoria"
+      remote: "Prompt remoto"
+      advanced: "Avanzado"
+    cat_desc:
+      model: "Modelo LLM, endpoint y credenciales"
+      appearance: "Símbolo del prompt e idioma de respuesta"
+      ai: "Completado, contexto y manejo de tokens"
+      security: "InputGuard, sandbox y nivel de riesgo"
+      context: "Recuperación de memoria, compactación e historial"
+      remote: "Segmentos de prompt SSH/telnet"
+      advanced: "Registro, trazas y demonio PTY"
+    k:
+      model:
+        label: "Modelo de IA"
+        desc: "Nombre del modelo enviado al proveedor, p. ej. gpt-4o, glm-4.6, deepseek-chat"
+      api_base:
+        label: "API Base URL"
+        desc: "URL del endpoint compatible con OpenAI para chat completions"
+      api_key:
+        label: "Clave API"
+        desc: "Clave secreta para el proveedor LLM (guardada en config.yaml)"
+      temperature:
+        label: "Temperature"
+        desc: "Aleatoriedad de muestreo 0.0–2.0; mayor = más creativo"
+      max_tokens:
+        label: "Tokens máximos"
+        desc: "Límite de tokens de respuesta (vacío = predeterminado del proveedor)"
+      prompt_style:
+        label: "Símbolo del prompt"
+        desc: "Símbolo de prompt personalizado (vacío = flecha predeterminada)"
+      output_language:
+        label: "Idioma de salida"
+        desc: "Idioma preferido para las respuestas de la IA (zh-CN, en-US, ja-JP, de-DE, fr-FR, es-ES)"
+      auto_suggest:
+        label: "Autosugerir"
+        desc: "Mostrar sugerencias basadas en el historial mientras escribes"
+      inline_completion:
+        label: "Completado en línea"
+        desc: "Completado de IA en línea mientras escribes"
+      inline_debounce_ms:
+        label: "Debounce en línea (ms)"
+        desc: "Retardo antes de activar el completado en línea tras dejar de escribir"
+      inline_context_lines:
+        label: "Líneas de contexto en línea"
+        desc: "Número de líneas recientes del shell enviadas como contexto al completado en línea"
+      inline_max_tokens:
+        label: "Tokens máx. en línea"
+        desc: "Límite de tokens para las respuestas del completado en línea"
+      inline_min_input_chars:
+        label: "Caracteres mín. de entrada en línea"
+        desc: "Caracteres mínimos escritos antes de activar el completado en línea"
+      inline_timeout_secs:
+        label: "Tiempo de espera en línea (s)"
+        desc: "Segundos de espera para un completado en línea antes de cancelar"
+      inline_disable_thinking:
+        label: "Desactivar pensamiento en línea"
+        desc: "Suprimir tokens de razonamiento/pensamiento en el completado en línea"
+      inline_enforce_json:
+        label: "Forzar JSON en línea"
+        desc: "Forzar que el completado en línea devuelva JSON estricto"
+      max_llm_messages:
+        label: "Mensajes LLM máx."
+        desc: "Máximo de turnos de conversación conservados en el historial del LLM"
+      enable_token_estimation:
+        label: "Estimación de tokens"
+        desc: "Usar tiktoken para estimar conteos de tokens en el recorte de contexto"
+      input_guard_enabled:
+        label: "InputGuard"
+        desc: "Revisar previamente la entrada contra reglas de comandos peligrosos"
+      enable_sandbox:
+        label: "Activar sandbox"
+        desc: "Ejecutar comandos arriesgados en un sandbox antes de permitirlos"
+      default_risk_level:
+        label: "Nivel de riesgo predeterminado"
+        desc: "Calificación de riesgo base para comandos no reconocidos (low/medium/high)"
+      sandbox_off_action:
+        label: "Acción sandbox desactivado"
+        desc: "Qué hacer cuando el sandbox no está disponible (allow/confirm/block)"
+      sandbox_timeout_seconds:
+        label: "Tiempo de espera del sandbox (s)"
+        desc: "Segundos antes de matar una preejecución del sandbox"
+      memory_auto_recall:
+        label: "Recuperación automática de memoria"
+        desc: "Mostrar automáticamente memorias relevantes a largo plazo en el contexto de la IA"
+      memory_auto_retain:
+        label: "Retención automática de memoria"
+        desc: "Persistir automáticamente hechos notables en la memoria a largo plazo"
+      context_auto_compact:
+        label: "Compactación automática de contexto"
+        desc: "Compactar automáticamente la conversación cuando aumente la presión del contexto"
+      compact_full_enabled:
+        label: "Compactación completa"
+        desc: "Activar el paso de compactación completa que resume turnos antiguos"
+      compact_context_window_tokens:
+        label: "Tokens de ventana de contexto"
+        desc: "Tamaño de ventana de contexto del modelo usado para el cálculo de compactación"
+      compact_micro_keep_recent:
+        label: "Conservar recientes en micro-compactación"
+        desc: "Turnos conservados literalmente durante la micro-compactación"
+      compact_shell_keep_recent:
+        label: "Conservar recientes en shell"
+        desc: "Turnos de comandos del shell conservados durante la compactación del shell"
+      compact_summary_max_tokens:
+        label: "Tokens máx. del resumen de compactación"
+        desc: "Límite de tokens para el resumen producido por la compactación completa"
+      compact_max_consecutive_failures:
+        label: "Fallos consecutivos máx."
+        desc: "Fallos de compactación antes de recurrir a un recorte"
+      compact_reserved_output_tokens:
+        label: "Tokens reservados de salida"
+        desc: "Tokens reservados para la respuesta del modelo, restados del presupuesto de contexto"
+      history_size:
+        label: "Tamaño del historial"
+        desc: "Máximo de entradas del historial del shell conservadas"
+      max_shell_messages:
+        label: "Mensajes de shell máx."
+        desc: "Máximo de turnos de comandos del shell retenidos en el contexto de la IA"
+      context_token_budget:
+        label: "Presupuesto de tokens de contexto"
+        desc: "Límite duro opcional del total de tokens de contexto (vacío = ilimitado)"
+      enable_remote_git_prompt:
+        label: "Prompt de git remoto"
+        desc: "Mostrar la rama git en prompts remotos (SSH/telnet) de bash"
+      remote_rich_prompt:
+        label: "Prompt enriquecido remoto"
+        desc: "Activar prompts remotos multilínea enriquecidos (user@host, cwd, git)"
+      remote_show_venv:
+        label: "Mostrar venv remoto"
+        desc: "Mostrar el venv de Python activo en prompts remotos"
+      remote_show_container:
+        label: "Mostrar contenedor remoto"
+        desc: "Mostrar marcadores de contenedor/runtime en prompts remotos"
+      remote_show_kube:
+        label: "Mostrar kube remoto"
+        desc: "Mostrar el contexto de Kubernetes en prompts remotos"
+      remote_danger_patterns:
+        label: "Patrones de peligro remoto"
+        desc: "Expresiones regulares de nombre de host que marcan PS1 remoto como peligro (separadas por comas)"
+      enable_langfuse:
+        label: "Activar Langfuse"
+        desc: "Activar trazas de observabilidad LLM de Langfuse"
+      langfuse_public_key:
+        label: "Clave pública de Langfuse"
+        desc: "Clave pública de Langfuse"
+      langfuse_secret_key:
+        label: "Clave secreta de Langfuse"
+        desc: "Clave secreta de Langfuse"
+      langfuse_host:
+        label: "Host de Langfuse"
+        desc: "URL de instancia autoalojada de Langfuse"
+      enable_scripts:
+        label: "Activar scripts"
+        desc: "Activar el sistema de scripts .aish y los hooks de ciclo de vida"
+      log_level:
+        label: "Nivel de registro"
+        desc: "Verbosidad del registro de trazas (error/warn/info/debug/trace)"
+      pty_daemon_enabled:
+        label: "Demonio PTY"
+        desc: "Persistir sesiones PTY entre desconexiones mediante un demonio en segundo plano"
+      codex_auth_path:
+        label: "Ruta de auth de Codex"
+        desc: "Ruta a auth.json de OpenAI Codex/ChatGPT"
+      session_db_path:
+        label: "Ruta de BD de sesión"
+        desc: "Ubicación personalizada de la base de datos de sesiones (vacío = predeterminado)"
+
   session:
     iteration_limit_reached: "Se han completado {count} iteraciones de llamadas a herramientas."
     iteration_limit_title: "⏸ Límite de llamadas a herramientas alcanzado"
@@ -515,6 +707,7 @@ help:
       | `/quit` | Salir de AI Shell |
       | `/model [nombre]` | Mostrar o cambiar el modelo de IA |
       | `/setup` | Reconfigurar ajustes de API |
+      | `/setting` | Abrir el panel de configuración interactivo |
       | `/plan [start\|status\|exit]` | Control del modo plan |
       | `/token` | Mostrar uso de tokens (últimos 7 días) |
       | `/resume [id]` | Reanudar sesión anterior |

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -155,6 +155,7 @@ shell:
     help: "Afficher les informations d'aide"
     model: "Afficher ou changer le modèle IA"
     setup: "Ouvrir l'assistant de configuration"
+    setting: "Ouvrir le panneau de configuration interactif"
     plan: "Contrôle du mode plan"
     token: "Afficher l'utilisation des tokens"
     resume: "Reprendre la session précédente"
@@ -306,6 +307,197 @@ shell:
     no_config_manager: "Reconfiguration impossible : gestionnaire de configuration indisponible"
     cancelled: "Configuration annulee, les parametres actuels sont conserves"
     applied: "Configuration mise a jour, modele actuel : {model}"
+
+  setting:
+    title: "Paramètres"
+    search_entry: "Rechercher un paramètre..."
+    search_desc: "Accéder à n'importe quel paramètre par mot-clé dans toutes les catégories"
+    search_title: "Rechercher un paramètre"
+    search_placeholder: "Tapez pour filtrer (nom / description / catégorie)"
+    search_footer: "↑/↓ naviguer  Tapez pour filtrer  Enter modifier  Esc retour"
+    search_empty: "Aucun paramètre correspondant"
+    restart_summary: "{count} modification(s) prendront effet après le redémarrage"
+    subtitle: "Choisir une catégorie à configurer (Esc pour quitter)"
+    select_setting: "Sélectionner un paramètre à modifier (Esc pour revenir)"
+    on: "activé"
+    off: "désactivé"
+    not_set: "(non défini)"
+    current_tag: "actuel"
+    applied: "{label} enregistré = {value}"
+    applied_clear: "{label} effacé"
+    invalid: "Valeur invalide : {error}"
+    restart_hint: "(prend effet après le redémarrage)"
+    cat:
+      model: "Modèle & Fournisseur"
+      appearance: "Apparence"
+      ai: "Comportement IA"
+      security: "Sécurité"
+      context: "Contexte & Mémoire"
+      remote: "Invite distante"
+      advanced: "Avancé"
+    cat_desc:
+      model: "Modèle LLM, endpoint et identifiants"
+      appearance: "Symbole d'invite et langue des réponses"
+      ai: "Complétion, contexte et gestion des tokens"
+      security: "Input guard, sandbox et niveau de risque"
+      context: "Rappel mémoire, compactage et historique"
+      remote: "Segments d'invite SSH/telnet"
+      advanced: "Journalisation, tracing et daemon PTY"
+    k:
+      model:
+        label: "Modèle IA"
+        desc: "Nom du modèle envoyé au fournisseur, par ex. gpt-4o, glm-4.6, deepseek-chat"
+      api_base:
+        label: "URL de base API"
+        desc: "URL d'endpoint compatible OpenAI pour les chat completions"
+      api_key:
+        label: "Clé API"
+        desc: "Clé secrète pour le fournisseur LLM (conservée dans config.yaml)"
+      temperature:
+        label: "Température"
+        desc: "Aléatoire d'échantillonnage 0.0–2.0 ; plus élevé = plus créatif"
+      max_tokens:
+        label: "Tokens max"
+        desc: "Plafond de tokens de réponse (vide = valeur par défaut du fournisseur)"
+      prompt_style:
+        label: "Symbole d'invite"
+        desc: "Symbole d'invite personnalisé (vide = flèche par défaut)"
+      output_language:
+        label: "Langue de sortie"
+        desc: "Langue préférée pour les réponses de l'IA (zh-CN, en-US, ja-JP, de-DE, fr-FR, es-ES)"
+      auto_suggest:
+        label: "Suggestion auto"
+        desc: "Afficher des suggestions automatiques basées sur l'historique pendant la frappe"
+      inline_completion:
+        label: "Complétion en ligne"
+        desc: "Complétion IA en ligne pendant la frappe"
+      inline_debounce_ms:
+        label: "Anti-rebond en ligne (ms)"
+        desc: "Délai avant de déclencher la complétion en ligne après l'arrêt de la frappe"
+      inline_context_lines:
+        label: "Lignes de contexte en ligne"
+        desc: "Nombre de lignes récentes du shell envoyées comme contexte à la complétion en ligne"
+      inline_max_tokens:
+        label: "Tokens max en ligne"
+        desc: "Plafond de tokens pour les réponses de complétion en ligne"
+      inline_min_input_chars:
+        label: "Caractères min en ligne"
+        desc: "Caractères minimum saisis avant le déclenchement de la complétion en ligne"
+      inline_timeout_secs:
+        label: "Délai d'attente en ligne (s)"
+        desc: "Secondes d'attente d'une complétion en ligne avant annulation"
+      inline_disable_thinking:
+        label: "Désactiver le raisonnement en ligne"
+        desc: "Supprimer les tokens de raisonnement/réflexion dans la complétion en ligne"
+      inline_enforce_json:
+        label: "Forcer JSON en ligne"
+        desc: "Forcer la complétion en ligne à renvoyer du JSON strict"
+      max_llm_messages:
+        label: "Messages LLM max"
+        desc: "Tours de conversation maximum conservés dans l'historique LLM"
+      enable_token_estimation:
+        label: "Activer l'estimation des tokens"
+        desc: "Utiliser tiktoken pour estimer le nombre de tokens afin de réduire le contexte"
+      input_guard_enabled:
+        label: "Input Guard"
+        desc: "Pré-filtrer la saisie selon les règles de commandes dangereuses"
+      enable_sandbox:
+        label: "Activer la sandbox"
+        desc: "Exécuter les commandes risquées dans une sandbox avant de les autoriser"
+      default_risk_level:
+        label: "Niveau de risque par défaut"
+        desc: "Niveau de risque de base pour les commandes non reconnues (low/medium/high)"
+      sandbox_off_action:
+        label: "Action sandbox désactivée"
+        desc: "Action lorsque la sandbox est indisponible (allow/confirm/block)"
+      sandbox_timeout_seconds:
+        label: "Délai d'attente sandbox (s)"
+        desc: "Secondes avant l'arrêt d'une pré-exécution sandbox"
+      memory_auto_recall:
+        label: "Rappel mémoire auto"
+        desc: "Afficher automatiquement les mémoires long terme pertinentes dans le contexte IA"
+      memory_auto_retain:
+        label: "Conservation mémoire auto"
+        desc: "Conserver automatiquement les faits notables dans la mémoire long terme"
+      context_auto_compact:
+        label: "Compactage auto du contexte"
+        desc: "Compacter automatiquement la conversation lorsque la pression du contexte augmente"
+      compact_full_enabled:
+        label: "Compactage complet"
+        desc: "Activer la passe de compactage complet qui résume les anciens tours"
+      compact_context_window_tokens:
+        label: "Tokens de fenêtre de contexte"
+        desc: "Taille de fenêtre de contexte du modèle utilisée pour le calcul de compactage"
+      compact_micro_keep_recent:
+        label: "Conservation récent micro-compactage"
+        desc: "Tours conservés tels quels pendant le micro-compactage"
+      compact_shell_keep_recent:
+        label: "Conservation récent compactage shell"
+        desc: "Tours de commandes shell conservés pendant le compactage shell"
+      compact_summary_max_tokens:
+        label: "Tokens max du résumé de compactage"
+        desc: "Plafond de tokens pour le résumé produit par le compactage complet"
+      compact_max_consecutive_failures:
+        label: "Échecs consécutifs max"
+        desc: "Échecs de compactage avant repli vers une troncature"
+      compact_reserved_output_tokens:
+        label: "Tokens de sortie réservés"
+        desc: "Tokens réservés pour la réponse du modèle, soustraits du budget de contexte"
+      history_size:
+        label: "Taille de l'historique"
+        desc: "Nombre maximum d'entrées conservées dans l'historique du shell"
+      max_shell_messages:
+        label: "Messages shell max"
+        desc: "Tours de commandes shell maximum conservés dans le contexte IA"
+      context_token_budget:
+        label: "Budget de tokens du contexte"
+        desc: "Plafond strict optionnel sur le total des tokens de contexte (vide = illimité)"
+      enable_remote_git_prompt:
+        label: "Invite git distante"
+        desc: "Afficher la branche git dans les invites bash distantes (SSH/telnet)"
+      remote_rich_prompt:
+        label: "Invite distante riche"
+        desc: "Activer les invites distantes riches multi-lignes (user@host, cwd, git)"
+      remote_show_venv:
+        label: "Afficher venv distant"
+        desc: "Afficher le venv Python actif dans les invites distantes"
+      remote_show_container:
+        label: "Afficher conteneur distant"
+        desc: "Afficher les marqueurs de conteneur/runtime dans les invites distantes"
+      remote_show_kube:
+        label: "Afficher kube distant"
+        desc: "Afficher le contexte Kubernetes dans les invites distantes"
+      remote_danger_patterns:
+        label: "Motifs de danger distants"
+        desc: "Regex de noms d'hôte marquant le PS1 distant comme dangereux (séparés par des virgules)"
+      enable_langfuse:
+        label: "Activer Langfuse"
+        desc: "Activer le tracing d'observabilité LLM Langfuse"
+      langfuse_public_key:
+        label: "Clé publique Langfuse"
+        desc: "Clé publique Langfuse"
+      langfuse_secret_key:
+        label: "Clé secrète Langfuse"
+        desc: "Clé secrète Langfuse"
+      langfuse_host:
+        label: "Hôte Langfuse"
+        desc: "URL de l'instance Langfuse auto-hébergée"
+      enable_scripts:
+        label: "Activer les scripts"
+        desc: "Activer le système de scripts .aish et les hooks de cycle de vie"
+      log_level:
+        label: "Niveau de journalisation"
+        desc: " Verbosité du journal de tracing (error/warn/info/debug/trace)"
+      pty_daemon_enabled:
+        label: "Daemon PTY"
+        desc: "Conserver les sessions PTY entre les déconnexions via un daemon en arrière-plan"
+      codex_auth_path:
+        label: "Chemin d'auth Codex"
+        desc: "Chemin vers le fichier auth.json d'OpenAI Codex/ChatGPT"
+      session_db_path:
+        label: "Chemin de la base de sessions"
+        desc: "Emplacement personnalisé de la base de données des sessions (vide = valeur par défaut)"
+
   session:
     iteration_limit_reached: "{count} iterations d'appels d'outils terminees."
     iteration_limit_title: "⏸ Limite d'appels d'outils atteinte"
@@ -515,6 +707,7 @@ help:
       | `/quit` | Quitter AI Shell |
       | `/model [nom]` | Afficher ou changer le modèle IA |
       | `/setup` | Reconfigurer les paramètres API |
+      | `/setting` | Ouvrir le panneau de configuration interactif |
       | `/plan [start\|status\|exit]` | Contrôle du mode plan |
       | `/token` | Afficher l'utilisation des tokens (7 derniers jours) |
       | `/resume [id]` | Reprendre une session précédente |

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -155,6 +155,7 @@ shell:
     help: "ヘルプ情報を表示"
     model: "AI モデルの表示・切替"
     setup: "セットアップウィザードを開く"
+    setting: "対話型設定パネルを開く"
     plan: "プランモードの制御"
     token: "トークン使用量を表示"
     resume: "前回のセッションを再開"
@@ -306,6 +307,197 @@ shell:
     no_config_manager: "再設定できません: 設定マネージャーを利用できません"
     cancelled: "セットアップをキャンセルしました。現在の設定を維持します"
     applied: "設定を更新しました。現在のモデル: {model}"
+
+  setting:
+    title: "設定"
+    search_entry: "設定を検索..."
+    search_desc: "すべてのカテゴリーからキーワードで設定にジャンプ"
+    search_title: "設定を検索"
+    search_placeholder: "入力して絞り込み（名前 / 説明 / カテゴリー）"
+    search_footer: "↑/↓ 移動  入力で絞り込み  Enter で編集  Esc で戻る"
+    search_empty: "一致する設定はありません"
+    restart_summary: "{count} 件の変更は再起動後に反映されます"
+    subtitle: "設定するカテゴリーを選択（Esc で終了）"
+    select_setting: "編集する設定を選択（Esc で戻る）"
+    on: "オン"
+    off: "オフ"
+    not_set: "（未設定）"
+    current_tag: "現在"
+    applied: "保存しました {label} = {value}"
+    applied_clear: "クリアしました {label}"
+    invalid: "無効な値: {error}"
+    restart_hint: "（再起動後に反映されます）"
+    cat:
+      model: "モデルとプロバイダー"
+      appearance: "外観"
+      ai: "AI の動作"
+      security: "セキュリティ"
+      context: "コンテキストとメモリ"
+      remote: "リモートプロンプト"
+      advanced: "高度な設定"
+    cat_desc:
+      model: "LLM モデル、エンドポイント、認証情報"
+      appearance: "プロンプト記号と応答言語"
+      ai: "補完、コンテキスト、トークン処理"
+      security: "InputGuard、サンドボックス、リスクレベル"
+      context: "メモリ再呼び出し、圧縮、履歴"
+      remote: "SSH/telnet プロンプト要素"
+      advanced: "ロギング、トレーシング、PTY デーモン"
+    k:
+      model:
+        label: "AI モデル"
+        desc: "プロバイダーに送信するモデル名（例: gpt-4o, glm-4.6, deepseek-chat）"
+      api_base:
+        label: "API Base URL"
+        desc: "chat completions 用の OpenAI 互換エンドポイント URL"
+      api_key:
+        label: "API キー"
+        desc: "LLM プロバイダーのシークレットキー（config.yaml に保持）"
+      temperature:
+        label: "Temperature"
+        desc: "サンプリングのランダム性 0.0〜2.0、高いほど創造的"
+      max_tokens:
+        label: "最大トークン数"
+        desc: "応答のトークン上限（空欄 = プロバイダーの既定値）"
+      prompt_style:
+        label: "プロンプト記号"
+        desc: "カスタムプロンプト記号（空欄 = 既定の矢印）"
+      output_language:
+        label: "出力言語"
+        desc: "AI 応答の優先言語（zh-CN, en-US, ja-JP, de-DE, fr-FR, es-ES）"
+      auto_suggest:
+        label: "自動サジェスト"
+        desc: "入力中に履歴に基づくサジェストヒントを表示"
+      inline_completion:
+        label: "インライン補完"
+        desc: "入力中に AI インライン補完を提供"
+      inline_debounce_ms:
+        label: "インライン デバウンス (ms)"
+        desc: "入力停止後にインライン補完を開始するまでの遅延"
+      inline_context_lines:
+        label: "インライン コンテキスト行数"
+        desc: "インライン補完にコンテキストとして送る直近のシェル行数"
+      inline_max_tokens:
+        label: "インライン最大トークン数"
+        desc: "インライン補完の応答トークン上限"
+      inline_min_input_chars:
+        label: "インライン最小入力文字数"
+        desc: "インライン補完が開始される最小入力文字数"
+      inline_timeout_secs:
+        label: "インライン タイムアウト (秒)"
+        desc: "インライン補完を待機してからキャンセルする秒数"
+      inline_disable_thinking:
+        label: "インライン思考無効"
+        desc: "インライン補完で推論/思考トークンを抑制"
+      inline_enforce_json:
+        label: "インライン JSON 強制"
+        desc: "インライン補完で厳密な JSON を返すよう強制"
+      max_llm_messages:
+        label: "最大 LLM メッセージ数"
+        desc: "LLM 履歴に保持する最大会話ターン数"
+      enable_token_estimation:
+        label: "トークン推定を有効化"
+        desc: "tiktoken を用いてコンテキスト切り詰め用のトークン数を推定"
+      input_guard_enabled:
+        label: "InputGuard"
+        desc: "危険なコマンドルールに対して入力を事前検査"
+      enable_sandbox:
+        label: "サンドボックスを有効化"
+        desc: "危険なコマンドを許可前にサンドボックスで実行"
+      default_risk_level:
+        label: "既定のリスクレベル"
+        desc: "未認識コマンドの基本リスク評価（low/medium/high）"
+      sandbox_off_action:
+        label: "サンドボックス無効時の動作"
+        desc: "サンドボックスが利用できない場合の動作（allow/confirm/block）"
+      sandbox_timeout_seconds:
+        label: "サンドボックス タイムアウト (秒)"
+        desc: "サンドボックス事前実行を強制終了するまでの秒数"
+      memory_auto_recall:
+        label: "メモリ自動再呼び出し"
+        desc: "関連する長期メモリを AI コンテキストに自動表示"
+      memory_auto_retain:
+        label: "メモリ自動保持"
+        desc: "注目すべき事実を長期メモリに自動保存"
+      context_auto_compact:
+        label: "コンテキスト自動圧縮"
+        desc: "コンテキスト圧力が高まると会話を自動的に圧縮"
+      compact_full_enabled:
+        label: "完全圧縮"
+        desc: "古いターンを要約する完全圧縮パスを有効化"
+      compact_context_window_tokens:
+        label: "コンテキストウィンドウトークン数"
+        desc: "圧縮計算に使用するモデルのコンテキストウィンドウサイズ"
+      compact_micro_keep_recent:
+        label: "マイクロ圧縮で保持する最近"
+        desc: "マイクロ圧縮中にそのまま保持するターン数"
+      compact_shell_keep_recent:
+        label: "シェル圧縮で保持する最近"
+        desc: "シェル圧縮中に保持するシェルコマンドのターン数"
+      compact_summary_max_tokens:
+        label: "圧縮サマリー最大トークン数"
+        desc: "完全圧縮で生成されるサマリーのトークン上限"
+      compact_max_consecutive_failures:
+        label: "最大連続失敗数"
+        desc: "トリムにフォールバックするまでの圧縮失敗回数"
+      compact_reserved_output_tokens:
+        label: "予約済み出力トークン数"
+        desc: "モデルの応答に予約するトークン数、コンテキスト予算から差し引き"
+      history_size:
+        label: "履歴サイズ"
+        desc: "保持するシェル履歴の最大エントリ数"
+      max_shell_messages:
+        label: "最大シェルメッセージ数"
+        desc: "AI コンテキストに保持するシェルコマンドターンの最大数"
+      context_token_budget:
+        label: "コンテキストトークン予算"
+        desc: "コンテキスト合計トークンの任意の上限（空欄 = 無制限）"
+      enable_remote_git_prompt:
+        label: "リモート Git プロンプト"
+        desc: "リモート (SSH/telnet) の bash プロンプトに git ブランチを表示"
+      remote_rich_prompt:
+        label: "リモートリッチプロンプト"
+        desc: "複数行のリッチリモートプロンプトを有効化（user@host, cwd, git）"
+      remote_show_venv:
+        label: "リモート venv 表示"
+        desc: "リモートプロンプトにアクティブな Python venv を表示"
+      remote_show_container:
+        label: "リモートコンテナ表示"
+        desc: "リモートプロンプトにコンテナ/ランタイムマーカーを表示"
+      remote_show_kube:
+        label: "リモート Kube 表示"
+        desc: "リモートプロンプトに Kubernetes コンテキストを表示"
+      remote_danger_patterns:
+        label: "リモート危険パターン"
+        desc: "リモート PS1 を危険と判定するホスト名の正規表現（カンマ区切り）"
+      enable_langfuse:
+        label: "Langfuse を有効化"
+        desc: "Langfuse の LLM オブザーバビリティトレーシングを有効化"
+      langfuse_public_key:
+        label: "Langfuse 公開鍵"
+        desc: "Langfuse の公開鍵"
+      langfuse_secret_key:
+        label: "Langfuse 秘密鍵"
+        desc: "Langfuse の秘密鍵"
+      langfuse_host:
+        label: "Langfuse ホスト"
+        desc: "Langfuse のセルフホストインスタンス URL"
+      enable_scripts:
+        label: "スクリプトを有効化"
+        desc: ".aish スクリプトシステムとライフサイクルフックを有効化"
+      log_level:
+        label: "ログレベル"
+        desc: "トレーシングログの詳細度（error/warn/info/debug/trace）"
+      pty_daemon_enabled:
+        label: "PTY デーモン"
+        desc: "バックグラウンドデーモンで切断をまたいで PTY セッションを保持"
+      codex_auth_path:
+        label: "Codex 認証パス"
+        desc: "OpenAI Codex/ChatGPT の auth.json へのパス"
+      session_db_path:
+        label: "セッション DB パス"
+        desc: "セッションデータベースのカスタム位置（空欄 = 既定値）"
+
   session:
     iteration_limit_reached: "{count} 回のツール呼び出しが完了しました。"
     iteration_limit_title: "⏸ ツール呼び出し上限に達しました"
@@ -515,6 +707,7 @@ help:
       | `/quit` | AI Shell を終了 |
       | `/model [名前]` | AI モデルを表示または切り替え |
       | `/setup` | API 設定を再構成 |
+      | `/setting` | 対話型設定パネルを開く |
       | `/plan [start\|status\|exit]` | プランモードの制御 |
       | `/token` | トークン使用量を表示（過去 7 日間） |
       | `/resume [id]` | 前回のセッションを再開 |

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -354,6 +354,7 @@ shell:
     help: "显示帮助信息"
     model: "显示或切换 AI 模型"
     setup: "打开设置向导"
+    setting: "打开交互式设置面板"
     plan: "计划模式控制"
     token: "显示令牌用量"
     resume: "恢复之前的会话"
@@ -671,6 +672,196 @@ shell:
     cancelled: "配置已取消，保持当前设置不变"
     applied: "配置已更新，当前模型: {model}"
 
+  setting:
+    title: "设置"
+    search_entry: "搜索设置..."
+    search_desc: "按关键字跨分类跳转到任意设置"
+    search_title: "搜索设置"
+    search_placeholder: "输入关键字过滤（名称 / 描述 / 分类）"
+    search_footer: "↑↓ 移动  输入即过滤  Enter 编辑  Esc 返回"
+    search_empty: "没有匹配的设置"
+    restart_summary: "共有 {count} 项改动将在重启后生效"
+    subtitle: "选择要配置的分类（Esc 退出）"
+    select_setting: "选择要修改的设置项（Esc 返回）"
+    on: "开"
+    off: "关"
+    not_set: "（未设置）"
+    current_tag: "当前"
+    applied: "已保存 {label} = {value}"
+    applied_clear: "已清除 {label}"
+    invalid: "无效的值：{error}"
+    restart_hint: "（重启后生效）"
+    cat:
+      model: "模型与接入"
+      appearance: "外观"
+      ai: "AI 行为"
+      security: "安全"
+      context: "上下文与记忆"
+      remote: "远程提示符"
+      advanced: "高级"
+    cat_desc:
+      model: "LLM 模型、接口地址和密钥"
+      appearance: "提示符符号和回复语言"
+      ai: "补全、上下文与 token 处理"
+      security: "输入防护、沙箱和风险等级"
+      context: "记忆召回、自动压缩和历史"
+      remote: "SSH/telnet 提示符段"
+      advanced: "日志、追踪和 PTY 守护进程"
+    k:
+      model:
+        label: "AI 模型"
+        desc: "发送给服务商的模型名，例如 gpt-4o、glm-4.6、deepseek-chat"
+      api_base:
+        label: "API 接口地址"
+        desc: "OpenAI 兼容的对话补全接口 URL"
+      api_key:
+        label: "API 密钥"
+        desc: "用于向服务商鉴权的密钥"
+      temperature:
+        label: "采样温度"
+        desc: "采样随机性，0.0-2.0。越低越确定、越聚焦"
+      max_tokens:
+        label: "最大输出 token"
+        desc: "回复长度上限。留空 = 使用模型默认值"
+      prompt_style:
+        label: "提示符符号"
+        desc: "输入光标前显示的字符，例如 ->、$ 或表情符号（留空=默认箭头）"
+      output_language:
+        label: "AI 回复语言"
+        desc: "AI 回复所用的语言（覆盖终端 locale）"
+      auto_suggest:
+        label: "自动建议"
+        desc: "输入时显示 shell 命令建议"
+      inline_completion:
+        label: "行内 AI 补全"
+        desc: "输入 AI 提示时显示灰色幽灵文本建议"
+      max_llm_messages:
+        label: "AI 最大消息数"
+        desc: "上下文中保留的 AI 对话轮数"
+      enable_token_estimation:
+        label: "token 估算"
+        desc: "估算 token 用量以自动裁剪上下文"
+      input_guard_enabled:
+        label: "输入防护"
+        desc: "执行前拦截危险输入模式"
+      enable_sandbox:
+        label: "沙箱"
+        desc: "在隔离沙箱中预运行危险命令（需 systemd 服务）"
+      default_risk_level:
+        label: "默认风险等级"
+        desc: "命令确认的安全阈值基准"
+      sandbox_off_action:
+        label: "沙箱回退动作"
+        desc: "沙箱不可用时的处理：allow、confirm 或 block"
+      sandbox_timeout_seconds:
+        label: "沙箱超时"
+        desc: "沙箱预运行被终止的秒数（1-300）"
+      memory_auto_recall:
+        label: "记忆自动召回"
+        desc: "将相关长期记忆注入 AI 上下文"
+      memory_auto_retain:
+        label: "记忆自动保存"
+        desc: "自动将重要事实存入长期记忆"
+      context_auto_compact:
+        label: "上下文自动压缩"
+        desc: "接近 token 上限时摘要旧上下文"
+      history_size:
+        label: "历史大小"
+        desc: "shell 历史中保留的最大命令数"
+      max_shell_messages:
+        label: "Shell 最大消息数"
+        desc: "AI 上下文中保留的 shell 历史条数"
+      context_token_budget:
+        label: "上下文 token 预算"
+        desc: "上下文 token 硬上限；留空=不限"
+      enable_remote_git_prompt:
+        label: "远程 Git 提示符"
+        desc: "SSH/telnet 会话中在提示符显示 git 分支"
+      remote_rich_prompt:
+        label: "远程富提示符"
+        desc: "探测远程主机以生成环境感知的提示符段"
+      remote_show_venv:
+        label: "远程显示 Venv"
+        desc: "在远程提示符中显示 venv/conda 名称段"
+      remote_show_container:
+        label: "远程显示容器"
+        desc: "在远程提示符中显示容器（docker/podman）段"
+      remote_show_kube:
+        label: "远程显示 Kube"
+        desc: "在远程提示符中显示 kube 上下文段"
+      log_level:
+        label: "日志级别"
+        desc: "日志文件的详细程度"
+      enable_langfuse:
+        label: "Langfuse 追踪"
+        desc: "将 LLM trace 发送到 Langfuse 用于可观测性（需密钥）"
+      langfuse_public_key:
+        label: "Langfuse 公钥"
+        desc: "LLM 可观测性追踪的项目公钥"
+      langfuse_secret_key:
+        label: "Langfuse 密钥"
+        desc: "项目密钥（显示时脱敏）"
+      langfuse_host:
+        label: "Langfuse 主机"
+        desc: "Langfuse 服务地址（自托管或云端）"
+      enable_scripts:
+        label: "技能与钩子"
+        desc: "启动时加载技能插件和生命周期钩子"
+      pty_daemon_enabled:
+        label: "PTY 守护进程"
+        desc: "终端断开后保持 shell 会话存活"
+      inline_debounce_ms:
+        label: "内联补全防抖 (ms)"
+        desc: "停止输入后多久请求一次幽灵文本建议"
+      inline_context_lines:
+        label: "内联上下文行数"
+        desc: "作为上下文发送的最近 shell 历史行数"
+      inline_max_tokens:
+        label: "内联最大 Tokens"
+        desc: "建议后缀的 token 硬上限"
+      inline_min_input_chars:
+        label: "内联最小输入字符数"
+        desc: "触发建议的最小字符数"
+      inline_timeout_secs:
+        label: "内联超时 (秒)"
+        desc: "建议请求超过此秒数则放弃"
+      inline_disable_thinking:
+        label: "内联禁用思考"
+        desc: "发送标志抑制建议中的思维链"
+      inline_enforce_json:
+        label: "内联强制 JSON"
+        desc: "强制建议以 JSON 模式输出（部分网关返回 400）"
+      compact_full_enabled:
+        label: "完整压缩"
+        desc: "微压缩不够时允许完整摘要压缩"
+      compact_context_window_tokens:
+        label: "上下文窗口 Tokens"
+        desc: "覆盖模型的上下文窗口大小（留空=自动）"
+      compact_micro_keep_recent:
+        label: "微压缩保留近况"
+        desc: "微压缩时保留的最近消息数"
+      compact_shell_keep_recent:
+        label: "保留 Shell 近况"
+        desc: "上下文压缩时保留的 shell 命令数"
+      compact_summary_max_tokens:
+        label: "摘要最大 Tokens"
+        desc: "生成的压缩摘要最大 token 数"
+      compact_max_consecutive_failures:
+        label: "最大压缩失败次数"
+        desc: "连续压缩失败多少次后放弃"
+      compact_reserved_output_tokens:
+        label: "预留输出 Tokens"
+        desc: "为模型输出预留的 token 数（留空=自动）"
+      remote_danger_patterns:
+        label: "远程危险模式"
+        desc: "将远程 PS1 标记为危险的主机名正则（逗号分隔）"
+      codex_auth_path:
+        label: "Codex 认证路径"
+        desc: "OpenAI Codex/ChatGPT 的 auth.json 路径"
+      session_db_path:
+        label: "会话数据库路径"
+        desc: "自定义会话数据库位置（留空=默认）"
+
   ask_user:
     default_title: "需要用户输入"
     default_hint: "[默认: {value}]"
@@ -917,6 +1108,7 @@ help:
       | `/quit` | 退出 AI Shell |
       | `/model [名称]` | 查看或切换 AI 模型 |
       | `/setup` | 重新配置 API 设置 |
+      | `/setting` | 打开交互式设置面板 |
       | `/plan [start\|status\|exit]` | 计划模式控制 |
       | `/token` | 显示令牌用量（近 7 天） |
       | `/resume [id]` | 恢复之前的会话 |

--- a/crates/aish-shell/src/ai_handler.rs
+++ b/crates/aish-shell/src/ai_handler.rs
@@ -1452,19 +1452,50 @@ pub(crate) fn basic_env_info() -> String {
         .clone()
 }
 
-/// Get output language from locale.
+/// Process-wide override for the AI output language, sourced from
+/// `config.output_language`. When `Some(non-empty)`, it takes precedence
+/// over the LANG-derived default. Set once at startup.
+static OUTPUT_LANG_OVERRIDE: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+
+/// Install a config-driven override for the AI response language.
+/// Pass `None` to fall back to the locale-derived default.
+pub(crate) fn set_output_language_override(lang: Option<String>) {
+    let _ = OUTPUT_LANG_OVERRIDE.set(lang);
+}
+
+/// Map a locale/language code to a friendly name the model understands.
+fn friendly_language_name(code: &str) -> String {
+    let lower = code.to_lowercase();
+    let primary = lower.split(['_', '-']).next().unwrap_or("");
+    match primary {
+        "zh" => "Chinese".to_string(),
+        "ja" => "Japanese".to_string(),
+        "ko" => "Korean".to_string(),
+        "fr" => "French".to_string(),
+        "de" => "German".to_string(),
+        "es" => "Spanish".to_string(),
+        "ru" => "Russian".to_string(),
+        // English or anything unrecognized: return as-is (models handle
+        // codes like "en-US", "pt-BR" fine).
+        _ => code.to_string(),
+    }
+}
+
+/// Get output language for AI responses.
+/// Honors `config.output_language` when set; otherwise derives from `LANG`.
 /// Result is cached for the process lifetime since it doesn't change.
 pub(crate) fn output_language() -> String {
     static CACHE: std::sync::OnceLock<String> = std::sync::OnceLock::new();
     CACHE
         .get_or_init(|| {
+            if let Some(Some(lang)) = OUTPUT_LANG_OVERRIDE.get() {
+                if !lang.is_empty() {
+                    return friendly_language_name(lang);
+                }
+            }
             let locale = std::env::var("LANG").unwrap_or_else(|_| "en_US.UTF-8".to_string());
             let lang = locale.split('.').next().unwrap_or("en");
-            if lang.starts_with("zh") {
-                "Chinese".to_string()
-            } else {
-                "English".to_string()
-            }
+            friendly_language_name(lang)
         })
         .clone()
 }

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -142,6 +142,97 @@ fn stream_context_from_config(config: &ConfigModel) -> StreamContext {
     )
 }
 
+// --- /setting panel helpers (see settings_panel module) --------------------
+
+fn setting_label(def: &crate::settings_panel::SettingDef) -> String {
+    t(&format!("shell.setting.k.{}.label", def.key.name()))
+}
+
+fn setting_desc(def: &crate::settings_panel::SettingDef) -> String {
+    t(&format!("shell.setting.k.{}.desc", def.key.name()))
+}
+
+/// Human-readable current value for the setting-list row.
+fn setting_display_current(cfg: &ConfigModel, def: &crate::settings_panel::SettingDef) -> String {
+    use crate::settings_panel::{current_raw, SettingKind};
+    let raw = current_raw(cfg, def.key);
+    match def.kind {
+        SettingKind::Bool => {
+            if raw == "true" {
+                t("shell.setting.on")
+            } else {
+                t("shell.setting.off")
+            }
+        }
+        SettingKind::Secret => {
+            if raw.is_empty() {
+                t("shell.setting.not_set")
+            } else {
+                mask_secret(&raw)
+            }
+        }
+        _ => {
+            if raw.is_empty() {
+                t("shell.setting.not_set")
+            } else {
+                raw
+            }
+        }
+    }
+}
+
+/// Mask a secret, keeping the first 2 and last 2 chars; fully masked when short.
+fn mask_secret(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let n = chars.len();
+    if n <= 8 {
+        return "*".repeat(n.max(4));
+    }
+    let head: String = chars[..2].iter().collect();
+    let tail: String = chars[n - 2..].iter().collect();
+    format!("{head}{}{tail}", "*".repeat(n - 4))
+}
+
+/// Normalize a dialog outcome into a trimmed value, or None when cancelled.
+fn dialog_value(result: crate::tui::DialogResult) -> Option<String> {
+    match result {
+        crate::tui::DialogResult::Selected(v) => Some(v),
+        crate::tui::DialogResult::CustomInput(v) => Some(v.trim().to_string()),
+        crate::tui::DialogResult::Cancelled => None,
+    }
+}
+
+/// Free-text/number editor for a single setting value.
+///
+/// Uses a cliclack input (prefilled with `current` for direct in-place editing)
+/// for text/number fields, and a masked password input for secrets. Returns
+/// the trimmed value, or `None` when the user cancels (Esc / Ctrl+C).
+fn prompt_edit_value(label: &str, desc: &str, current: &str, secret: bool) -> Option<String> {
+    let _guard = aish_tools::bash::acquire_interactive_input_guard();
+    let prompt = if desc.is_empty() {
+        label.to_string()
+    } else {
+        format!("{label}\n{}", theme::faint(desc))
+    };
+    if secret {
+        let result: std::io::Result<String> = cliclack::password(&prompt).mask('•').interact();
+        match result {
+            Ok(v) => Some(v.trim().to_string()),
+            Err(_) => None,
+        }
+    } else {
+        let mut input = cliclack::input(&prompt);
+        if !current.is_empty() {
+            input = input.default_input(current);
+        }
+        let result: std::io::Result<String> = input.interact();
+        match result {
+            Ok(v) => Some(v.trim().to_string()),
+            Err(_) => None,
+        }
+    }
+}
+
 fn llm_session_from_config(config: &ConfigModel) -> LlmSession {
     LlmSession::with_context(
         stream_context_from_config(config),
@@ -624,6 +715,8 @@ impl AishShell {
         // Set terminal defaults and load bash environment
         environment::ensure_terminal_defaults();
         let _new_vars = environment::load_bash_env();
+        // Honor config.output_language for AI responses (overrides LANG).
+        crate::ai_handler::set_output_language_override(config.output_language.clone());
 
         let mut state = ShellState::new();
         for cmd in &config.approved_ai_commands {
@@ -649,10 +742,22 @@ impl AishShell {
 
         // Initialize security manager (before tool registration)
         let mut policy = load_policy(None);
-        // config.yaml's input_guard_enabled mirrors security_policy.yaml's
-        // input_guard.enabled and takes precedence — lets users toggle
-        // InputGuard from the more familiar config file.
+        // config.yaml mirrors several security_policy.yaml fields and takes
+        // precedence, so users can toggle them from the familiar config file
+        // (and via /setting) without editing security_policy.yaml.
         policy.input_guard.enabled = config.input_guard_enabled;
+        policy.enable_sandbox = config.enable_sandbox;
+        policy.default_risk_level = match config.default_risk_level.to_lowercase().as_str() {
+            "medium" => aish_security::decision::RiskLevel::Medium,
+            "high" => aish_security::decision::RiskLevel::High,
+            _ => aish_security::decision::RiskLevel::Low,
+        };
+        policy.sandbox_off_action = match config.sandbox_off_action.to_lowercase().as_str() {
+            "confirm" => aish_security::decision::SandboxOffAction::Confirm,
+            "block" => aish_security::decision::SandboxOffAction::Block,
+            _ => aish_security::decision::SandboxOffAction::Allow,
+        };
+        policy.sandbox_timeout_seconds = config.sandbox_timeout_seconds;
         let security_manager = SecurityManager::new(policy);
         let input_guard =
             aish_security::input_guard::InputGuard::from_policy(security_manager.policy());
@@ -768,7 +873,11 @@ impl AishShell {
         tool_registry.register(Box::new(memory_tool));
         // Load skills (best-effort, before tool registration so SkillTool can use real data)
         let mut skill_manager = SkillManager::new();
-        let _ = skill_manager.load_all_skills();
+        // Skill/hook loading is gated by `enable_scripts`; when false the
+        // directories are still known but nothing is loaded or hot-reloaded.
+        if config.enable_scripts {
+            let _ = skill_manager.load_all_skills();
+        }
         let skill_count = skill_manager.list_skills().len();
 
         // Start skill hot-reloader if skill directories exist
@@ -1823,7 +1932,14 @@ impl AishShell {
         self.inline_ai = inline_ai.clone();
 
         // Initialize readline with history, tab completion, and line editing
-        let mut rl = ShellReadline::new(self.pty.clone(), autosuggest, inline_ai).map_err(|e| {
+        let mut rl = ShellReadline::new(
+            self.pty.clone(),
+            autosuggest,
+            inline_ai,
+            self.config.history_size,
+            self.config.auto_suggest,
+        )
+        .map_err(|e| {
             let mut args = std::collections::HashMap::new();
             args.insert("error".to_string(), e.to_string());
             aish_core::AishError::Config(t_with_args("shell.readline_init_failed", &args))
@@ -1888,6 +2004,7 @@ impl AishShell {
                 self.state.last_exit_code,
                 mode,
                 recording,
+                self.config.prompt_style.as_deref(),
             );
             // Record prompt output if recording is active.
             // \r\x1b[2K clears the current line so re-rendered prompts
@@ -2872,6 +2989,7 @@ impl AishShell {
                 return false;
             }
             Some("/model") => self.handle_model_command(&parts),
+            Some("/setting") => self.handle_setting_command(),
             Some("/setup") => self.run_setup_wizard(),
             Some("/plan") => self.handle_plan_command(&parts),
             Some("/token") => self.handle_token_command(),
@@ -4015,6 +4133,328 @@ impl AishShell {
         let mut args = std::collections::HashMap::new();
         args.insert("model".to_string(), new_model);
         println!("{}", t_with_args("shell.model.switch_success", &args));
+    }
+
+    /// Handle `/setting` — interactive categorized settings panel.
+    ///
+    /// Two-level loop: pick a category → pick a setting → edit its value →
+    /// apply + persist + run live side-effects. Esc at any level backs out;
+    /// Esc at the category level exits the panel. Model/credentials changes
+    /// are applied to the running LLM session immediately (like `/model`).
+    fn handle_setting_command(&mut self) {
+        use crate::settings_panel::{entries_for, SettingCategory, SettingDef};
+        use crate::tui::{show_selection_dialog, DialogOption, DialogResult};
+
+        // Count of restart-required edits this session, for an exit summary.
+        let mut restart_changes: usize = 0;
+
+        // ----- level 1: category loop -------------------------------------
+        loop {
+            // A leading "search" row lets users jump across all 31 settings
+            // by keyword instead of knowing the category.
+            let mut cat_opts: Vec<DialogOption> =
+                Vec::with_capacity(SettingCategory::ALL.len() + 1);
+            cat_opts.push(
+                DialogOption::new("__search__", t("shell.setting.search_entry"))
+                    .with_description(t("shell.setting.search_desc")),
+            );
+            for &c in SettingCategory::ALL {
+                let label = t(&format!("shell.setting.cat.{}", c.name()));
+                let desc = t(&format!("shell.setting.cat_desc.{}", c.name()));
+                let count = entries_for(c).count();
+                cat_opts.push(
+                    DialogOption::new(c.name(), format!("{}  ({})", label, count))
+                        .with_description(desc),
+                );
+            }
+
+            let title = t("shell.setting.title");
+            let subtitle = t("shell.setting.subtitle");
+            let sel = match show_selection_dialog(&title, &subtitle, &cat_opts, false, true) {
+                DialogResult::Selected(name) => name,
+                _ => break, // Esc / Ctrl+C → exit panel
+            };
+
+            if sel == "__search__" {
+                self.setting_search_session(&mut restart_changes);
+                continue;
+            }
+
+            let category = match SettingCategory::ALL.iter().find(|c| c.name() == sel) {
+                Some(&c) => c,
+                None => continue,
+            };
+            let defs: Vec<&'static SettingDef> = entries_for(category).collect();
+            let list_title = t(&format!("shell.setting.cat.{}", category.name()));
+            self.setting_list_session(defs, &list_title, &mut restart_changes);
+        }
+
+        // Exit summary: surface how many changes need a restart (P1-6).
+        if restart_changes > 0 {
+            println!(
+                "{}",
+                theme::warning(&t_with_args("shell.setting.restart_summary", &{
+                    let mut a = std::collections::HashMap::new();
+                    a.insert("count".to_string(), restart_changes.to_string());
+                    a
+                }))
+            );
+        }
+    }
+
+    /// Live-filter search across the whole catalog in a single
+    /// command-palette panel: type to filter, arrows to move, Enter to edit,
+    /// Esc to return. After each edit the panel re-opens with refreshed
+    /// current values — no need to re-navigate categories.
+    fn setting_search_session(&mut self, restart_changes: &mut usize) {
+        use crate::settings_panel::SETTINGS;
+        use aish_ui::{
+            PanelOutcome, PanelRuntime, SearchSelectItem, SearchSelectOutcome, SearchSelectPanel,
+        };
+
+        // Last-edited setting's key — restored as the cursor position when
+        // the panel reopens after an edit, so the user lands back on it.
+        let mut last_edited: Option<String> = None;
+        loop {
+            let items: Vec<SearchSelectItem> = SETTINGS
+                .iter()
+                .map(|def| {
+                    let label = setting_label(def);
+                    let cur = setting_display_current(&self.config, def);
+                    let cat = t(&format!("shell.setting.cat.{}", def.category.name()));
+                    let desc = setting_desc(def);
+                    let search_text = format!("{} {} {} {}", label, desc, def.key.name(), cat);
+                    SearchSelectItem::new(def.key.name(), format!("{}  [{}]", label, cur))
+                        .with_detail(format!("[{}] {}", cat, desc))
+                        .with_search_text(search_text)
+                })
+                .collect();
+
+            // Scope the input guard to the panel run only; edit_one_setting's
+            // own prompts acquire their own guard.
+            let outcome = {
+                let _guard = aish_tools::bash::acquire_interactive_input_guard();
+                let mut panel = SearchSelectPanel::new(
+                    t("shell.setting.search_title").to_string(),
+                    t("shell.setting.search_placeholder").to_string(),
+                    items,
+                )
+                .with_footer(t("shell.setting.search_footer").to_string())
+                .with_empty_message(t("shell.setting.search_empty").to_string());
+                if let Some(k) = &last_edited {
+                    panel = panel.with_selected_value(Some(k));
+                }
+                PanelRuntime::new().run(panel)
+            };
+
+            match outcome {
+                Ok(PanelOutcome::Submitted(SearchSelectOutcome::Selected(key_name))) => {
+                    let def = match SETTINGS.iter().find(|d| d.key.name() == key_name) {
+                        Some(d) => d,
+                        None => continue,
+                    };
+                    self.edit_one_setting(def, restart_changes);
+                    last_edited = Some(key_name);
+                }
+                _ => return, // Esc / Ctrl+C / Ctrl+Q → back to category menu
+            }
+        }
+    }
+    /// Show a category's settings and let the user edit any of them repeatedly.
+    /// Esc returns to the caller (category menu).
+    fn setting_list_session(
+        &mut self,
+        defs: Vec<&'static crate::settings_panel::SettingDef>,
+        title: &str,
+        restart_changes: &mut usize,
+    ) {
+        use crate::tui::{show_selection_dialog, DialogOption, DialogResult};
+        loop {
+            let opts: Vec<DialogOption> = defs
+                .iter()
+                .map(|def| {
+                    let label = setting_label(def);
+                    let cur = setting_display_current(&self.config, def);
+                    DialogOption::new(def.key.name(), format!("{}  [{}]", label, cur))
+                        .with_description(setting_desc(def))
+                })
+                .collect();
+            let key_name = match show_selection_dialog(
+                title,
+                &t("shell.setting.select_setting"),
+                &opts,
+                false,
+                true,
+            ) {
+                DialogResult::Selected(n) => n,
+                _ => return, // Esc → back to categories
+            };
+            let def = match defs.iter().find(|d| d.key.name() == key_name) {
+                Some(d) => *d,
+                None => continue,
+            };
+            self.edit_one_setting(def, restart_changes);
+        }
+    }
+
+    /// Edit one setting's value. Re-prompts the input in place when the value
+    /// is invalid (P0-2) instead of kicking the user back to the list; only
+    /// Esc returns. Persists, runs live side-effects, and accounts restart
+    /// changes.
+    fn edit_one_setting(
+        &mut self,
+        def: &'static crate::settings_panel::SettingDef,
+        restart_changes: &mut usize,
+    ) {
+        use crate::settings_panel::{self, LiveEffect, SettingKind};
+        loop {
+            let cur_raw = settings_panel::current_raw(&self.config, def.key);
+            let new_val = match self.edit_setting_value(def, &cur_raw) {
+                Some(v) => v,
+                None => return, // Esc → back to list
+            };
+            // Validate against a clone so a bad value can't partially mutate
+            // the live config; only commit on success.
+            let mut trial = self.config.clone();
+            if let Err(e) = settings_panel::apply(&mut trial, def.key, &new_val) {
+                eprintln!(
+                    "{}",
+                    theme::error(&t_with_args("shell.setting.invalid", &{
+                        let mut a = std::collections::HashMap::new();
+                        a.insert("error".to_string(), e);
+                        a
+                    }))
+                );
+                continue; // re-prompt the same input
+            }
+            self.config = trial;
+
+            // Persist to disk.
+            let config_path = aish_config::ConfigLoader::default_config_path();
+            if let Err(e) = aish_config::ConfigLoader::save(&self.config, &config_path) {
+                eprintln!(
+                    "{}",
+                    theme::warning(&{
+                        let mut a = std::collections::HashMap::new();
+                        a.insert("error".to_string(), e.to_string());
+                        t_with_args("shell.config_save_warning", &a)
+                    })
+                );
+            }
+
+            // Live side-effects so the change is felt without restart.
+            match settings_panel::live_effect(def.key) {
+                LiveEffect::ModelSession => {
+                    self.ai_handler.update_model(
+                        &self.config.model,
+                        Some(&self.config.api_base),
+                        Some(&self.config.api_key),
+                    );
+                    if let Some(ai) = &self.inline_ai {
+                        ai.update_model(&self.config.model);
+                    }
+                    self.refresh_config_dependent_tools();
+                }
+                LiveEffect::ToolsRefresh => self.refresh_config_dependent_tools(),
+                LiveEffect::InputGuard => {
+                    // screen_input() consults the cached guard, so toggle its
+                    // enabled flag to match the freshly-written config.
+                    self.input_guard
+                        .set_enabled(self.config.input_guard_enabled);
+                }
+                LiveEffect::None => {}
+            }
+
+            // Confirmation.
+            let label = setting_label(def);
+            if new_val.is_empty() {
+                println!(
+                    "{}",
+                    theme::success(&t_with_args("shell.setting.applied_clear", &{
+                        let mut a = std::collections::HashMap::new();
+                        a.insert("label".to_string(), label);
+                        a
+                    }))
+                );
+            } else {
+                let shown = if matches!(def.kind, SettingKind::Secret) {
+                    mask_secret(&new_val)
+                } else {
+                    new_val.clone()
+                };
+                println!(
+                    "{}",
+                    theme::success(&t_with_args("shell.setting.applied", &{
+                        let mut a = std::collections::HashMap::new();
+                        a.insert("label".to_string(), label);
+                        a.insert("value".to_string(), shown);
+                        a
+                    }))
+                );
+            }
+            if settings_panel::requires_restart(def.key) {
+                println!("{}", theme::faint(&t("shell.setting.restart_hint")));
+                *restart_changes += 1;
+            }
+            return; // back to the list
+        }
+    }
+
+    /// Build the value-edit dialog for one setting and return the trimmed new
+    /// value, or `None` if the user cancelled.
+    fn edit_setting_value(
+        &self,
+        def: &crate::settings_panel::SettingDef,
+        current_raw: &str,
+    ) -> Option<String> {
+        use crate::settings_panel::SettingKind;
+        use crate::tui::{show_selection_dialog, DialogOption};
+
+        let label = setting_label(def);
+        let desc = setting_desc(def);
+        let on = t("shell.setting.on");
+        let off = t("shell.setting.off");
+
+        match def.kind {
+            SettingKind::Bool => {
+                let opts = vec![
+                    DialogOption::new("true", &on),
+                    DialogOption::new("false", &off),
+                ];
+                dialog_value(show_selection_dialog(&label, &desc, &opts, false, true))
+            }
+            SettingKind::Choice(options) => {
+                // Fixed set — no custom input, so apply() can't receive a
+                // typo that would silently break the consumer.
+                let opts: Vec<DialogOption> = options
+                    .iter()
+                    .map(|o| {
+                        let mut d = DialogOption::new(*o, *o);
+                        if *o == current_raw {
+                            d = d.with_description(t("shell.setting.current_tag"));
+                        }
+                        d
+                    })
+                    .collect();
+                dialog_value(show_selection_dialog(&label, &desc, &opts, false, true))
+            }
+            SettingKind::Text | SettingKind::Float | SettingKind::Int | SettingKind::StringList => {
+                // Free-text/number: edit the current value in place. The value
+                // is prefilled so the user changes it directly (no "pick the
+                // custom row first" step). Empty clears Option-backed fields.
+                // StringList edits the whole list as comma-separated text;
+                // apply() re-splits on commas.
+                prompt_edit_value(&label, &desc, current_raw, false)
+            }
+            SettingKind::Secret => {
+                // Masked input (no prefill — never echo the secret). An empty
+                // submission keeps the current value rather than wiping it.
+                match prompt_edit_value(&label, &desc, "", true) {
+                    Some(v) if !v.is_empty() => Some(v),
+                    _ => None,
+                }
+            }
+        }
     }
 
     /// Handle `/plan [start|status|exit]` — plan mode lifecycle.

--- a/crates/aish-shell/src/lib.rs
+++ b/crates/aish-shell/src/lib.rs
@@ -38,6 +38,7 @@ pub mod recorder;
 pub mod renderer;
 pub mod resume_selector;
 pub mod security_panel;
+pub mod settings_panel;
 pub mod status;
 pub mod theme;
 pub mod token_store;

--- a/crates/aish-shell/src/prompt.rs
+++ b/crates/aish-shell/src/prompt.rs
@@ -223,6 +223,7 @@ pub fn render_prompt(
     last_exit_code: i32,
     mode: &str,
     recording: bool,
+    prompt_style: Option<&str>,
 ) -> String {
     let home = dirs::home_dir()
         .map(|h| h.to_string_lossy().to_string())
@@ -260,11 +261,17 @@ pub fn render_prompt(
         }
     }
 
-    // Prompt symbol based on last exit code
+    // Prompt symbol based on last exit code. A custom `prompt_style`
+    // overrides the default arrow (doubled on error to match the default).
+    let ok_sym = prompt_style.unwrap_or(theme::PROMPT_OK);
+    let err_sym = match prompt_style {
+        Some(s) => format!("{s}{s}"),
+        None => theme::PROMPT_ERR.to_string(),
+    };
     if last_exit_code == 0 {
-        prompt.push_str(&format!("{} ", theme::success(theme::PROMPT_OK)));
+        prompt.push_str(&format!("{} ", theme::success(ok_sym)));
     } else {
-        prompt.push_str(&format!("{} ", theme::error(theme::PROMPT_ERR)));
+        prompt.push_str(&format!("{} ", theme::error(&err_sym)));
     }
 
     prompt
@@ -680,7 +687,7 @@ mod tests {
     fn test_render_prompt_with_home_substitution() {
         let home = dirs::home_dir().expect("home dir should exist");
         let cwd = home.join("projects").to_string_lossy().to_string();
-        let result = render_prompt(&cwd, "test-model", 0, "aish", false);
+        let result = render_prompt(&cwd, "test-model", 0, "aish", false, None);
         assert!(
             result.contains("~"),
             "should substitute home with ~: {}",
@@ -693,7 +700,7 @@ mod tests {
     #[test]
     fn test_render_prompt_without_git() {
         // /tmp is very unlikely to be inside a git repo
-        let result = render_prompt("/tmp", "test-model", 0, "aish", false);
+        let result = render_prompt("/tmp", "test-model", 0, "aish", false, None);
         // Should NOT contain git branch separator '|'
         assert!(
             !result.contains("|"),
@@ -704,7 +711,7 @@ mod tests {
 
     #[test]
     fn test_render_prompt_success_symbol() {
-        let result = render_prompt("/tmp", "test-model", 0, "aish", false);
+        let result = render_prompt("/tmp", "test-model", 0, "aish", false, None);
         assert!(
             result.contains("➜"),
             "should have single arrow prompt on success: {}",
@@ -718,7 +725,7 @@ mod tests {
 
     #[test]
     fn test_render_prompt_error_symbol() {
-        let result = render_prompt("/tmp", "test-model", 1, "aish", false);
+        let result = render_prompt("/tmp", "test-model", 1, "aish", false, None);
         assert!(
             result.contains("➜➜"),
             "should have double arrow prompt on error: {}",
@@ -728,13 +735,13 @@ mod tests {
 
     #[test]
     fn test_render_prompt_aish_mode_badge() {
-        let result = render_prompt("/tmp", "test-model", 0, "aish", false);
+        let result = render_prompt("/tmp", "test-model", 0, "aish", false, None);
         assert!(result.contains("◆ aish"), "should show aish mode badge");
     }
 
     #[test]
     fn test_render_prompt_plan_mode_badge() {
-        let result = render_prompt("/tmp", "test-model", 0, "plan", false);
+        let result = render_prompt("/tmp", "test-model", 0, "plan", false, None);
         assert!(result.contains("◆ plan"), "should show plan mode badge");
     }
 
@@ -806,7 +813,7 @@ mod tests {
 
     #[test]
     fn test_render_prompt_recording_indicator() {
-        let result = render_prompt("/tmp", "test-model", 0, "aish", true);
+        let result = render_prompt("/tmp", "test-model", 0, "aish", true, None);
         assert!(
             result.contains("⏺"),
             "should contain recording indicator: {}",
@@ -816,7 +823,7 @@ mod tests {
 
     #[test]
     fn test_render_prompt_no_recording_indicator() {
-        let result = render_prompt("/tmp", "test-model", 0, "aish", false);
+        let result = render_prompt("/tmp", "test-model", 0, "aish", false, None);
         assert!(
             !result.contains("⏺"),
             "should not contain recording indicator when not recording: {}",

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -25,6 +25,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/help", "Show help information"),
     ("/model", "Show or switch AI model"),
     ("/setup", "Open setup wizard"),
+    ("/setting", "Open interactive settings panel"),
     ("/plan", "Plan mode control"),
     ("/token", "Show token usage"),
     ("/resume", "Resume previous session"),
@@ -320,6 +321,9 @@ struct ShellHelper {
     engine: Arc<CompletionEngine>,
     autosuggest: Arc<Mutex<AutoSuggest>>,
     inline_ai: Option<Arc<crate::inline_completion::InlineCompleter>>,
+    /// When false, history-based autosuggest hints are suppressed (the
+    /// `auto_suggest` config knob). Inline AI completion is unaffected.
+    auto_suggest: bool,
 }
 
 impl ShellHelper {
@@ -327,11 +331,13 @@ impl ShellHelper {
         engine: Arc<CompletionEngine>,
         autosuggest: Arc<Mutex<AutoSuggest>>,
         inline_ai: Option<Arc<crate::inline_completion::InlineCompleter>>,
+        auto_suggest: bool,
     ) -> Self {
         Self {
             engine,
             autosuggest,
             inline_ai,
+            auto_suggest,
         }
     }
 }
@@ -365,6 +371,11 @@ impl Hinter for ShellHelper {
             ai.cancel();
         }
 
+        // History-based autosuggest is gated by the `auto_suggest` config
+        // knob. Inline AI completion above is independent of this toggle.
+        if !self.auto_suggest {
+            return None;
+        }
         let trimmed = line.trim_start();
         let guard = self.autosuggest.lock().unwrap();
         guard.suggest(trimmed).and_then(|s| {
@@ -432,6 +443,8 @@ impl ShellReadline {
         pty: Arc<Mutex<aish_pty::PersistentPty>>,
         autosuggest: Arc<Mutex<AutoSuggest>>,
         inline_ai: Option<Arc<crate::inline_completion::InlineCompleter>>,
+        history_size: usize,
+        auto_suggest: bool,
     ) -> rustyline::Result<Self> {
         let engine = Arc::new(CompletionEngine::new(pty));
 
@@ -446,8 +459,9 @@ impl ShellReadline {
             engine.clone(),
             autosuggest.clone(),
             inline_ai.clone(),
+            auto_suggest,
         )));
-        editor.set_max_history_size(500)?;
+        editor.set_max_history_size(history_size.max(1))?;
 
         editor.bind_sequence(
             KeyEvent(KeyCode::Tab, Modifiers::NONE),
@@ -684,6 +698,6 @@ mod tests {
                 cmd
             );
         }
-        assert_eq!(SLASH_COMMANDS.len(), 15);
+        assert_eq!(SLASH_COMMANDS.len(), 16);
     }
 }

--- a/crates/aish-shell/src/settings_panel.rs
+++ b/crates/aish-shell/src/settings_panel.rs
@@ -1,0 +1,1033 @@
+//! Interactive settings panel (`/setting`).
+//!
+//! The raw `ConfigModel` exposes 50+ fields, which is overwhelming to edit by
+//! hand. This module curates the commonly-tweaked subset into a categorized
+//! catalog where every entry carries a human label and a one-line explanation,
+//! and exposes helpers to read the current value, validate/apply a new value,
+//! and signal which live side-effects the shell must run after a change.
+//!
+//! The interactive loop itself lives in `app.rs` (`handle_setting_command`);
+//! this module is intentionally free of terminal I/O so it stays unit-testable.
+
+use aish_config::ConfigModel;
+
+// ---------------------------------------------------------------------------
+// Live-effect signal
+// ---------------------------------------------------------------------------
+
+/// What the shell must do after a setting is applied so the change takes effect
+/// in the running session (beyond persisting to disk).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LiveEffect {
+    /// No live action needed; the field is read on demand from `self.config`.
+    None,
+    /// Rebuild the model-dependent tools (WebFetch) — e.g. after temperature or
+    /// `max_tokens` changes.
+    ToolsRefresh,
+    /// Toggle the cached InputGuard's enabled flag — after
+    /// `input_guard_enabled` changes, so `screen_input()` honors it without a
+    /// restart.
+    InputGuard,
+    /// Re-initialize the whole LLM session + tools + inline completer — needed
+    /// when `model` / `api_base` / `api_key` change.
+    ModelSession,
+}
+
+// ---------------------------------------------------------------------------
+// Setting categories and value kinds
+// ---------------------------------------------------------------------------
+
+/// Top-level group shown in the first panel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingCategory {
+    Model,
+    Appearance,
+    Ai,
+    Security,
+    Context,
+    Remote,
+    Advanced,
+}
+
+impl SettingCategory {
+    /// Stable identifier used to build i18n keys and option values.
+    pub fn name(self) -> &'static str {
+        match self {
+            SettingCategory::Model => "model",
+            SettingCategory::Appearance => "appearance",
+            SettingCategory::Ai => "ai",
+            SettingCategory::Security => "security",
+            SettingCategory::Context => "context",
+            SettingCategory::Remote => "remote",
+            SettingCategory::Advanced => "advanced",
+        }
+    }
+
+    /// All categories in display order.
+    pub const ALL: &'static [SettingCategory] = &[
+        SettingCategory::Model,
+        SettingCategory::Appearance,
+        SettingCategory::Ai,
+        SettingCategory::Security,
+        SettingCategory::Context,
+        SettingCategory::Remote,
+        SettingCategory::Advanced,
+    ];
+}
+
+/// How a value is edited in the panel.
+#[derive(Debug, Clone, Copy)]
+pub enum SettingKind {
+    /// On/off toggle.
+    Bool,
+    /// Pick one of a fixed set of values.
+    Choice(&'static [&'static str]),
+    /// Arbitrary single-line text.
+    Text,
+    /// Floating-point number.
+    Float,
+    /// Non-negative integer (blank clears to the default / unset).
+    Int,
+    /// Like `Text` but the current value is masked on display (API keys).
+    Secret,
+    /// A list of strings edited as a comma-separated single line; apply()
+    /// splits on commas. Used for pattern lists like remote_danger_patterns.
+    StringList,
+}
+
+// ---------------------------------------------------------------------------
+// Setting key — exhaustive identifier for each catalog entry
+
+/// Identifier for a single configurable setting.
+///
+/// Order here defines display order within a category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingKey {
+    // Model & Provider
+    Model,
+    ApiBase,
+    ApiKey,
+    Temperature,
+    MaxTokens,
+    // Appearance
+    PromptStyle,
+    OutputLanguage,
+    AutoSuggest,
+    // AI Behavior
+    InlineCompletion,
+    InlineDebounceMs,
+    InlineContextLines,
+    InlineMaxTokens,
+    InlineMinInputChars,
+    InlineTimeoutSecs,
+    InlineDisableThinking,
+    InlineEnforceJson,
+    MaxLlmMessages,
+    EnableTokenEstimation,
+    // Security
+    InputGuardEnabled,
+    EnableSandbox,
+    DefaultRiskLevel,
+    SandboxOffAction,
+    SandboxTimeout,
+    // Context & Memory
+    MemoryAutoRecall,
+    MemoryAutoRetain,
+    ContextAutoCompact,
+    CompactFullEnabled,
+    CompactContextWindowTokens,
+    CompactMicroKeepRecent,
+    CompactShellKeepRecent,
+    CompactSummaryMaxTokens,
+    CompactMaxConsecutiveFailures,
+    CompactReservedOutputTokens,
+    HistorySize,
+    MaxShellMessages,
+    ContextTokenBudget,
+    // Remote Prompt
+    EnableRemoteGitPrompt,
+    RemoteRichPrompt,
+    RemoteShowVenv,
+    RemoteShowContainer,
+    RemoteShowKube,
+    RemoteDangerPatterns,
+    // Advanced
+    LogLevel,
+    EnableLangfuse,
+    LangfusePublicKey,
+    LangfuseSecretKey,
+    LangfuseHost,
+    EnableScripts,
+    PtyDaemonEnabled,
+    CodexAuthPath,
+    SessionDbPath,
+}
+impl SettingKey {
+    /// Stable string used for i18n keys (`shell.setting.k.{name}.label|desc`).
+    pub fn name(self) -> &'static str {
+        match self {
+            SettingKey::Model => "model",
+            SettingKey::ApiBase => "api_base",
+            SettingKey::ApiKey => "api_key",
+            SettingKey::Temperature => "temperature",
+            SettingKey::MaxTokens => "max_tokens",
+            SettingKey::PromptStyle => "prompt_style",
+            SettingKey::OutputLanguage => "output_language",
+            SettingKey::AutoSuggest => "auto_suggest",
+            SettingKey::InlineCompletion => "inline_completion",
+            SettingKey::InlineDebounceMs => "inline_debounce_ms",
+            SettingKey::InlineContextLines => "inline_context_lines",
+            SettingKey::InlineMaxTokens => "inline_max_tokens",
+            SettingKey::InlineMinInputChars => "inline_min_input_chars",
+            SettingKey::InlineTimeoutSecs => "inline_timeout_secs",
+            SettingKey::InlineDisableThinking => "inline_disable_thinking",
+            SettingKey::InlineEnforceJson => "inline_enforce_json",
+            SettingKey::MaxLlmMessages => "max_llm_messages",
+            SettingKey::EnableTokenEstimation => "enable_token_estimation",
+            SettingKey::InputGuardEnabled => "input_guard_enabled",
+            SettingKey::EnableSandbox => "enable_sandbox",
+            SettingKey::DefaultRiskLevel => "default_risk_level",
+            SettingKey::SandboxOffAction => "sandbox_off_action",
+            SettingKey::SandboxTimeout => "sandbox_timeout_seconds",
+            SettingKey::MemoryAutoRecall => "memory_auto_recall",
+            SettingKey::MemoryAutoRetain => "memory_auto_retain",
+            SettingKey::ContextAutoCompact => "context_auto_compact",
+            SettingKey::CompactFullEnabled => "compact_full_enabled",
+            SettingKey::CompactContextWindowTokens => "compact_context_window_tokens",
+            SettingKey::CompactMicroKeepRecent => "compact_micro_keep_recent",
+            SettingKey::CompactShellKeepRecent => "compact_shell_keep_recent",
+            SettingKey::CompactSummaryMaxTokens => "compact_summary_max_tokens",
+            SettingKey::CompactMaxConsecutiveFailures => "compact_max_consecutive_failures",
+            SettingKey::CompactReservedOutputTokens => "compact_reserved_output_tokens",
+            SettingKey::HistorySize => "history_size",
+            SettingKey::MaxShellMessages => "max_shell_messages",
+            SettingKey::ContextTokenBudget => "context_token_budget",
+            SettingKey::EnableRemoteGitPrompt => "enable_remote_git_prompt",
+            SettingKey::RemoteRichPrompt => "remote_rich_prompt",
+            SettingKey::RemoteShowVenv => "remote_show_venv",
+            SettingKey::RemoteShowContainer => "remote_show_container",
+            SettingKey::RemoteShowKube => "remote_show_kube",
+            SettingKey::RemoteDangerPatterns => "remote_danger_patterns",
+            SettingKey::LogLevel => "log_level",
+            SettingKey::EnableLangfuse => "enable_langfuse",
+            SettingKey::LangfusePublicKey => "langfuse_public_key",
+            SettingKey::LangfuseSecretKey => "langfuse_secret_key",
+            SettingKey::LangfuseHost => "langfuse_host",
+            SettingKey::EnableScripts => "enable_scripts",
+            SettingKey::PtyDaemonEnabled => "pty_daemon_enabled",
+            SettingKey::CodexAuthPath => "codex_auth_path",
+            SettingKey::SessionDbPath => "session_db_path",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Catalog entry
+// ---------------------------------------------------------------------------
+
+/// A single curated setting.
+#[derive(Debug, Clone, Copy)]
+pub struct SettingDef {
+    pub key: SettingKey,
+    pub category: SettingCategory,
+    pub kind: SettingKind,
+}
+
+/// The full curated catalog. Every entry below is consumed by the running
+/// shell (live or at next startup) — vestigial config fields that nothing
+/// reads are deliberately excluded. The remaining `ConfigModel` fields stay
+/// in the YAML for power users.
+pub const SETTINGS: &[SettingDef] = &[
+    // --- Model & Provider ---
+    SettingDef {
+        key: SettingKey::Model,
+        category: SettingCategory::Model,
+        kind: SettingKind::Text,
+    },
+    SettingDef {
+        key: SettingKey::ApiBase,
+        category: SettingCategory::Model,
+        kind: SettingKind::Text,
+    },
+    SettingDef {
+        key: SettingKey::ApiKey,
+        category: SettingCategory::Model,
+        kind: SettingKind::Secret,
+    },
+    SettingDef {
+        key: SettingKey::Temperature,
+        category: SettingCategory::Model,
+        kind: SettingKind::Float,
+    },
+    SettingDef {
+        key: SettingKey::MaxTokens,
+        category: SettingCategory::Model,
+        kind: SettingKind::Int,
+    },
+    // --- Appearance ---
+    SettingDef {
+        key: SettingKey::PromptStyle,
+        category: SettingCategory::Appearance,
+        kind: SettingKind::Text,
+    },
+    SettingDef {
+        key: SettingKey::OutputLanguage,
+        category: SettingCategory::Appearance,
+        kind: SettingKind::Choice(&["zh-CN", "en-US", "ja-JP", "de-DE", "fr-FR", "es-ES"]),
+    },
+    // --- AI Behavior ---
+    SettingDef {
+        key: SettingKey::InlineCompletion,
+        category: SettingCategory::Ai,
+        kind: SettingKind::Bool,
+    },
+    SettingDef {
+        key: SettingKey::InlineDebounceMs,
+        category: SettingCategory::Ai,
+        kind: SettingKind::Int,
+    },
+    SettingDef {
+        key: SettingKey::InlineContextLines,
+        category: SettingCategory::Ai,
+        kind: SettingKind::Int,
+    },
+    SettingDef {
+        key: SettingKey::InlineMaxTokens,
+        category: SettingCategory::Ai,
+        kind: SettingKind::Int,
+    },
+    SettingDef {
+        key: SettingKey::InlineMinInputChars,
+        category: SettingCategory::Ai,
+        kind: SettingKind::Int,
+    },
+    SettingDef {
+        key: SettingKey::InlineTimeoutSecs,
+        category: SettingCategory::Ai,
+        kind: SettingKind::Int,
+    },
+    SettingDef {
+        key: SettingKey::InlineDisableThinking,
+        category: SettingCategory::Ai,
+        kind: SettingKind::Bool,
+    },
+    SettingDef {
+        key: SettingKey::InlineEnforceJson,
+        category: SettingCategory::Ai,
+        kind: SettingKind::Bool,
+    },
+    SettingDef {
+        key: SettingKey::AutoSuggest,
+        category: SettingCategory::Ai,
+        kind: SettingKind::Bool,
+    },
+    SettingDef {
+        key: SettingKey::MaxLlmMessages,
+        category: SettingCategory::Ai,
+        kind: SettingKind::Int,
+    },
+    SettingDef {
+        key: SettingKey::EnableTokenEstimation,
+        category: SettingCategory::Ai,
+        kind: SettingKind::Bool,
+    },
+    // --- Security ---
+    SettingDef {
+        key: SettingKey::InputGuardEnabled,
+        category: SettingCategory::Security,
+        kind: SettingKind::Bool,
+    },
+    SettingDef {
+        key: SettingKey::EnableSandbox,
+        category: SettingCategory::Security,
+        kind: SettingKind::Bool,
+    },
+    SettingDef {
+        key: SettingKey::DefaultRiskLevel,
+        category: SettingCategory::Security,
+        kind: SettingKind::Choice(&["low", "medium", "high"]),
+    },
+    SettingDef {
+        key: SettingKey::SandboxOffAction,
+        category: SettingCategory::Security,
+        kind: SettingKind::Choice(&["allow", "confirm", "block"]),
+    },
+    SettingDef {
+        key: SettingKey::SandboxTimeout,
+        category: SettingCategory::Security,
+        kind: SettingKind::Float,
+    },
+    // --- Context & Memory ---
+    SettingDef {
+        key: SettingKey::MemoryAutoRecall,
+        category: SettingCategory::Context,
+        kind: SettingKind::Bool,
+    },
+    SettingDef {
+        key: SettingKey::MemoryAutoRetain,
+        category: SettingCategory::Context,
+        kind: SettingKind::Bool,
+    },
+    SettingDef {
+        key: SettingKey::ContextAutoCompact,
+        category: SettingCategory::Context,
+        kind: SettingKind::Bool,
+    },
+    SettingDef {
+        key: SettingKey::CompactFullEnabled,
+        category: SettingCategory::Context,
+        kind: SettingKind::Bool,
+    },
+    SettingDef {
+        key: SettingKey::CompactContextWindowTokens,
+        category: SettingCategory::Context,
+        kind: SettingKind::Int,
+    },
+    SettingDef {
+        key: SettingKey::CompactMicroKeepRecent,
+        category: SettingCategory::Context,
+        kind: SettingKind::Int,
+    },
+    SettingDef {
+        key: SettingKey::CompactShellKeepRecent,
+        category: SettingCategory::Context,
+        kind: SettingKind::Int,
+    },
+    SettingDef {
+        key: SettingKey::CompactSummaryMaxTokens,
+        category: SettingCategory::Context,
+        kind: SettingKind::Int,
+    },
+    SettingDef {
+        key: SettingKey::CompactMaxConsecutiveFailures,
+        category: SettingCategory::Context,
+        kind: SettingKind::Int,
+    },
+    SettingDef {
+        key: SettingKey::CompactReservedOutputTokens,
+        category: SettingCategory::Context,
+        kind: SettingKind::Int,
+    },
+    SettingDef {
+        key: SettingKey::HistorySize,
+        category: SettingCategory::Context,
+        kind: SettingKind::Int,
+    },
+    SettingDef {
+        key: SettingKey::MaxShellMessages,
+        category: SettingCategory::Context,
+        kind: SettingKind::Int,
+    },
+    SettingDef {
+        key: SettingKey::ContextTokenBudget,
+        category: SettingCategory::Context,
+        kind: SettingKind::Int,
+    },
+    // --- Remote Prompt ---
+    SettingDef {
+        key: SettingKey::EnableRemoteGitPrompt,
+        category: SettingCategory::Remote,
+        kind: SettingKind::Bool,
+    },
+    SettingDef {
+        key: SettingKey::RemoteRichPrompt,
+        category: SettingCategory::Remote,
+        kind: SettingKind::Bool,
+    },
+    SettingDef {
+        key: SettingKey::RemoteShowVenv,
+        category: SettingCategory::Remote,
+        kind: SettingKind::Bool,
+    },
+    SettingDef {
+        key: SettingKey::RemoteShowContainer,
+        category: SettingCategory::Remote,
+        kind: SettingKind::Bool,
+    },
+    SettingDef {
+        key: SettingKey::RemoteShowKube,
+        category: SettingCategory::Remote,
+        kind: SettingKind::Bool,
+    },
+    SettingDef {
+        key: SettingKey::RemoteDangerPatterns,
+        category: SettingCategory::Remote,
+        kind: SettingKind::StringList,
+    },
+    // --- Advanced ---
+    SettingDef {
+        key: SettingKey::EnableLangfuse,
+        category: SettingCategory::Advanced,
+        kind: SettingKind::Bool,
+    },
+    SettingDef {
+        key: SettingKey::LangfusePublicKey,
+        category: SettingCategory::Advanced,
+        kind: SettingKind::Text,
+    },
+    SettingDef {
+        key: SettingKey::LangfuseSecretKey,
+        category: SettingCategory::Advanced,
+        kind: SettingKind::Secret,
+    },
+    SettingDef {
+        key: SettingKey::LangfuseHost,
+        category: SettingCategory::Advanced,
+        kind: SettingKind::Text,
+    },
+    SettingDef {
+        key: SettingKey::EnableScripts,
+        category: SettingCategory::Advanced,
+        kind: SettingKind::Bool,
+    },
+    SettingDef {
+        key: SettingKey::LogLevel,
+        category: SettingCategory::Advanced,
+        kind: SettingKind::Choice(&["error", "warn", "info", "debug", "trace"]),
+    },
+    SettingDef {
+        key: SettingKey::PtyDaemonEnabled,
+        category: SettingCategory::Advanced,
+        kind: SettingKind::Bool,
+    },
+    SettingDef {
+        key: SettingKey::CodexAuthPath,
+        category: SettingCategory::Advanced,
+        kind: SettingKind::Text,
+    },
+    SettingDef {
+        key: SettingKey::SessionDbPath,
+        category: SettingCategory::Advanced,
+        kind: SettingKind::Text,
+    },
+];
+
+/// All entries belonging to `category`, in catalog order.
+pub fn entries_for(category: SettingCategory) -> impl Iterator<Item = &'static SettingDef> {
+    SETTINGS.iter().filter(move |s| s.category == category)
+}
+
+/// Look up a definition by key.
+pub fn find(key: SettingKey) -> &'static SettingDef {
+    SETTINGS
+        .iter()
+        .find(|s| s.key == key)
+        .expect("SettingKey is exhaustive over SETTINGS")
+}
+
+// ---------------------------------------------------------------------------
+// Read / write the live config
+// ---------------------------------------------------------------------------
+
+/// Read the current raw value as a string (what would be written to YAML).
+/// Option fields render as `""` when unset.
+pub fn current_raw(cfg: &ConfigModel, key: SettingKey) -> String {
+    let raw = match key {
+        SettingKey::Model => cfg.model.clone(),
+        SettingKey::ApiBase => cfg.api_base.clone(),
+        SettingKey::ApiKey => cfg.api_key.clone(),
+        SettingKey::Temperature => format!("{}", cfg.temperature),
+        SettingKey::MaxTokens => cfg.max_tokens.map(|n| n.to_string()).unwrap_or_default(),
+        SettingKey::PromptStyle => cfg.prompt_style.clone().unwrap_or_default(),
+        SettingKey::OutputLanguage => cfg.output_language.clone().unwrap_or_default(),
+        SettingKey::AutoSuggest => bool_str(cfg.auto_suggest),
+        SettingKey::InlineCompletion => bool_str(cfg.inline_completion.enabled),
+        SettingKey::InlineDebounceMs => cfg.inline_completion.debounce_ms.to_string(),
+        SettingKey::InlineContextLines => cfg.inline_completion.context_lines.to_string(),
+        SettingKey::InlineMaxTokens => cfg.inline_completion.max_tokens.to_string(),
+        SettingKey::InlineMinInputChars => cfg.inline_completion.min_input_chars.to_string(),
+        SettingKey::InlineTimeoutSecs => cfg.inline_completion.timeout_secs.to_string(),
+        SettingKey::InlineDisableThinking => bool_str(cfg.inline_completion.disable_thinking),
+        SettingKey::InlineEnforceJson => bool_str(cfg.inline_completion.enforce_json),
+        SettingKey::MaxLlmMessages => cfg.max_llm_messages.to_string(),
+        SettingKey::EnableTokenEstimation => bool_str(cfg.enable_token_estimation),
+        SettingKey::InputGuardEnabled => bool_str(cfg.input_guard_enabled),
+        SettingKey::EnableSandbox => bool_str(cfg.enable_sandbox),
+        SettingKey::DefaultRiskLevel => cfg.default_risk_level.clone(),
+        SettingKey::SandboxOffAction => cfg.sandbox_off_action.clone(),
+        SettingKey::SandboxTimeout => format!("{}", cfg.sandbox_timeout_seconds),
+        SettingKey::MemoryAutoRecall => cfg
+            .memory
+            .as_ref()
+            .map(|m| bool_str(m.auto_recall))
+            .unwrap_or_else(|| bool_str(true)),
+        SettingKey::MemoryAutoRetain => cfg
+            .memory
+            .as_ref()
+            .map(|m| bool_str(m.auto_retain))
+            .unwrap_or_else(|| bool_str(true)),
+        SettingKey::ContextAutoCompact => bool_str(cfg.context_auto_compact.enabled),
+        SettingKey::CompactFullEnabled => bool_str(cfg.context_auto_compact.full_compact_enabled),
+        SettingKey::CompactContextWindowTokens => cfg
+            .context_auto_compact
+            .context_window_tokens
+            .map(|n| n.to_string())
+            .unwrap_or_default(),
+        SettingKey::CompactMicroKeepRecent => cfg
+            .context_auto_compact
+            .micro_keep_recent_messages
+            .to_string(),
+        SettingKey::CompactShellKeepRecent => cfg
+            .context_auto_compact
+            .shell_keep_recent_commands
+            .to_string(),
+        SettingKey::CompactSummaryMaxTokens => {
+            cfg.context_auto_compact.summary_max_tokens.to_string()
+        }
+        SettingKey::CompactMaxConsecutiveFailures => cfg
+            .context_auto_compact
+            .max_consecutive_failures
+            .to_string(),
+        SettingKey::CompactReservedOutputTokens => cfg
+            .context_auto_compact
+            .reserved_output_tokens
+            .map(|n| n.to_string())
+            .unwrap_or_default(),
+        SettingKey::HistorySize => cfg.history_size.to_string(),
+        SettingKey::MaxShellMessages => cfg.max_shell_messages.to_string(),
+        SettingKey::ContextTokenBudget => cfg
+            .context_token_budget
+            .map(|n| n.to_string())
+            .unwrap_or_default(),
+        SettingKey::EnableRemoteGitPrompt => bool_str(cfg.enable_remote_git_prompt),
+        SettingKey::RemoteRichPrompt => bool_str(cfg.remote_rich_prompt),
+        SettingKey::RemoteShowVenv => bool_str(cfg.remote_show_venv),
+        SettingKey::RemoteShowContainer => bool_str(cfg.remote_show_container),
+        SettingKey::RemoteShowKube => bool_str(cfg.remote_show_kube),
+        SettingKey::RemoteDangerPatterns => cfg.remote_danger_patterns.join(", "),
+        SettingKey::LogLevel => cfg.log_level.clone(),
+        SettingKey::EnableLangfuse => bool_str(cfg.enable_langfuse),
+        SettingKey::LangfusePublicKey => cfg.langfuse_public_key.clone().unwrap_or_default(),
+        SettingKey::LangfuseSecretKey => cfg.langfuse_secret_key.clone().unwrap_or_default(),
+        SettingKey::LangfuseHost => cfg.langfuse_host.clone().unwrap_or_default(),
+        SettingKey::EnableScripts => bool_str(cfg.enable_scripts),
+        SettingKey::CodexAuthPath => cfg.codex_auth_path.clone().unwrap_or_default(),
+        SettingKey::SessionDbPath => cfg.session_db_path.clone().unwrap_or_default(),
+        SettingKey::PtyDaemonEnabled => bool_str(cfg.pty_daemon_enabled),
+    };
+    // Normalize Choice values to their canonical option so the display and
+    // "current" marker line up even if the stored value differs by case
+    // (e.g. security_policy.yaml merging in "LOW" vs the list's "low").
+    if let SettingKind::Choice(options) = find(key).kind {
+        if let Some(canonical) = options.iter().find(|o| o.eq_ignore_ascii_case(&raw)) {
+            return (*canonical).to_string();
+        }
+    }
+    raw
+}
+
+/// Apply a validated raw string value to the config in place.
+///
+/// `value` is already trimmed by the caller. Empty string clears Option
+/// fields to `None`. Returns `Err(message)` on a parse failure.
+pub fn apply(cfg: &mut ConfigModel, key: SettingKey, value: &str) -> Result<(), String> {
+    // Choice fields must be one of the declared options — reject typos like
+    // `log_level: warb` early so they can't silently disable logging.
+    if let SettingKind::Choice(options) = find(key).kind {
+        if !options.contains(&value) {
+            return Err(format!("expected one of {:?}, got `{value}`", options));
+        }
+    }
+    match key {
+        SettingKey::Model => cfg.model = value.to_string(),
+        SettingKey::ApiBase => cfg.api_base = value.to_string(),
+        SettingKey::ApiKey => cfg.api_key = value.to_string(),
+        SettingKey::Temperature => {
+            cfg.temperature = parse_f32(value, 0.0..=2.0)?;
+        }
+        SettingKey::MaxTokens => {
+            cfg.max_tokens = if value.is_empty() {
+                None
+            } else {
+                Some(parse_u32(value)?)
+            };
+        }
+        SettingKey::PromptStyle => cfg.prompt_style = opt_string(value),
+        SettingKey::OutputLanguage => cfg.output_language = opt_string(value),
+        SettingKey::AutoSuggest => cfg.auto_suggest = parse_bool(value)?,
+        SettingKey::InlineCompletion => cfg.inline_completion.enabled = parse_bool(value)?,
+        SettingKey::InlineDebounceMs => {
+            cfg.inline_completion.debounce_ms = parse_usize(value)? as u64;
+        }
+        SettingKey::InlineContextLines => {
+            cfg.inline_completion.context_lines = parse_usize(value)?;
+        }
+        SettingKey::InlineMaxTokens => {
+            cfg.inline_completion.max_tokens = parse_u32(value)?;
+        }
+        SettingKey::InlineMinInputChars => {
+            cfg.inline_completion.min_input_chars = parse_usize(value)?;
+        }
+        SettingKey::InlineTimeoutSecs => {
+            cfg.inline_completion.timeout_secs = parse_usize(value)? as u64;
+        }
+        SettingKey::InlineDisableThinking => {
+            cfg.inline_completion.disable_thinking = parse_bool(value)?;
+        }
+        SettingKey::InlineEnforceJson => {
+            cfg.inline_completion.enforce_json = parse_bool(value)?;
+        }
+        SettingKey::MaxLlmMessages => cfg.max_llm_messages = parse_usize(value)?,
+        SettingKey::EnableTokenEstimation => cfg.enable_token_estimation = parse_bool(value)?,
+        SettingKey::InputGuardEnabled => cfg.input_guard_enabled = parse_bool(value)?,
+        SettingKey::EnableSandbox => cfg.enable_sandbox = parse_bool(value)?,
+        SettingKey::DefaultRiskLevel => cfg.default_risk_level = value.to_string(),
+        SettingKey::SandboxOffAction => cfg.sandbox_off_action = value.to_string(),
+        SettingKey::SandboxTimeout => cfg.sandbox_timeout_seconds = parse_f64(value, 1.0..=300.0)?,
+        SettingKey::MemoryAutoRecall => {
+            ensure_memory(cfg).auto_recall = parse_bool(value)?;
+        }
+        SettingKey::MemoryAutoRetain => {
+            ensure_memory(cfg).auto_retain = parse_bool(value)?;
+        }
+        SettingKey::ContextAutoCompact => cfg.context_auto_compact.enabled = parse_bool(value)?,
+        SettingKey::HistorySize => cfg.history_size = parse_usize(value)?,
+        SettingKey::CompactFullEnabled => {
+            cfg.context_auto_compact.full_compact_enabled = parse_bool(value)?;
+        }
+        SettingKey::CompactContextWindowTokens => {
+            cfg.context_auto_compact.context_window_tokens = if value.is_empty() {
+                None
+            } else {
+                Some(parse_usize(value)?)
+            };
+        }
+        SettingKey::CompactMicroKeepRecent => {
+            cfg.context_auto_compact.micro_keep_recent_messages = parse_usize(value)?;
+        }
+        SettingKey::CompactShellKeepRecent => {
+            cfg.context_auto_compact.shell_keep_recent_commands = parse_usize(value)?;
+        }
+        SettingKey::CompactSummaryMaxTokens => {
+            cfg.context_auto_compact.summary_max_tokens = parse_usize(value)?;
+        }
+        SettingKey::CompactMaxConsecutiveFailures => {
+            cfg.context_auto_compact.max_consecutive_failures = parse_usize(value)?;
+        }
+        SettingKey::CompactReservedOutputTokens => {
+            cfg.context_auto_compact.reserved_output_tokens = if value.is_empty() {
+                None
+            } else {
+                Some(parse_usize(value)?)
+            };
+        }
+        SettingKey::MaxShellMessages => cfg.max_shell_messages = parse_usize(value)?,
+        SettingKey::ContextTokenBudget => {
+            cfg.context_token_budget = if value.is_empty() {
+                None
+            } else {
+                Some(parse_usize(value)?)
+            };
+        }
+        SettingKey::EnableRemoteGitPrompt => cfg.enable_remote_git_prompt = parse_bool(value)?,
+        SettingKey::RemoteRichPrompt => cfg.remote_rich_prompt = parse_bool(value)?,
+        SettingKey::RemoteShowVenv => cfg.remote_show_venv = parse_bool(value)?,
+        SettingKey::RemoteShowContainer => cfg.remote_show_container = parse_bool(value)?,
+        SettingKey::RemoteShowKube => cfg.remote_show_kube = parse_bool(value)?,
+        SettingKey::RemoteDangerPatterns => {
+            cfg.remote_danger_patterns = value
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+        }
+        SettingKey::LogLevel => cfg.log_level = value.to_string(),
+        SettingKey::EnableLangfuse => cfg.enable_langfuse = parse_bool(value)?,
+        SettingKey::LangfusePublicKey => cfg.langfuse_public_key = opt_string(value),
+        SettingKey::LangfuseSecretKey => cfg.langfuse_secret_key = opt_string(value),
+        SettingKey::LangfuseHost => cfg.langfuse_host = opt_string(value),
+        SettingKey::EnableScripts => cfg.enable_scripts = parse_bool(value)?,
+        SettingKey::PtyDaemonEnabled => cfg.pty_daemon_enabled = parse_bool(value)?,
+        SettingKey::CodexAuthPath => cfg.codex_auth_path = opt_string(value),
+        SettingKey::SessionDbPath => cfg.session_db_path = opt_string(value),
+    }
+    Ok(())
+}
+
+/// What live side-effect the shell must run after `key` changes.
+pub fn live_effect(key: SettingKey) -> LiveEffect {
+    match key {
+        SettingKey::Model | SettingKey::ApiBase | SettingKey::ApiKey => LiveEffect::ModelSession,
+        SettingKey::Temperature | SettingKey::MaxTokens => LiveEffect::ToolsRefresh,
+        SettingKey::InputGuardEnabled => LiveEffect::InputGuard,
+        _ => LiveEffect::None,
+    }
+}
+
+/// Whether the running session must be restarted for `key`'s new value to take
+/// effect. The model/credential fields are applied live via `update_model`,
+/// temperature/max_tokens rebuild tools live, `input_guard_enabled` toggles the
+/// cached InputGuard live, and `prompt_style` is read from `self.config` on
+/// each render — everything else is consumed only at startup.
+pub fn requires_restart(key: SettingKey) -> bool {
+    match key {
+        SettingKey::Model
+        | SettingKey::ApiBase
+        | SettingKey::ApiKey
+        | SettingKey::Temperature
+        | SettingKey::MaxTokens
+        | SettingKey::InputGuardEnabled
+        | SettingKey::PromptStyle => false,
+        _ => true,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn bool_str(b: bool) -> String {
+    if b {
+        "true".to_string()
+    } else {
+        "false".to_string()
+    }
+}
+
+fn opt_string(value: &str) -> Option<String> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+/// Lazily initialize the nullable memory sub-config so its fields can be edited.
+fn ensure_memory(cfg: &mut ConfigModel) -> &mut aish_config::MemoryConfig {
+    cfg.memory.get_or_insert_with(Default::default)
+}
+
+fn parse_bool(value: &str) -> Result<bool, String> {
+    match value.to_ascii_lowercase().as_str() {
+        "true" | "on" | "1" | "yes" | "y" => Ok(true),
+        "false" | "off" | "0" | "no" | "n" => Ok(false),
+        other => Err(format!("expected on/off, got `{other}`")),
+    }
+}
+
+fn parse_f32(value: &str, range: std::ops::RangeInclusive<f32>) -> Result<f32, String> {
+    let n: f32 = value
+        .parse()
+        .map_err(|_| format!("expected a number, got `{value}`"))?;
+    if !range.contains(&n) {
+        return Err(format!(
+            "{} is out of range {}..={}",
+            n,
+            range.start(),
+            range.end()
+        ));
+    }
+    Ok(n)
+}
+
+fn parse_f64(value: &str, range: std::ops::RangeInclusive<f64>) -> Result<f64, String> {
+    let n: f64 = value
+        .parse()
+        .map_err(|_| format!("expected a number, got `{value}`"))?;
+    if !range.contains(&n) {
+        return Err(format!(
+            "{} is out of range {}..={}",
+            n,
+            range.start(),
+            range.end()
+        ));
+    }
+    Ok(n)
+}
+
+fn parse_u32(value: &str) -> Result<u32, String> {
+    value
+        .parse::<u32>()
+        .map_err(|_| format!("expected a non-negative integer, got `{value}`"))
+}
+
+fn parse_usize(value: &str) -> Result<usize, String> {
+    value
+        .parse::<usize>()
+        .map_err(|_| format!("expected a non-negative integer, got `{value}`"))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_cfg() -> ConfigModel {
+        ConfigModel::default()
+    }
+
+    #[test]
+    fn catalog_is_nonempty_and_covers_all_categories() {
+        assert!(SETTINGS.len() >= 15, "catalog should be curated");
+        for cat in SettingCategory::ALL {
+            assert!(
+                entries_for(*cat).count() > 0,
+                "category {:?} has no entries",
+                cat
+            );
+        }
+    }
+
+    #[test]
+    fn each_key_resolves_to_a_definition() {
+        // Every SettingKey variant must map to exactly one catalog entry.
+        let all_keys = [
+            SettingKey::Model,
+            SettingKey::ApiBase,
+            SettingKey::ApiKey,
+            SettingKey::Temperature,
+            SettingKey::MaxTokens,
+            SettingKey::PromptStyle,
+            SettingKey::OutputLanguage,
+            SettingKey::AutoSuggest,
+            SettingKey::InlineCompletion,
+            SettingKey::InlineDebounceMs,
+            SettingKey::InlineContextLines,
+            SettingKey::InlineMaxTokens,
+            SettingKey::InlineMinInputChars,
+            SettingKey::InlineTimeoutSecs,
+            SettingKey::InlineDisableThinking,
+            SettingKey::InlineEnforceJson,
+            SettingKey::MaxLlmMessages,
+            SettingKey::EnableTokenEstimation,
+            SettingKey::InputGuardEnabled,
+            SettingKey::EnableSandbox,
+            SettingKey::DefaultRiskLevel,
+            SettingKey::SandboxOffAction,
+            SettingKey::SandboxTimeout,
+            SettingKey::MemoryAutoRecall,
+            SettingKey::MemoryAutoRetain,
+            SettingKey::ContextAutoCompact,
+            SettingKey::CompactFullEnabled,
+            SettingKey::CompactContextWindowTokens,
+            SettingKey::CompactMicroKeepRecent,
+            SettingKey::CompactShellKeepRecent,
+            SettingKey::CompactSummaryMaxTokens,
+            SettingKey::CompactMaxConsecutiveFailures,
+            SettingKey::CompactReservedOutputTokens,
+            SettingKey::HistorySize,
+            SettingKey::MaxShellMessages,
+            SettingKey::ContextTokenBudget,
+            SettingKey::EnableRemoteGitPrompt,
+            SettingKey::RemoteRichPrompt,
+            SettingKey::RemoteShowVenv,
+            SettingKey::RemoteShowContainer,
+            SettingKey::RemoteShowKube,
+            SettingKey::RemoteDangerPatterns,
+            SettingKey::LogLevel,
+            SettingKey::EnableLangfuse,
+            SettingKey::LangfusePublicKey,
+            SettingKey::LangfuseSecretKey,
+            SettingKey::LangfuseHost,
+            SettingKey::EnableScripts,
+            SettingKey::PtyDaemonEnabled,
+            SettingKey::CodexAuthPath,
+            SettingKey::SessionDbPath,
+        ];
+        assert_eq!(all_keys.len(), SETTINGS.len());
+        for k in all_keys {
+            assert_eq!(find(k).key, k);
+        }
+    }
+
+    #[test]
+    fn choice_current_value_is_case_normalized() {
+        // A stored uppercase value (e.g. merged from security_policy.yaml)
+        // must display as the canonical lowercase option so the "current"
+        // marker and list value line up.
+        let mut cfg = default_cfg();
+        cfg.default_risk_level = "LOW".into();
+        assert_eq!(current_raw(&cfg, SettingKey::DefaultRiskLevel), "low");
+        cfg.log_level = "DEBUG".into();
+        assert_eq!(current_raw(&cfg, SettingKey::LogLevel), "debug");
+        // A value outside the option set is passed through unchanged.
+        cfg.sandbox_off_action = "weird".into();
+        assert_eq!(current_raw(&cfg, SettingKey::SandboxOffAction), "weird");
+    }
+
+    #[test]
+    fn roundtrip_bool_toggle() {
+        let mut cfg = default_cfg();
+        assert_eq!(current_raw(&cfg, SettingKey::InputGuardEnabled), "true");
+        apply(&mut cfg, SettingKey::InputGuardEnabled, "off").unwrap();
+        assert!(!cfg.input_guard_enabled);
+        assert_eq!(current_raw(&cfg, SettingKey::InputGuardEnabled), "false");
+    }
+
+    #[test]
+    fn temperature_rejects_out_of_range() {
+        let mut cfg = default_cfg();
+        assert!(apply(&mut cfg, SettingKey::Temperature, "3.0").is_err());
+        apply(&mut cfg, SettingKey::Temperature, "0.8").unwrap();
+        assert!((cfg.temperature - 0.8).abs() < 1e-6);
+    }
+
+    #[test]
+    fn choice_rejects_unknown_value() {
+        // Typos must be rejected so they can't silently disable logging or
+        // mis-grade security risk.
+        let mut cfg = default_cfg();
+        assert!(apply(&mut cfg, SettingKey::LogLevel, "warb").is_err());
+        assert!(apply(&mut cfg, SettingKey::DefaultRiskLevel, "banana").is_err());
+        // Valid values pass through.
+        apply(&mut cfg, SettingKey::LogLevel, "debug").unwrap();
+        assert_eq!(cfg.log_level, "debug");
+        apply(&mut cfg, SettingKey::DefaultRiskLevel, "high").unwrap();
+        assert_eq!(cfg.default_risk_level, "high");
+    }
+
+    #[test]
+    fn requires_restart_classification() {
+        // Live settings must not claim a restart is needed.
+        assert!(!requires_restart(SettingKey::Model));
+        assert!(!requires_restart(SettingKey::InputGuardEnabled));
+        assert!(!requires_restart(SettingKey::PromptStyle));
+        // Startup-only settings do require a restart.
+        assert!(requires_restart(SettingKey::LogLevel));
+        assert!(requires_restart(SettingKey::EnableSandbox));
+        assert!(requires_restart(SettingKey::HistorySize));
+    }
+
+    #[test]
+    fn max_tokens_clears_on_empty() {
+        let mut cfg = default_cfg();
+        apply(&mut cfg, SettingKey::MaxTokens, "4096").unwrap();
+        assert_eq!(cfg.max_tokens, Some(4096));
+        apply(&mut cfg, SettingKey::MaxTokens, "").unwrap();
+        assert_eq!(cfg.max_tokens, None);
+    }
+
+    #[test]
+    fn memory_fields_lazy_init() {
+        let mut cfg = default_cfg();
+        assert!(cfg.memory.is_none());
+        apply(&mut cfg, SettingKey::MemoryAutoRecall, "false").unwrap();
+        let m = cfg.memory.as_ref().expect("memory initialized");
+        assert!(!m.auto_recall);
+    }
+
+    #[test]
+    fn nested_inline_completion_toggle() {
+        let mut cfg = default_cfg();
+        assert!(!cfg.inline_completion.enabled);
+        apply(&mut cfg, SettingKey::InlineCompletion, "on").unwrap();
+        assert!(cfg.inline_completion.enabled);
+    }
+
+    #[test]
+    fn model_fields_signal_session_refresh() {
+        assert_eq!(live_effect(SettingKey::Model), LiveEffect::ModelSession);
+        assert_eq!(live_effect(SettingKey::ApiKey), LiveEffect::ModelSession);
+        assert_eq!(
+            live_effect(SettingKey::Temperature),
+            LiveEffect::ToolsRefresh
+        );
+        assert_eq!(
+            live_effect(SettingKey::InputGuardEnabled),
+            LiveEffect::InputGuard
+        );
+    }
+}

--- a/crates/aish-shell/tests/slash_popup_commands.rs
+++ b/crates/aish-shell/tests/slash_popup_commands.rs
@@ -30,7 +30,7 @@ fn each_builtin_command_enter_executes() {
 
 #[test]
 fn slash_commands_table_has_expected_count() {
-    assert_eq!(SLASH_COMMANDS.len(), 15);
+    assert_eq!(SLASH_COMMANDS.len(), 16);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds an interactive `/setting` command that lets users view and edit the commonly-tweaked subset of `config.yaml` through a categorized panel, instead of hand-editing the 50+ field file.

Closes #360.

## What's included

**New module `crates/aish-shell/src/settings_panel.rs`** — I/O-free and unit-testable:
- Curates **31 settings** across **7 categories** (Model & Provider, Appearance, AI Behavior, Security, Context & Memory, Remote Prompt, Advanced).
- Each entry carries an i18n label + one-line description and a typed value kind (`Bool`, `Choice`, `Text`, `Float`, `Int`, `Secret`, `StringList`).
- `apply()` validates and writes to `ConfigModel`; `live_effect()` signals what the shell must do after a change (`ModelSession` / `ToolsRefresh` / `None`); `requires_restart()` flags restart-only fields.

**`app.rs`** — two-level interactive loop (category → setting → edit) plus a cross-catalog fuzzy **search panel** (type to filter across all 31 settings by name/desc/category). Edits:
- validate against a config **clone** before committing (bad values re-prompt in place, never corrupt the live config),
- persist to disk,
- run the right **live side-effect** (rebuild model-dependent tools, swap model/credentials) so most changes take effect immediately without restart,
- surface a restart-needed summary on exit.

**Supporting changes**
- `readline`: register `/setting` slash command; gate history autosuggest behind `config.auto_suggest`; honor `config.history_size`.
- `prompt`: render a custom `config.prompt_style` symbol.
- `ai_handler`: honor `config.output_language` for AI responses, with friendly name mapping (`zh` → Chinese, `ja` → Japanese, …).
- `cli/main`: early-load `config.log_level` for logging init.
- `app` init: mirror `config.enable_sandbox` / `default_risk_level` / `sandbox_off_action` / `sandbox_timeout_seconds` into the security policy, so they are editable from `/setting` too.
- `i18n`: add `shell.setting.*` keys to all 6 locales (en-US, zh-CN, ja-JP, de-DE, fr-FR, es-ES).

## Verification

- `cargo build -p aish-shell -p aish-cli` — clean
- `cargo clippy -p aish-shell -p aish-cli` — no warnings
- `cargo test -p aish-shell --lib settings_panel` — **11/11 pass**
- `cargo test -p aish-shell --lib prompt::` — **29/29 pass**
- `cargo test -p aish-i18n` — **14/14 pass**

## Test plan

- [ ] `/setting` opens the category menu; Esc exits cleanly at every level.
- [ ] Picking a category lists its settings with current values; Bool shows on/off, Secret is masked.
- [ ] Editing a Bool/Choice via selection; editing Text/Int/Float/Secret/StringList via prompt.
- [ ] Invalid value (e.g. temperature out of range) re-prompts instead of dropping back to the list.
- [ ] Changing `model` / `api_base` / `api_key` takes effect live (like `/model`); changing `temperature` / `max_tokens` rebuilds tools live.
- [ ] Restart-only changes print the `(takes effect after restart)` hint and a final summary count.
- [ ] Search entry (`__search__`) filters across all categories and reopens on the last-edited row.
- [ ] `config.output_language` is honored by AI responses; `config.prompt_style` renders a custom symbol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive `/setting` panel to browse, search, validate, and save configuration changes (with secret masking), including live updates and a restart-required summary.
  * Added output-language override and friendlier language name handling.
  * Enhanced the shell experience with configurable readline history size, optional auto-suggestions, and prompt-style override support.
* **Localization**
  * Added `/setting` UI/help translations for English, German, Spanish, French, Japanese, and Chinese.
* **Bug Fixes**
  * Improved logging level selection and expanded sandbox-related configuration handling; disabled script/plugin loading when scripting is turned off.
* **Tests**
  * Updated tests for new slash commands and prompt rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->