### PR TITLE
feat(shell): redesign /setting as flat single-panel UI

### DIFF
--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -314,6 +314,8 @@ shell:
     search_desc: "Per Stichwort zu jeder Einstellung in allen Kategorien springen"
     search_title: "Einstellungen suchen"
     search_placeholder: "Tippen zum Filtern (Name / Beschreibung / Kategorie)"
+    footer_idle: "↑↓ bewegen · ←/→ Kategorie · Space/Enter bearbeiten · Ctrl+R zurücksetzen · Esc beenden"
+    footer_editing: "Enter anwenden · Esc abbrechen"
     search_footer: "↑/↓ bewegen · Tippen filtert · Enter bearbeiten · Esc zurück"
     search_empty: "Keine passenden Einstellungen"
     restart_summary: "{count} Änderung(en) werden nach Neustart wirksam"

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -678,6 +678,8 @@ shell:
     search_desc: "Jump to any setting by keyword across all categories"
     search_title: "Search settings"
     search_placeholder: "Type to filter (name / description / category)"
+    footer_idle: "↑↓ move · ←/→ category · Space/Enter edit · Ctrl+R reset · Esc exit"
+    footer_editing: "Enter apply · Esc cancel"
     search_footer: "Up/Down move  Type to filter  Enter edit  Esc back"
     search_empty: "No matching settings"
     restart_summary: "{count} change(s) will take effect after restart"

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -314,6 +314,8 @@ shell:
     search_desc: "Salta a cualquier ajuste por palabra clave en todas las categorías"
     search_title: "Buscar ajustes"
     search_placeholder: "Escribe para filtrar (nombre / descripción / categoría)"
+    footer_idle: "↑↓ mover · ←/→ categoría · Space/Enter editar · Ctrl+R restablecer · Esc salir"
+    footer_editing: "Enter aplicar · Esc cancelar"
     search_footer: "↑/↓ mover  Escribe para filtrar  Enter editar  Esc volver"
     search_empty: "No hay ajustes coincidentes"
     restart_summary: "{count} cambio(s) se aplicarán tras reiniciar"

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -314,6 +314,8 @@ shell:
     search_desc: "Accéder à n'importe quel paramètre par mot-clé dans toutes les catégories"
     search_title: "Rechercher un paramètre"
     search_placeholder: "Tapez pour filtrer (nom / description / catégorie)"
+    footer_idle: "↑↓ naviguer · ←/→ catégorie · Space/Enter modifier · Ctrl+R réinitialiser · Esc quitter"
+    footer_editing: "Enter appliquer · Esc annuler"
     search_footer: "↑/↓ naviguer  Tapez pour filtrer  Enter modifier  Esc retour"
     search_empty: "Aucun paramètre correspondant"
     restart_summary: "{count} modification(s) prendront effet après le redémarrage"

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -314,6 +314,8 @@ shell:
     search_desc: "すべてのカテゴリーからキーワードで設定にジャンプ"
     search_title: "設定を検索"
     search_placeholder: "入力して絞り込み（名前 / 説明 / カテゴリー）"
+    footer_idle: "↑↓ 移動 · ←/→ カテゴリ · Space/Enter 編集 · Ctrl+R リセット · Esc 終了"
+    footer_editing: "Enter 適用 · Esc キャンセル"
     search_footer: "↑/↓ 移動  入力で絞り込み  Enter で編集  Esc で戻る"
     search_empty: "一致する設定はありません"
     restart_summary: "{count} 件の変更は再起動後に反映されます"

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -678,6 +678,8 @@ shell:
     search_desc: "按关键字跨分类跳转到任意设置"
     search_title: "搜索设置"
     search_placeholder: "输入关键字过滤（名称 / 描述 / 分类）"
+    footer_idle: "↑↓ 移动 · ←/→ 切分类 · 空格/Enter 编辑 · Ctrl+R 重置 · Esc 退出"
+    footer_editing: "Enter 应用 · Esc 取消"
     search_footer: "↑↓ 移动  输入即过滤  Enter 编辑  Esc 返回"
     search_empty: "没有匹配的设置"
     restart_summary: "共有 {count} 项改动将在重启后生效"

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -193,14 +193,22 @@ fn mask_secret(s: &str) -> String {
     format!("{head}{}{tail}", "*".repeat(n - 4))
 }
 
