### PR TITLE
feat(shell): /setting UX polish — choice picker, category memory, slash prefill

### DIFF
--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -540,7 +540,18 @@ impl AishShell {
                 (name.to_string(), aish_i18n::t(&i18n_key))
             })
             .collect();
-        match aish_ui::SlashInputSession::new(commands, prompt.to_string()).run() {
+        let session = aish_ui::SlashInputSession::new(commands, prompt.to_string());
+        // When triggered by Tab on a `/` prefix, pre-fill the popup with
+        // the text the user had already typed.
+        let session = {
+            let prefill = crate::readline::take_slash_prefill();
+            if prefill.is_empty() {
+                session
+            } else {
+                session.with_input(prefill)
+            }
+        };
+        match session.run() {
             Ok(outcome) => outcome,
             Err(_) => aish_ui::SlashInputOutcome::Cancelled,
         }
@@ -4156,16 +4167,18 @@ impl AishShell {
         // Count of restart-required edits this session, for an exit summary.
         let mut restart_changes: usize = 0;
         let mut last_key: Option<String> = None;
+        let mut last_category: usize = 0;
         let mut pending_error: Option<String> = None;
 
         loop {
-            // Rebuild items every iteration so values refresh after each edit
-            // (the cursor is restored to `last_key` via with_selected_key).
+            // Rebuild items every iteration so values refresh after each edit.
+            // `last_key` restores the cursor; `last_category` keeps the user on
+            // the same chip instead of bouncing back to "All" after each edit.
             let (cats, items) = Self::build_settings_items(&self.config);
             let panel = SettingsPanel::new(t("shell.setting.title").to_string(), cats, items)
                 .with_search_placeholder(t("shell.setting.search_placeholder"))
                 .with_footer_idle(t("shell.setting.footer_idle"))
-                .with_footer_editing(t("shell.setting.footer_editing"))
+                .with_active_category(last_category)
                 .with_selected_key(last_key.as_deref())
                 .with_error(pending_error.clone());
 
@@ -4174,15 +4187,29 @@ impl AishShell {
                 PanelRuntime::new().run(panel)
             };
 
+            let outcome = match outcome {
+                Ok(PanelOutcome::Submitted(o)) => o,
+                Ok(PanelOutcome::Cancelled) => {
+                    // Defensive: panel always submits Cancelled with a chip
+                    // attached, but fall back to the snapshot if not.
+                    break;
+                }
+                Err(_) => break,
+            };
+            // Remember the chip the user ended on — whether they applied an
+            // edit, reset, opened a sub-editor, or cancelled out. This keeps
+            // them on the same chip on the next panel re-open.
+            last_category = outcome.active_category();
+
             match outcome {
-                Ok(PanelOutcome::Submitted(SettingsOutcome::Applied { key, value })) => {
+                SettingsOutcome::Applied { key, value, .. } => {
                     let Some(k) = Self::resolve_setting_key(&key) else {
                         continue;
                     };
                     last_key = Some(key);
                     self.apply_or_queue_error(k, &value, &mut restart_changes, &mut pending_error);
                 }
-                Ok(PanelOutcome::Submitted(SettingsOutcome::Reset { key })) => {
+                SettingsOutcome::Reset { key, .. } => {
                     let Some(k) = Self::resolve_setting_key(&key) else {
                         continue;
                     };
@@ -4195,7 +4222,7 @@ impl AishShell {
                     );
                     last_key = Some(key);
                 }
-                Ok(PanelOutcome::Submitted(SettingsOutcome::RequestExternalEdit { key })) => {
+                SettingsOutcome::RequestExternalEdit { key, .. } => {
                     let Some(k) = Self::resolve_setting_key(&key) else {
                         continue;
                     };
@@ -4206,9 +4233,9 @@ impl AishShell {
                     let cur_raw = settings_panel::current_raw(&self.config, k);
                     let secret = matches!(def.kind, SettingKind::Secret);
                     // Pop a single external input; we return to the panel
-                    // afterwards regardless of outcome.
-                    // Empty submission on a Secret prompt is a no-op (skip),
-                    // not a wipe — mirrors the legacy edit_setting_value guard.
+                    // afterwards regardless of outcome. Empty submission on
+                    // a Secret prompt is a no-op (skip), not a wipe — mirrors
+                    // the legacy edit_setting_value guard.
                     let submitted = prompt_edit_value(&label, &desc, &cur_raw, secret);
                     let skip = secret && submitted.as_deref().is_some_and(|v| v.is_empty());
                     if let Some(v) = submitted {
@@ -4222,7 +4249,18 @@ impl AishShell {
                         }
                     }
                 }
-                _ => break, // Cancelled / Esc at top level / Ctrl+Q
+                SettingsOutcome::RequestChoiceSelect { key, .. } => {
+                    let Some(k) = Self::resolve_setting_key(&key) else {
+                        continue;
+                    };
+                    last_key = Some(key);
+                    // Pop a one-shot choice list (shows every option with the
+                    // current value tagged). Returns to the panel after.
+                    if let Some(v) = self.prompt_choice_value(k) {
+                        self.apply_or_queue_error(k, &v, &mut restart_changes, &mut pending_error);
+                    }
+                }
+                SettingsOutcome::Cancelled { .. } => break,
             }
         }
 
@@ -4236,6 +4274,37 @@ impl AishShell {
                     a
                 }))
             );
+        }
+    }
+
+    /// Pop a one-shot selection list for a `Choice` setting so the user can
+    /// see every option at a glance (instead of cycling blind with `<`/`>`).
+    /// The current value is tagged. Returns `None` on Esc.
+    fn prompt_choice_value(&self, key: crate::settings_panel::SettingKey) -> Option<String> {
+        use crate::settings_panel::{self, SettingKind};
+        use crate::tui::{show_selection_dialog, DialogOption, DialogResult};
+
+        let def = settings_panel::find(key);
+        let opts = match def.kind {
+            SettingKind::Choice(o) => o,
+            _ => return None,
+        };
+        let cur = settings_panel::current_raw(&self.config, key);
+        let label = setting_label(def);
+        let desc = setting_desc(def);
+        let options: Vec<DialogOption> = opts
+            .iter()
+            .map(|o| {
+                let mut d = DialogOption::new(*o, *o);
+                if o.eq_ignore_ascii_case(&cur) {
+                    d = d.with_description(t("shell.setting.current_tag"));
+                }
+                d
+            })
+            .collect();
+        match show_selection_dialog(&label, &desc, &options, false, true) {
+            DialogResult::Selected(v) => Some(v),
+            _ => None,
         }
     }
 

--- a/crates/aish-shell/src/completion.rs
+++ b/crates/aish-shell/src/completion.rs
@@ -27,6 +27,18 @@ impl CompletionEngine {
             return None;
         }
 
+        // Built-in slash command completion: when the first word starts with
+        // `/` and has no whitespace yet, complete from SLASH_COMMANDS. This
+        // covers the case where the popup dismissed to readline (e.g. after
+        // Tab-completing `/setup `) and the user backspaced to a partial
+        // prefix — Tab in readline now completes slash commands natively.
+        if before.starts_with('/') && !before.contains(char::is_whitespace) {
+            let pairs = filter_extending_pairs(line, pos, 0, complete_slash_command(before));
+            if !pairs.is_empty() {
+                return Some((0, pairs));
+            }
+        }
+
         let (word_start, pairs) = if should_complete_path_locally(
             line.get(word_start_at(line, pos)..pos).unwrap_or(""),
         ) {
@@ -91,6 +103,24 @@ fn filter_extending_pairs(
         .collect()
 }
 
+/// Complete built-in slash commands for a `/`-prefixed first word.
+///
+/// `before_cursor` is the line text up to the cursor. Returns matching
+/// command names as `Pair`s (display = name, replacement = name), or an
+/// empty `Vec` when nothing matches. Callers should apply
+/// `filter_extending_pairs` to drop exact matches.
+fn complete_slash_command(before_cursor: &str) -> Vec<Pair> {
+    let query = before_cursor.to_lowercase();
+    crate::readline::SLASH_COMMANDS
+        .iter()
+        .filter(|(name, _)| name.to_lowercase().starts_with(&query))
+        .map(|(name, _)| Pair {
+            display: (*name).to_string(),
+            replacement: (*name).to_string(),
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -129,5 +159,42 @@ mod tests {
             "LCP should extend /usr prefix, got {lcp:?}"
         );
         assert_ne!(lcp, "r/");
+    }
+
+    #[test]
+    fn slash_command_completes_partial_prefix() {
+        let pairs = complete_slash_command("/set");
+        let names: Vec<&str> = pairs.iter().map(|p| p.replacement.as_str()).collect();
+        assert!(names.contains(&"/setup"), "expected /setup in {names:?}");
+        assert!(
+            names.contains(&"/setting"),
+            "expected /setting in {names:?}"
+        );
+    }
+
+    #[test]
+    fn slash_command_completes_unambiguous_prefix() {
+        let pairs = complete_slash_command("/setu");
+        let names: Vec<&str> = pairs.iter().map(|p| p.replacement.as_str()).collect();
+        assert_eq!(names, vec!["/setup"]);
+    }
+
+    #[test]
+    fn slash_command_exact_match_filtered_out() {
+        // `/setup` is an exact command — filter_extending_pairs drops it.
+        let pairs = filter_extending_pairs("/setup", 6, 0, complete_slash_command("/setup"));
+        assert!(pairs.is_empty(), "exact match should be filtered out");
+    }
+
+    #[test]
+    fn slash_command_non_matching_prefix_returns_empty() {
+        let pairs = complete_slash_command("/xyz");
+        assert!(pairs.is_empty());
+    }
+
+    #[test]
+    fn slash_command_slash_alone_matches_all() {
+        let pairs = complete_slash_command("/");
+        assert!(pairs.len() > 1, "bare `/` should match all commands");
     }
 }

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -53,8 +53,28 @@ static MODE_TOGGLE_REQUESTED: AtomicBool = AtomicBool::new(false);
 /// Flag set by `CtrlOHandler` when Ctrl+O is pressed.
 static CTRL_O_REQUESTED: AtomicBool = AtomicBool::new(false);
 
-/// Flag set by `SlashHandler` when `/` is pressed on an empty line.
+/// Flag set by `SlashHandler` when `/` is pressed on an empty line, or by
+/// `TabCompletionHandler` when Tab is pressed on a `/`-prefixed first word.
 static SLASH_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+/// When the slash popup is triggered by Tab (not by bare `/`), this holds
+/// the current line text so the popup can pre-fill its input field. Set by
+/// `TabCompletionHandler`, consumed by `run_slash_input_session`.
+static SLASH_PREFILL: Mutex<String> = Mutex::new(String::new());
+
+/// Store the text to pre-fill the slash popup with (called from Tab handler).
+fn set_slash_prefill(text: String) {
+    if let Ok(mut s) = SLASH_PREFILL.lock() {
+        *s = text;
+    }
+}
+/// Consume the stored pre-fill text, returning an empty `String` if none.
+pub(crate) fn take_slash_prefill() -> String {
+    match SLASH_PREFILL.lock() {
+        Ok(mut s) => std::mem::take(&mut *s),
+        Err(_) => String::new(),
+    }
+}
 
 /// Max gap between Tab presses to count as "double Tab" (bash second-tab list).
 const DOUBLE_TAB_MS: u128 = 800;
@@ -127,6 +147,24 @@ impl ConditionalEventHandler for TabCompletionHandler {
 
         let line = ctx.line();
         let pos = clamp_pos(line, ctx.pos());
+
+        // When Tab is pressed on a `/`-prefixed first word that matches a
+        // built-in slash command, re-open the interactive popup (with the
+        // current text pre-filled) instead of showing a bash-style column
+        // list. This covers the case where the popup dismissed to readline
+        // and the user backspaced to a partial prefix.
+        let before = line.get(..pos).unwrap_or(line);
+        if before.starts_with('/') && !before.contains(char::is_whitespace) {
+            let query = before.to_lowercase();
+            if SLASH_COMMANDS
+                .iter()
+                .any(|(name, _)| name.to_lowercase().starts_with(&query))
+            {
+                set_slash_prefill(before.to_string());
+                SLASH_REQUESTED.store(true, Ordering::SeqCst);
+                return Some(Cmd::Interrupt);
+            }
+        }
         let Some((_word_start, pairs)) = self.engine.complete(line, pos) else {
             if let Ok(mut state) = TAB_STATE.lock() {
                 state.pending_list = false;

--- a/crates/aish-ui/src/settings_ui.rs
+++ b/crates/aish-ui/src/settings_ui.rs
@@ -66,13 +66,43 @@ pub struct SettingsCategoryInfo {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SettingsOutcome {
     /// Bool flip, Choice change, or external-edit submit applied.
-    Applied { key: String, value: String },
+    Applied {
+        key: String,
+        value: String,
+        active_category: usize,
+    },
     /// Reset-to-default requested (Ctrl+R on a row).
-    Reset { key: String },
+    Reset { key: String, active_category: usize },
     /// User hit Enter on a Text/Int/Float/Secret/StringList field.
-    RequestExternalEdit { key: String },
+    RequestExternalEdit { key: String, active_category: usize },
+    /// User hit Enter on a Choice field — caller pops a one-shot selection
+    /// list (the user wants to see all options at a glance, not cycle blind).
+    /// `</>` still cycles inline for power users.
+    RequestChoiceSelect { key: String, active_category: usize },
     /// Esc at top level, Ctrl+C, or Ctrl+Q.
-    Cancelled,
+    Cancelled { active_category: usize },
+}
+
+impl SettingsOutcome {
+    /// The chip that was active when this outcome was produced. The caller
+    /// uses it to restore the cursor's chip across panel re-opens.
+    pub fn active_category(&self) -> usize {
+        match self {
+            SettingsOutcome::Applied {
+                active_category, ..
+            }
+            | SettingsOutcome::Reset {
+                active_category, ..
+            }
+            | SettingsOutcome::RequestExternalEdit {
+                active_category, ..
+            }
+            | SettingsOutcome::RequestChoiceSelect {
+                active_category, ..
+            }
+            | SettingsOutcome::Cancelled { active_category } => *active_category,
+        }
+    }
 }
 
 /// Color tint for the four state badges rendered on each row.
@@ -151,6 +181,13 @@ impl SettingsPanel {
                 self.selected = idx;
             }
         }
+        self
+    }
+
+    /// Restore the active category chip across panel re-opens (so editing a
+    /// row in category N does not bounce the user back to "All").
+    pub fn with_active_category(mut self, idx: usize) -> Self {
+        self.set_active_category(idx);
         self
     }
 
@@ -254,6 +291,7 @@ impl SettingsPanel {
         SettingsOutcome::Applied {
             key: item.key.clone(),
             value: next,
+            active_category: self.active_category,
         }
     }
 
@@ -275,6 +313,7 @@ impl SettingsPanel {
         Some(SettingsOutcome::Applied {
             key: item.key.clone(),
             value: item.options[next].clone(),
+            active_category: self.active_category,
         })
     }
 
@@ -282,6 +321,7 @@ impl SettingsPanel {
         let idx = self.current_visible()?;
         Some(SettingsOutcome::Reset {
             key: self.items[idx].key.clone(),
+            active_category: self.active_category,
         })
     }
 
@@ -290,13 +330,17 @@ impl SettingsPanel {
         let item = &self.items[idx];
         match item.kind {
             SettingsValueKind::Bool => Some(self.apply_bool_toggle(item)),
-            SettingsValueKind::Choice => self.apply_choice_step(item, true),
+            SettingsValueKind::Choice => Some(SettingsOutcome::RequestChoiceSelect {
+                key: item.key.clone(),
+                active_category: self.active_category,
+            }),
             SettingsValueKind::Text
             | SettingsValueKind::Float
             | SettingsValueKind::Int
             | SettingsValueKind::Secret
             | SettingsValueKind::StringList => Some(SettingsOutcome::RequestExternalEdit {
                 key: item.key.clone(),
+                active_category: self.active_category,
             }),
         }
     }
@@ -694,7 +738,7 @@ impl SettingsPanel {
                 "Space/Enter toggle · Ctrl+R reset · ←/→ category · Esc exit"
             }
             SettingsValueKind::Choice => {
-                "</> step · Enter cycle · Ctrl+R reset · ←/→ category · Esc exit"
+                "</> step · Enter select · Ctrl+R reset · ←/→ category · Esc exit"
             }
             _ => "Enter edit · Ctrl+R reset · ←/→ category · Esc exit",
         };
@@ -755,14 +799,20 @@ impl PanelComponent for SettingsPanel {
                     self.selected = 0;
                     PanelEvent::Continue
                 } else {
-                    PanelEvent::Cancel
+                    PanelEvent::Submit(SettingsOutcome::Cancelled {
+                        active_category: self.active_category,
+                    })
                 }
             }
             KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                PanelEvent::Cancel
+                PanelEvent::Submit(SettingsOutcome::Cancelled {
+                    active_category: self.active_category,
+                })
             }
             KeyCode::Char('q') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                PanelEvent::Submit(SettingsOutcome::Cancelled)
+                PanelEvent::Submit(SettingsOutcome::Cancelled {
+                    active_category: self.active_category,
+                })
             }
             KeyCode::Tab => {
                 self.switch_category(1);
@@ -1007,45 +1057,50 @@ mod tests {
             vec![bool_item("b", "B", "true")],
         );
         let o = panel.activate_current().unwrap();
-        assert_eq!(
-            o,
-            SettingsOutcome::Applied {
-                key: "b".into(),
-                value: "false".into()
-            }
-        );
+        match o {
+            SettingsOutcome::Applied { key, value, .. } if key == "b" && value == "false" => {}
+            other => panic!("expected Applied(b,false), got {:?}", other),
+        }
     }
 
     #[test]
     fn choice_step_wraps_around() {
+        // apply_choice_step (driven by `<`/`>`) still cycles through values.
         let panel = SettingsPanel::new(
             "t",
             vec![cat("A", Color::Cyan)],
             vec![choice_item("c", "low", &["low", "medium", "high"])],
         );
         // forward from index 0 → 1
-        let o = panel.activate_current().unwrap();
-        assert_eq!(
-            o,
-            SettingsOutcome::Applied {
-                key: "c".into(),
-                value: "medium".into()
-            }
-        );
+        match panel.apply_choice_step(&panel.items[0], true).unwrap() {
+            SettingsOutcome::Applied { key, value, .. } if key == "c" && value == "medium" => {}
+            other => panic!("expected Applied(c,medium), got {:?}", other),
+        }
         // Forward from the last wraps to first.
         let panel2 = SettingsPanel::new(
             "t",
             vec![cat("A", Color::Cyan)],
             vec![choice_item("c", "high", &["low", "medium", "high"])],
         );
-        let o = panel2.activate_current().unwrap();
-        assert_eq!(
-            o,
-            SettingsOutcome::Applied {
-                key: "c".into(),
-                value: "low".into()
-            }
+        match panel2.apply_choice_step(&panel2.items[0], true).unwrap() {
+            SettingsOutcome::Applied { key, value, .. } if key == "c" && value == "low" => {}
+            other => panic!("expected Applied(c,low), got {:?}", other),
+        }
+    }
+
+    /// Enter on a Choice row now emits RequestChoiceSelect (caller pops a list),
+    /// not an inline cycle. Power users still cycle inline with `<`/`>`.
+    #[test]
+    fn choice_activate_emits_request_choice_select() {
+        let panel = SettingsPanel::new(
+            "t",
+            vec![cat("A", Color::Cyan)],
+            vec![choice_item("c", "low", &["low", "medium", "high"])],
         );
+        match panel.activate_current().unwrap() {
+            SettingsOutcome::RequestChoiceSelect { key, .. } if key == "c" => {}
+            other => panic!("expected RequestChoiceSelect, got {:?}", other),
+        }
     }
 
     #[test]
@@ -1127,7 +1182,10 @@ mod tests {
         let items = vec![bool_item("b", "B", "true")];
         let panel = SettingsPanel::new("t", vec![cat("A", Color::Cyan)], items);
         let outcome = panel.reset_current().unwrap();
-        assert_eq!(outcome, SettingsOutcome::Reset { key: "b".into() });
+        match outcome {
+            SettingsOutcome::Reset { key, .. } if key == "b" => {}
+            other => panic!("expected Reset(b), got {:?}", other),
+        }
     }
 
     /// `<` on a Choice row steps backward; `>` steps forward.
@@ -1137,22 +1195,16 @@ mod tests {
         let panel = SettingsPanel::new("t", vec![cat("A", Color::Cyan)], items);
         // Backward from medium → low.
         let back = panel.apply_choice_step(&panel.items[0], false).unwrap();
-        assert_eq!(
-            back,
-            SettingsOutcome::Applied {
-                key: "c".into(),
-                value: "low".into()
-            }
-        );
+        match back {
+            SettingsOutcome::Applied { key, value, .. } if key == "c" && value == "low" => {}
+            other => panic!("expected Applied(c,low), got {:?}", other),
+        }
         // Forward from medium → high.
         let fwd = panel.apply_choice_step(&panel.items[0], true).unwrap();
-        assert_eq!(
-            fwd,
-            SettingsOutcome::Applied {
-                key: "c".into(),
-                value: "high".into()
-            }
-        );
+        match fwd {
+            SettingsOutcome::Applied { key, value, .. } if key == "c" && value == "high" => {}
+            other => panic!("expected Applied(c,high), got {:?}", other),
+        }
     }
 
     /// Text-kind rows emit RequestExternalEdit on activate (delegated to caller).
@@ -1174,7 +1226,7 @@ mod tests {
         };
         let panel = SettingsPanel::new("t", vec![cat("A", Color::Cyan)], vec![item]);
         match panel.activate_current().unwrap() {
-            SettingsOutcome::RequestExternalEdit { key } if key == "x" => {}
+            SettingsOutcome::RequestExternalEdit { key, .. } if key == "x" => {}
             other => panic!("expected RequestExternalEdit, got {:?}", other),
         }
     }

--- a/crates/aish-ui/src/slash_input.rs
+++ b/crates/aish-ui/src/slash_input.rs
@@ -99,8 +99,10 @@ impl SlashInputSession {
         Ok(outcome)
     }
 
-    /// Override input after construction (for integration tests).
-    #[doc(hidden)]
+    /// Pre-fill the input after construction.
+    ///
+    /// Used when re-opening the popup from readline Tab completion on a
+    /// `/` prefix — the popup starts with the text the user had typed.
     pub fn with_input(mut self, input: impl Into<String>) -> Self {
         self.input = input.into();
         self.cursor = self.input.len();
@@ -151,14 +153,6 @@ impl SlashInputSession {
             .collect();
         self.selected = 0;
         self.clamp_selected();
-    }
-
-    fn matching_name_count(&self) -> usize {
-        let query = self.command_query().to_lowercase();
-        self.commands
-            .iter()
-            .filter(|(name, _)| name.to_lowercase().starts_with(&query))
-            .count()
     }
 
     fn replace_command_token(&mut self, new_command: &str) {
@@ -230,12 +224,6 @@ impl SlashInputSession {
             return Some(SlashInputOutcome::Command(trimmed.to_string()));
         }
         if !self.filtered.is_empty() {
-            let query = self.command_query();
-            let match_count = self.matching_name_count();
-            // Ambiguous prefix (e.g. /r): return to readline instead of guessing.
-            if match_count > 1 && query != "/" {
-                return Some(SlashInputOutcome::Dismissed(self.input.clone()));
-            }
             let Some(command) = self.selected_command_name().map(str::to_string) else {
                 return Some(SlashInputOutcome::Dismissed(self.input.clone()));
             };
@@ -573,6 +561,7 @@ mod tests {
             ("/help".into(), "Show help information".into()),
             ("/model".into(), "Show or switch AI model".into()),
             ("/setup".into(), "Open setup wizard".into()),
+            ("/setting".into(), "Open interactive settings panel".into()),
             ("/plan".into(), "Plan mode control".into()),
             ("/token".into(), "Show token usage".into()),
             ("/resume".into(), "Resume previous session".into()),
@@ -728,12 +717,27 @@ mod tests {
     }
 
     #[test]
-    fn ambiguous_prefix_enter_dismisses_to_readline() {
+    fn enter_on_ambiguous_prefix_executes_highlighted() {
         let commands = all_slash_commands();
         let mut session = session_with_commands("/r", &commands);
+        // /resume precedes /record; default highlight is the first match.
         assert_eq!(
             session.handle_event(key(KeyCode::Enter, KeyModifiers::NONE)),
-            Some(SlashInputOutcome::Dismissed("/r".into()))
+            Some(SlashInputOutcome::Command("/resume".into()))
+        );
+    }
+
+    /// Regression: typing `/se`, navigating Down to `/setting`, then pressing
+    /// Enter must execute `/setting` — not dismiss with the partial `/se`.
+    #[test]
+    fn enter_after_down_arrow_executes_selected_command() {
+        let commands = all_slash_commands();
+        let mut session = session_with_commands("/se", &commands);
+        // /se matches /setup (selected=0) and /setting (selected=1).
+        session.handle_event(key(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(
+            session.handle_event(key(KeyCode::Enter, KeyModifiers::NONE)),
+            Some(SlashInputOutcome::Command("/setting".into()))
         );
     }
 


### PR DESCRIPTION
Closes #369.

## Overview

Three follow-up UX fixes to the flat `/setting` panel shipped in #368, plus a behavior consistency fix for the slash popup:

1. **Choice Enter → full selection list** — pops `show_selection_dialog` showing every option with the current value tagged, instead of cycling blind. `</>` still cycles inline for power users.
2. **Category chip memory across re-opens** — editing a row in category N no longer bounces the cursor back to "All" when the panel rebuilds.
3. **Tab on `/`-prefix → re-opens slash popup with pre-fill** — matches the bare-`/` trigger behavior; covers the case where the popup dismissed to readline and the user backspaced to a partial prefix.
4. **Slash popup Enter unified** — drops the ambiguous-prefix dismiss path so Enter always executes the highlighted row, consistent with `Down → Enter`.

## Why

See #369 for the full rationale. Short version:

- Choice cycling blind doesn't scale past 3-4 options (log level, language).
- Category re-bounce breaks the "edit two rows in the same category" flow.
- Tab on `/set` after a dismissed popup showing a bash column list is inconsistent with bare `/`.
- `/r<Enter>` dismissing without executing while `/r<Down><Enter>` executes the highlight is surprising.

## What changed

**`crates/aish-ui/src/settings_ui.rs`** — `SettingsOutcome` now carries `active_category: usize` on every variant, with an `active_category()` accessor. Choice-Enter emits a new `RequestChoiceSelect { key, active_category }` variant instead of inline cycle. `with_active_category(idx)` builder restores the chip across re-opens. Cancel paths (`Esc` / `Ctrl+C` / `Ctrl+Q`) emit `Submitted(Cancelled { active_category })` so the caller can remember the chip even on exit. Footer copy: `</> step · Enter select`.

**`crates/aish-shell/src/app.rs`** — `handle_setting_command` snapshots `last_category = outcome.active_category()` before dispatch and feeds it back via `with_active_category(last_category)` on the next iteration. New `prompt_choice_value(key)` pops `show_selection_dialog` over `SettingKind::Choice` options, tagging the current value with `t("shell.setting.current_tag")`.

**`crates/aish-shell/src/readline.rs`** — New `SLASH_PREFILL: Mutex<String>` slot with `set_slash_prefill` / `take_slash_prefill`. `TabCompletionHandler` now intercepts Tab on a `/`-prefixed first word that matches a built-in command: stashes the line text, raises `SLASH_REQUESTED`, and returns `Cmd::Interrupt` — same path bare `/` takes. `run_slash_input_session` consumes the pre-fill via `SlashInputSession::with_input`.

**`crates/aish-shell/src/completion.rs`** — New `complete_slash_command(before_cursor)` returns matching `Pair`s for `/`-prefixed first words, used by `CompletionEngine::complete` as a fallback when the Tab handler doesn't intercept (e.g. menu-completion mode).

**`crates/aish-ui/src/slash_input.rs`** — Removed `matching_name_count` and the ambiguous-prefix dismiss branch in `handle_submit`. Enter on a non-exact prefix now executes `selected_command_name()` uniformly. `with_input` doc updated (no longer `#[doc(hidden)]`).

## Behavior compatibility

- `SettingsOutcome` shape change: public enum, but the only consumer outside `aish-ui` is `aish-shell` (updated in this PR). No down-stream breakage.
- `</>` cycling preserved — Choice power-user flow unchanged.
- All i18n keys retained; `shell.setting.current_tag` already exists in every locale.
- `Ok(PanelOutcome::Cancelled) => break` retained as a defensive fallback for `PanelRuntime` internal errors (e.g. zero terminal size).

## Tests

- `completion.rs`: 5 new unit tests for `complete_slash_command` (partial prefix, unambiguous prefix, exact-match filtering, non-matching prefix, bare `/`).
- `settings_ui.rs`: existing Choice/Reset tests updated to match the new outcome shape; new `choice_activate_emits_request_choice_select` locks the Enter-on-Choice contract.
- `slash_input.rs`: `ambiguous_prefix_enter_dismisses_to_readline` → `enter_on_ambiguous_prefix_executes_highlighted`; new `enter_after_down_arrow_executes_selected_command` regression for `/se → Down → Enter executes /setting`.

## Verification

- `cargo build -p aish-shell -p aish-ui` ✅
- `cargo test -p aish-ui --lib` → 55 passed; 0 failed ✅
- `cargo test -p aish-shell --lib` → 352 passed; 0 failed ✅
- `cargo clippy -p aish-shell -p aish-ui --all-targets -- -D warnings` ✅

## Out of scope

`SettingsPanel::footer_editing` field and `with_footer_editing` setter became dead code after #368 (render_footer routes through context_footer). Left untouched here to keep this PR's blast radius small — will clean up separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added slash-command completion while typing `/`, including Tab to reopen the command picker with the current text.
  * Pressing Enter now runs the highlighted slash command even for partial matches.
  * Added a dedicated selection dialog for choice-based settings.

* **Improvements**
  * Settings panels now remember the active category when reopened or after an action.
  * Updated settings guidance to clarify that pressing Enter selects a choice.
  * Empty submissions for secret settings continue to leave existing values unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->