### PR TITLE
fix(release): unblock Release Preparation resolve-release-pr args

### DIFF
--- a/.github/actions/resolve-release-pr/action.yml
+++ b/.github/actions/resolve-release-pr/action.yml
@@ -34,7 +34,8 @@ runs:
         GH_TOKEN: ${{ github.token }}
         INPUT_PR_NUMBER: ${{ inputs.pr_number }}
         INPUT_REPOSITORY: ${{ inputs.repository }}
-      run: python3 packaging/scripts/resolve_release_pr.py \
-        --pr-number "$INPUT_PR_NUMBER" \
-        --repository "$INPUT_REPOSITORY" \
-        --github-output "$GITHUB_OUTPUT"
+      run: |
+        python3 packaging/scripts/resolve_release_pr.py \
+          --pr-number "$INPUT_PR_NUMBER" \
+          --repository "$INPUT_REPOSITORY" \
+          --github-output "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Fix composite action `.github/actions/resolve-release-pr` so `run:` uses a YAML block scalar (`|`).
- Without this, YAML collapses the multiline command and bash turns `--pr-number` into an argument with a leading space, so Release Preparation fails immediately with `the following arguments are required: --pr-number` even when `pr_number` was provided.

Fixes #373

## Why

Observed on Release Preparation for the v0.3.7 prep PR: preflight failed before any PR mergeability / fork checks. Env already had `INPUT_PR_NUMBER`, so this is an action scripting bug on `main`, not a bad release PR.

## Test plan

- [ ] Merge this PR
- [ ] Re-run **Release Preparation** against an upstream `release/vX.Y.Z-prep` PR (`gh workflow run release-preparation.yml --ref main -f pr_number=<N>`)
- [ ] Confirm **Validate release PR context** succeeds and continues to metadata / dry-run jobs