### PR TITLE
fix(wizard): create config dir before first-run save

### DIFF
--- a/crates/aish-config/src/loader.rs
+++ b/crates/aish-config/src/loader.rs
@@ -343,4 +343,22 @@ mod tests {
             None => std::env::remove_var("AISH_CODEX_AUTH_PATH"),
         }
     }
+    #[test]
+    fn save_creates_missing_parent_directory() {
+        // Regression for first-run setup wizard: when ~/.config/aish/ does
+        // not yet exist, ConfigLoader::save must create it rather than fail
+        // with ENOENT/EACCES. The setup wizard previously called
+        // std::fs::write directly and hit this bug.
+        let dir = tempfile::tempdir().unwrap();
+        // Parent dir does not exist yet — the nested aish/ folder.
+        let path = dir.path().join("aish").join("config.yaml");
+        assert!(!path.parent().unwrap().exists());
+
+        let config = ConfigModel::default();
+        ConfigLoader::save(&config, &path).unwrap();
+
+        assert!(path.exists(), "config file should have been created");
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert!(on_disk.contains("model:"));
+    }
 }

--- a/crates/aish-shell/src/wizard/mod.rs
+++ b/crates/aish-shell/src/wizard/mod.rs
@@ -1196,13 +1196,11 @@ impl SetupWizard {
             .as_ref()
             .map(|path| path.display().to_string());
 
-        // Save to config file.
+        // Save to config file. ConfigLoader::save ensures the parent
+        // directory exists (first-run case where ~/.config/aish/ does
+        // not yet exist) and reports the path in the error message.
         let config_path = self.config_dir.join("config.yaml");
-        let yaml_content = serde_yaml::to_string(&config)
-            .map_err(|e| AishError::Config(format!("Failed to serialize config: {}", e)))?;
-
-        std::fs::write(&config_path, yaml_content)
-            .map_err(|e| AishError::Config(format!("Failed to write config: {}", e)))?;
+        aish_config::ConfigLoader::save(&config, &config_path)?;
 
         let path = format_config_path(&config_path);
         let mut args = std::collections::HashMap::new();


### PR DESCRIPTION
## Summary

On first run, `aish setup` (and `/setup`) failed to persist the configuration after the user successfully verified a provider, API base, and model. The save step errored with a missing-folder / permission-denied message and the verified config was lost.

Fixes #364

## Root cause

`SetupWizard::save_config` wrote the config via `std::fs::write(&config_path, ...)` directly, bypassing `aish_config::ConfigLoader::save`. On a fresh install `~/.config/aish/` does not yet exist and `std::fs::write` does not create parent directories, so the write failed with `ENOENT` (or `EACCES` when `~/.config/` has restrictive permissions).

`ConfigLoader::save` already handles this correctly (`create_dir_all(parent)` before writing) and reports the path in the error message — the wizard just didn't use it.

## Changes

- `crates/aish-shell/src/wizard/mod.rs`: `save_config` now calls `ConfigLoader::save` instead of re-implementing serialize + `std::fs::write`. This gets parent-dir creation, consistent error messages, and a single save path.
- `crates/aish-config/src/loader.rs`: add regression test `save_creates_missing_parent_directory` asserting `save` succeeds when the parent directory is absent (the first-run scenario).

## Verification

- `cargo check -p aish-shell -p aish-config`
- `cargo test -p aish-config --lib` — 31 passed (incl. new regression test)
- `cargo clippy -p aish-shell -p aish-config --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

## Checklist

- [x] Code comments in English
- [x] No exhaustive command-based fix
- [x] Regression test covers the first-run save path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration saving during setup by automatically creating missing parent directories.
  * Configuration save errors now use consistent handling and reporting.

* **Tests**
  * Added coverage verifying configurations are saved successfully to new nested paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->