-/// Normalize a dialog outcome into a trimmed value, or None when cancelled.
-fn dialog_value(result: crate::tui::DialogResult) -> Option<String> {
-    match result {
-        crate::tui::DialogResult::Selected(v) => Some(v),
-        crate::tui::DialogResult::CustomInput(v) => Some(v.trim().to_string()),
-        crate::tui::DialogResult::Cancelled => None,
+/// Accent color per setting category — used by the chips and row icons in
+/// the new `/setting` panel.
+fn category_color_for(c: crate::settings_panel::SettingCategory) -> ratatui::style::Color {
+    use crate::settings_panel::SettingCategory;
+    use ratatui::style::Color;
+    match c {
+        SettingCategory::Model => Color::Cyan,
+        SettingCategory::Appearance => Color::Magenta,
+        SettingCategory::Ai => Color::LightGreen,
+        SettingCategory::Security => Color::LightRed,
+        SettingCategory::Context => Color::LightBlue,
+        SettingCategory::Remote => Color::LightMagenta,
+        SettingCategory::Advanced => Color::Gray,
     }
 }
+
 
 /// Free-text/number editor for a single setting value.
 ///
@@ -4135,61 +4143,106 @@ impl AishShell {
         println!("{}", t_with_args("shell.model.switch_success", &args));
     }
 
-    /// Handle `/setting` — interactive categorized settings panel.
+    /// Handle `/setting` — single-screen settings panel.
     ///
-    /// Two-level loop: pick a category → pick a setting → edit its value →
-    /// apply + persist + run live side-effects. Esc at any level backs out;
-    /// Esc at the category level exits the panel. Model/credentials changes
-    /// are applied to the running LLM session immediately (like `/model`).
+    /// Flat layout: category chips on top, type-to-filter list, inline edit
+    /// for Bool/Choice (Space toggle, `<`/`>` step, Enter cycle), and Enter
+    /// on Text/Int/Float/Secret/StringList pops a one-shot external editor
+    /// then returns to the panel at the same row. Esc exits; Ctrl+R resets
+    /// the highlighted row to factory default.
     fn handle_setting_command(&mut self) {
-        use crate::settings_panel::{entries_for, SettingCategory, SettingDef};
-        use crate::tui::{show_selection_dialog, DialogOption, DialogResult};
+        use crate::settings_panel::{self, SettingKind};
+        use aish_ui::{PanelOutcome, PanelRuntime, SettingsOutcome, SettingsPanel};
 
         // Count of restart-required edits this session, for an exit summary.
         let mut restart_changes: usize = 0;
+        let mut last_key: Option<String> = None;
+        let mut pending_error: Option<String> = None;
 
-        // ----- level 1: category loop -------------------------------------
         loop {
-            // A leading "search" row lets users jump across all 31 settings
-            // by keyword instead of knowing the category.
-            let mut cat_opts: Vec<DialogOption> =
-                Vec::with_capacity(SettingCategory::ALL.len() + 1);
-            cat_opts.push(
-                DialogOption::new("__search__", t("shell.setting.search_entry"))
-                    .with_description(t("shell.setting.search_desc")),
-            );
-            for &c in SettingCategory::ALL {
-                let label = t(&format!("shell.setting.cat.{}", c.name()));
-                let desc = t(&format!("shell.setting.cat_desc.{}", c.name()));
-                let count = entries_for(c).count();
-                cat_opts.push(
-                    DialogOption::new(c.name(), format!("{}  ({})", label, count))
-                        .with_description(desc),
-                );
-            }
+            // Rebuild items every iteration so values refresh after each edit
+            // (the cursor is restored to `last_key` via with_selected_key).
+            let (cats, items) = Self::build_settings_items(&self.config);
+            let panel = SettingsPanel::new(
+                t("shell.setting.title").to_string(),
+                cats,
+                items,
+            )
+            .with_search_placeholder(t("shell.setting.search_placeholder"))
+            .with_footer_idle(t("shell.setting.footer_idle"))
+            .with_footer_editing(t("shell.setting.footer_editing"))
+            .with_selected_key(last_key.as_deref())
+            .with_error(pending_error.clone());
 
-            let title = t("shell.setting.title");
-            let subtitle = t("shell.setting.subtitle");
-            let sel = match show_selection_dialog(&title, &subtitle, &cat_opts, false, true) {
-                DialogResult::Selected(name) => name,
-                _ => break, // Esc / Ctrl+C → exit panel
+            let outcome = {
+                let _guard = aish_tools::bash::acquire_interactive_input_guard();
+                PanelRuntime::new().run(panel)
             };
 
-            if sel == "__search__" {
-                self.setting_search_session(&mut restart_changes);
-                continue;
+            match outcome {
+                Ok(PanelOutcome::Submitted(SettingsOutcome::Applied { key, value })) => {
+                    let Some(k) = Self::resolve_setting_key(&key) else {
+                        continue;
+                    };
+                    last_key = Some(key);
+                    if let Err(e) = self.apply_setting_value(k, &value, &mut restart_changes) {
+                        pending_error = Some(t_with_args("shell.setting.invalid", &{
+                            let mut a = std::collections::HashMap::new();
+                            a.insert("error".to_string(), e);
+                            a
+                        }));
+                    }
+                }
+                Ok(PanelOutcome::Submitted(SettingsOutcome::Reset { key })) => {
+                    let Some(k) = Self::resolve_setting_key(&key) else {
+                        continue;
+                    };
+                    let default_val = settings_panel::default_raw_of(k);
+                    if let Err(e) = self.apply_setting_value(k, &default_val, &mut restart_changes)
+                    {
+                        pending_error = Some(t_with_args("shell.setting.invalid", &{
+                            let mut a = std::collections::HashMap::new();
+                            a.insert("error".to_string(), e);
+                            a
+                        }));
+                    }
+                    last_key = Some(key);
+                }
+                Ok(PanelOutcome::Submitted(SettingsOutcome::RequestExternalEdit { key })) => {
+                    let Some(k) = Self::resolve_setting_key(&key) else {
+                        continue;
+                    };
+                    last_key = Some(key.clone());
+                    let def = settings_panel::find(k);
+                    let label = setting_label(def);
+                    let desc = setting_desc(def);
+                    let cur_raw = settings_panel::current_raw(&self.config, k);
+                    let secret = matches!(def.kind, SettingKind::Secret);
+                    // Pop a single external input; we return to the panel
+                    // afterwards regardless of outcome.
+                    // Empty submission on a Secret prompt is a no-op (skip),
+                    // not a wipe — mirrors the legacy edit_setting_value guard.
+                    let submitted = prompt_edit_value(&label, &desc, &cur_raw, secret);
+                    let skip = secret && submitted.as_deref().is_some_and(|v| v.is_empty());
+                    if let Some(v) = submitted {
+                        if skip {
+                            // Preserve cursor on this row, do not commit.
+                        } else if let Err(e) =
+                            self.apply_setting_value(k, &v, &mut restart_changes)
+                        {
+                            pending_error = Some(t_with_args("shell.setting.invalid", &{
+                                let mut a = std::collections::HashMap::new();
+                                a.insert("error".to_string(), e);
+                                a
+                            }));
+                        }
+                    }
+                }
+                _ => break, // Cancelled / Esc at top level / Ctrl+Q
             }
-
-            let category = match SettingCategory::ALL.iter().find(|c| c.name() == sel) {
-                Some(&c) => c,
-                None => continue,
-            };
-            let defs: Vec<&'static SettingDef> = entries_for(category).collect();
-            let list_title = t(&format!("shell.setting.cat.{}", category.name()));
-            self.setting_list_session(defs, &list_title, &mut restart_changes);
         }
 
-        // Exit summary: surface how many changes need a restart (P1-6).
+        // Exit summary: surface how many changes need a restart.
         if restart_changes > 0 {
             println!(
                 "{}",
@@ -4202,259 +4255,158 @@ impl AishShell {
         }
     }
 
-    /// Live-filter search across the whole catalog in a single
-    /// command-palette panel: type to filter, arrows to move, Enter to edit,
-    /// Esc to return. After each edit the panel re-opens with refreshed
-    /// current values — no need to re-navigate categories.
-    fn setting_search_session(&mut self, restart_changes: &mut usize) {
+    /// Resolve a settings-panel item key back to its `SettingKey`.
+    /// Returns `None` if the catalog was mutated out-of-band (defensive).
+    fn resolve_setting_key(name: &str) -> Option<crate::settings_panel::SettingKey> {
         use crate::settings_panel::SETTINGS;
-        use aish_ui::{
-            PanelOutcome, PanelRuntime, SearchSelectItem, SearchSelectOutcome, SearchSelectPanel,
+        SETTINGS.iter().find(|d| d.key.name() == name).map(|d| d.key)
+    }
+
+    /// Apply `new_val` to `key`: validate, persist, run live side-effects,
+    /// emit a confirmation line. On validation failure returns `Err(msg)`
+    /// so the caller can surface it in the panel without losing the cursor.
+    fn apply_setting_value(
+        &mut self,
+        key: crate::settings_panel::SettingKey,
+        new_val: &str,
+        restart_changes: &mut usize,
+    ) -> Result<(), String> {
+        use crate::settings_panel::{self, LiveEffect, SettingKind};
+
+        // Validate against a clone so a bad value can't partially mutate
+        // the live config; only commit on success.
+        let mut trial = self.config.clone();
+        settings_panel::apply(&mut trial, key, new_val)?;
+        self.config = trial;
+
+        // Persist to disk.
+        let config_path = aish_config::ConfigLoader::default_config_path();
+        if let Err(e) = aish_config::ConfigLoader::save(&self.config, &config_path) {
+            eprintln!(
+                "{}",
+                theme::warning(&{
+                    let mut a = std::collections::HashMap::new();
+                    a.insert("error".to_string(), e.to_string());
+                    t_with_args("shell.config_save_warning", &a)
+                })
+            );
+        }
+
+        // Live side-effects so the change is felt without restart.
+        match settings_panel::live_effect(key) {
+            LiveEffect::ModelSession => {
+                self.ai_handler.update_model(
+                    &self.config.model,
+                    Some(&self.config.api_base),
+                    Some(&self.config.api_key),
+                );
+                if let Some(ai) = &self.inline_ai {
+                    ai.update_model(&self.config.model);
+                }
+                self.refresh_config_dependent_tools();
+            }
+            LiveEffect::ToolsRefresh => self.refresh_config_dependent_tools(),
+            LiveEffect::InputGuard => {
+                self.input_guard
+                    .set_enabled(self.config.input_guard_enabled);
+            }
+            LiveEffect::None => {}
+        }
+
+        // Confirmation line below the panel.
+        let def = settings_panel::find(key);
+        let label = setting_label(def);
+        if new_val.is_empty() {
+            println!(
+                "{}",
+                theme::success(&t_with_args("shell.setting.applied_clear", &{
+                    let mut a = std::collections::HashMap::new();
+                    a.insert("label".to_string(), label);
+                    a
+                }))
+            );
+        } else {
+            let shown = if matches!(def.kind, SettingKind::Secret) {
+                mask_secret(new_val)
+            } else {
+                new_val.to_string()
+            };
+            println!(
+                "{}",
+                theme::success(&t_with_args("shell.setting.applied", &{
+                    let mut a = std::collections::HashMap::new();
+                    a.insert("label".to_string(), label);
+                    a.insert("value".to_string(), shown);
+                    a
+                }))
+            );
+        }
+        if settings_panel::requires_restart(key) {
+            println!("{}", theme::faint(&t("shell.setting.restart_hint")));
+            *restart_changes += 1;
+        }
+        Ok(())
+    }
+
+    /// Build the panel data from the live config. Pure function so it stays
+    /// easy to test and avoids borrow conflicts against `self`.
+    fn build_settings_items(
+        config: &ConfigModel,
+    ) -> (Vec<aish_ui::SettingsCategoryInfo>, Vec<aish_ui::SettingsItem>) {
+        use crate::settings_panel::{self, SettingCategory, SettingKind, SETTINGS};
+        use aish_ui::{SettingsCategoryInfo, SettingsItem, SettingsValueKind};
+
+        let cats: Vec<SettingsCategoryInfo> = SettingCategory::ALL
+            .iter()
+            .map(|&c| SettingsCategoryInfo {
+                label: t(&format!("shell.setting.cat.{}", c.name())).to_string(),
+                icon: c.icon().to_string(),
+                color: category_color_for(c),
+            })
+            .collect();
+
+        let cat_index_of = |c: SettingCategory| {
+            SettingCategory::ALL
+                .iter()
+                .position(|&x| x == c)
+                .unwrap_or(0)
         };
 
-        // Last-edited setting's key — restored as the cursor position when
-        // the panel reopens after an edit, so the user lands back on it.
-        let mut last_edited: Option<String> = None;
-        loop {
-            let items: Vec<SearchSelectItem> = SETTINGS
-                .iter()
-                .map(|def| {
-                    let label = setting_label(def);
-                    let cur = setting_display_current(&self.config, def);
-                    let cat = t(&format!("shell.setting.cat.{}", def.category.name()));
-                    let desc = setting_desc(def);
-                    let search_text = format!("{} {} {} {}", label, desc, def.key.name(), cat);
-                    SearchSelectItem::new(def.key.name(), format!("{}  [{}]", label, cur))
-                        .with_detail(format!("[{}] {}", cat, desc))
-                        .with_search_text(search_text)
-                })
-                .collect();
-
-            // Scope the input guard to the panel run only; edit_one_setting's
-            // own prompts acquire their own guard.
-            let outcome = {
-                let _guard = aish_tools::bash::acquire_interactive_input_guard();
-                let mut panel = SearchSelectPanel::new(
-                    t("shell.setting.search_title").to_string(),
-                    t("shell.setting.search_placeholder").to_string(),
-                    items,
-                )
-                .with_footer(t("shell.setting.search_footer").to_string())
-                .with_empty_message(t("shell.setting.search_empty").to_string());
-                if let Some(k) = &last_edited {
-                    panel = panel.with_selected_value(Some(k));
-                }
-                PanelRuntime::new().run(panel)
-            };
-
-            match outcome {
-                Ok(PanelOutcome::Submitted(SearchSelectOutcome::Selected(key_name))) => {
-                    let def = match SETTINGS.iter().find(|d| d.key.name() == key_name) {
-                        Some(d) => d,
-                        None => continue,
-                    };
-                    self.edit_one_setting(def, restart_changes);
-                    last_edited = Some(key_name);
-                }
-                _ => return, // Esc / Ctrl+C / Ctrl+Q → back to category menu
-            }
-        }
-    }
-    /// Show a category's settings and let the user edit any of them repeatedly.
-    /// Esc returns to the caller (category menu).
-    fn setting_list_session(
-        &mut self,
-        defs: Vec<&'static crate::settings_panel::SettingDef>,
-        title: &str,
-        restart_changes: &mut usize,
-    ) {
-        use crate::tui::{show_selection_dialog, DialogOption, DialogResult};
-        loop {
-            let opts: Vec<DialogOption> = defs
-                .iter()
-                .map(|def| {
-                    let label = setting_label(def);
-                    let cur = setting_display_current(&self.config, def);
-                    DialogOption::new(def.key.name(), format!("{}  [{}]", label, cur))
-                        .with_description(setting_desc(def))
-                })
-                .collect();
-            let key_name = match show_selection_dialog(
-                title,
-                &t("shell.setting.select_setting"),
-                &opts,
-                false,
-                true,
-            ) {
-                DialogResult::Selected(n) => n,
-                _ => return, // Esc → back to categories
-            };
-            let def = match defs.iter().find(|d| d.key.name() == key_name) {
-                Some(d) => *d,
-                None => continue,
-            };
-            self.edit_one_setting(def, restart_changes);
-        }
-    }
-
-    /// Edit one setting's value. Re-prompts the input in place when the value
-    /// is invalid (P0-2) instead of kicking the user back to the list; only
-    /// Esc returns. Persists, runs live side-effects, and accounts restart
-    /// changes.
-    fn edit_one_setting(
-        &mut self,
-        def: &'static crate::settings_panel::SettingDef,
-        restart_changes: &mut usize,
-    ) {
-        use crate::settings_panel::{self, LiveEffect, SettingKind};
-        loop {
-            let cur_raw = settings_panel::current_raw(&self.config, def.key);
-            let new_val = match self.edit_setting_value(def, &cur_raw) {
-                Some(v) => v,
-                None => return, // Esc → back to list
-            };
-            // Validate against a clone so a bad value can't partially mutate
-            // the live config; only commit on success.
-            let mut trial = self.config.clone();
-            if let Err(e) = settings_panel::apply(&mut trial, def.key, &new_val) {
-                eprintln!(
-                    "{}",
-                    theme::error(&t_with_args("shell.setting.invalid", &{
-                        let mut a = std::collections::HashMap::new();
-                        a.insert("error".to_string(), e);
-                        a
-                    }))
-                );
-                continue; // re-prompt the same input
-            }
-            self.config = trial;
-
-            // Persist to disk.
-            let config_path = aish_config::ConfigLoader::default_config_path();
-            if let Err(e) = aish_config::ConfigLoader::save(&self.config, &config_path) {
-                eprintln!(
-                    "{}",
-                    theme::warning(&{
-                        let mut a = std::collections::HashMap::new();
-                        a.insert("error".to_string(), e.to_string());
-                        t_with_args("shell.config_save_warning", &a)
-                    })
-                );
-            }
-
-            // Live side-effects so the change is felt without restart.
-            match settings_panel::live_effect(def.key) {
-                LiveEffect::ModelSession => {
-                    self.ai_handler.update_model(
-                        &self.config.model,
-                        Some(&self.config.api_base),
-                        Some(&self.config.api_key),
-                    );
-                    if let Some(ai) = &self.inline_ai {
-                        ai.update_model(&self.config.model);
-                    }
-                    self.refresh_config_dependent_tools();
-                }
-                LiveEffect::ToolsRefresh => self.refresh_config_dependent_tools(),
-                LiveEffect::InputGuard => {
-                    // screen_input() consults the cached guard, so toggle its
-                    // enabled flag to match the freshly-written config.
-                    self.input_guard
-                        .set_enabled(self.config.input_guard_enabled);
-                }
-                LiveEffect::None => {}
-            }
-
-            // Confirmation.
-            let label = setting_label(def);
-            if new_val.is_empty() {
-                println!(
-                    "{}",
-                    theme::success(&t_with_args("shell.setting.applied_clear", &{
-                        let mut a = std::collections::HashMap::new();
-                        a.insert("label".to_string(), label);
-                        a
-                    }))
-                );
-            } else {
-                let shown = if matches!(def.kind, SettingKind::Secret) {
-                    mask_secret(&new_val)
-                } else {
-                    new_val.clone()
+        let items: Vec<SettingsItem> = SETTINGS
+            .iter()
+            .map(|def| {
+                let cur_raw = settings_panel::current_raw(config, def.key);
+                let display = setting_display_current(config, def);
+                let (kind, options) = match def.kind {
+                    SettingKind::Bool => (SettingsValueKind::Bool, Vec::new()),
+                    SettingKind::Choice(opts) => (
+                        SettingsValueKind::Choice,
+                        opts.iter().map(|s| s.to_string()).collect(),
+                    ),
+                    SettingKind::Text => (SettingsValueKind::Text, Vec::new()),
+                    SettingKind::Float => (SettingsValueKind::Float, Vec::new()),
+                    SettingKind::Int => (SettingsValueKind::Int, Vec::new()),
+                    SettingKind::Secret => (SettingsValueKind::Secret, Vec::new()),
+                    SettingKind::StringList => (SettingsValueKind::StringList, Vec::new()),
                 };
-                println!(
-                    "{}",
-                    theme::success(&t_with_args("shell.setting.applied", &{
-                        let mut a = std::collections::HashMap::new();
-                        a.insert("label".to_string(), label);
-                        a.insert("value".to_string(), shown);
-                        a
-                    }))
-                );
-            }
-            if settings_panel::requires_restart(def.key) {
-                println!("{}", theme::faint(&t("shell.setting.restart_hint")));
-                *restart_changes += 1;
-            }
-            return; // back to the list
-        }
-    }
-
-    /// Build the value-edit dialog for one setting and return the trimmed new
-    /// value, or `None` if the user cancelled.
-    fn edit_setting_value(
-        &self,
-        def: &crate::settings_panel::SettingDef,
-        current_raw: &str,
-    ) -> Option<String> {
-        use crate::settings_panel::SettingKind;
-        use crate::tui::{show_selection_dialog, DialogOption};
-
-        let label = setting_label(def);
-        let desc = setting_desc(def);
-        let on = t("shell.setting.on");
-        let off = t("shell.setting.off");
-
-        match def.kind {
-            SettingKind::Bool => {
-                let opts = vec![
-                    DialogOption::new("true", &on),
-                    DialogOption::new("false", &off),
-                ];
-                dialog_value(show_selection_dialog(&label, &desc, &opts, false, true))
-            }
-            SettingKind::Choice(options) => {
-                // Fixed set — no custom input, so apply() can't receive a
-                // typo that would silently break the consumer.
-                let opts: Vec<DialogOption> = options
-                    .iter()
-                    .map(|o| {
-                        let mut d = DialogOption::new(*o, *o);
-                        if *o == current_raw {
-                            d = d.with_description(t("shell.setting.current_tag"));
-                        }
-                        d
-                    })
-                    .collect();
-                dialog_value(show_selection_dialog(&label, &desc, &opts, false, true))
-            }
-            SettingKind::Text | SettingKind::Float | SettingKind::Int | SettingKind::StringList => {
-                // Free-text/number: edit the current value in place. The value
-                // is prefilled so the user changes it directly (no "pick the
-                // custom row first" step). Empty clears Option-backed fields.
-                // StringList edits the whole list as comma-separated text;
-                // apply() re-splits on commas.
-                prompt_edit_value(&label, &desc, current_raw, false)
-            }
-            SettingKind::Secret => {
-                // Masked input (no prefill — never echo the secret). An empty
-                // submission keeps the current value rather than wiping it.
-                match prompt_edit_value(&label, &desc, "", true) {
-                    Some(v) if !v.is_empty() => Some(v),
-                    _ => None,
+                SettingsItem {
+                    key: def.key.name().to_string(),
+                    label: setting_label(def),
+                    desc: setting_desc(def),
+                    current_raw: cur_raw.clone(),
+                    display_value: display,
+                    default_raw: settings_panel::default_raw_of(def.key).to_string(),
+                    category_index: cat_index_of(def.category),
+                    kind,
+                    options,
+                    changed: settings_panel::is_changed(def.key, &cur_raw),
+                    restart_required: settings_panel::requires_restart(def.key),
                 }
-            }
-        }
+            })
+            .collect();
+
+
+        (cats, items)
     }
 
     /// Handle `/plan [start|status|exit]` — plan mode lifecycle.

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -209,7 +209,6 @@ fn category_color_for(c: crate::settings_panel::SettingCategory) -> ratatui::sty
     }
 }
 
-
 /// Free-text/number editor for a single setting value.
 ///
 /// Uses a cliclack input (prefilled with `current` for direct in-place editing)
@@ -4163,16 +4162,12 @@ impl AishShell {
             // Rebuild items every iteration so values refresh after each edit
             // (the cursor is restored to `last_key` via with_selected_key).
             let (cats, items) = Self::build_settings_items(&self.config);
-            let panel = SettingsPanel::new(
-                t("shell.setting.title").to_string(),
-                cats,
-                items,
-            )
-            .with_search_placeholder(t("shell.setting.search_placeholder"))
-            .with_footer_idle(t("shell.setting.footer_idle"))
-            .with_footer_editing(t("shell.setting.footer_editing"))
-            .with_selected_key(last_key.as_deref())
-            .with_error(pending_error.clone());
+            let panel = SettingsPanel::new(t("shell.setting.title").to_string(), cats, items)
+                .with_search_placeholder(t("shell.setting.search_placeholder"))
+                .with_footer_idle(t("shell.setting.footer_idle"))
+                .with_footer_editing(t("shell.setting.footer_editing"))
+                .with_selected_key(last_key.as_deref())
+                .with_error(pending_error.clone());
 
             let outcome = {
                 let _guard = aish_tools::bash::acquire_interactive_input_guard();
@@ -4185,27 +4180,19 @@ impl AishShell {
                         continue;
                     };
                     last_key = Some(key);
-                    if let Err(e) = self.apply_setting_value(k, &value, &mut restart_changes) {
-                        pending_error = Some(t_with_args("shell.setting.invalid", &{
-                            let mut a = std::collections::HashMap::new();
-                            a.insert("error".to_string(), e);
-                            a
-                        }));
-                    }
+                    self.apply_or_queue_error(k, &value, &mut restart_changes, &mut pending_error);
                 }
                 Ok(PanelOutcome::Submitted(SettingsOutcome::Reset { key })) => {
                     let Some(k) = Self::resolve_setting_key(&key) else {
                         continue;
                     };
                     let default_val = settings_panel::default_raw_of(k);
-                    if let Err(e) = self.apply_setting_value(k, &default_val, &mut restart_changes)
-                    {
-                        pending_error = Some(t_with_args("shell.setting.invalid", &{
-                            let mut a = std::collections::HashMap::new();
-                            a.insert("error".to_string(), e);
-                            a
-                        }));
-                    }
+                    self.apply_or_queue_error(
+                        k,
+                        &default_val,
+                        &mut restart_changes,
+                        &mut pending_error,
+                    );
                     last_key = Some(key);
                 }
                 Ok(PanelOutcome::Submitted(SettingsOutcome::RequestExternalEdit { key })) => {
@@ -4225,16 +4212,13 @@ impl AishShell {
                     let submitted = prompt_edit_value(&label, &desc, &cur_raw, secret);
                     let skip = secret && submitted.as_deref().is_some_and(|v| v.is_empty());
                     if let Some(v) = submitted {
-                        if skip {
-                            // Preserve cursor on this row, do not commit.
-                        } else if let Err(e) =
-                            self.apply_setting_value(k, &v, &mut restart_changes)
-                        {
-                            pending_error = Some(t_with_args("shell.setting.invalid", &{
-                                let mut a = std::collections::HashMap::new();
-                                a.insert("error".to_string(), e);
-                                a
-                            }));
+                        if !skip {
+                            self.apply_or_queue_error(
+                                k,
+                                &v,
+                                &mut restart_changes,
+                                &mut pending_error,
+                            );
                         }
                     }
                 }
@@ -4259,7 +4243,32 @@ impl AishShell {
     /// Returns `None` if the catalog was mutated out-of-band (defensive).
     fn resolve_setting_key(name: &str) -> Option<crate::settings_panel::SettingKey> {
         use crate::settings_panel::SETTINGS;
-        SETTINGS.iter().find(|d| d.key.name() == name).map(|d| d.key)
+        SETTINGS
+            .iter()
+            .find(|d| d.key.name() == name)
+            .map(|d| d.key)
+    }
+
+    /// Apply `new_val` to `key` and either clear `pending_error` (on success)
+    /// or replace it with the localized validation message (on failure).
+    /// Centralizing this here guarantees the error shown always reflects the
+    /// most recent edit's outcome — no stale messages can persist across
+    /// edits, which was a real bug before this helper existed.
+    fn apply_or_queue_error(
+        &mut self,
+        key: crate::settings_panel::SettingKey,
+        new_val: &str,
+        restart_changes: &mut usize,
+        pending_error: &mut Option<String>,
+    ) {
+        *pending_error = None;
+        if let Err(e) = self.apply_setting_value(key, new_val, restart_changes) {
+            *pending_error = Some(t_with_args("shell.setting.invalid", &{
+                let mut a = std::collections::HashMap::new();
+                a.insert("error".to_string(), e);
+                a
+            }));
+        }
     }
 
     /// Apply `new_val` to `key`: validate, persist, run live side-effects,
@@ -4352,7 +4361,10 @@ impl AishShell {
     /// easy to test and avoids borrow conflicts against `self`.
     fn build_settings_items(
         config: &ConfigModel,
-    ) -> (Vec<aish_ui::SettingsCategoryInfo>, Vec<aish_ui::SettingsItem>) {
+    ) -> (
+        Vec<aish_ui::SettingsCategoryInfo>,
+        Vec<aish_ui::SettingsItem>,
+    ) {
         use crate::settings_panel::{self, SettingCategory, SettingKind, SETTINGS};
         use aish_ui::{SettingsCategoryInfo, SettingsItem, SettingsValueKind};
 
@@ -4404,7 +4416,6 @@ impl AishShell {
                 }
             })
             .collect();
-
 
         (cats, items)
     }

--- a/crates/aish-shell/src/settings_panel.rs
+++ b/crates/aish-shell/src/settings_panel.rs
@@ -75,6 +75,22 @@ impl SettingCategory {
     ];
 }
 
+impl SettingCategory {
+    /// Short glyph shown next to the category label in chips and row icons.
+    /// Pure ASCII-ish unicode so it renders in any terminal.
+    pub fn icon(self) -> &'static str {
+        match self {
+            SettingCategory::Model => "◆",
+            SettingCategory::Appearance => "◐",
+            SettingCategory::Ai => "✦",
+            SettingCategory::Security => "▓",
+            SettingCategory::Context => "▣",
+            SettingCategory::Remote => "⌘",
+            SettingCategory::Advanced => "⚙",
+        }
+    }
+}
+
 /// How a value is edited in the panel.
 #[derive(Debug, Clone, Copy)]
 pub enum SettingKind {
@@ -513,6 +529,22 @@ pub fn find(key: SettingKey) -> &'static SettingDef {
         .iter()
         .find(|s| s.key == key)
         .expect("SettingKey is exhaustive over SETTINGS")
+}
+
+/// The factory-default raw value for `key`, derived from `ConfigModel::default()`.
+///
+/// Deriving (rather than hand-mirroring the defaults) eliminates drift: if a
+/// default changes in `aish-config`, this function tracks it automatically.
+/// Used to mark a row as "changed" (current != default) and to power the
+/// reset-to-default action.
+pub fn default_raw_of(key: SettingKey) -> String {
+    let cfg = ConfigModel::default();
+    current_raw(&cfg, key)
+}
+
+/// Whether the current raw value differs from the factory default.
+pub fn is_changed(key: SettingKey, current_raw: &str) -> bool {
+    current_raw != default_raw_of(key)
 }
 
 // ---------------------------------------------------------------------------
@@ -1029,5 +1061,38 @@ mod tests {
             live_effect(SettingKey::InputGuardEnabled),
             LiveEffect::InputGuard
         );
+        assert_eq!(live_effect(SettingKey::InputGuardEnabled), LiveEffect::InputGuard);
+    }
+
+    /// Regression: `default_raw_of` must match `current_raw(ConfigModel::default())`
+    /// for every key. Previously `default_raw_of(RemoteDangerPatterns)` was
+    /// hand-mirrored to `""`, which (a) flagged every fresh install as changed
+    /// and (b) made Ctrl+R reset silently wipe the production-safety patterns.
+    /// Deriving from `ConfigModel::default()` makes drift impossible.
+    #[test]
+    fn default_raw_of_matches_configmodel_default_for_all_keys() {
+        let cfg = ConfigModel::default();
+        for def in SETTINGS {
+            let expected = current_raw(&cfg, def.key);
+            let actual = default_raw_of(def.key);
+            assert_eq!(
+                actual, expected,
+                "default_raw_of({:?}) drifts from ConfigModel::default()",
+                def.key
+            );
+        }
+    }
+
+    /// The RemoteDangerPatterns default specifically — non-empty and matches
+    /// the factory list. Catches the original P1 wipe bug directly.
+    #[test]
+    fn default_raw_of_remote_danger_patterns_is_factory_list() {
+        let d = default_raw_of(SettingKey::RemoteDangerPatterns);
+        assert!(!d.is_empty(), "danger patterns default must not be empty");
+        assert!(d.contains("^prod-"));
+        assert!(d.contains("^production"));
+        // Fresh config matches default → is_changed must be false.
+        let fresh = current_raw(&ConfigModel::default(), SettingKey::RemoteDangerPatterns);
+        assert!(!is_changed(SettingKey::RemoteDangerPatterns, &fresh));
     }
 }

--- a/crates/aish-shell/src/settings_panel.rs
+++ b/crates/aish-shell/src/settings_panel.rs
@@ -1061,10 +1061,6 @@ mod tests {
             live_effect(SettingKey::InputGuardEnabled),
             LiveEffect::InputGuard
         );
-        assert_eq!(
-            live_effect(SettingKey::InputGuardEnabled),
-            LiveEffect::InputGuard
-        );
     }
 
     /// Regression: `default_raw_of` must match `current_raw(ConfigModel::default())`

--- a/crates/aish-shell/src/settings_panel.rs
+++ b/crates/aish-shell/src/settings_panel.rs
@@ -1061,7 +1061,10 @@ mod tests {
             live_effect(SettingKey::InputGuardEnabled),
             LiveEffect::InputGuard
         );
-        assert_eq!(live_effect(SettingKey::InputGuardEnabled), LiveEffect::InputGuard);
+        assert_eq!(
+            live_effect(SettingKey::InputGuardEnabled),
+            LiveEffect::InputGuard
+        );
     }
 
     /// Regression: `default_raw_of` must match `current_raw(ConfigModel::default())`

--- a/crates/aish-ui/src/lib.rs
+++ b/crates/aish-ui/src/lib.rs
@@ -3,6 +3,7 @@ mod expand;
 mod history;
 mod runtime;
 mod select;
+mod settings_ui;
 mod slash_input;
 
 pub use choice::{ChoiceOutcome, ChoicePanel};
@@ -10,4 +11,7 @@ pub use expand::ExpandPanel;
 pub use history::{HistoryOutcome, HistoryPanel, HistoryRecord};
 pub use runtime::{PanelComponent, PanelError, PanelEvent, PanelOutcome, PanelRuntime};
 pub use select::{SearchSelectItem, SearchSelectOutcome, SearchSelectPanel};
+pub use settings_ui::{
+    SettingsCategoryInfo, SettingsItem, SettingsOutcome, SettingsPanel, SettingsValueKind,
+};
 pub use slash_input::{SlashInputOutcome, SlashInputSession};

--- a/crates/aish-ui/src/settings_ui.rs
+++ b/crates/aish-ui/src/settings_ui.rs
@@ -88,7 +88,6 @@ enum Badge {
     SecretSet,
 }
 
-
 /// The composite panel itself.
 #[derive(Debug, Clone)]
 pub struct SettingsPanel {
@@ -172,11 +171,11 @@ impl SettingsPanel {
         }
     }
 
-    fn item_matches_filter(&self, idx: usize) -> bool {
+    /// Whether the item matches the search query (independent of the
+    /// active-category filter). Used for chip counts so they reflect the
+    /// query across all categories, not just the active one.
+    fn item_matches_query(&self, idx: usize) -> bool {
         let item = &self.items[idx];
-        if self.active_category != 0 && item.category_index + 1 != self.active_category {
-            return false;
-        }
         let q = self.query.trim().to_lowercase();
         if q.is_empty() {
             return true;
@@ -189,6 +188,14 @@ impl SettingsPanel {
         })
         .to_lowercase();
         q.split_whitespace().all(|tok| hay.contains(tok))
+    }
+
+    fn item_matches_filter(&self, idx: usize) -> bool {
+        let item = &self.items[idx];
+        if self.active_category != 0 && item.category_index + 1 != self.active_category {
+            return false;
+        }
+        self.item_matches_query(idx)
     }
 
     fn visible_indices(&self) -> Vec<usize> {
@@ -307,8 +314,7 @@ impl SettingsPanel {
             return;
         }
         frame.render_widget(
-            Paragraph::new("─".repeat(width))
-                .style(Style::default().fg(Color::DarkGray)),
+            Paragraph::new("─".repeat(width)).style(Style::default().fg(Color::DarkGray)),
             area,
         );
     }
@@ -339,16 +345,21 @@ impl SettingsPanel {
         if area.width < 8 {
             return;
         }
-        // Count per real category (only among currently filtered).
-        let visible = self.visible_indices();
+        // Count per real category among query-matching items, IGNORING the
+        // active-category filter — otherwise selecting a category collapses
+        // every other chip to (0) and All(N) shows only the active count.
         let mut counts = vec![0usize; self.categories.len()];
-        for &i in &visible {
+        let mut total = 0usize;
+        for i in 0..self.items.len() {
+            if !self.item_matches_query(i) {
+                continue;
+            }
+            total += 1;
             let ci = self.items[i].category_index;
             if ci < counts.len() {
                 counts[ci] += 1;
             }
         }
-        let total = visible.len();
 
         // Build chip descriptors: (text, style, display_width). Index 0 = All.
         let all_active = self.active_category == 0;
@@ -415,7 +426,9 @@ impl SettingsPanel {
         if left_more {
             spans.push(Span::styled(
                 "‹ ",
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
             ));
         }
         for (text, style, _) in chips.iter().take(last + 1).skip(first) {
@@ -424,7 +437,9 @@ impl SettingsPanel {
         if right_more {
             spans.push(Span::styled(
                 " ›",
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
             ));
         }
 
@@ -435,10 +450,15 @@ impl SettingsPanel {
         let area = padded_area(area);
         let prompt_span = Span::styled(
             "search ❯ ",
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
         );
         let (text, style) = if self.query.is_empty() {
-            (self.search_placeholder.clone(), Style::default().fg(Color::DarkGray))
+            (
+                self.search_placeholder.clone(),
+                Style::default().fg(Color::DarkGray),
+            )
         } else {
             (self.query.clone(), Style::default().fg(Color::White))
         };
@@ -493,7 +513,10 @@ impl SettingsPanel {
             } else {
                 Style::default().fg(Color::DarkGray)
             };
-            let desc = truncate_str(&item.desc, (area.width as usize).saturating_sub(DESCRIPTION_INDENT.width()));
+            let desc = truncate_str(
+                &item.desc,
+                (area.width as usize).saturating_sub(DESCRIPTION_INDENT.width()),
+            );
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
                     Span::raw(DESCRIPTION_INDENT),
@@ -603,14 +626,13 @@ impl SettingsPanel {
         if item.changed {
             spans.push(Span::styled(
                 " ✱",
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
             ));
         }
         if item.restart_required {
-            spans.push(Span::styled(
-                " ↻",
-                Style::default().fg(Color::LightRed),
-            ));
+            spans.push(Span::styled(" ↻", Style::default().fg(Color::LightRed)));
         }
 
         Line::from(spans)
@@ -640,7 +662,10 @@ impl SettingsPanel {
             let line = Line::from(vec![
                 Span::styled("↳ ", Style::default().fg(Color::DarkGray)),
                 Span::styled(
-                    truncate_str(&item.desc, (area.width as usize).saturating_sub(hint.width() + 3)),
+                    truncate_str(
+                        &item.desc,
+                        (area.width as usize).saturating_sub(hint.width() + 3),
+                    ),
                     Style::default().fg(Color::Gray),
                 ),
                 Span::styled(hint, Style::default().fg(Color::DarkGray)),
@@ -665,8 +690,12 @@ impl SettingsPanel {
 
     fn context_footer(&self, item: &SettingsItem) -> String {
         let base = match item.kind {
-            SettingsValueKind::Bool => "Space/Enter toggle · Ctrl+R reset · ←/→ category · Esc exit",
-            SettingsValueKind::Choice => "</> step · Enter cycle · Ctrl+R reset · ←/→ category · Esc exit",
+            SettingsValueKind::Bool => {
+                "Space/Enter toggle · Ctrl+R reset · ←/→ category · Esc exit"
+            }
+            SettingsValueKind::Choice => {
+                "</> step · Enter cycle · Ctrl+R reset · ←/→ category · Esc exit"
+            }
             _ => "Enter edit · Ctrl+R reset · ←/→ category · Esc exit",
         };
         if item.changed {
@@ -807,7 +836,11 @@ impl PanelComponent for SettingsPanel {
                         }
                     }
                 }
-                self.push_query(if key.code == KeyCode::Char('<') { '<' } else { ',' });
+                self.push_query(if key.code == KeyCode::Char('<') {
+                    '<'
+                } else {
+                    ','
+                });
                 PanelEvent::Continue
             }
             KeyCode::Char('>') | KeyCode::Char('.') => {
@@ -818,7 +851,11 @@ impl PanelComponent for SettingsPanel {
                         }
                     }
                 }
-                self.push_query(if key.code == KeyCode::Char('>') { '>' } else { '.' });
+                self.push_query(if key.code == KeyCode::Char('>') {
+                    '>'
+                } else {
+                    '.'
+                });
                 PanelEvent::Continue
             }
             KeyCode::Char('r') if key.modifiers.contains(KeyModifiers::CONTROL) => self
@@ -932,7 +969,11 @@ mod tests {
             label: label.into(),
             desc: "desc".into(),
             current_raw: cur.into(),
-            display_value: if cur == "true" { "on".into() } else { "off".into() },
+            display_value: if cur == "true" {
+                "on".into()
+            } else {
+                "off".into()
+            },
             default_raw: "false".into(),
             category_index: 0,
             kind: SettingsValueKind::Bool,
@@ -1026,6 +1067,36 @@ mod tests {
         assert_eq!(vis, vec![2]);
     }
 
+    /// Regression: chip counts must use the query filter only, NOT the
+    /// active-category filter. Before the fix, selecting a category
+    /// collapsed every other chip to (0) and `All(N)` shrank to the
+    /// active count, misleading users about cross-category matches.
+    #[test]
+    fn chip_counts_ignore_active_category() {
+        let mut items = vec![
+            bool_item("a", "Alpha", "true"),
+            bool_item("b", "Beta", "false"),
+            choice_item("c", "low", &["low", "high"]),
+        ];
+        items[0].category_index = 0; // A
+        items[1].category_index = 0; // A
+        items[2].category_index = 1; // B
+        let cats = vec![cat("A", Color::Cyan), cat("B", Color::Magenta)];
+        let mut panel = SettingsPanel::new("t", cats, items);
+        panel.set_active_category(2); // focus B
+                                      // item_matches_query is the chip-count predicate; it must NOT
+                                      // depend on active_category. All 3 items still match an empty query.
+        let q_matches: Vec<usize> = (0..panel.items.len())
+            .filter(|&i| panel.item_matches_query(i))
+            .collect();
+        assert_eq!(q_matches, vec![0, 1, 2]);
+        // But item_matches_filter (list visibility) honors active_category.
+        let f_matches: Vec<usize> = (0..panel.items.len())
+            .filter(|&i| panel.item_matches_filter(i))
+            .collect();
+        assert_eq!(f_matches, vec![2]);
+    }
+
     /// Categorize/Left/Right/Tab all funnel through `switch_category`; verify
     /// the resulting `active_category` and that `selected` resets to 0.
     #[test]
@@ -1045,7 +1116,7 @@ mod tests {
         assert_eq!(panel.active_category, 2);
         panel.switch_category(1);
         assert_eq!(panel.active_category, 0); // wrapped
-        // Backward from All wraps to last.
+                                              // Backward from All wraps to last.
         panel.switch_category(-1);
         assert_eq!(panel.active_category, 2);
     }
@@ -1112,11 +1183,7 @@ mod tests {
     /// and cursor math stays in bounds.
     #[test]
     fn empty_items_is_safe() {
-        let panel: SettingsPanel = SettingsPanel::new(
-            "t",
-            vec![cat("A", Color::Cyan)],
-            Vec::new(),
-        );
+        let panel: SettingsPanel = SettingsPanel::new("t", vec![cat("A", Color::Cyan)], Vec::new());
         assert!(panel.visible_indices().is_empty());
         assert!(panel.current_visible().is_none());
         assert!(panel.reset_current().is_none());

--- a/crates/aish-ui/src/settings_ui.rs
+++ b/crates/aish-ui/src/settings_ui.rs
@@ -1,0 +1,1134 @@
+//! Composite settings panel — the single-screen `/setting` UI.
+//!
+//! A self-contained `PanelComponent` that renders category chips, a flat
+//! searchable list with rich per-row state, and handles Bool/Choice editing
+//! inline (no second panel round-trip). Text/Int/Float/Secret/StringList
+//! fields emit `RequestExternalEdit` so the caller can pop its own input
+//! prompt without leaving the panel's event loop on return.
+
+use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+use unicode_width::UnicodeWidthStr;
+
+use crate::{PanelComponent, PanelEvent};
+
+const PANEL_PADDING_X: u16 = 2;
+const MIN_PANEL_HEIGHT: u16 = 8;
+const MIN_LIST_ROWS: usize = 4;
+const DESCRIPTION_INDENT: &str = "      ";
+
+/// How a setting's value is edited.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsValueKind {
+    Bool,
+    Choice,
+    Text,
+    Float,
+    Int,
+    Secret,
+    StringList,
+}
+
+/// One row in the panel. Built by the caller from the live config + catalog.
+#[derive(Debug, Clone)]
+pub struct SettingsItem {
+    pub key: String,
+    pub label: String,
+    pub desc: String,
+    /// Raw current value (what `apply()` would consume).
+    pub current_raw: String,
+    /// Friendly current value for display (e.g. "开"/"关", masked secret).
+    pub display_value: String,
+    /// Factory default raw value — powers the `✱` changed marker and `r` reset.
+    pub default_raw: String,
+    /// Index into the `categories` slice passed to the panel.
+    pub category_index: usize,
+    pub kind: SettingsValueKind,
+    /// For `Choice` only — the legal values in display order.
+    pub options: Vec<String>,
+    pub changed: bool,
+    pub restart_required: bool,
+}
+
+/// Category chip metadata.
+#[derive(Debug, Clone)]
+pub struct SettingsCategoryInfo {
+    pub label: String,
+    pub icon: String,
+    pub color: Color,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettingsOutcome {
+    /// Bool flip, Choice change, or external-edit submit applied.
+    Applied { key: String, value: String },
+    /// Reset-to-default requested (Ctrl+R on a row).
+    Reset { key: String },
+    /// User hit Enter on a Text/Int/Float/Secret/StringList field.
+    RequestExternalEdit { key: String },
+    /// Esc at top level, Ctrl+C, or Ctrl+Q.
+    Cancelled,
+}
+
+/// Color tint for the four state badges rendered on each row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Badge {
+    /// Bool = true.
+    BoolOn,
+    /// Bool = false.
+    BoolOff,
+    /// Secret field with empty value.
+    SecretUnset,
+    /// Non-empty secret (masked).
+    SecretSet,
+}
+
+
+/// The composite panel itself.
+#[derive(Debug, Clone)]
+pub struct SettingsPanel {
+    title: String,
+    categories: Vec<SettingsCategoryInfo>,
+    items: Vec<SettingsItem>,
+    /// 0 = "All", 1..=N = the Nth category.
+    active_category: usize,
+    query: String,
+    selected: usize,
+    search_placeholder: String,
+    footer_idle: String,
+    footer_editing: String,
+    error_msg: Option<String>,
+}
+
+impl SettingsPanel {
+    pub fn new(
+        title: impl Into<String>,
+        categories: Vec<SettingsCategoryInfo>,
+        items: Vec<SettingsItem>,
+    ) -> Self {
+        Self {
+            title: title.into(),
+            categories,
+            items,
+            active_category: 0,
+            query: String::new(),
+            selected: 0,
+            search_placeholder: "Type to filter…".to_string(),
+            footer_idle: "↑↓ move · ←/→ category · Space/Enter edit · Ctrl+R reset · Esc exit"
+                .to_string(),
+            footer_editing: "Enter apply · Esc cancel".to_string(),
+            error_msg: None,
+        }
+    }
+
+    pub fn with_search_placeholder(mut self, s: impl Into<String>) -> Self {
+        self.search_placeholder = s.into();
+        self
+    }
+
+    pub fn with_footer_idle(mut self, s: impl Into<String>) -> Self {
+        self.footer_idle = s.into();
+        self
+    }
+
+    pub fn with_footer_editing(mut self, s: impl Into<String>) -> Self {
+        self.footer_editing = s.into();
+        self
+    }
+
+    /// Position the cursor on the row whose key matches, if visible.
+    pub fn with_selected_key(mut self, key: Option<&str>) -> Self {
+        if let Some(k) = key {
+            if let Some(idx) = self
+                .visible_indices()
+                .iter()
+                .position(|i| self.items[*i].key == k)
+            {
+                self.selected = idx;
+            }
+        }
+        self
+    }
+
+    /// Show a transient red error line below the list (cleared on next key).
+    pub fn with_error(mut self, msg: Option<String>) -> Self {
+        self.error_msg = msg.filter(|m| !m.trim().is_empty());
+        self
+    }
+
+    pub fn active_category(&self) -> usize {
+        self.active_category
+    }
+
+    pub fn set_active_category(&mut self, idx: usize) {
+        if idx < self.categories.len() + 1 {
+            self.active_category = idx;
+            self.selected = 0;
+        }
+    }
+
+    fn item_matches_filter(&self, idx: usize) -> bool {
+        let item = &self.items[idx];
+        if self.active_category != 0 && item.category_index + 1 != self.active_category {
+            return false;
+        }
+        let q = self.query.trim().to_lowercase();
+        if q.is_empty() {
+            return true;
+        }
+        let hay = format!("{} {} {} {}", item.label, item.desc, item.key, {
+            self.categories
+                .get(item.category_index)
+                .map(|c| c.label.as_str())
+                .unwrap_or("")
+        })
+        .to_lowercase();
+        q.split_whitespace().all(|tok| hay.contains(tok))
+    }
+
+    fn visible_indices(&self) -> Vec<usize> {
+        (0..self.items.len())
+            .filter(|i| self.item_matches_filter(*i))
+            .collect()
+    }
+
+    fn current_visible(&self) -> Option<usize> {
+        self.visible_indices().get(self.selected).copied()
+    }
+
+    fn clamp_selected(&mut self) {
+        let len = self.visible_indices().len();
+        if len == 0 {
+            self.selected = 0;
+        } else if self.selected >= len {
+            self.selected = len - 1;
+        }
+    }
+
+    fn move_cursor(&mut self, delta: isize) {
+        let len = self.visible_indices().len();
+        if len == 0 {
+            self.selected = 0;
+            return;
+        }
+        let mut next = self.selected as isize + delta;
+        if next < 0 {
+            next = 0;
+        }
+        if next as usize >= len {
+            next = (len - 1) as isize;
+        }
+        self.selected = next as usize;
+    }
+
+    fn switch_category(&mut self, dir: isize) {
+        let n = self.categories.len() + 1; // +1 for "All"
+        let mut next = self.active_category as isize + dir;
+        if next < 0 {
+            next = (n - 1) as isize;
+        }
+        if next as usize >= n {
+            next = 0;
+        }
+        self.active_category = next as usize;
+        self.selected = 0;
+    }
+
+    fn apply_bool_toggle(&self, item: &SettingsItem) -> SettingsOutcome {
+        let next = match item.current_raw.as_str() {
+            "true" => "false".to_string(),
+            _ => "true".to_string(),
+        };
+        SettingsOutcome::Applied {
+            key: item.key.clone(),
+            value: next,
+        }
+    }
+
+    fn apply_choice_step(&self, item: &SettingsItem, forward: bool) -> Option<SettingsOutcome> {
+        if item.options.is_empty() {
+            return None;
+        }
+        let current = item
+            .options
+            .iter()
+            .position(|o| o.eq_ignore_ascii_case(&item.current_raw))
+            .unwrap_or(0);
+        let n = item.options.len();
+        let next = if forward {
+            (current + 1) % n
+        } else {
+            (current + n - 1) % n
+        };
+        Some(SettingsOutcome::Applied {
+            key: item.key.clone(),
+            value: item.options[next].clone(),
+        })
+    }
+
+    fn reset_current(&self) -> Option<SettingsOutcome> {
+        let idx = self.current_visible()?;
+        Some(SettingsOutcome::Reset {
+            key: self.items[idx].key.clone(),
+        })
+    }
+
+    fn activate_current(&self) -> Option<SettingsOutcome> {
+        let idx = self.current_visible()?;
+        let item = &self.items[idx];
+        match item.kind {
+            SettingsValueKind::Bool => Some(self.apply_bool_toggle(item)),
+            SettingsValueKind::Choice => self.apply_choice_step(item, true),
+            SettingsValueKind::Text
+            | SettingsValueKind::Float
+            | SettingsValueKind::Int
+            | SettingsValueKind::Secret
+            | SettingsValueKind::StringList => Some(SettingsOutcome::RequestExternalEdit {
+                key: item.key.clone(),
+            }),
+        }
+    }
+
+    // ---------------- rendering helpers -------------------------------------
+
+    fn chrome_lines(&self) -> u16 {
+        // divider + title + chips + search + footer + desc + (optional error)
+        6 + u16::from(self.error_msg.is_some())
+    }
+
+    fn render_divider(&self, frame: &mut ratatui::Frame<'_>, area: Rect) {
+        let width = area.width as usize;
+        if width == 0 {
+            return;
+        }
+        frame.render_widget(
+            Paragraph::new("─".repeat(width))
+                .style(Style::default().fg(Color::DarkGray)),
+            area,
+        );
+    }
+
+    fn render_title(&self, frame: &mut ratatui::Frame<'_>, area: Rect) {
+        let area = padded_area(area);
+        let total = self.items.len();
+        let shown = self.visible_indices().len();
+        let title = format!("{}  ({shown}/{total})", self.title);
+        let mut spans = vec![Span::styled(
+            title,
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )];
+        if shown < total {
+            spans.push(Span::styled(
+                format!("  · filtered {}", shown),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+        frame.render_widget(Paragraph::new(Line::from(spans)), area);
+    }
+
+    fn render_chips(&self, frame: &mut ratatui::Frame<'_>, area: Rect) {
+        use unicode_width::UnicodeWidthStr;
+        let area = padded_area(area);
+        if area.width < 8 {
+            return;
+        }
+        // Count per real category (only among currently filtered).
+        let visible = self.visible_indices();
+        let mut counts = vec![0usize; self.categories.len()];
+        for &i in &visible {
+            let ci = self.items[i].category_index;
+            if ci < counts.len() {
+                counts[ci] += 1;
+            }
+        }
+        let total = visible.len();
+
+        // Build chip descriptors: (text, style, display_width). Index 0 = All.
+        let all_active = self.active_category == 0;
+        let all_style = if all_active {
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+        let all_text = format!(" All({}) ", total);
+        let mut chips: Vec<(String, Style, usize)> =
+            vec![(all_text.clone(), all_style, all_text.width())];
+        for (i, cat) in self.categories.iter().enumerate() {
+            let active = self.active_category == i + 1;
+            let style = if active {
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(cat.color)
+                    .add_modifier(Modifier::BOLD)
+            } else if counts[i] == 0 {
+                Style::default().fg(Color::DarkGray)
+            } else {
+                Style::default().fg(cat.color)
+            };
+            // Separator space goes on the right of each chip.
+            let body = format!(" {} {}({})  ", cat.icon, cat.label, counts[i]);
+            let w = body.width();
+            chips.push((body, style, w));
+        }
+        let active_idx = self.active_category.min(chips.len() - 1);
+
+        // Window around the active chip. Start with just active, then expand
+        // outward as long as we stay within `area.width`. This guarantees the
+        // active chip is always fully visible — no mid-chip truncation.
+        let area_w = area.width as usize;
+        let mut first = active_idx;
+        let mut last = active_idx;
+        let mut w = chips[active_idx].2;
+        // Expand left first (bias toward showing the predecessor).
+        while first > 0 {
+            let nw = w + chips[first - 1].2;
+            if nw > area_w {
+                break;
+            }
+            first -= 1;
+            w = nw;
+        }
+        // Then expand right.
+        while last + 1 < chips.len() {
+            let nw = w + chips[last + 1].2;
+            if nw > area_w {
+                break;
+            }
+            last += 1;
+            w = nw;
+        }
+
+        let left_more = first > 0;
+        let right_more = last + 1 < chips.len();
+
+        let mut spans: Vec<Span<'_>> = Vec::new();
+        if left_more {
+            spans.push(Span::styled(
+                "‹ ",
+                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            ));
+        }
+        for (text, style, _) in chips.iter().take(last + 1).skip(first) {
+            spans.push(Span::styled(text.clone(), *style));
+        }
+        if right_more {
+            spans.push(Span::styled(
+                " ›",
+                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            ));
+        }
+
+        frame.render_widget(Paragraph::new(Line::from(spans)), area);
+    }
+
+    fn render_search(&self, frame: &mut ratatui::Frame<'_>, area: Rect) {
+        let area = padded_area(area);
+        let prompt_span = Span::styled(
+            "search ❯ ",
+            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        );
+        let (text, style) = if self.query.is_empty() {
+            (self.search_placeholder.clone(), Style::default().fg(Color::DarkGray))
+        } else {
+            (self.query.clone(), Style::default().fg(Color::White))
+        };
+        let mut spans = vec![prompt_span, Span::styled(text, style)];
+        if !self.query.is_empty() {
+            // Caret.
+            spans.push(Span::styled("▏", Style::default().fg(Color::Cyan)));
+        }
+        let line = truncate_line(spans, area.width as usize);
+        frame.render_widget(Paragraph::new(line), area);
+    }
+
+    fn render_entries(&self, frame: &mut ratatui::Frame<'_>, area: Rect) {
+        let area = padded_area(area);
+        let entries = self.visible_indices();
+        if entries.is_empty() {
+            frame.render_widget(
+                Paragraph::new("  No matches — press Esc to clear the filter.")
+                    .style(Style::default().fg(Color::DarkGray)),
+                area,
+            );
+            return;
+        }
+
+        // Two lines per row: value line + desc line.
+        let row_h = 2usize;
+        let visible_limit = ((area.height as usize) / row_h).max(1);
+        let scroll = (self.selected / visible_limit) * visible_limit;
+        let end = (scroll + visible_limit).min(entries.len());
+
+        let mut y = area.y;
+        let bottom = area.y.saturating_add(area.height);
+
+        for row in scroll..end {
+            if y >= bottom {
+                break;
+            }
+            let abs = row;
+            let item_idx = entries[abs];
+            let selected = abs == self.selected;
+            // marker line
+            let line1 = self.render_item_line(item_idx, selected, abs, scroll, end, entries.len());
+            frame.render_widget(Paragraph::new(line1), Rect::new(area.x, y, area.width, 1));
+            y = y.saturating_add(1);
+            if y >= bottom {
+                break;
+            }
+            // desc line
+            let item = &self.items[item_idx];
+            let desc_style = if selected {
+                Style::default().fg(Color::Gray)
+            } else {
+                Style::default().fg(Color::DarkGray)
+            };
+            let desc = truncate_str(&item.desc, (area.width as usize).saturating_sub(DESCRIPTION_INDENT.width()));
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::raw(DESCRIPTION_INDENT),
+                    Span::styled(desc, desc_style),
+                ])),
+                Rect::new(area.x, y, area.width, 1),
+            );
+            y = y.saturating_add(1);
+        }
+    }
+
+    fn render_item_line(
+        &self,
+        item_idx: usize,
+        selected: bool,
+        abs: usize,
+        scroll: usize,
+        end: usize,
+        total: usize,
+    ) -> Line<'_> {
+        let item = &self.items[item_idx];
+        let marker = if selected {
+            "▶"
+        } else if abs == scroll && scroll > 0 {
+            "▲"
+        } else if abs + 1 == end && end < total {
+            "▼"
+        } else {
+            " "
+        };
+        let marker_style = if selected {
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+
+        let cat = self
+            .categories
+            .get(item.category_index)
+            .filter(|_| self.active_category == 0);
+        let icon_style = if selected {
+            Style::default()
+                .fg(cat.map(|c| c.color).unwrap_or(Color::Cyan))
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(cat.map(|c| c.color).unwrap_or(Color::DarkGray))
+        };
+        let icon = cat.map(|c| c.icon.as_str()).unwrap_or("·");
+
+        let label_style = if selected {
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::Gray)
+        };
+
+        let mut spans = vec![
+            Span::styled(format!("{marker} "), marker_style),
+            Span::styled(format!("{icon} "), icon_style),
+            Span::styled(item.label.as_str(), label_style),
+        ];
+
+        // Value column — pushed to the right would need width math; keep it
+        // inline but visually separated. For Bool we show a colored dot before
+        // the value text to give the row an at-a-glance state.
+        let badge = match item.kind {
+            SettingsValueKind::Bool => {
+                if item.current_raw == "true" {
+                    Some(Badge::BoolOn)
+                } else {
+                    Some(Badge::BoolOff)
+                }
+            }
+            SettingsValueKind::Secret => {
+                if item.current_raw.is_empty() {
+                    Some(Badge::SecretUnset)
+                } else {
+                    Some(Badge::SecretSet)
+                }
+            }
+            _ => None,
+        };
+        if let Some(b) = badge {
+            let (glyph, color) = match b {
+                Badge::BoolOn => ("●", Color::LightGreen),
+                Badge::BoolOff => ("○", Color::DarkGray),
+                Badge::SecretUnset => ("△", Color::Yellow),
+                Badge::SecretSet => ("◆", Color::LightMagenta),
+            };
+            spans.push(Span::raw("  "));
+            spans.push(Span::styled(glyph, Style::default().fg(color)));
+        }
+
+        // Value text (dim for unselected, accent for selected).
+        let value_style = if selected {
+            Style::default().fg(Color::LightCyan)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+        spans.push(Span::raw("  "));
+        spans.push(Span::styled(item.display_value.as_str(), value_style));
+
+        // Trailing state badges.
+        if item.changed {
+            spans.push(Span::styled(
+                " ✱",
+                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            ));
+        }
+        if item.restart_required {
+            spans.push(Span::styled(
+                " ↻",
+                Style::default().fg(Color::LightRed),
+            ));
+        }
+
+        Line::from(spans)
+    }
+
+    fn render_desc_or_error(&self, frame: &mut ratatui::Frame<'_>, area: Rect) {
+        let area = padded_area(area);
+        if let Some(err) = &self.error_msg {
+            frame.render_widget(
+                Paragraph::new(truncate_str(err, area.width as usize)).style(
+                    Style::default()
+                        .fg(Color::LightRed)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                area,
+            );
+            return;
+        }
+        if let Some(idx) = self.current_visible() {
+            let item = &self.items[idx];
+            // Show default as a hint when changed.
+            let hint = if item.changed && !item.default_raw.is_empty() {
+                format!("   [default: {}]", item.default_raw)
+            } else {
+                String::new()
+            };
+            let line = Line::from(vec![
+                Span::styled("↳ ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    truncate_str(&item.desc, (area.width as usize).saturating_sub(hint.width() + 3)),
+                    Style::default().fg(Color::Gray),
+                ),
+                Span::styled(hint, Style::default().fg(Color::DarkGray)),
+            ]);
+            frame.render_widget(Paragraph::new(line), area);
+        }
+    }
+
+    fn render_footer(&self, frame: &mut ratatui::Frame<'_>, area: Rect) {
+        let area = padded_area(area);
+        // Contextual footer: depends on the selected row's kind.
+        let footer = self
+            .current_visible()
+            .map(|i| self.context_footer(&self.items[i]))
+            .unwrap_or_else(|| self.footer_idle.clone());
+        frame.render_widget(
+            Paragraph::new(truncate_str(&footer, area.width as usize))
+                .style(Style::default().fg(Color::DarkGray)),
+            area,
+        );
+    }
+
+    fn context_footer(&self, item: &SettingsItem) -> String {
+        let base = match item.kind {
+            SettingsValueKind::Bool => "Space/Enter toggle · Ctrl+R reset · ←/→ category · Esc exit",
+            SettingsValueKind::Choice => "</> step · Enter cycle · Ctrl+R reset · ←/→ category · Esc exit",
+            _ => "Enter edit · Ctrl+R reset · ←/→ category · Esc exit",
+        };
+        if item.changed {
+            format!("{base}   · ✱ changed")
+        } else {
+            base.to_string()
+        }
+    }
+}
+
+impl PanelComponent for SettingsPanel {
+    type Output = SettingsOutcome;
+
+    fn desired_height(&self, _terminal_width: u16, terminal_height: u16) -> u16 {
+        // Estimate: up to 10 visible rows (2 lines each) + chrome.
+        let rows = self.items.len().clamp(MIN_LIST_ROWS, 10);
+        let h = (rows as u16) * 2 + self.chrome_lines();
+        h.clamp(MIN_PANEL_HEIGHT, terminal_height.max(1))
+    }
+
+    fn render(&self, frame: &mut ratatui::Frame<'_>, area: Rect) {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1), // divider
+                Constraint::Length(1), // title
+                Constraint::Length(1), // chips
+                Constraint::Length(1), // search
+                Constraint::Min(1),    // entries
+                Constraint::Length(1), // desc / error
+                Constraint::Length(1), // footer
+            ])
+            .split(area);
+
+        self.render_divider(frame, chunks[0]);
+        self.render_title(frame, chunks[1]);
+        self.render_chips(frame, chunks[2]);
+        self.render_search(frame, chunks[3]);
+        self.render_entries(frame, chunks[4]);
+        self.render_desc_or_error(frame, chunks[5]);
+        self.render_footer(frame, chunks[6]);
+    }
+
+    fn handle_event(&mut self, event: Event) -> PanelEvent<Self::Output> {
+        self.error_msg = None; // clear transient error on any key
+        let Event::Key(key) = event else {
+            return PanelEvent::Continue;
+        };
+        if key.kind == KeyEventKind::Release {
+            return PanelEvent::Continue;
+        }
+
+        match key.code {
+            KeyCode::Esc => {
+                if !self.query.is_empty() {
+                    self.query.clear();
+                    self.selected = 0;
+                    PanelEvent::Continue
+                } else {
+                    PanelEvent::Cancel
+                }
+            }
+            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                PanelEvent::Cancel
+            }
+            KeyCode::Char('q') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                PanelEvent::Submit(SettingsOutcome::Cancelled)
+            }
+            KeyCode::Tab => {
+                self.switch_category(1);
+                PanelEvent::Continue
+            }
+            KeyCode::BackTab => {
+                self.switch_category(-1);
+                PanelEvent::Continue
+            }
+            KeyCode::Up => {
+                self.move_cursor(-1);
+                PanelEvent::Continue
+            }
+            KeyCode::Down => {
+                self.move_cursor(1);
+                PanelEvent::Continue
+            }
+            KeyCode::PageUp => {
+                self.move_cursor(-5);
+                PanelEvent::Continue
+            }
+            KeyCode::PageDown => {
+                self.move_cursor(5);
+                PanelEvent::Continue
+            }
+            KeyCode::Left => {
+                self.switch_category(-1);
+                PanelEvent::Continue
+            }
+            KeyCode::Right => {
+                self.switch_category(1);
+                PanelEvent::Continue
+            }
+            KeyCode::Home => {
+                self.selected = 0;
+                PanelEvent::Continue
+            }
+            KeyCode::End => {
+                self.clamp_selected();
+                let len = self.visible_indices().len();
+                if len > 0 {
+                    self.selected = len - 1;
+                }
+                PanelEvent::Continue
+            }
+            KeyCode::Enter => self
+                .activate_current()
+                .map(PanelEvent::Submit)
+                .unwrap_or(PanelEvent::Continue),
+            KeyCode::Char(' ') => {
+                // Space toggles Bool on the current row; otherwise it's a
+                // search character.
+                if let Some(idx) = self.current_visible() {
+                    if self.items[idx].kind == SettingsValueKind::Bool {
+                        return PanelEvent::Submit(self.apply_bool_toggle(&self.items[idx]));
+                    }
+                }
+                self.push_query(' ');
+                PanelEvent::Continue
+            }
+            KeyCode::Backspace => {
+                self.query.pop();
+                self.clamp_selected();
+                PanelEvent::Continue
+            }
+            KeyCode::Char('<') | KeyCode::Char(',') => {
+                if let Some(idx) = self.current_visible() {
+                    if self.items[idx].kind == SettingsValueKind::Choice {
+                        if let Some(o) = self.apply_choice_step(&self.items[idx], false) {
+                            return PanelEvent::Submit(o);
+                        }
+                    }
+                }
+                self.push_query(if key.code == KeyCode::Char('<') { '<' } else { ',' });
+                PanelEvent::Continue
+            }
+            KeyCode::Char('>') | KeyCode::Char('.') => {
+                if let Some(idx) = self.current_visible() {
+                    if self.items[idx].kind == SettingsValueKind::Choice {
+                        if let Some(o) = self.apply_choice_step(&self.items[idx], true) {
+                            return PanelEvent::Submit(o);
+                        }
+                    }
+                }
+                self.push_query(if key.code == KeyCode::Char('>') { '>' } else { '.' });
+                PanelEvent::Continue
+            }
+            KeyCode::Char('r') if key.modifiers.contains(KeyModifiers::CONTROL) => self
+                .reset_current()
+                .map(PanelEvent::Submit)
+                .unwrap_or(PanelEvent::Continue),
+            KeyCode::Char(ch)
+                if !key.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                self.push_query(ch);
+                PanelEvent::Continue
+            }
+            _ => PanelEvent::Continue,
+        }
+    }
+}
+
+impl SettingsPanel {
+    fn push_query(&mut self, ch: char) {
+        self.query.push(ch);
+        self.selected = 0;
+        self.clamp_selected();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layout / truncation helpers
+// ---------------------------------------------------------------------------
+
+fn padded_area(area: Rect) -> Rect {
+    let padding = PANEL_PADDING_X.min(area.width / 2);
+    Rect::new(
+        area.x + padding,
+        area.y,
+        area.width.saturating_sub(padding * 2),
+        area.height,
+    )
+}
+
+fn truncate_str(s: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+    let mut out = String::new();
+    let mut w = 0usize;
+    for ch in s.chars() {
+        let cw = unicode_width_ch(ch);
+        if w + cw > max_width {
+            out.push('…');
+            break;
+        }
+        w += cw;
+        out.push(ch);
+    }
+    out
+}
+
+fn truncate_line(spans: Vec<Span<'_>>, max_width: usize) -> Line<'_> {
+    if max_width == 0 {
+        return Line::from(Vec::new());
+    }
+    let mut out: Vec<Span<'_>> = Vec::with_capacity(spans.len());
+    let mut w = 0usize;
+    for sp in spans {
+        let sw = sp.content.width();
+        if w + sw > max_width {
+            // Truncate this span's content to fit, append ellipsis.
+            let remaining = max_width.saturating_sub(w);
+            if remaining > 1 {
+                let mut piece = String::new();
+                let mut pw = 0usize;
+                for ch in sp.content.chars() {
+                    let cw = unicode_width_ch(ch);
+                    if pw + cw + 1 > remaining {
+                        break;
+                    }
+                    pw += cw;
+                    piece.push(ch);
+                }
+                piece.push('…');
+                out.push(Span::styled(piece, sp.style));
+            }
+            break;
+        }
+        w += sw;
+        out.push(sp);
+    }
+    Line::from(out)
+}
+
+fn unicode_width_ch(ch: char) -> usize {
+    ch.to_string().width()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cat(label: &str, color: Color) -> SettingsCategoryInfo {
+        SettingsCategoryInfo {
+            label: label.into(),
+            icon: "◆".into(),
+            color,
+        }
+    }
+
+    fn bool_item(key: &str, label: &str, cur: &str) -> SettingsItem {
+        SettingsItem {
+            key: key.into(),
+            label: label.into(),
+            desc: "desc".into(),
+            current_raw: cur.into(),
+            display_value: if cur == "true" { "on".into() } else { "off".into() },
+            default_raw: "false".into(),
+            category_index: 0,
+            kind: SettingsValueKind::Bool,
+            options: vec![],
+            changed: cur != "false",
+            restart_required: false,
+        }
+    }
+
+    fn choice_item(key: &str, cur: &str, opts: &[&str]) -> SettingsItem {
+        SettingsItem {
+            key: key.into(),
+            label: key.into(),
+            desc: "desc".into(),
+            current_raw: cur.into(),
+            display_value: cur.into(),
+            default_raw: opts[0].into(),
+            category_index: 0,
+            kind: SettingsValueKind::Choice,
+            options: opts.iter().map(|s| s.to_string()).collect(),
+            changed: cur != opts[0],
+            restart_required: false,
+        }
+    }
+
+    #[test]
+    fn bool_toggle_emits_inverse() {
+        let panel = SettingsPanel::new(
+            "t",
+            vec![cat("A", Color::Cyan)],
+            vec![bool_item("b", "B", "true")],
+        );
+        let o = panel.activate_current().unwrap();
+        assert_eq!(
+            o,
+            SettingsOutcome::Applied {
+                key: "b".into(),
+                value: "false".into()
+            }
+        );
+    }
+
+    #[test]
+    fn choice_step_wraps_around() {
+        let panel = SettingsPanel::new(
+            "t",
+            vec![cat("A", Color::Cyan)],
+            vec![choice_item("c", "low", &["low", "medium", "high"])],
+        );
+        // forward from index 0 → 1
+        let o = panel.activate_current().unwrap();
+        assert_eq!(
+            o,
+            SettingsOutcome::Applied {
+                key: "c".into(),
+                value: "medium".into()
+            }
+        );
+        // Forward from the last wraps to first.
+        let panel2 = SettingsPanel::new(
+            "t",
+            vec![cat("A", Color::Cyan)],
+            vec![choice_item("c", "high", &["low", "medium", "high"])],
+        );
+        let o = panel2.activate_current().unwrap();
+        assert_eq!(
+            o,
+            SettingsOutcome::Applied {
+                key: "c".into(),
+                value: "low".into()
+            }
+        );
+    }
+
+    #[test]
+    fn filter_by_query_and_category() {
+        let mut items = vec![
+            bool_item("a", "Alpha", "true"),
+            bool_item("b", "Beta", "false"),
+            choice_item("c", "low", &["low", "high"]),
+        ];
+        items[2].category_index = 1;
+        let cats = vec![cat("A", Color::Cyan), cat("B", Color::Magenta)];
+        let panel = SettingsPanel::new("t", cats, items);
+        // No filter: all 3 visible.
+        assert_eq!(panel.visible_indices().len(), 3);
+        // Category filter to B (index 2 = category_index 1).
+        let mut p2 = panel.clone();
+        p2.set_active_category(2);
+        let vis = p2.visible_indices();
+        assert_eq!(vis, vec![2]);
+    }
+
+    /// Categorize/Left/Right/Tab all funnel through `switch_category`; verify
+    /// the resulting `active_category` and that `selected` resets to 0.
+    #[test]
+    fn switch_category_rotates_and_resets_cursor() {
+        let items = vec![
+            bool_item("a", "Alpha", "true"),
+            bool_item("b", "Beta", "false"),
+        ];
+        let cats = vec![cat("A", Color::Cyan), cat("B", Color::Magenta)];
+        let mut panel = SettingsPanel::new("t", cats, items);
+        panel.selected = 1;
+        // Forward through All → A → B → wrap to All.
+        panel.switch_category(1);
+        assert_eq!(panel.active_category, 1);
+        assert_eq!(panel.selected, 0);
+        panel.switch_category(1);
+        assert_eq!(panel.active_category, 2);
+        panel.switch_category(1);
+        assert_eq!(panel.active_category, 0); // wrapped
+        // Backward from All wraps to last.
+        panel.switch_category(-1);
+        assert_eq!(panel.active_category, 2);
+    }
+
+    /// Ctrl+R on a row should emit `Reset { key }`.
+    #[test]
+    fn ctrl_r_resets_current_row() {
+        let items = vec![bool_item("b", "B", "true")];
+        let panel = SettingsPanel::new("t", vec![cat("A", Color::Cyan)], items);
+        let outcome = panel.reset_current().unwrap();
+        assert_eq!(outcome, SettingsOutcome::Reset { key: "b".into() });
+    }
+
+    /// `<` on a Choice row steps backward; `>` steps forward.
+    #[test]
+    fn choice_step_backward_and_forward() {
+        let items = vec![choice_item("c", "medium", &["low", "medium", "high"])];
+        let panel = SettingsPanel::new("t", vec![cat("A", Color::Cyan)], items);
+        // Backward from medium → low.
+        let back = panel.apply_choice_step(&panel.items[0], false).unwrap();
+        assert_eq!(
+            back,
+            SettingsOutcome::Applied {
+                key: "c".into(),
+                value: "low".into()
+            }
+        );
+        // Forward from medium → high.
+        let fwd = panel.apply_choice_step(&panel.items[0], true).unwrap();
+        assert_eq!(
+            fwd,
+            SettingsOutcome::Applied {
+                key: "c".into(),
+                value: "high".into()
+            }
+        );
+    }
+
+    /// Text-kind rows emit RequestExternalEdit on activate (delegated to caller).
+    #[test]
+    fn text_kind_requests_external_edit() {
+        use crate::SettingsItem;
+        let item = SettingsItem {
+            key: "x".into(),
+            label: "X".into(),
+            desc: "d".into(),
+            current_raw: "v".into(),
+            display_value: "v".into(),
+            default_raw: String::new(),
+            category_index: 0,
+            kind: SettingsValueKind::Text,
+            options: vec![],
+            changed: false,
+            restart_required: false,
+        };
+        let panel = SettingsPanel::new("t", vec![cat("A", Color::Cyan)], vec![item]);
+        match panel.activate_current().unwrap() {
+            SettingsOutcome::RequestExternalEdit { key } if key == "x" => {}
+            other => panic!("expected RequestExternalEdit, got {:?}", other),
+        }
+    }
+
+    /// An empty items list renders the "no matches" branch without panic,
+    /// and cursor math stays in bounds.
+    #[test]
+    fn empty_items_is_safe() {
+        let panel: SettingsPanel = SettingsPanel::new(
+            "t",
+            vec![cat("A", Color::Cyan)],
+            Vec::new(),
+        );
+        assert!(panel.visible_indices().is_empty());
+        assert!(panel.current_visible().is_none());
+        assert!(panel.reset_current().is_none());
+        // activate_current on empty list is a no-op (None).
+        assert!(panel.activate_current().is_none());
+    }
+
+    #[test]
+    fn changed_marker_detected() {
+        let item = bool_item("b", "B", "true");
+        assert!(item.changed);
+        let item2 = bool_item("b", "B", "false");
+        assert!(!item2.changed);
+    }
+}


### PR DESCRIPTION
Closes #367.

## Overview

Redesigns the `/setting` built-in command from a 3-level menu (category → setting → editor) into a single flat composite panel with category chips, live type-to-filter, inline Bool/Choice editing, and rich per-row state visualization.

## Why

The current `/setting` interaction cost is too high (see #367 for the full rationale):

- Editing one setting requires `category → item → edit → Enter → list → Esc → category`. Editing two items in the same category re-walks two levels.
- Bool fields (≈1/3 of all settings) open a second `ChoicePanel` just to pick `true/false` — 4 keystrokes for one toggle.
- Rows show only `Label [current]` with no signal for changed-vs-default, restart-required, or secret-unset state.
- The search entry is buried as the first row of the category menu.
- Validation failures re-pop the editor, separating the error from the input.

## What changed

**New composite panel** (`crates/aish-ui/src/settings_ui.rs`, `SettingsPanel: PanelComponent`):

- **Category chips row** — `All` + 7 categories with icons and live match counts. `Tab` / `Shift+Tab` / `←` / `→` to switch. The active chip is always fully visible (the window expands outward around it, with `‹` / `›` scroll indicators when truncated).
- **Type-to-filter list** — filters by name/description/category; two-line rows (value line + description line).
- **Inline editing** (no second panel):
  - Bool: `Space` / `Enter` toggles directly.
  - Choice: `<` / `>` or `Enter` cycles values.
  - Text/Int/Float/Secret/StringList: `Enter` pops an external editor, then **returns to the same row** (no more back-to-category loop).
  - `Ctrl+R`: reset highlighted row to factory default.
- **Rich row state**:
  - Category icon tinted per category.
  - Bool status dot (`●` green = on / `○` grey = off).
  - Secret marker (`◆` purple = set / `△` yellow = unset).
  - `✱` changed (vs default), `↻` restart-required, `[default: …]` hint on the description line.
- **Inline error feedback** — validation failures render a red line below the list and preserve the cursor (no prompt re-pop).

**Shell-side refactor** (`crates/aish-shell/src/app.rs`, `settings_panel.rs`):

- `handle_setting_command` flattened to a single panel loop.
- Extracted `apply_setting_value` (validate → persist → live effect → confirmation) reused by all edit paths.
- Extracted pure `build_settings_items(&ConfigModel)` to avoid borrow conflicts.
- `default_raw_of(key)` now **derives from `ConfigModel::default()`** instead of a hand-mirrored string table. This kills a P1 bug where `default_raw_of(RemoteDangerPatterns)` returned `""` while the real default populates 8 patterns — making `Ctrl+R` silently wipe the production-host safety guardrail.

## Behavior compatibility

- All existing i18n keys retained. Only two new keys added per locale: `shell.setting.footer_idle` and `shell.setting.footer_editing`.
- Live-effect semantics (ModelSession / ToolsRefresh / InputGuard / None) unchanged.
- Empty password submission on a Secret prompt is a no-op (preserves the legacy `edit_setting_value` guard that was nearly lost in the rewrite).

## Tests

- `aish-ui`: 47 → 52 tests (+5). New coverage: `switch_category` rotation + cursor reset, `Ctrl+R` reset dispatch, Choice step in both directions, Text-kind `RequestExternalEdit` dispatch, empty-list safety.
- `aish-shell` `settings_panel`: +2 regression tests — `default_raw_of` matches `ConfigModel::default()` for all 49 keys (permanent drift guard), and `default_raw_of(RemoteDangerPatterns)` is the factory list specifically.

## Verification

```
cargo clippy --workspace --all-targets -- -D warnings   ✅ clean
cargo test --workspace                                   ✅ all suites green
```

Smoke-tested in a live terminal: query filtering, Bool toggle via `Space`, Choice cycle via `Enter`, category switching via `Tab` and `←`/`→` (including the rightmost `⚙ Advanced` chip scrolling fully into view with `‹` indicator), footer hints rotating by selected-row kind.

## Files

- `crates/aish-ui/src/settings_ui.rs` — new (1134 lines, the `SettingsPanel` composite component)
- `crates/aish-ui/src/lib.rs` — export the new types
- `crates/aish-shell/src/app.rs` — flatten `handle_setting_command` + extract helpers
- `crates/aish-shell/src/settings_panel.rs` — add `default_raw_of` (derived), `is_changed`, `SettingCategory::icon`
- `crates/aish-i18n/locales/{6 locales}.yaml` — add `footer_idle` / `footer_editing`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned the `/setting` experience as a single-screen panel with category chips, search/filtering, inline editing, reset, and richer keyboard shortcuts.
  * Settings now clearly show current vs default, mark changed values, and indicate when a restart is required; secret/text-like entries use external editing when applicable.
  * Added new localized footer help text for idle vs editing states (German, English, Spanish, French, Japanese, Simplified Chinese).
* **Tests**
  * Added automated coverage for default/changed detection and settings panel interactions (toggling, choice navigation, filtering, reset, and external-edit behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->