### PR TITLE
Release v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.7] - 2026-07-20
+
+### Added
+
+- Added the Agent tool and built-in sub-agents (`explore`, `plan`, `general-purpose`, `troubleshoot`), including spawn progress in the shell TUI and isolated skill execution through spawn.
+- Added an interactive `/setting` panel for config editing, with a flat single-panel layout, choice picker, category memory, and slash-command prefill.
+- Added a centralized theme system with display polish and session management improvements.
+- Added audit logging for shell and agent activity.
+- Added PTY daemon attach architecture for session persistence across reconnects.
+- Added inline AI completion with ghost text in the interactive shell.
+- Added `PromptAssembly` to unify MainChat and sub-agent system prompt and tool spec assembly.
 
 ### Changed
 
-- Added `PromptAssembly` to unify MainChat and sub-agent system prompt and tool spec assembly; removed legacy `LlmSession` prompt filtering APIs.
 - Moved per-tool routing guidance into tool descriptions; tool usage remains in tool prompts. Oracle delegates tool choice to descriptions (no duplicated routing tables). If you customize `~/.config/aish/prompts/oracle.md`, remove duplicated tool-selection sections that mirror tool descriptions.
 - Added explicit routing between `Agent(subagent_type=plan)` and `enter_plan_mode`; `enter_plan_mode` keeps routing in its description and usage-only text in its prompt appendix.
 - Expanded built-in sub-agent system prompts (explore/plan/general-purpose) with read-only rules and efficient search strategy; Agent `prompt` schema now requires scope and thoroughness.
-- Converted embedded LLM prompt templates (`oracle`, `cmd_error`, `failure_diagnose`) to English-only; SSH error-correction context injection is English as well. Removed unused embedded templates (`error_detect`, `system_diagnose`, `guess_command`) and stale copies under `crates/aish-shell/prompts/` (runtime source: `aish-prompts/src/manager.rs`).
+- Converted embedded LLM prompt templates (`oracle`, `cmd_error`, `failure_diagnose`) to English-only; SSH error-correction context injection is English as well.
+- Migrated `/diagnose` to the troubleshoot sub-agent spawn path.
+
+### Fixed
+
+- Fixed `web_fetch` HTML entity decoding to a single pass to prevent double-decoding.
+- Fixed PTY Ctrl+C handling to kill the foreground process group so pagers unblock reliably.
+- Fixed PTY bash rcfile handling to use a unique temp file created with mode `0600`.
+- Fixed a PTY file-descriptor leak and sub-shell echo behavior.
+- Fixed sub-agent tool inheritance from the parent and abort-on-Ctrl+C cancellation.
+- Fixed the sub-agent UI flag reset when the Agent tool ends.
+- Fixed packaged skills seeding so install overwrites bundled skill files as intended.
+- Fixed the setup wizard so the config directory is created before the first-run save.
+- Fixed diagnose confirm-execute to use `has_alternatives` when presenting choices.
+- Fixed Release Preparation preflight so `resolve-release-pr` preserves `--pr-number` after YAML parsing.
+
+### Removed
+
+- Removed unused embedded prompt templates (`error_detect`, `system_diagnose`, `guess_command`) and stale copies under `crates/aish-shell/prompts/`.
+- Removed legacy `LlmSession` prompt filtering APIs in favor of `PromptAssembly`.
+- Removed `docs/skills-guide.md`.
 
 ## [0.3.6] - 2026-07-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "aish-cli"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "aish-config"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "aish-context"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "aish-core",
  "serde",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "aish-core"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "aish-hosts"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "aish-i18n"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "aish-llm"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "aish-context",
  "aish-core",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "aish-memory"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "aish-core",
  "chrono",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "aish-prompts"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "aish-pty"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "aish-scripts"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "aish-security"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "libc",
  "regex",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "aish-session"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "aish-core",
  "chrono",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "aish-shell"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "aish-config",
  "aish-context",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "aish-skills"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "aish-tools"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "aish-core",
  "aish-i18n",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "aish-ui"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "crossterm 0.28.1",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"


### PR DESCRIPTION
## Summary

- Bump workspace version to **0.3.7**
- Publish changelog for changes since v0.3.6

### Highlights

- **Agent tool / sub-agents**: explore, plan, general-purpose, troubleshoot; spawn progress in TUI; isolated skills via spawn
- **`/setting` panel**: interactive config editing (flat single-panel, choice picker, category memory)
- **Theme system**, audit logging, PTY daemon attach (session persistence)
- **Inline AI completion** with ghost text
- **PromptAssembly** unification + tool routing guidance in descriptions
- Fixes: web_fetch HTML entities, PTY Ctrl+C / rcfile / fd leak, sub-agent cancel & inheritance, packaging skills seed, wizard config dir
- Includes the Release Preparation `resolve-release-pr` fix already on `main` (#372 / #373)

## Local verification

- [x] `python3 packaging/tests/test_resolve_release_pr.py -q`
- [x] `make ci-check`

## Release checklist

- [ ] CI green
- [ ] Manually run **Release Preparation** (Actions → fill `pr_number`)
- [ ] Merge this PR
- [ ] Tag `v0.3.7` on merged `main` and push to upstream


Made with [Cursor](https://cursor.com)