### PR TITLE
feat: Markdown 表格渲染重构 + @path 文件提及 + spinner CJK 修复 + LLM 重试

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "aish-md-table"
+version = "0.3.7"
+dependencies = [
+ "richrs",
+ "unicode-width",
+]
+
+[[package]]
 name = "aish-memory"
 version = "0.3.7"
 dependencies = [
@@ -243,6 +251,7 @@ dependencies = [
  "aish-hosts",
  "aish-i18n",
  "aish-llm",
+ "aish-md-table",
  "aish-memory",
  "aish-prompts",
  "aish-pty",
@@ -263,6 +272,7 @@ dependencies = [
  "nix 0.29.0",
  "open",
  "parking_lot",
+ "pulldown-cmark",
  "ratatui",
  "regex",
  "reqwest",
@@ -329,6 +339,7 @@ version = "0.3.7"
 dependencies = [
  "crossterm 0.28.1",
  "ratatui",
+ "tempfile",
  "thiserror 2.0.18",
  "unicode-width",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/aish-core",
+    "crates/aish-md-table",
     "crates/aish-config",
     "crates/aish-hosts",
     "crates/aish-i18n",
@@ -91,6 +92,7 @@ uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 # Markdown
+pulldown-cmark = "0.10"
 richrs = { version = "0.2", features = ["syntax", "markdown"] }
 
 # System info
@@ -107,6 +109,7 @@ tempfile = "3"
 
 # Internal crates
 aish-core = { path = "crates/aish-core" }
+aish-md-table = { path = "crates/aish-md-table" }
 aish-config = { path = "crates/aish-config" }
 aish-hosts = { path = "crates/aish-hosts" }
 aish-i18n = { path = "crates/aish-i18n" }

--- a/crates/aish-llm/src/api/anthropic_messages.rs
+++ b/crates/aish-llm/src/api/anthropic_messages.rs
@@ -9,7 +9,10 @@ use crate::openai_sse_bridge::translate_anthropic_sse_stream;
 use crate::types::{ChatMessage, ToolSpec};
 use crate::usage::TokenUsage;
 
-use super::{effective_max_tokens, format_http_error, StreamContext};
+use super::{
+    effective_max_tokens, format_http_error, is_retryable_network_err, is_retryable_status,
+    retry_backoff_delay, StreamContext, MAX_HTTP_RETRIES,
+};
 
 pub fn resolve_anthropic_messages_url(base_url: &str) -> String {
     let normalized = base_url.trim().trim_end_matches('/');
@@ -60,34 +63,63 @@ pub async fn stream(
 
     let url = resolve_anthropic_messages_url(&ctx.api_base);
     let http = Client::new();
-    let resp = http
-        .post(&url)
-        .header("x-api-key", &ctx.api_key)
-        .header("anthropic-version", "2023-06-01")
-        .header("Content-Type", "application/json")
-        .timeout(std::time::Duration::from_secs(120))
-        .json(&body)
-        .send()
-        .await
-        .map_err(|e| AishError::Llm(e.to_string()))?;
 
-    if !resp.status().is_success() {
+    // Retry transient failures (5xx, 429, connect/timeout errors) with
+    // exponential backoff. Non-retryable status codes surface immediately.
+    let mut last_err: Option<AishError> = None;
+    for attempt in 0..=MAX_HTTP_RETRIES {
+        if attempt > 0 {
+            let delay = retry_backoff_delay(attempt);
+            tracing::warn!(
+                "Retrying Anthropic request (attempt {}/{}) after {:?}",
+                attempt + 1,
+                MAX_HTTP_RETRIES + 1,
+                delay
+            );
+            tokio::time::sleep(delay).await;
+        }
+
+        let resp = match http
+            .post(&url)
+            .header("x-api-key", &ctx.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .header("Content-Type", "application/json")
+            .timeout(std::time::Duration::from_secs(120))
+            .json(&body)
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) if is_retryable_network_err(&e) => {
+                last_err = Some(AishError::Llm(e.to_string()));
+                continue;
+            }
+            Err(e) => return Err(AishError::Llm(e.to_string())),
+        };
+
         let status = resp.status();
+        if status.is_success() {
+            if stream {
+                return Ok(LlmResponse::Stream(translate_anthropic_sse_stream(resp)));
+            }
+            let json_body: Value = resp
+                .json()
+                .await
+                .map_err(|e| AishError::Llm(e.to_string()))?;
+            return Ok(LlmResponse::Json(anthropic_response_to_openai_json(
+                &json_body,
+            )));
+        }
+
         let text = resp.text().await.unwrap_or_default();
+        if is_retryable_status(status) && attempt < MAX_HTTP_RETRIES {
+            last_err = Some(AishError::Llm(format_http_error(status, &text)));
+            continue;
+        }
         return Err(AishError::Llm(format_http_error(status, &text)));
     }
 
-    if stream {
-        Ok(LlmResponse::Stream(translate_anthropic_sse_stream(resp)))
-    } else {
-        let json_body: Value = resp
-            .json()
-            .await
-            .map_err(|e| AishError::Llm(e.to_string()))?;
-        Ok(LlmResponse::Json(anthropic_response_to_openai_json(
-            &json_body,
-        )))
-    }
+    Err(last_err.unwrap_or_else(|| AishError::Llm("Request failed after retries".into())))
 }
 
 pub async fn test_connection(ctx: &StreamContext) -> Result<(), String> {

--- a/crates/aish-llm/src/api/mod.rs
+++ b/crates/aish-llm/src/api/mod.rs
@@ -188,6 +188,37 @@ pub(crate) fn format_http_error(status: reqwest::StatusCode, body: &str) -> Stri
     }
 }
 
+// ---------------------------------------------------------------------------
+// HTTP retry helpers — shared across all dialect adapters.
+// ---------------------------------------------------------------------------
+
+/// Maximum number of retry attempts for transient HTTP failures.
+/// Total attempts = MAX_HTTP_RETRIES + 1 (initial attempt + retries).
+pub(crate) const MAX_HTTP_RETRIES: u32 = 3;
+
+/// HTTP status codes that indicate a transient failure worth retrying:
+/// rate limiting (429) and common server-side errors (500/502/503/504).
+/// Excludes 501 (Not Implemented) and 5xx codes that signal bugs.
+pub(crate) fn is_retryable_status(status: reqwest::StatusCode) -> bool {
+    matches!(status.as_u16(), 429 | 500 | 502 | 503 | 504)
+}
+
+/// Network-layer errors (connection, timeout, connection reset) that are
+/// typically transient and safe to retry.
+pub(crate) fn is_retryable_network_err(e: &reqwest::Error) -> bool {
+    e.is_connect() || e.is_timeout()
+}
+
+/// Exponential backoff delay for a retry attempt (0-indexed).
+/// Returns 0 for the first attempt (no delay before initial request).
+/// Sequence: attempt 0 = 0ms, 1 = 500ms, 2 = 1000ms, 3 = 2000ms.
+pub(crate) fn retry_backoff_delay(attempt: u32) -> std::time::Duration {
+    match attempt {
+        0 => std::time::Duration::ZERO,
+        n => std::time::Duration::from_millis(500u64 << (n - 1).min(4)),
+    }
+}
+
 pub(crate) fn effective_max_tokens(max_tokens: Option<u32>) -> u32 {
     match max_tokens {
         None | Some(0) => crate::client::DEFAULT_MAX_TOKENS,

--- a/crates/aish-llm/src/client.rs
+++ b/crates/aish-llm/src/client.rs
@@ -1,6 +1,9 @@
 use aish_core::AishError;
 use reqwest::Client;
 
+use crate::api::{
+    is_retryable_network_err, is_retryable_status, retry_backoff_delay, MAX_HTTP_RETRIES,
+};
 use crate::llm_stream::LlmStream;
 use crate::model_id::resolve_model_for_api;
 use crate::types::{ChatMessage, ToolSpec};
@@ -189,34 +192,64 @@ impl LlmClient {
         }
 
         let url = format!("{}/chat/completions", self.api_base);
-        let resp = self
-            .http
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", self.api_key))
-            .header("Content-Type", "application/json")
-            .timeout(std::time::Duration::from_secs(120))
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| AishError::Llm(e.to_string()))?;
 
-        if !resp.status().is_success() {
+        // Retry transient failures (5xx, 429, connect/timeout errors) with
+        // exponential backoff. Errors that signal a bug or auth issue are
+        // surfaced immediately.
+        let mut last_err: Option<AishError> = None;
+        for attempt in 0..=MAX_HTTP_RETRIES {
+            if attempt > 0 {
+                let delay = retry_backoff_delay(attempt);
+                tracing::warn!(
+                    "Retrying chat completion (attempt {}/{}) after {:?}",
+                    attempt + 1,
+                    MAX_HTTP_RETRIES + 1,
+                    delay
+                );
+                tokio::time::sleep(delay).await;
+            }
+
+            let resp = match self
+                .http
+                .post(&url)
+                .header("Authorization", format!("Bearer {}", self.api_key))
+                .header("Content-Type", "application/json")
+                .timeout(std::time::Duration::from_secs(120))
+                .json(&body)
+                .send()
+                .await
+            {
+                Ok(r) => r,
+                Err(e) if is_retryable_network_err(&e) => {
+                    last_err = Some(AishError::Llm(e.to_string()));
+                    continue;
+                }
+                Err(e) => return Err(AishError::Llm(e.to_string())),
+            };
+
             let status = resp.status();
+            if status.is_success() {
+                if stream {
+                    return Ok(LlmResponse::Stream(LlmStream::from_http(resp)));
+                }
+                let text = resp
+                    .text()
+                    .await
+                    .map_err(|e| AishError::Llm(e.to_string()))?;
+                let json: serde_json::Value = serde_json::from_str(&text)
+                    .map_err(|e| AishError::Llm(format!("JSON parse error: {}", e)))?;
+                return Ok(LlmResponse::Json(json));
+            }
+
             let text = resp.text().await.unwrap_or_default();
+            if is_retryable_status(status) && attempt < MAX_HTTP_RETRIES {
+                last_err = Some(AishError::Llm(format_http_error(status, &text)));
+                continue;
+            }
             return Err(AishError::Llm(format_http_error(status, &text)));
         }
 
-        if stream {
-            Ok(LlmResponse::Stream(LlmStream::from_http(resp)))
-        } else {
-            let text = resp
-                .text()
-                .await
-                .map_err(|e| AishError::Llm(e.to_string()))?;
-            let json: serde_json::Value = serde_json::from_str(&text)
-                .map_err(|e| AishError::Llm(format!("JSON parse error: {}", e)))?;
-            Ok(LlmResponse::Json(json))
-        }
+        Err(last_err.unwrap_or_else(|| AishError::Llm("Request failed after retries".into())))
     }
 }
 

--- a/crates/aish-llm/src/providers/codex.rs
+++ b/crates/aish-llm/src/providers/codex.rs
@@ -1065,6 +1065,19 @@ pub async fn create_openai_responses_http_response(
                     return Ok(resp);
                 }
                 let text = resp.text().await.unwrap_or_default();
+                if crate::api::is_retryable_status(status)
+                    && attempt + 1 < CODEX_MAX_REQUEST_ATTEMPTS
+                {
+                    let delay = crate::api::retry_backoff_delay(attempt);
+                    warn!(
+                        attempt,
+                        status = status.as_u16(),
+                        delay_ms = delay.as_millis() as u64,
+                        "Retryable HTTP status, backing off"
+                    );
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
                 return Err(CodexError::Http(format!("{status} {text}")));
             }
             Err(e) if e.is_connect() || e.is_timeout() => {
@@ -1180,6 +1193,19 @@ pub async fn create_codex_http_response(
 
                 if !status.is_success() {
                     let text = resp.text().await.unwrap_or_default();
+                    if crate::api::is_retryable_status(status)
+                        && attempt + 1 < CODEX_MAX_REQUEST_ATTEMPTS
+                    {
+                        let delay = crate::api::retry_backoff_delay(attempt);
+                        warn!(
+                            attempt,
+                            status = status.as_u16(),
+                            delay_ms = delay.as_millis() as u64,
+                            "Retryable HTTP status, backing off"
+                        );
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    }
                     return Err(CodexError::Http(format!("{status} {text}")));
                 }
 

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -1262,41 +1262,13 @@ impl LlmSession {
                 metadata: None,
             });
 
-            // Execute with retry: try once, retry once on failure.
-            // Mirrors Python's normalize_tool_result + error recovery pattern.
-            let result = {
-                let first = tool
-                    .as_ref()
-                    .execute_async_in_session(args.clone(), self)
-                    .await;
-                if first.ok || is_short_circuit_result(&first) {
-                    first
-                } else {
-                    // Retry once — log the retry attempt
-                    tracing::warn!(
-                        "Tool '{}' failed, retrying once: {}",
-                        tool_call.name,
-                        first.output
-                    );
-                    let second = tool
-                        .as_ref()
-                        .execute_async_in_session(args.clone(), self)
-                        .await;
-                    if second.ok {
-                        second
-                    } else {
-                        // Combine both error messages for diagnostic clarity
-                        ToolResult {
-                            ok: false,
-                            output: format!(
-                                "{}\n(retry also failed: {})",
-                                first.output, second.output
-                            ),
-                            meta: second.meta,
-                        }
-                    }
-                }
-            };
+            // Execute once. ToolResult::error is always deterministic in the
+            // current toolset (file-not-found, bad args, policy block, HTTP 4xx),
+            // so a blind retry would just duplicate the call and the error.
+            let result = tool
+                .as_ref()
+                .execute_async_in_session(args.clone(), self)
+                .await;
 
             // Update plan state based on tool result metadata
             if let Some(ref meta) = result.meta {

--- a/crates/aish-md-table/Cargo.toml
+++ b/crates/aish-md-table/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "aish-md-table"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+# Pin to default features only — md_table needs `segment`/`style`, not the
+# `syntax` (syntect) or `markdown` (pulldown-cmark) features that the workspace
+# pulls in for aish-shell. This keeps the test binary under a few MB instead of
+# the 39 MB that drags the OOM killer in when the system swap is full.
+richrs = "0.2"
+unicode-width = { workspace = true }

--- a/crates/aish-md-table/src/lib.rs
+++ b/crates/aish-md-table/src/lib.rs
@@ -171,12 +171,25 @@ fn parse_inline(text: &str) -> Spans {
             }
         }
 
-        // Italic: *...* or _..._
+        // Italic: *...* or _...*
         if c == '*' || c == '_' {
             if let Some(rel) = find_unescaped(&chars[i + 1..], c) {
+                // CommonMark forbids intraword `_` emphasis: `foo_bar_baz`
+                // must not italicize, or identifiers and paths in table cells
+                // get mangled (underscores consumed as delimiters). `*` allows
+                // intraword emphasis, so guard only `_`: reject when a `_`
+                // delimiter is flanked by an alphanumeric on either side.
+                let close = i + 1 + rel;
+                let intraword_underscore = c == '_'
+                    && ((i > 0 && chars[i - 1].is_alphanumeric())
+                        || (close + 1 < n && chars[close + 1].is_alphanumeric()));
                 // Reject `* foo *` — interior must not start with whitespace
                 // (CommonMark rule). Trailing whitespace inside is also invalid.
-                if rel > 0 && !chars[i + 1].is_whitespace() && !chars[i + rel].is_whitespace() {
+                if rel > 0
+                    && !chars[i + 1].is_whitespace()
+                    && !chars[i + rel].is_whitespace()
+                    && !intraword_underscore
+                {
                     flush!();
                     let inner: String = chars[i + 1..i + 1 + rel].iter().collect();
                     for mut s in parse_inline(&inner) {
@@ -679,6 +692,26 @@ mod tests {
         let spans = parse_inline(r"a\*b");
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].text, "a*b");
+    }
+
+    #[test]
+    fn intraword_underscore_not_emphasis() {
+        // CommonMark forbids intraword `_` emphasis: identifiers and paths
+        // like `foo_bar_baz` must keep underscores verbatim, not italicize
+        // the middle token.
+        let spans = parse_inline("foo_bar_baz");
+        assert_eq!(spans.len(), 1, "expected a single plain span");
+        assert_eq!(spans[0].text, "foo_bar_baz");
+        assert!(spans[0].style.attributes.italic != Some(true));
+    }
+
+    #[test]
+    fn word_bounded_underscore_is_emphasis() {
+        // `_world_` flanked by spaces remains valid italic emphasis.
+        let spans = parse_inline("hello _world_ end");
+        assert_eq!(spans.len(), 3);
+        assert_eq!(spans[1].text, "world");
+        assert!(spans[1].style.attributes.italic == Some(true));
     }
 
     #[test]

--- a/crates/aish-md-table/src/lib.rs
+++ b/crates/aish-md-table/src/lib.rs
@@ -1,0 +1,789 @@
+//! Markdown pipe-table renderer with CJK-aware width and cell wrapping.
+//!
+//! Replaces the previous `richrs::table::Table` based renderer, which had two
+//! problems:
+//! 1. It never wrapped cell content — cells wider than their column overflowed
+//!    and broke the right border alignment.
+//! 2. It rendered cell text verbatim, so inline markdown (`**bold**`, `` `code` ``)
+//!    showed up as literal asterisks/backticks.
+//!
+//! This module mirrors the algorithm used by the project's TypeScript renderer
+//! (`oh-my-pi/packages/tui/src/components/markdown.ts`): compute natural and
+//! minimum-word widths per column, distribute available width by grow potential,
+//! then wrap each cell to its allocated width (breaking long tokens so columns
+//! never overflow).
+
+use richrs::segment::{Segment, Segments};
+use richrs::style::Style;
+use unicode_width::UnicodeWidthChar;
+use unicode_width::UnicodeWidthStr;
+
+/// One styled text run. Public so callers (e.g. the paragraph wrapper in
+/// `md_render`) can build spans from parsed inline tokens and feed them to
+/// [`wrap_spans`].
+#[derive(Clone)]
+pub struct Span {
+    pub text: String,
+    pub style: Style,
+}
+
+impl Span {
+    /// Create a span with the given text and no styling.
+    #[inline]
+    pub fn plain(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            style: Style::default(),
+        }
+    }
+
+    /// Create a span with the given text and style.
+    #[inline]
+    pub fn styled(text: impl Into<String>, style: Style) -> Self {
+        Self {
+            text: text.into(),
+            style,
+        }
+    }
+
+    /// Visible width of this span's text (CJK = 2 cells).
+    #[inline]
+    pub fn width(&self) -> usize {
+        UnicodeWidthStr::width(self.text.as_str())
+    }
+}
+
+pub type Spans = Vec<Span>;
+
+/// Horizontal padding (in cells) applied to each side of every cell.
+const CELL_PADDING: usize = 1;
+
+/// Box-drawing glyphs used to frame the table.
+struct BoxChars {
+    top_left: char,
+    top_right: char,
+    bottom_left: char,
+    bottom_right: char,
+    horizontal: char,
+    vertical: char,
+    left_tee: char,
+    right_tee: char,
+    top_tee: char,
+    bottom_tee: char,
+    cross: char,
+}
+
+const BOX: BoxChars = BoxChars {
+    top_left: '┌',
+    top_right: '┐',
+    bottom_left: '└',
+    bottom_right: '┘',
+    horizontal: '─',
+    vertical: '│',
+    left_tee: '├',
+    right_tee: '┤',
+    top_tee: '┬',
+    bottom_tee: '┴',
+    cross: '┼',
+};
+
+/// Parse a markdown pipe-table row into trimmed cell strings.
+/// Returns `None` when the line is not a valid `| ... | ... |` row.
+fn parse_pipe_row(line: &str) -> Option<Vec<String>> {
+    let trimmed = line.trim();
+    if !trimmed.starts_with('|') || !trimmed.ends_with('|') || trimmed.len() < 2 {
+        return None;
+    }
+    let inner = &trimmed[1..trimmed.len() - 1];
+    let cells: Vec<String> = inner.split('|').map(|s| s.trim().to_string()).collect();
+    if cells.is_empty() {
+        return None;
+    }
+    Some(cells)
+}
+
+/// Parse inline markdown into styled spans.
+///
+/// Recognizes: `` `code` ``, `**bold**`, `*italic*`, `_italic_`, and backslash
+/// escapes for markdown-special characters. Nested styling (e.g. `**bold `code`**`)
+/// is supported via recursion on bold/italic runs.
+fn parse_inline(text: &str) -> Spans {
+    let chars: Vec<char> = text.chars().collect();
+    let n = chars.len();
+    let mut spans: Spans = Vec::new();
+    let mut buf = String::new();
+    let mut i = 0;
+
+    macro_rules! flush {
+        () => {
+            if !buf.is_empty() {
+                spans.push(Span {
+                    text: std::mem::take(&mut buf),
+                    style: Style::default(),
+                });
+            }
+        };
+    }
+
+    while i < n {
+        let c = chars[i];
+
+        // Backslash escape — only for markdown-special characters; a bare
+        // backslash before any other char is preserved verbatim.
+        if c == '\\' && i + 1 < n {
+            let next = chars[i + 1];
+            if matches!(
+                next,
+                '*' | '_' | '`' | '\\' | '|' | '[' | ']' | '(' | ')' | '<' | '>'
+            ) {
+                buf.push(next);
+                i += 2;
+                continue;
+            }
+        }
+
+        // Inline code: `...` — find the next backtick; no nesting inside.
+        if c == '`' {
+            if let Some(rel) = find_unescaped(&chars[i + 1..], '`') {
+                flush!();
+                let code: String = chars[i + 1..i + 1 + rel].iter().collect();
+                spans.push(Span {
+                    text: code,
+                    // Reverse video mirrors richrs::markdown's inline-code style.
+                    style: Style::new().reverse(),
+                });
+                i = i + 1 + rel + 1;
+                continue;
+            }
+        }
+
+        // Bold: **...**  (must consume both stars; otherwise fall through to italic)
+        if c == '*' && i + 1 < n && chars[i + 1] == '*' {
+            if let Some(rel) = find_double_star(&chars[i + 2..]) {
+                flush!();
+                let inner: String = chars[i + 2..i + 2 + rel].iter().collect();
+                for mut s in parse_inline(&inner) {
+                    s.style = s.style.clone().bold();
+                    spans.push(s);
+                }
+                i = i + 2 + rel + 2;
+                continue;
+            }
+        }
+
+        // Italic: *...* or _..._
+        if c == '*' || c == '_' {
+            if let Some(rel) = find_unescaped(&chars[i + 1..], c) {
+                // Reject `* foo *` — interior must not start with whitespace
+                // (CommonMark rule). Trailing whitespace inside is also invalid.
+                if rel > 0 && !chars[i + 1].is_whitespace() && !chars[i + rel].is_whitespace() {
+                    flush!();
+                    let inner: String = chars[i + 1..i + 1 + rel].iter().collect();
+                    for mut s in parse_inline(&inner) {
+                        s.style = s.style.clone().italic();
+                        spans.push(s);
+                    }
+                    i = i + 1 + rel + 1;
+                    continue;
+                }
+            }
+        }
+
+        buf.push(c);
+        i += 1;
+    }
+
+    flush!();
+    if spans.is_empty() {
+        spans.push(Span::plain(""));
+    }
+    spans
+}
+
+/// Find the next occurrence of `target` in `chars`, skipping backslash escapes.
+/// Returns the index relative to the start of `chars`.
+fn find_unescaped(chars: &[char], target: char) -> Option<usize> {
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] == '\\' && i + 1 < chars.len() {
+            i += 2;
+            continue;
+        }
+        if chars[i] == target {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Find the next `**` (double-star) close delimiter in `chars`.
+fn find_double_star(chars: &[char]) -> Option<usize> {
+    let mut i = 0;
+    while i + 1 < chars.len() {
+        if chars[i] == '\\' && i + 1 < chars.len() {
+            i += 2;
+            continue;
+        }
+        if chars[i] == '*' && chars[i + 1] == '*' {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Total visible width of a span sequence.
+pub fn spans_width(spans: &[Span]) -> usize {
+    spans.iter().map(|s| s.width()).sum()
+}
+
+/// Width of the longest whitespace-delimited token across all spans.
+/// Used as the floor a column can shrink to without breaking words.
+fn longest_token_width(spans: &[Span]) -> usize {
+    let mut max = 0usize;
+    for span in spans {
+        for tok in span.text.split(char::is_whitespace) {
+            if tok.is_empty() {
+                continue;
+            }
+            let w = UnicodeWidthStr::width(tok);
+            if w > max {
+                max = w;
+            }
+        }
+    }
+    max.max(1)
+}
+
+/// Drop trailing whitespace-only spans and trim trailing whitespace from the
+/// final text span. Keeps wrapped lines free of dangling spaces that would
+/// otherwise push the right border off the calculated column width.
+fn trim_trailing_whitespace(spans: &mut Spans) {
+    loop {
+        // Snapshot the trailing span's text so we don't hold an immutable
+        // borrow of `spans` across the mutable `pop`/`truncate` below.
+        let Some(text) = spans.last().map(|s| s.text.clone()) else {
+            return;
+        };
+        if text.is_empty() || text.chars().all(char::is_whitespace) {
+            spans.pop();
+            continue;
+        }
+        let trimmed_len = text.trim_end().len();
+        if trimmed_len < text.len() {
+            spans.last_mut().unwrap().text.truncate(trimmed_len);
+        }
+        return;
+    }
+}
+
+/// Tokenize spans into `(text, style)` units where every unit is either a run
+/// of non-whitespace characters or a single whitespace character. Whitespace
+/// is preserved as its own token so spacing can be reconstructed, and dropped
+/// at line boundaries during wrapping.
+fn tokenize(spans: &[Span]) -> Vec<(String, Style)> {
+    let mut tokens = Vec::new();
+    for span in spans {
+        let mut cur = String::new();
+        for ch in span.text.chars() {
+            if ch.is_whitespace() {
+                if !cur.is_empty() {
+                    tokens.push((std::mem::take(&mut cur), span.style.clone()));
+                }
+                tokens.push((ch.to_string(), span.style.clone()));
+            } else {
+                cur.push(ch);
+            }
+        }
+        if !cur.is_empty() {
+            tokens.push((cur, span.style.clone()));
+        }
+    }
+    tokens
+}
+
+/// Wrap a span sequence to `width` cells, breaking any single token that is
+/// wider than the column. Returns one or more lines (each a `Spans`).
+///
+/// Algorithm mirrors `wrap_single_line` in `pi-natives/src/text.rs`:
+/// - Long tokens (width > column) are broken grapheme-by-grapheme, never
+///   exceeding the column width.
+/// - Other tokens wrap at word boundaries; whitespace at the wrap point is
+///   dropped so it doesn't land at the start of the next line.
+pub fn wrap_spans(spans: &[Span], width: usize) -> Vec<Spans> {
+    if width == 0 {
+        return vec![spans.to_vec()];
+    }
+    if spans_width(spans) <= width {
+        let mut line = spans.to_vec();
+        trim_trailing_whitespace(&mut line);
+        return vec![line];
+    }
+
+    let tokens = tokenize(spans);
+    let mut lines: Vec<Spans> = Vec::new();
+    let mut cur: Spans = Vec::new();
+    let mut cur_width = 0usize;
+
+    for (text, style) in tokens {
+        let tw = UnicodeWidthStr::width(text.as_str());
+        let is_whitespace = !text.is_empty() && text.chars().all(char::is_whitespace);
+
+        // Token wider than the whole column — break it grapheme by grapheme.
+        if !is_whitespace && tw > width {
+            if cur_width > 0 {
+                trim_trailing_whitespace(&mut cur);
+                lines.push(std::mem::take(&mut cur));
+                cur_width = 0;
+            }
+            let mut piece = String::new();
+            let mut piece_w = 0usize;
+            for ch in text.chars() {
+                let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
+                if piece_w + cw > width && piece_w > 0 {
+                    cur.push(Span {
+                        text: std::mem::take(&mut piece),
+                        style: style.clone(),
+                    });
+                    lines.push(std::mem::take(&mut cur));
+                    piece_w = 0;
+                }
+                piece.push(ch);
+                piece_w += cw;
+            }
+            if !piece.is_empty() {
+                cur.push(Span {
+                    text: piece,
+                    style: style.clone(),
+                });
+                cur_width = piece_w;
+            }
+            continue;
+        }
+
+        if cur_width + tw > width {
+            // Token doesn't fit on the current line — flush and start fresh.
+            trim_trailing_whitespace(&mut cur);
+            if !cur.is_empty() {
+                lines.push(std::mem::take(&mut cur));
+            }
+            cur_width = 0;
+            if is_whitespace {
+                // Drop whitespace that would otherwise begin a new line.
+                continue;
+            }
+            cur.push(Span {
+                text,
+                style: style.clone(),
+            });
+            cur_width = tw;
+        } else {
+            cur.push(Span {
+                text,
+                style: style.clone(),
+            });
+            cur_width += tw;
+        }
+    }
+
+    if !cur.is_empty() {
+        trim_trailing_whitespace(&mut cur);
+        lines.push(cur);
+    }
+    if lines.is_empty() {
+        lines.push(Vec::new());
+    }
+    lines
+}
+
+/// Allocate column widths within `available` cells.
+///
+/// Each column has a natural width (the widest cell) and a minimum width (the
+/// widest single word — a column can't shrink below this without breaking
+/// words). When the natural total fits, return it unchanged; otherwise shrink
+/// columns in proportion to their grow potential (`natural - min`), flooring
+/// each at its minimum.
+fn compute_widths(cols: &[(usize, usize)], available: usize) -> Vec<usize> {
+    if cols.is_empty() {
+        return Vec::new();
+    }
+    let natural_total: usize = cols.iter().map(|(n, _)| *n).sum();
+    if natural_total <= available {
+        return cols.iter().map(|(n, _)| *n).collect();
+    }
+
+    let min_total: usize = cols.iter().map(|(_, m)| *m).sum();
+    if min_total >= available {
+        // Even minimums overflow `available`: hard-cap every column to an equal
+        // share and let `wrap_spans` break long tokens. This keeps the table
+        // within `max_width` at the cost of splitting unbreakable words —
+        // preferable to a table wider than the terminal.
+        let per_col = available.checked_div(cols.len()).unwrap_or(1).max(1);
+        return cols.iter().map(|_| per_col).collect();
+    }
+
+    let grow_total: usize = cols.iter().map(|(n, m)| n.saturating_sub(*m)).sum();
+    let extra = available.saturating_sub(min_total);
+
+    let mut widths: Vec<usize> = cols
+        .iter()
+        .map(|(n, m)| *m + n.saturating_sub(*m) * extra / grow_total.max(1))
+        .collect();
+
+    // Distribute the integer-rounding remainder left-to-right.
+    let allocated: usize = widths.iter().sum();
+    let mut remainder = available.saturating_sub(allocated);
+    let cols_len = widths.len();
+    let mut idx = 0;
+    while remainder > 0 {
+        widths[idx % cols_len] += 1;
+        remainder -= 1;
+        idx += 1;
+    }
+
+    widths
+}
+
+/// Horizontal padding for one side of a cell.
+fn pad() -> String {
+    " ".repeat(CELL_PADDING)
+}
+
+/// Push a horizontal border line (top, mid, or bottom).
+fn push_border(segs: &mut Segments, kind: BorderKind, widths: &[usize], border_style: &Style) {
+    let (left, mid, right) = match kind {
+        BorderKind::Top => (BOX.top_left, BOX.top_tee, BOX.top_right),
+        BorderKind::Mid => (BOX.left_tee, BOX.cross, BOX.right_tee),
+        BorderKind::Bottom => (BOX.bottom_left, BOX.bottom_tee, BOX.bottom_right),
+    };
+
+    let mut line = String::new();
+    line.push(left);
+    for (i, w) in widths.iter().enumerate() {
+        let cell_w = w + CELL_PADDING * 2;
+        line.push_str(&BOX.horizontal.to_string().repeat(cell_w));
+        if i + 1 < widths.len() {
+            line.push(mid);
+        }
+    }
+    line.push(right);
+
+    segs.push(Segment::styled(line, border_style.clone()));
+    segs.push(Segment::newline());
+}
+
+#[derive(Clone, Copy)]
+enum BorderKind {
+    Top,
+    Mid,
+    Bottom,
+}
+
+/// Push one physical row. `cell_at(i)` returns the wrapped spans for column `i`
+/// on this line (empty if that cell has fewer wrapped lines than the row max).
+fn push_row<F>(
+    segs: &mut Segments,
+    widths: &[usize],
+    border_style: &Style,
+    header_style: &Option<Style>,
+    cell_at: F,
+) where
+    F: Fn(usize) -> Spans,
+{
+    // Left border.
+    segs.push(Segment::styled(
+        BOX.vertical.to_string(),
+        border_style.clone(),
+    ));
+    for (i, &w) in widths.iter().enumerate() {
+        // Left padding.
+        segs.push(Segment::new(pad()));
+
+        let cell_spans = cell_at(i);
+        let used = spans_width(&cell_spans);
+
+        // Cell content. `header_style` (if any) layers on top of inline styles
+        // so a `**bold**` header still reads as bold + reverse inside code.
+        for s in &cell_spans {
+            let combined = match header_style {
+                Some(hs) => s.style.clone().combine(hs),
+                None => s.style.clone(),
+            };
+            if combined.is_empty() {
+                segs.push(Segment::new(s.text.clone()));
+            } else {
+                segs.push(Segment::styled(s.text.clone(), combined));
+            }
+        }
+
+        // Right-pad the cell so the next vertical lands at the right column.
+        let pad_right = w.saturating_sub(used);
+        if pad_right > 0 {
+            segs.push(Segment::new(" ".repeat(pad_right)));
+        }
+
+        // Right padding.
+        segs.push(Segment::new(pad()));
+
+        // Column separator / right border.
+        segs.push(Segment::styled(
+            BOX.vertical.to_string(),
+            border_style.clone(),
+        ));
+    }
+
+    segs.push(Segment::newline());
+}
+
+/// Render a markdown pipe table to segments.
+///
+/// Returns `None` when `lines` is not a valid pipe table (missing header row,
+/// bad separator, or no columns).
+pub fn render(lines: &[&str], max_width: usize) -> Option<Segments> {
+    let header_cells = parse_pipe_row(lines.first()?)?;
+    let sep = lines.get(1)?.trim();
+    if !sep
+        .chars()
+        .all(|c| c == '|' || c == '-' || c == ':' || c == ' ')
+    {
+        return None;
+    }
+    let col_count = header_cells.len();
+    if col_count == 0 {
+        return None;
+    }
+
+    // Parse every cell into styled spans up front.
+    let header_spans: Vec<Spans> = header_cells.iter().map(|h| parse_inline(h)).collect();
+    let mut row_spans: Vec<Vec<Spans>> = Vec::new();
+    for line in lines.iter().skip(2) {
+        if let Some(cells) = parse_pipe_row(line) {
+            if cells.len() == col_count {
+                row_spans.push(cells.iter().map(|c| parse_inline(c)).collect());
+            }
+        }
+    }
+
+    // Compute natural + minimum-word widths per column.
+    let border_overhead = col_count + 1;
+    let padding_overhead = col_count * CELL_PADDING * 2;
+    let available = max_width
+        .saturating_sub(border_overhead)
+        .saturating_sub(padding_overhead);
+
+    let mut cols: Vec<(usize, usize)> = Vec::with_capacity(col_count);
+    for i in 0..col_count {
+        let mut natural = spans_width(&header_spans[i]);
+        let mut min_word = longest_token_width(&header_spans[i]);
+        for row in &row_spans {
+            let w = spans_width(&row[i]);
+            if w > natural {
+                natural = w;
+            }
+            let mw = longest_token_width(&row[i]);
+            if mw > min_word {
+                min_word = mw;
+            }
+        }
+        cols.push((natural, min_word.max(1)));
+    }
+
+    let widths = compute_widths(&cols, available);
+
+    let mut segs = Segments::new();
+    let border_style = Style::new().dim();
+    let header_style = Style::new().bold();
+
+    push_border(&mut segs, BorderKind::Top, &widths, &border_style);
+
+    // Header rows (may wrap to multiple physical lines).
+    let header_wrapped: Vec<Vec<Spans>> = (0..col_count)
+        .map(|i| wrap_spans(&header_spans[i], widths[i]))
+        .collect();
+    let header_line_count = header_wrapped.iter().map(|c| c.len()).max().unwrap_or(1);
+    for line_idx in 0..header_line_count {
+        push_row(
+            &mut segs,
+            &widths,
+            &border_style,
+            &Some(header_style.clone()),
+            |i| header_wrapped[i].get(line_idx).cloned().unwrap_or_default(),
+        );
+    }
+
+    push_border(&mut segs, BorderKind::Mid, &widths, &border_style);
+
+    for row in &row_spans {
+        let row_wrapped: Vec<Vec<Spans>> = (0..col_count)
+            .map(|i| wrap_spans(&row[i], widths[i]))
+            .collect();
+        let line_count = row_wrapped.iter().map(|c| c.len()).max().unwrap_or(1);
+        for line_idx in 0..line_count {
+            push_row(&mut segs, &widths, &border_style, &None, |i| {
+                row_wrapped[i].get(line_idx).cloned().unwrap_or_default()
+            });
+        }
+    }
+
+    push_border(&mut segs, BorderKind::Bottom, &widths, &border_style);
+
+    Some(segs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Plain visible text of a segment stream, with all styling stripped.
+    /// Uses `Segments::plain_text` so UTF-8 (CJK) survives intact.
+    fn plain(segs: &Segments) -> String {
+        segs.plain_text()
+    }
+
+    /// Visible width of each `│`-prefixed row. All data rows must share the
+    /// same width or the right border is misaligned.
+    fn right_border_columns(plain: &str) -> Vec<usize> {
+        plain
+            .lines()
+            .filter(|l| l.starts_with('│'))
+            .map(UnicodeWidthStr::width)
+            .collect()
+    }
+
+    #[test]
+    fn parses_simple_pipe_row() {
+        let cells = parse_pipe_row("| a | b |").unwrap();
+        assert_eq!(cells, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn rejects_non_pipe_line() {
+        assert!(parse_pipe_row("hello").is_none());
+        assert!(parse_pipe_row("| only-left").is_none());
+    }
+
+    #[test]
+    fn parses_bold_and_code() {
+        let spans = parse_inline("**hi** `code`");
+        // Three spans: bold "hi", plain " ", reverse "code"
+        assert_eq!(spans.len(), 3);
+        assert_eq!(spans[0].text, "hi");
+        assert!(spans[0].style.attributes.bold == Some(true));
+        assert_eq!(spans[2].text, "code");
+        assert!(spans[2].style.attributes.reverse == Some(true));
+    }
+
+    #[test]
+    fn respects_escape() {
+        let spans = parse_inline(r"a\*b");
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].text, "a*b");
+    }
+
+    #[test]
+    fn renders_simple_ascii_table() {
+        let lines = vec!["| Name | Value |", "|------|-------|", "| Foo  | 100   |"];
+        let segs = render(&lines, 80).unwrap();
+        let plain = plain(&segs);
+        assert!(plain.contains("Name"));
+        assert!(plain.contains("Foo"));
+        assert!(plain.contains("100"));
+        // Borders aligned: every │-prefixed row has the same width.
+        let cols = right_border_columns(&plain);
+        assert!(
+            cols.iter().all(|&w| w == cols[0]),
+            "misaligned rows: {:?}",
+            cols
+        );
+    }
+
+    #[test]
+    fn wraps_long_cjk_cell_so_borders_align() {
+        // Reproduces the user-reported case: a long mixed CJK/ASCII cell that
+        // previously overflowed its column and broke the right border.
+        let lines = vec![
+            "| 类别 | 数量 | 内容 |",
+            "|------|------|------|",
+            "| **环境信息** | 3 条 | 系统 `10.10.17.243` 装有企业微信（多 IP）；API Key 存在 `SECRET_GENERIC_SK_API_KEY`；130 的密码 `uos111` |",
+            "| **测试记录** | 7 条 | 工具调用测试、记忆存储功能测试等 |",
+        ];
+        let segs = render(&lines, 80).unwrap();
+        let plain = plain(&segs);
+
+        // Inline markdown must not appear literally.
+        assert!(!plain.contains("**"), "literal ** leaked: {}", plain);
+        // Border alignment: all │-prefixed data rows share the same width.
+        let cols = right_border_columns(&plain);
+        assert!(
+            cols.iter().all(|&w| w == cols[0]),
+            "misaligned borders: {:?}",
+            cols
+        );
+        // No row may exceed the requested width.
+        for line in plain.lines() {
+            assert!(
+                UnicodeWidthStr::width(line) <= 80 + 4,
+                "row wider than terminal: {:?}",
+                line
+            );
+        }
+    }
+
+    #[test]
+    fn breaks_long_unbreakable_token() {
+        // One column, terminal width 20. A 40-char token must wrap across
+        // multiple physical rows, none exceeding the column width.
+        let lines = vec![
+            "| x |",
+            "|---|",
+            "| aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa |",
+        ];
+        let segs = render(&lines, 20).unwrap();
+        let plain = plain(&segs);
+        for line in plain.lines().filter(|l| l.starts_with('│')) {
+            let w = UnicodeWidthStr::width(line);
+            assert!(w <= 20, "row wider: {} in {:?}", w, line);
+        }
+        let all_a: String = plain.chars().filter(|c| *c == 'a').collect();
+        assert_eq!(all_a.len(), 40);
+    }
+
+    #[test]
+    fn handles_empty_cell() {
+        let lines = vec!["| a | b |", "|---|---|", "| | x |"];
+        let segs = render(&lines, 40).unwrap();
+        let plain = plain(&segs);
+        assert!(plain.contains("x"));
+        let cols = right_border_columns(&plain);
+        assert!(cols.iter().all(|&w| w == cols[0]));
+    }
+
+    #[test]
+    fn left_border_present_on_every_row() {
+        // Regression: push_row once lost its left-border `│` push during a
+        // refactor, producing rows that started with a space instead. Every
+        // non-empty rendered line must begin with a box-drawing glyph.
+        let lines = vec![
+            "| 用户 | PID | %MEM | %CPU | RSS(KB) | 进程 |",
+            "|------|-----|------|------|---------|------|",
+            "| xzx  | 2742 | 3.8  | 35.8 | 622,108 | service-manager |",
+        ];
+        let plain = plain(&render(&lines, 80).unwrap());
+        for line in plain.lines() {
+            let first = line.chars().next();
+            assert!(
+                matches!(first, Some('│' | '┌' | '├' | '└')),
+                "row missing left border, starts with {:?}: {:?}",
+                first,
+                line
+            );
+        }
+    }
+
+    #[test]
+    fn returns_none_for_invalid_separator() {
+        let lines = vec!["| a | b |", "| x y |", "| 1 | 2 |"];
+        assert!(render(&lines, 40).is_none());
+    }
+}

--- a/crates/aish-shell/Cargo.toml
+++ b/crates/aish-shell/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 aish-core.workspace = true
+aish-md-table.workspace = true
 base64.workspace = true
 aish-config.workspace = true
 aish-hosts.workspace = true
@@ -35,6 +36,7 @@ uuid.workspace = true
 dirs.workspace = true
 reqwest.workspace = true
 richrs.workspace = true
+pulldown-cmark.workspace = true
 regex.workspace = true
 shellexpand = "2.1"
 sysinfo.workspace = true

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -557,6 +557,23 @@ impl AishShell {
         }
     }
 
+    /// Run the `@path` file-mention popup, seeded with the readline state
+    /// captured by `AtFileHandler`. `line` is the buffer without `@`;
+    /// `at_pos` is where `@` was about to be inserted.
+    fn run_file_mention_session(
+        &self,
+        prompt: &str,
+        line: &str,
+        at_pos: usize,
+    ) -> aish_ui::FileMentionOutcome {
+        let prefix = line[..at_pos].to_string();
+        let cwd = std::path::PathBuf::from(&self.state.cwd);
+        let session = aish_ui::FileMentionSession::new(&cwd, prompt.to_string(), prefix);
+        session
+            .run()
+            .unwrap_or(aish_ui::FileMentionOutcome::Cancelled)
+    }
+
     /// Security gate: check AI input for secrets and prompt the user.
     /// Returns `true` to continue, `false` if the user aborted (caller should skip).
     /// When secrets are detected and the user chooses "Redact", `question` is
@@ -2082,6 +2099,30 @@ impl AishShell {
                         }
                         continue;
                     }
+                    // Check if `@` inside an AI prompt triggered the file-mention popup
+                    if matches!(e, rustyline::error::ReadlineError::Interrupted)
+                        && rl.was_at_file_requested()
+                    {
+                        if let Some((line, at_pos)) = crate::readline::take_at_file_context() {
+                            match self.run_file_mention_session(&prompt_str, &line, at_pos) {
+                                aish_ui::FileMentionOutcome::Selected(path) => {
+                                    let before = &line[..at_pos];
+                                    let after = &line[at_pos..];
+                                    let new_line = format!("{before}@{path} {after}");
+                                    if self.read_line_after_at_file(&mut rl, &prompt_str, &new_line)
+                                    {
+                                        break;
+                                    }
+                                }
+                                aish_ui::FileMentionOutcome::Cancelled => {
+                                    if self.read_line_after_at_file(&mut rl, &prompt_str, &line) {
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        continue;
+                    }
                     // Interrupt (Ctrl-C) — handle double-press exit
                     if matches!(e, rustyline::error::ReadlineError::Interrupted) {
                         // Record newline so cast replay moves cursor to next line
@@ -2826,6 +2867,55 @@ impl AishShell {
         }
     }
 
+    /// After the file-mention popup closes, re-enter readline with the
+    /// spliced text pre-filled. Supports nested `@` and `/` popups.
+    /// Returns `true` when the main shell loop should exit.
+    fn read_line_after_at_file(
+        &mut self,
+        rl: &mut ShellReadline,
+        prompt: &str,
+        initial: &str,
+    ) -> bool {
+        let mut prefill = initial.to_string();
+        loop {
+            match rl.read_line_with_initial(prompt, (&prefill, "")) {
+                Ok(Some(line)) => return self.process_readline_submission(&line),
+                Ok(None) => return false,
+                Err(rustyline::error::ReadlineError::Interrupted) => {
+                    if rl.was_at_file_requested() {
+                        if let Some((line2, at_pos)) = crate::readline::take_at_file_context() {
+                            match self.run_file_mention_session(prompt, &line2, at_pos) {
+                                aish_ui::FileMentionOutcome::Selected(path) => {
+                                    let before = &line2[..at_pos];
+                                    let after = &line2[at_pos..];
+                                    prefill = format!("{before}@{path} {after}");
+                                }
+                                aish_ui::FileMentionOutcome::Cancelled => {
+                                    prefill = line2;
+                                }
+                            }
+                        }
+                    } else if rl.was_slash_requested() {
+                        match self.run_slash_input_session(prompt) {
+                            aish_ui::SlashInputOutcome::Command(cmd) => {
+                                self.apply_slash_popup_command(rl, prompt, &cmd);
+                                return false;
+                            }
+                            aish_ui::SlashInputOutcome::Dismissed(text) => {
+                                prefill = text;
+                            }
+                            aish_ui::SlashInputOutcome::Cancelled => return false,
+                        }
+                    } else {
+                        crate::recorder::shared_record_output(&self.shared_recorder, "\r\n");
+                        return self.handle_ctrl_c();
+                    }
+                }
+                Err(_) => return false,
+            }
+        }
+    }
+
     /// Record last command outcome for `;` quick-fix and `/diagnose`.
     fn track_command_failure_state(&mut self, command: &str, exit_code: i32) {
         use aish_i18n::t;
@@ -2905,6 +2995,83 @@ impl AishShell {
                 let exit_code = self.execute_script(input);
                 self.record_history(input, exit_code);
                 self.track_command_failure_state(input, exit_code);
+                false
+            }
+            crate::types::InputIntent::Ai => {
+                // Popup-recovery AI path: the line was assembled inside a
+                // slash/@ popup and submitted via `read_line_with_initial`,
+                // so it does not flow through the main loop's Ai branch.
+                // Mirror that branch's essentials (InputGuard, security
+                // gate, handle_question, streaming/non-streaming render,
+                // cancellation, history) so `@file` mentions reach the LLM.
+                let mut question = input::extract_ai_question(input);
+                if question.is_empty() {
+                    return false;
+                }
+                if !self.screen_ai_prompt(&question) {
+                    return false;
+                }
+                if !self.check_security_gate(&mut question) {
+                    return false;
+                }
+                let ai_prefix = if input.starts_with('\u{ff1b}') {
+                    "\u{ff1b}"
+                } else {
+                    ";"
+                };
+                crate::recorder::shared_record_input(
+                    &self.shared_recorder,
+                    &format!("{}{}\n", ai_prefix, question),
+                );
+                let old_sigint = self.install_ai_sigint_handler();
+                let mut esc_watcher =
+                    CrosstermEscWatcher::start(self.ai_handler.cancellation_token_arc());
+                let token_ptr = self.ai_handler.cancellation_token() as *const CancellationToken;
+                let runtime = match tokio::runtime::Runtime::new() {
+                    Ok(rt) => rt,
+                    Err(err) => {
+                        esc_watcher.stop();
+                        Self::restore_ai_sigint_handler(old_sigint);
+                        eprintln!("{}", theme::error(&format!("runtime error: {err}")));
+                        return false;
+                    }
+                };
+                let result = runtime.block_on(async {
+                    tokio::select! {
+                        r = self.ai_handler.handle_question(&question) => r,
+                        _ = poll_cancelled(token_ptr) => {
+                            Err(aish_core::AishError::Cancelled)
+                        }
+                    }
+                });
+                esc_watcher.stop();
+                Self::restore_ai_sigint_handler(old_sigint);
+                self.sync_state_from_pty_cwd();
+                let did_stream = self.streamed_content.load(Ordering::SeqCst);
+                match result {
+                    Ok(response) => {
+                        if self.ai_handler.cancellation_token().is_cancelled() {
+                            println!("{}", theme::warning(&t("shell.interrupted")));
+                        } else if !did_stream && !response.trim().is_empty() {
+                            let mut sep = ShellRenderer::new();
+                            sep.set_shared_recorder(self.shared_recorder.clone());
+                            sep.render_separator();
+                            print_md_with_recording(&response, &self.shared_recorder);
+                            sep.render_separator();
+                        }
+                    }
+                    Err(aish_core::AishError::Cancelled) => {
+                        println!("{}", theme::warning(&t("shell.interrupted")));
+                    }
+                    Err(e) => {
+                        if !matches!(e, aish_core::AishError::Llm(_)) {
+                            let msg = t("shell.error.llm_error_message")
+                                .replace("{error}", &e.to_string());
+                            eprintln!("{}", theme::error(&msg));
+                        }
+                    }
+                }
+                self.record_history(input, 0);
                 false
             }
             _ => {

--- a/crates/aish-shell/src/inline_completion.rs
+++ b/crates/aish-shell/src/inline_completion.rs
@@ -431,12 +431,17 @@ use aish_llm::CancellationToken;
 use crate::autosuggest::AutoSuggest;
 use crate::input::extract_ai_question;
 
-/// Single-cell spinner that replaces the `◆` icon in the `◆ aish` mode badge
-/// while an inline-completion LLM call is in flight. `aish` stays visible.
+/// Single-cell spinner that replaces ONLY the `◆` icon at column 1 of the
+/// prompt while an inline-completion LLM call is in flight. `aish` and the
+/// rest of the badge stay exactly where rustyline rendered them — the
+/// spinner never rewrites them, so nothing shifts regardless of how the
+/// terminal measures `◆`'s width.
 ///
-/// Each frame is a Braille spinner glyph + space + `aish` (6 cols),
-/// cycling through the 8-frame `theme::SPINNER_STATUS` Braille pattern. The
-/// width matches `◆ aish` exactly so the rest of the prompt never shifts.
+/// Each frame is a single accent-colored Braille glyph from
+/// `theme::SPINNER_STATUS` (8-frame "⣾⣽⣻⢿⡿⣟⣯⣷" cycle), written to
+/// column 1. On CJK terminals that render `◆` as 2 columns, the terminal
+/// auto-clears the second column of the `◆` cell when the narrow spinner
+/// glyph overwrites its first — `aish` never moves.
 ///
 /// Writes go directly to stderr via `\x1b7` (save cursor) + optional
 /// `\x1b[<N>A` (move up N lines, navigating to the prompt line when input
@@ -598,6 +603,11 @@ impl PromptSpinner {
 
     /// Cancel current task and synchronously write the restore sequence.
     /// No-op if no spinner was started. Idempotent.
+    ///
+    /// Only the `◆` icon cell is rewritten — the rest of the badge
+    /// (`aish`, path, etc.) stays exactly where rustyline rendered it, so
+    /// nothing shifts regardless of how the terminal measures the width
+    /// of `◆` (ambiguous-width glyph — 1 col on some terminals, 2 on CJK).
     fn stop(&self) {
         let prev = self.token.lock().unwrap().take();
         let Some(tok) = prev else {
@@ -607,8 +617,8 @@ impl PromptSpinner {
         self.handle.lock().unwrap().take();
         let up = Self::up_prefix(self.lines_up());
         let mut stderr = std::io::stderr().lock();
-        let badge = crate::theme::accent(&format!("{} aish", crate::theme::MODE_ICON));
-        let _ = write!(stderr, "\x1b7{}\x1b[1G{}\x1b8", up, badge);
+        let icon = crate::theme::accent(crate::theme::MODE_ICON);
+        let _ = write!(stderr, "\x1b7{}\x1b[1G{}\x1b8", up, icon);
     }
 
     /// Cancel current task without writing restore (used internally by
@@ -622,31 +632,46 @@ impl PromptSpinner {
     }
 }
 
-/// Spinner frame sequence using Braille glyphs from `theme::SPINNER_STATUS`
-/// (the 8-frame "⣾⣽⣻⢿⡿⣟⣯⣷" cycle). The spinner glyph replaces only the `◆`
-/// icon while `aish` stays visible.
+/// Spinner frame sequence: one Braille glyph per frame (accent-colored).
 ///
-/// The `◆` badge glyph (U+25C6) is East-Asian-Width Ambiguous — it occupies
-/// 2 columns in CJK locales but 1 elsewhere — while Braille spinner glyphs are
-/// Neutral (always 1 column). Each frame pads the spinner glyph so its visible
-/// width matches the badge in every locale, keeping `aish` aligned and avoiding
-/// a stale trailing cell during the animation.
+/// The spinner replaces ONLY the `◆` icon cell (column 1). The rest of
+/// the badge (`aish`, path, prompt symbol) is left untouched — rustyline
+/// already rendered it, and rewriting it would risk shifting `aish` when
+/// the terminal's measurement of `◆` (an East-Asian-Width Ambiguous
+/// glyph) disagrees with our `term_char_width` estimate.
+///
+/// Because each frame is a single 1-column glyph written to column 1,
+/// there is no width-mismatch with the badge and no trailing-cell
+/// residue to clean up. On CJK terminals that render `◆` as 2 columns,
+/// the terminal automatically clears the second column of the `◆` cell
+/// when the narrow spinner glyph overwrites its first column — the
+/// visible gap is absorbed by the space that already follows `◆` in the
+/// badge, so `aish` never moves.
 fn spinner_frames() -> &'static [String] {
     static FRAMES: std::sync::LazyLock<Vec<String>> = std::sync::LazyLock::new(|| {
-        let icon_w =
-            crate::prompt::term_char_width(crate::theme::MODE_ICON.chars().next().unwrap_or('◆'));
+        // The single-cell spinner design hinges on MODE_ICON and every
+        // SPINNER_STATUS glyph being exactly ONE terminal cell. A multi-char
+        // MODE_ICON (or a multi-char spinner glyph) would write multiple
+        // cells and silently reintroduce the aish-shift regression.
+        debug_assert!(
+            crate::theme::MODE_ICON.chars().count() == 1,
+            "MODE_ICON must be exactly one character; multi-cell icons break \
+             the single-cell spinner design (got {:?})",
+            crate::theme::MODE_ICON
+        );
+        debug_assert!(
+            crate::theme::SPINNER_STATUS
+                .iter()
+                .all(|s| s.chars().count() == 1),
+            "every SPINNER_STATUS glyph must be exactly one character"
+        );
         crate::theme::SPINNER_STATUS
             .iter()
-            .map(|&ch| {
-                let glyph = ch.chars().next().unwrap_or(' ');
-                let pad = icon_w.saturating_sub(crate::prompt::term_char_width(glyph));
-                crate::theme::accent(&format!("{}{} aish", ch, " ".repeat(pad)))
-            })
+            .map(|&ch| crate::theme::accent(ch))
             .collect()
     });
     &FRAMES
 }
-
 /// RAII guard: stops the spinner on drop. Used in `prefetch()` to guarantee
 /// the restore sequence fires on every return path (cancel, timeout, error,
 /// sanitize None, success). No-op if `start()` was never called.
@@ -1263,6 +1288,29 @@ mod completer_tests {
         }
     }
 
+    /// Strip ANSI CSI sequences (SGR color codes etc.) from `s`, leaving
+    /// only the visible content characters. Used by tests to compare what
+    /// the terminal actually renders, not the escape-laden raw output.
+    fn strip_sgr(s: &str) -> String {
+        let mut out = String::new();
+        let mut chars = s.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '\x1b' && chars.peek() == Some(&'[') {
+                chars.next(); // consume '['
+                              // Consume the rest of the CSI sequence up to the final byte
+                              // (any ASCII alphabetic, e.g. 'm' for SGR, 'G' for CHA).
+                for ci in chars.by_ref() {
+                    if ci.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
     #[test]
     fn hint_no_op_for_too_short_input() {
         let provider = Arc::new(FakeCompletionProvider::new("list files"));
@@ -1573,5 +1621,132 @@ mod completer_tests {
             "spinner should start when wrapped but not at exact boundary"
         );
         s.stop_internal();
+    }
+
+    /// Core invariant of the new spinner design: each frame is a SINGLE
+    /// glyph that overwrites ONLY the `◆` cell at column 1. Because
+    /// nothing else is rewritten, `aish` can never shift — regardless of
+    /// how the terminal measures `◆`'s width (the root cause of the old
+    /// `◆ aishh` bug and the "aish shifts by one column" regression).
+    ///
+    /// The assertion strips SGR color codes and verifies the remaining
+    /// content is EXACTLY one Braille glyph — not just that one is
+    /// present. The old buggy code (`accent("⣾ aish")`) also contains
+    /// exactly one Braille glyph but has trailing ` aish`; this test
+    /// catches that because it asserts no other characters follow.
+    #[test]
+    fn spinner_frame_is_single_glyph() {
+        let frames = spinner_frames();
+        assert!(!frames.is_empty(), "spinner must have frames");
+        for (i, frame) in frames.iter().enumerate() {
+            let stripped = strip_sgr(frame);
+            let mut chars = stripped.chars();
+            let glyph = chars.next().unwrap_or_else(|| {
+                panic!("frame {i} is empty after SGR strip (full frame {frame:?})")
+            });
+            assert!(
+                ('\u{2800}'..='\u{28FF}').contains(&glyph),
+                "frame {i} must start with a Braille glyph, got {glyph:?} \
+                 (stripped {stripped:?}, full frame {frame:?})"
+            );
+            assert_eq!(
+                chars.next(),
+                None,
+                "frame {i} must be EXACTLY one cell after SGR strip, got \
+                 {stripped:?}; any extra cell would shift `aish` on terminals \
+                 whose `◆` width differs from our estimate"
+            );
+        }
+    }
+
+    /// The restore written by `stop()` must also be exactly `MODE_ICON` —
+    /// a single glyph that overwrites ONLY the cell the spinner took over.
+    /// A multi-cell restore (the old `◆ aish` approach) is what left the
+    /// spinner's trailing `h` on screen (`◆ aishh` bug).
+    ///
+    /// Strips SGR codes and asserts the content equals MODE_ICON exactly,
+    /// so a regression to `accent(format!("{} aish", MODE_ICON))` (which
+    /// would pass a mere "contains one ◆" check) is caught.
+    #[test]
+    fn stop_restore_is_single_icon_glyph() {
+        // Reconstruct what `stop()` writes: theme::accent(MODE_ICON).
+        let restore = crate::theme::accent(crate::theme::MODE_ICON);
+        let stripped = strip_sgr(&restore);
+        assert_eq!(
+            stripped,
+            crate::theme::MODE_ICON,
+            "stop() restore must be exactly MODE_ICON after SGR strip, got \
+             {stripped:?} (full {restore:?}); a multi-cell restore leaves the \
+             spinner's trailing `h` on screen (`◆ aishh` bug)"
+        );
+        assert_eq!(
+            crate::theme::MODE_ICON.chars().count(),
+            1,
+            "MODE_ICON must be a single character for the single-cell spinner \
+             design to work (got {:?})",
+            crate::theme::MODE_ICON
+        );
+    }
+
+    /// End-to-end character-buffer model driven by REAL production output:
+    /// the spinner frame and the restore glyph are taken from
+    /// `spinner_frames()[0]` and `theme::accent(MODE_ICON)` respectively,
+    /// stripped of SGR codes, and applied to a hand-rolled screen row. The
+    /// test verifies that cells beyond index 0 are NEVER touched — this is
+    /// what guarantees `aish` never moves.
+    #[test]
+    fn spinner_and_restore_touch_only_icon_cell() {
+        // Drive the model with REAL production output, not hardcoded glyphs.
+        let spinner_content = strip_sgr(&spinner_frames()[0]);
+        let restore_content = strip_sgr(&crate::theme::accent(crate::theme::MODE_ICON));
+
+        // Both must be exactly one character for the single-cell design.
+        assert_eq!(
+            spinner_content.chars().count(),
+            1,
+            "spinner frame must be one cell: {spinner_content:?}"
+        );
+        assert_eq!(
+            restore_content.chars().count(),
+            1,
+            "restore must be one cell: {restore_content:?}"
+        );
+
+        let spinner_glyph: char = spinner_content.chars().next().unwrap();
+        let restore_glyph: char = restore_content.chars().next().unwrap();
+
+        // Seed: the prompt row as rustyline rendered it.
+        let icon_char = crate::theme::MODE_ICON.chars().next().unwrap();
+        let seed: Vec<char> = std::iter::once(icon_char)
+            .chain(" aish ~/path ➜".chars())
+            .collect();
+
+        // Spinner overwrites ONLY cell 0.
+        let mut after_spinner = seed.clone();
+        after_spinner[0] = spinner_glyph;
+        // Cells 1+ must be byte-identical to seed — no shift.
+        assert_eq!(
+            &after_spinner[1..],
+            &seed[1..],
+            "spinner must not touch any cell beyond the icon"
+        );
+        let spinner_rendered: String = after_spinner.iter().collect();
+        // `aish` did NOT move — it's still at the same offset.
+        assert!(
+            spinner_rendered.contains(" aish "),
+            "spinner must not shift `aish`: got {spinner_rendered:?}"
+        );
+
+        // stop() restores ONLY cell 0.
+        let mut after_restore = after_spinner;
+        after_restore[0] = restore_glyph;
+        // Fully restored to original seed — byte-identical.
+        assert_eq!(
+            after_restore, seed,
+            "prompt must be byte-identical after spinner + restore"
+        );
+        let restored: String = after_restore.iter().collect();
+        // Regression markers must NOT appear.
+        assert!(!restored.contains("aishh"), "no `aishh` residue");
     }
 }

--- a/crates/aish-shell/src/lib.rs
+++ b/crates/aish-shell/src/lib.rs
@@ -31,6 +31,7 @@ pub mod inline_completion;
 pub mod input;
 pub mod keyboard;
 pub mod llm_event_ui;
+pub mod md_render;
 pub mod nl_detect;
 pub mod prompt;
 pub mod readline;

--- a/crates/aish-shell/src/md_render.rs
+++ b/crates/aish-shell/src/md_render.rs
@@ -1,0 +1,510 @@
+//! Markdown renderer with width-aware paragraph wrapping and nested lists.
+//!
+//! Replaces `richrs::markdown::Markdown` for the `ContentSegment::Markdown`
+//! branch. Two improvements over richrs:
+//!
+//! 1. **Paragraph wrapping** — text is wrapped at `width` using
+//!    [`aish_md_table::wrap_spans`], so long paragraphs no longer overflow the
+//!    terminal. Inline styles (bold/italic/code) are preserved across breaks.
+//!
+//! 2. **Nested lists** — a `list_stack` tracks depth. Each level indents 2
+//!    cells, and continuation lines use a hanging indent aligned with the
+//!    bullet text, so wrapped item content stays readable at any depth.
+
+use pulldown_cmark::{Event, Parser, Tag, TagEnd};
+use richrs::segment::{Segment, Segments};
+use richrs::style::Style;
+use unicode_width::UnicodeWidthStr;
+
+use aish_md_table::{spans_width, wrap_spans, Span};
+
+/// Render markdown `text` to terminal segments, wrapping at `width`.
+pub fn render(text: &str, width: usize) -> Segments {
+    let mut r = Renderer {
+        width,
+        segs: Segments::new(),
+        list_stack: Vec::new(),
+        bold: false,
+        italic: false,
+        para_buf: Vec::new(),
+        heading_level: None,
+        heading_buf: Vec::new(),
+        pending_bullet: None,
+        item_indent: String::new(),
+        in_code_block: false,
+        quote_depth: 0,
+        link_url: None,
+        in_link: false,
+    };
+    for event in Parser::new(text) {
+        r.handle(event);
+    }
+    // Flush any trailing paragraph text (tight list items without End events).
+    r.flush_paragraph();
+    r.segs
+}
+
+struct ListState {
+    ordered: bool,
+    next_number: u64,
+}
+
+struct Renderer {
+    width: usize,
+    segs: Segments,
+    /// One entry per nesting level; depth = len - 1.
+    list_stack: Vec<ListState>,
+    /// Inline style state accumulated during paragraph/item rendering.
+    bold: bool,
+    italic: bool,
+    /// Buffer for paragraph inline spans; flushed on paragraph/item end.
+    para_buf: Vec<Span>,
+    /// Active heading level (None outside a heading).
+    heading_level: Option<u32>,
+    /// Buffer for heading spans.
+    heading_buf: Vec<Span>,
+    /// Bullet + indent prefix for the current list item's first line.
+    /// `Some(prefix)` means the next `flush_paragraph` call should emit the
+    /// prefix on its first line (the bullet hasn't been printed yet).
+    pending_bullet: Option<String>,
+    /// Hanging indent for the current list item, carried across multiple
+    /// paragraphs (loose lists). Set on `Start(Item)`, cleared on `End(Item)`.
+    /// When `pending_bullet` is `None` but this is non-empty, continuation
+    item_indent: String,
+    /// Whether we're inside a `CodeBlock` (indented or fenced that slipped
+    /// through `split_content`). Text is emitted verbatim with indentation.
+    in_code_block: bool,
+    /// Blockquote nesting depth. Each level reserves 2 cells (│ + space) and
+    /// applies dim+italic to the quoted content.
+    quote_depth: usize,
+    /// Current link URL (set on `Start(Link)`, consumed on `End(Link)`).
+    link_url: Option<String>,
+    /// Whether we're inside a `Link` element (text gets underline + URL suffix).
+    in_link: bool,
+}
+
+impl Renderer {
+    fn current_style(&self) -> Style {
+        let mut s = Style::default();
+        if self.bold {
+            s = s.bold();
+        }
+        if self.italic {
+            s = s.italic();
+        }
+        s
+    }
+
+    fn handle(&mut self, event: Event) {
+        match event {
+            Event::Start(tag) => self.start(tag),
+            Event::End(end) => self.end(end),
+            Event::Text(t) => self.text(&t),
+            Event::Code(code) => self.inline_code(&code),
+            // Soft and hard breaks are both treated as inline whitespace —
+            // wrapping handles line splitting. Flushing on HardBreak would
+            // fragment a single paragraph into two.
+            Event::SoftBreak | Event::HardBreak => self.para_buf.push(Span::plain(" ")),
+            Event::Rule => {
+                self.flush_paragraph();
+                let w = self.width.clamp(1, 80);
+                self.segs.push(Segment::new("─".repeat(w)));
+                self.segs.push(Segment::newline());
+            }
+            _ => {}
+        }
+    }
+
+    fn start(&mut self, tag: Tag) {
+        match tag {
+            Tag::Paragraph => {
+                self.para_buf.clear();
+            }
+            Tag::Heading { level, .. } => {
+                self.heading_level = Some(level as u32);
+                self.heading_buf.clear();
+            }
+            Tag::Strong => self.bold = true,
+            Tag::Emphasis => self.italic = true,
+            Tag::CodeBlock(_) => {
+                // Fenced code blocks are split off by `split_content` before
+                // this renderer runs; indented code blocks (4-space) reach
+                // here and are emitted verbatim with indentation.
+                self.flush_paragraph();
+                self.in_code_block = true;
+            }
+            Tag::List(start) => {
+                let ordered = start.is_some();
+                let number = start.unwrap_or(1);
+                self.list_stack.push(ListState {
+                    ordered,
+                    next_number: number,
+                });
+            }
+            Tag::Item => {
+                self.flush_paragraph();
+                self.start_list_item();
+            }
+            Tag::BlockQuote => {
+                self.flush_paragraph();
+                self.quote_depth += 1;
+            }
+            Tag::Link { dest_url, .. } => {
+                self.link_url = Some(dest_url.into_string());
+                self.in_link = true;
+            }
+            _ => {}
+        }
+    }
+
+    fn end(&mut self, end: TagEnd) {
+        match end {
+            TagEnd::Paragraph => {
+                self.flush_paragraph();
+            }
+            TagEnd::Heading(_) => {
+                self.flush_heading();
+            }
+            TagEnd::Strong => self.bold = false,
+            TagEnd::Emphasis => self.italic = false,
+            TagEnd::CodeBlock => {
+                self.in_code_block = false;
+                self.segs.push(Segment::newline());
+            }
+            TagEnd::List(_) => {
+                self.list_stack.pop();
+                if self.list_stack.is_empty() {
+                    // Blank line after the outermost list.
+                    self.segs.push(Segment::newline());
+                }
+            }
+            TagEnd::Item => {
+                // Tight-list items have raw Text (no Paragraph); flush whatever
+                // accumulated so the item content is printed.
+                self.flush_paragraph();
+                self.item_indent.clear();
+            }
+            TagEnd::BlockQuote => {
+                self.quote_depth = self.quote_depth.saturating_sub(1);
+            }
+            TagEnd::Link => {
+                // Append the URL as a dim suffix so the destination is visible.
+                if let Some(url) = self.link_url.take() {
+                    self.para_buf
+                        .push(Span::styled(format!(" ({url})"), Style::new().dim()));
+                }
+                self.in_link = false;
+            }
+            _ => {}
+        }
+    }
+
+    fn text(&mut self, t: &str) {
+        if self.in_code_block {
+            // Indented code block that `split_content` didn't catch: emit
+            // verbatim with 4-space indent, no inline parsing.
+            for line in t.lines() {
+                self.segs.push(Segment::new(format!("    {line}")));
+                self.segs.push(Segment::newline());
+            }
+        } else if self.heading_level.is_some() {
+            // Heading style (bold) is applied uniformly in `flush_heading`;
+            // store plain text here so we don't double-apply.
+            self.heading_buf.push(Span::plain(t.to_string()));
+        } else {
+            let mut style = self.current_style();
+            if self.in_link {
+                style = style.underline();
+            }
+            self.para_buf.push(Span::styled(t.to_string(), style));
+        }
+    }
+
+    fn inline_code(&mut self, code: &str) {
+        self.para_buf.push(Span::styled(
+            format!(" {} ", code.trim()),
+            Style::new().reverse(),
+        ));
+    }
+    fn start_list_item(&mut self) {
+        let depth = self.list_stack.len().saturating_sub(1);
+        let indent = "  ".repeat(depth);
+        let bullet = match self.list_stack.last_mut() {
+            Some(list) if list.ordered => {
+                let n = list.next_number;
+                list.next_number += 1;
+                format!("{}. ", n)
+            }
+            _ => "• ".to_string(),
+        };
+        let full = format!("{indent}{bullet}");
+        self.pending_bullet = Some(full.clone());
+        // Hanging indent for continuation lines and subsequent paragraphs
+        // within this item: spaces matching the bullet line's width.
+        self.item_indent = " ".repeat(UnicodeWidthStr::width(full.as_str()));
+    }
+
+    /// Flush `para_buf` as one or more wrapped lines. If a bullet is pending
+    /// (list item first line), emit it as the first-line prefix and use a
+    /// space-padded hanging indent for continuation lines.
+    fn flush_paragraph(&mut self) {
+        if self.para_buf.is_empty() {
+            // Even an empty paragraph in a list item should consume the bullet
+            // so numbering stays correct.
+            if let Some(bullet) = self.pending_bullet.take() {
+                self.segs.push(Segment::new(bullet));
+                self.segs.push(Segment::newline());
+            }
+            return;
+        }
+
+        // Blockquote path: wrap to width minus quote border, prefix each line
+        // with │, apply dim+italic. Keeps quote visually distinct without
+        // interfering with list-indent math.
+        if self.quote_depth > 0 {
+            self.flush_quote();
+            return;
+        }
+
+        let first_prefix = self
+            .pending_bullet
+            .take()
+            .unwrap_or_else(|| self.item_indent.clone());
+        // Continuation indent: same visible width as first_prefix, all spaces.
+        let cont_prefix = " ".repeat(UnicodeWidthStr::width(first_prefix.as_str()));
+        // Available content width = terminal width minus the prefix.
+        let prefix_w = UnicodeWidthStr::width(cont_prefix.as_str());
+        let avail = self.width.saturating_sub(prefix_w).max(1);
+
+        let lines = wrap_spans(&self.para_buf, avail);
+        for (i, line) in lines.iter().enumerate() {
+            let prefix = if i == 0 { &first_prefix } else { &cont_prefix };
+            if !prefix.is_empty() {
+                self.segs.push(Segment::new(prefix.clone()));
+            }
+            push_spans(&mut self.segs, line);
+            self.segs.push(Segment::newline());
+        }
+
+        // Blank line after a top-level paragraph; inside lists, keep items
+        // tight (no extra blank line between wrapped content and the next
+        // item).
+        if self.list_stack.is_empty() {
+            self.segs.push(Segment::newline());
+        }
+
+        self.para_buf.clear();
+    }
+
+    /// Flush paragraph content as a blockquote: each line gets a `│ ` prefix
+    /// per nesting level and dim+italic styling.
+    fn flush_quote(&mut self) {
+        let quote_prefix = "│ ".repeat(self.quote_depth);
+        let prefix_w = UnicodeWidthStr::width(quote_prefix.as_str());
+        let avail = self.width.saturating_sub(prefix_w).max(1);
+
+        let dim_italic = Style::new().dim().italic();
+        let lines = wrap_spans(&self.para_buf, avail);
+        for line in lines.iter() {
+            self.segs
+                .push(Segment::styled(quote_prefix.clone(), Style::new().dim()));
+            for span in line {
+                let combined = span.style.clone().combine(&dim_italic);
+                self.segs.push(Segment::styled(span.text.clone(), combined));
+            }
+            self.segs.push(Segment::newline());
+        }
+        self.segs.push(Segment::newline());
+        self.para_buf.clear();
+    }
+
+    fn flush_heading(&mut self) {
+        let level = self.heading_level.take().unwrap_or(1);
+        let bold = Style::new().bold();
+
+        for span in &self.heading_buf {
+            let combined = span.style.clone().combine(&bold);
+            if combined.is_empty() {
+                self.segs.push(Segment::new(span.text.clone()));
+            } else {
+                self.segs.push(Segment::styled(span.text.clone(), combined));
+            }
+        }
+        self.segs.push(Segment::newline());
+
+        // H1/H2 get a character underline sized to the heading text (not a
+        // fixed 40 chars), capped to terminal width.
+        if level <= 2 {
+            let hw = spans_width(&self.heading_buf);
+            let underline_w = hw.min(self.width).max(1);
+            let ch = if level == 1 { '═' } else { '─' };
+            self.segs
+                .push(Segment::new(ch.to_string().repeat(underline_w)));
+            self.segs.push(Segment::newline());
+        }
+
+        self.segs.push(Segment::newline());
+        self.heading_buf.clear();
+    }
+}
+
+/// Push a slice of spans as segments, emitting plain text unstyled and styled
+/// text with its ANSI codes.
+fn push_spans(segs: &mut Segments, spans: &[Span]) {
+    for span in spans {
+        if span.style.is_empty() {
+            segs.push(Segment::new(span.text.clone()));
+        } else {
+            segs.push(Segment::styled(span.text.clone(), span.style.clone()));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Strip ANSI escapes for layout assertions.
+    fn plain(segs: &Segments) -> String {
+        segs.plain_text()
+    }
+
+    #[test]
+    fn wraps_long_paragraph() {
+        let md = "This is a very long paragraph that should wrap at the terminal width instead of overflowing off the right side of the screen.";
+        let out = plain(&render(md, 40));
+        for line in out.lines() {
+            assert!(
+                UnicodeWidthStr::width(line) <= 40,
+                "line exceeds width 40: {:?}",
+                line
+            );
+        }
+        // Content survives across wrapped lines.
+        let joined: String = out.chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(joined.contains("paragraph"));
+    }
+
+    #[test]
+    fn preserves_inline_bold_in_paragraph() {
+        let md = "This has **bold** text in a paragraph that is long enough to wrap across multiple lines of output.";
+        let ansi = render(md, 30).to_ansi();
+        // Bold ANSI escape (ESC [ 1 m) must appear somewhere.
+        assert!(ansi.contains("\x1b[1m"), "no bold SGR in output");
+    }
+
+    #[test]
+    fn nested_unordered_list_indent() {
+        let md = "- outer\n  - inner\n";
+        let out = plain(&render(md, 80));
+        let lines: Vec<&str> = out.lines().filter(|l| !l.trim().is_empty()).collect();
+        // outer at column 0, inner at column 2
+        let outer = lines.iter().find(|l| l.contains("outer")).unwrap();
+        let inner = lines.iter().find(|l| l.contains("inner")).unwrap();
+        assert_eq!(
+            outer.find('•'),
+            Some(0),
+            "outer bullet at col 0: {:?}",
+            outer
+        );
+        assert_eq!(
+            inner.find('•'),
+            Some(2),
+            "inner bullet at col 2: {:?}",
+            inner
+        );
+    }
+
+    #[test]
+    fn ordered_list_numbers() {
+        let md = "1. first\n2. second\n3. third\n";
+        let out = plain(&render(md, 80));
+        assert!(out.contains("1. first"));
+        assert!(out.contains("2. second"));
+        assert!(out.contains("3. third"));
+    }
+
+    #[test]
+    fn hanging_indent_for_wrapped_list_item() {
+        // A long item whose text wraps: continuation lines must align under
+        // the item text, not under the bullet.
+        let md = "- a really long list item that will definitely need to wrap across multiple terminal lines";
+        let out = plain(&render(md, 30));
+        let lines: Vec<&str> = out.lines().collect();
+        // First line starts with bullet at col 0.
+        assert!(lines[0].starts_with("•"));
+        // Continuation lines start with spaces (hanging indent), not text.
+        for line in &lines[1..] {
+            if line.trim().is_empty() {
+                continue;
+            }
+            assert!(
+                line.starts_with("  "),
+                "continuation not hanging-indented: {:?}",
+                line
+            );
+        }
+    }
+
+    #[test]
+    fn heading_underline_matches_text_width() {
+        let md = "# Hi\n";
+        let out = plain(&render(md, 80));
+        // Underline line should be 2 chars (width of "Hi"), not 40.
+        let underline = out.lines().find(|l| l.chars().all(|c| c == '═'));
+        assert!(underline.is_some(), "no H1 underline found");
+        assert_eq!(
+            UnicodeWidthStr::width(underline.unwrap()),
+            2,
+            "underline should match heading width"
+        );
+    }
+
+    #[test]
+    fn inline_code_reversestyled() {
+        let md = "Use `println!` to print.";
+        let ansi = render(md, 80).to_ansi();
+        // Reverse video SGR (ESC [ 7 m) for inline code.
+        assert!(ansi.contains("\x1b[7m"), "no reverse SGR for inline code");
+    }
+
+    #[test]
+    fn preserves_cjk_width_in_wrap() {
+        let md = "这是一段很长的中文段落内容用于测试换行功能是否正确处理中文字符的显示宽度";
+        let out = plain(&render(md, 20));
+        for line in out.lines() {
+            assert!(
+                UnicodeWidthStr::width(line) <= 20,
+                "CJK line exceeds width: {:?} (w={})",
+                line,
+                UnicodeWidthStr::width(line)
+            );
+        }
+    }
+
+    #[test]
+    fn blockquote_has_pipe_prefix() {
+        let md = "> quoted text\n> second line";
+        let out = plain(&render(md, 80));
+        for line in out.lines().filter(|l| !l.trim().is_empty()) {
+            assert!(
+                line.starts_with('│'),
+                "blockquote line missing │ prefix: {:?}",
+                line
+            );
+        }
+        assert!(out.contains("quoted text"));
+    }
+
+    #[test]
+    fn link_text_underlined_with_url_suffix() {
+        let md = "See [docs](https://example.com) for info.";
+        let ansi = render(md, 80).to_ansi();
+        // Link text gets underline SGR.
+        assert!(ansi.contains("\x1b[4m"), "no underline for link text");
+        // URL appears as a dim suffix.
+        assert!(ansi.contains("https://example.com"), "URL not in output");
+        // Dim SGR (ESC [ 2 m) somewhere for the URL suffix.
+        assert!(ansi.contains("\x1b[2m"), "no dim for URL suffix");
+    }
+}

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -75,6 +75,38 @@ pub(crate) fn take_slash_prefill() -> String {
         Err(_) => String::new(),
     }
 }
+/// Flag set by `AtFileHandler` when `@` is typed inside an AI prompt line.
+static AT_FILE_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+/// Snapshot of the readline buffer captured when `@` triggers the file
+/// mention popup: the full line text (without the `@`) and the cursor
+/// offset where `@` was about to be inserted. Consumed by
+/// `run_file_mention_session` to splice the selected path back in.
+#[derive(Clone)]
+struct AtFileContext {
+    line: String,
+    at_pos: usize,
+}
+
+static AT_FILE_CONTEXT: Mutex<Option<AtFileContext>> = Mutex::new(None);
+
+/// Record the readline state at the moment `@` was pressed (called from
+/// `AtFileHandler`). `line` excludes the `@` itself; `at_pos` is the byte
+/// offset where `@` would have been inserted.
+fn set_at_file_context(line: String, at_pos: usize) {
+    if let Ok(mut guard) = AT_FILE_CONTEXT.lock() {
+        *guard = Some(AtFileContext { line, at_pos });
+    }
+}
+
+/// Consume the captured readline state, returning `(line, at_pos)` or
+/// `None` if no `@` trigger is pending.
+pub(crate) fn take_at_file_context() -> Option<(String, usize)> {
+    match AT_FILE_CONTEXT.lock() {
+        Ok(mut guard) => guard.take().map(|c| (c.line, c.at_pos)),
+        Err(_) => None,
+    }
+}
 
 /// Max gap between Tab presses to count as "double Tab" (bash second-tab list).
 const DOUBLE_TAB_MS: u128 = 800;
@@ -259,6 +291,45 @@ impl ConditionalEventHandler for SlashHandler {
                 {
                     SLASH_REQUESTED.store(true, Ordering::SeqCst);
                     return Some(Cmd::Interrupt);
+                }
+            }
+        }
+        None
+    }
+}
+
+/// Event handler that sets a flag when `@` is typed inside an AI prompt
+/// line (`;` / `；` prefix), then returns `Cmd::Interrupt` to break out of
+/// `read_line` for the file-mention popup. The `@` must sit at a token
+/// boundary (after whitespace, tab, or the `;` prefix) so prose like
+/// `user@host` never triggers it.
+struct AtFileHandler;
+
+impl ConditionalEventHandler for AtFileHandler {
+    fn handle(
+        &self,
+        evt: &Event,
+        _n_repeat: RepeatCount,
+        _positive: bool,
+        ctx: &EventContext<'_>,
+    ) -> Option<Cmd> {
+        if let Event::KeySeq(keys) = evt {
+            if let Some(key) = keys.first() {
+                if key.1 == Modifiers::NONE && key.0 == KeyCode::Char('@') {
+                    let line = ctx.line();
+                    if crate::input::is_ai_prompt_line(line) {
+                        let pos = ctx.pos();
+                        let before_ok = pos == 0
+                            || matches!(
+                                line[..pos].chars().next_back(),
+                                Some(' ') | Some('\t') | Some(';') | Some('\u{ff1b}')
+                            );
+                        if before_ok {
+                            set_at_file_context(line.to_string(), pos);
+                            AT_FILE_REQUESTED.store(true, Ordering::SeqCst);
+                            return Some(Cmd::Interrupt);
+                        }
+                    }
                 }
             }
         }
@@ -530,6 +601,12 @@ impl ShellReadline {
             EventHandler::Conditional(Box::new(SlashHandler)),
         );
 
+        // Bind `@` in AI-mode lines for the file-mention popup
+        editor.bind_sequence(
+            KeyEvent(KeyCode::Char('@'), Modifiers::NONE),
+            EventHandler::Conditional(Box::new(AtFileHandler)),
+        );
+
         // Bind Right Arrow and Ctrl+F to accept the inline AI ghost, and
         // bind the line-submit keys to clear it before rustyline repaints.
         // rustyline's `EventHandler` is not `Clone`, so each binding needs
@@ -598,6 +675,12 @@ impl ShellReadline {
     /// The flag is consumed on read.
     pub fn was_slash_requested(&self) -> bool {
         SLASH_REQUESTED.swap(false, Ordering::SeqCst)
+    }
+
+    /// Check whether `@` in an AI prompt triggered the last `Interrupted`
+    /// error. The flag is consumed on read.
+    pub fn was_at_file_requested(&self) -> bool {
+        AT_FILE_REQUESTED.swap(false, Ordering::SeqCst)
     }
 
     /// Read a line with initial text pre-filled, letting the user edit and

--- a/crates/aish-shell/src/renderer.rs
+++ b/crates/aish-shell/src/renderer.rs
@@ -2,12 +2,8 @@ use std::io::{self, Write};
 
 use crate::recorder::SharedRecorder;
 use crate::theme;
-use richrs::color::Color;
 use richrs::console::Console;
-use richrs::markdown::Markdown;
-use richrs::style::Style;
 use richrs::syntax::Syntax;
-use richrs::table::{Column, Row, Table};
 
 // ---------------------------------------------------------------------------
 // Content splitting: code blocks → tables → regular markdown
@@ -231,47 +227,13 @@ fn split_tables(text: &str) -> Vec<(bool, String)> {
 // Table rendering via richrs Table
 // ---------------------------------------------------------------------------
 
-/// Render a markdown pipe table using richrs Table.
+/// Render a markdown pipe table to segments.
+///
+/// Delegates to [`crate::md_table::render`] — a self-contained renderer that
+/// wraps cell content to column widths (so long CJK cells no longer break the
+/// right border) and parses inline markdown (`**bold**`, `` `code` ``).
 fn render_table_to_segments(lines: &[&str], width: usize) -> Option<richrs::segment::Segments> {
-    let headers = parse_pipe_row(lines.first()?)?;
-    let sep = lines.get(1)?.trim();
-    if !sep
-        .chars()
-        .all(|c| c == '|' || c == '-' || c == ':' || c == ' ')
-    {
-        return None;
-    }
-
-    let mut table = Table::new()
-        .border_style(Style::new().dim())
-        .header_style(Style::new().bold());
-
-    for h in &headers {
-        table.add_column(Column::new(h.as_str()));
-    }
-
-    for line in lines.iter().skip(2) {
-        if let Some(cells) = parse_pipe_row(line) {
-            if cells.len() == headers.len() {
-                table.add_row(Row::new(cells));
-            }
-        }
-    }
-
-    Some(table.render(width))
-}
-
-fn parse_pipe_row(line: &str) -> Option<Vec<String>> {
-    let trimmed = line.trim();
-    if !trimmed.starts_with('|') || !trimmed.ends_with('|') {
-        return None;
-    }
-    let inner = &trimmed[1..trimmed.len().saturating_sub(1)];
-    let cells: Vec<String> = inner.split('|').map(|s| s.trim().to_string()).collect();
-    if cells.is_empty() {
-        return None;
-    }
-    Some(cells)
+    aish_md_table::render(lines, width)
 }
 
 // ---------------------------------------------------------------------------
@@ -373,15 +335,7 @@ impl ShellRenderer {
                     last_was_markdown = false;
                 }
                 ContentSegment::Markdown(content) => {
-                    let inline_style = Style::new()
-                        .with_color(Color::Rgb {
-                            r: crate::theme::ACCENT_RGB.0,
-                            g: crate::theme::ACCENT_RGB.1,
-                            b: crate::theme::ACCENT_RGB.2,
-                        })
-                        .bold();
-                    let md = Markdown::new(&content).inline_code_style(inline_style);
-                    let segs = md.render(self.terminal_width);
+                    let segs = crate::md_render::render(&content, self.terminal_width);
                     {
                         let mut ansi = segs.to_ansi();
                         if ansi.ends_with("\n\n") {
@@ -463,21 +417,7 @@ impl Default for ShellRenderer {
 mod tests {
     use super::*;
 
-    // --- pipe row parsing ---
-
-    #[test]
-    fn test_parse_pipe_row() {
-        assert_eq!(
-            parse_pipe_row("| a | b | c |").unwrap(),
-            vec!["a", "b", "c"]
-        );
-    }
-    #[test]
-    fn test_parse_pipe_row_invalid() {
-        assert!(parse_pipe_row("no pipes").is_none());
-    }
-
-    // --- table rendering (richrs Table) ---
+    // --- table rendering (md_table) ---
 
     #[test]
     fn test_render_table_to_segments() {

--- a/crates/aish-tools/src/web_fetch/utils.rs
+++ b/crates/aish-tools/src/web_fetch/utils.rs
@@ -10,6 +10,11 @@ use reqwest::{redirect, Client, StatusCode, Url};
 
 const MAX_URL_LENGTH: usize = 2000;
 const MAX_HTTP_CONTENT_LENGTH: usize = 10 * 1024 * 1024;
+/// Max retry attempts for transient network errors (connect/timeout) on the
+/// initial `.send()`. HTTP status codes are not errors at this layer — they
+/// are returned in the response and classified by the caller — so 4xx/5xx do
+/// not retry here.
+const MAX_FETCH_RETRIES: u32 = 2;
 const FETCH_TIMEOUT_SECS: u64 = 60;
 const MAX_REDIRECTS: usize = 10;
 pub(crate) const MAX_MARKDOWN_LENGTH: usize = 100_000;
@@ -133,6 +138,38 @@ pub(crate) async fn fetch_url_content(raw_url: &str) -> Result<FetchedContent, F
     })
 }
 
+/// Send a GET request, retrying transient network-layer failures
+/// (`is_connect()` / `is_timeout()`) up to [`MAX_FETCH_RETRIES`] times with
+/// short exponential backoff. Non-transient errors (DNS, TLS, body decode)
+/// surface immediately. HTTP status codes live in the returned `Response`
+/// and are classified by the caller — they are not retried here.
+async fn send_with_retry(client: &Client, url: &Url) -> Result<reqwest::Response, FetchFailure> {
+    let mut last_err: Option<String> = None;
+    for attempt in 0..=MAX_FETCH_RETRIES {
+        if attempt > 0 {
+            // 500ms, then 1000ms.
+            tokio::time::sleep(Duration::from_millis(500u64 << (attempt - 1))).await;
+        }
+        match client
+            .get(url.clone())
+            .header(ACCEPT, "text/markdown, text/html, text/plain, */*")
+            .header(USER_AGENT, USER_AGENT_VALUE)
+            .send()
+            .await
+        {
+            Ok(r) => return Ok(r),
+            Err(e) if e.is_connect() || e.is_timeout() => {
+                last_err = Some(e.to_string());
+                continue;
+            }
+            Err(e) => return Err(FetchFailure::Request(e.to_string())),
+        }
+    }
+    Err(FetchFailure::Request(
+        last_err.unwrap_or_else(|| "request failed after retries".into()),
+    ))
+}
+
 async fn get_with_permitted_redirects(
     client: &Client,
     url: Url,
@@ -148,13 +185,7 @@ async fn get_with_permitted_redirects(
     ensure_public_host(&url)
         .await
         .map_err(FetchFailure::Blocked)?;
-    let response = client
-        .get(url.clone())
-        .header(ACCEPT, "text/markdown, text/html, text/plain, */*")
-        .header(USER_AGENT, USER_AGENT_VALUE)
-        .send()
-        .await
-        .map_err(|error| FetchFailure::Request(error.to_string()))?;
+    let response = send_with_retry(client, &url).await?;
 
     if is_redirect_status(response.status()) {
         let location = response

--- a/crates/aish-ui/Cargo.toml
+++ b/crates/aish-ui/Cargo.toml
@@ -8,3 +8,6 @@ crossterm.workspace = true
 ratatui.workspace = true
 thiserror.workspace = true
 unicode-width.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/aish-ui/src/file_mention.rs
+++ b/crates/aish-ui/src/file_mention.rs
@@ -1,0 +1,756 @@
+//! `@path` file-mention popup: a fuzzy file picker for AI-mode input.
+//!
+//! Opened by typing `@` while composing an AI prompt (`;` prefix). Lists
+//! files and directories under the current working directory, fuzzy-filtered
+//! by whatever the user types after `@`. Selecting a directory descends into
+//! it (seeds the query with `dir/` and refreshes); selecting a file — or
+//! pressing Enter on free-typed text — yields the path to the caller, which
+//! splices it back into the readline buffer next to the `@`.
+
+use std::collections::HashSet;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use crossterm::{
+    cursor, event,
+    event::{Event, KeyCode, KeyEventKind, KeyModifiers},
+    execute,
+};
+use ratatui::{
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+
+use crate::slash_input::{
+    drain_pending_events, longest_common_prefix, open_inline_terminal, strip_ansi, RawModeGuard,
+};
+
+/// Outcome of the file-mention session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileMentionOutcome {
+    /// User selected a path (relative to cwd; directories keep a trailing `/`).
+    Selected(String),
+    /// User cancelled (Esc / Ctrl+C / Backspace past the `@`).
+    Cancelled,
+}
+
+const MAX_VISIBLE_FILES: usize = 10;
+const MAX_PANEL_HEIGHT: u16 = 12;
+/// Cap the recursive scan so enormous trees cannot stall the popup. Hit
+/// early on projects with vendored dependencies; raised once `.gitignore`-
+/// style skipping trims the obvious offenders.
+const MAX_FILES_SCANNED: usize = 5000;
+const MAX_SCAN_DEPTH: usize = 10;
+/// Bound the filtered list; the popup scrolls within `MAX_VISIBLE_FILES`.
+const MAX_FILTERED: usize = 50;
+
+/// Build artifacts, VCS state, and dependency trees skipped by the scan.
+/// Hidden directories (`.foo`) are skipped separately.
+const IGNORED_DIRS: &[&str] = &[
+    ".git",
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    ".next",
+    ".cache",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".tox",
+    "coverage",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".idea",
+    ".vscode",
+    ".sass-cache",
+    "out",
+    "deps",
+    "_build",
+];
+
+#[derive(Debug, Clone)]
+pub(crate) struct FileCandidate {
+    /// Relative path from cwd with `/` separators. Directories keep a
+    /// trailing `/` so display, filtering, and descent stay consistent.
+    path: String,
+    is_dir: bool,
+}
+
+/// Inline `@path` file-mention popup.
+///
+/// Renders the shell prompt + the fixed line text before `@` + the editable
+/// `@query` on the first row, and a fuzzy-filtered file list below it.
+pub struct FileMentionSession {
+    prompt: String,
+    /// Fixed text on the line before `@` (e.g. `"; analyze "`). Shown for
+    /// context; not editable from within the popup.
+    prefix: String,
+    /// Editable text after `@`.
+    query: String,
+    cursor: usize,
+    selected: usize,
+    filtered: Vec<usize>,
+    candidates: Vec<FileCandidate>,
+}
+
+impl FileMentionSession {
+    /// Build a new session rooted at `cwd`. `prefix` is the text already on
+    /// the line before the `@` (shown for context, not editable here).
+    pub fn new(cwd: &Path, prompt: String, prefix: String) -> Self {
+        let candidates = scan_files(cwd);
+        let mut session = Self {
+            prompt: strip_ansi(&prompt),
+            prefix,
+            query: String::new(),
+            cursor: 0,
+            selected: 0,
+            filtered: Vec::new(),
+            candidates,
+        };
+        session.update_filtered();
+        session
+    }
+
+    /// Pre-fill the query after construction (e.g. when reopening from
+    /// readline with text already typed after `@`).
+    pub fn with_query(mut self, query: impl Into<String>) -> Self {
+        self.query = query.into();
+        self.cursor = self.query.len();
+        self.update_filtered();
+        self
+    }
+
+    /// Run the session in raw mode. Returns the outcome.
+    pub fn run(mut self) -> io::Result<FileMentionOutcome> {
+        let _guard = RawModeGuard::enter()?;
+        // Rustyline appends a newline after returning on Cmd::Interrupt;
+        // move back to the original prompt line before ratatui queries the
+        // cursor position for the inline viewport.
+        execute!(io::stdout(), cursor::MoveToColumn(0), cursor::MoveUp(1))?;
+        // Drain stale keyboard events before ratatui issues DSR queries.
+        drain_pending_events()?;
+        let mut viewport_height = self.panel_height();
+        let mut terminal = open_inline_terminal(viewport_height)?;
+
+        let outcome = loop {
+            let desired = self.panel_height();
+            if desired != viewport_height {
+                let _ = terminal.clear();
+                drop(terminal);
+                viewport_height = desired;
+                terminal = open_inline_terminal(viewport_height)?;
+            }
+            let _ = terminal.autoresize();
+            terminal.draw(|frame| self.render(frame, frame.area()))?;
+
+            let event = event::read()?;
+            if let Some(result) = self.handle_event(event) {
+                break result;
+            }
+        };
+
+        // All terminal cleanup MUST happen while still in raw mode.
+        let _ = terminal.clear();
+        drop(terminal);
+        drop(_guard);
+        let _ = io::stdout().flush();
+        Ok(outcome)
+    }
+
+    /// Dispatch a keyboard event without raw-mode TUI (for integration tests).
+    #[doc(hidden)]
+    pub fn dispatch_event(&mut self, event: Event) -> Option<FileMentionOutcome> {
+        self.handle_event(event)
+    }
+
+    fn panel_height(&self) -> u16 {
+        if self.filtered.is_empty() {
+            return 1;
+        }
+        (1 + self.filtered.len().min(MAX_VISIBLE_FILES) as u16).min(MAX_PANEL_HEIGHT)
+    }
+
+    fn update_filtered(&mut self) {
+        let query = self.query.trim().trim_start_matches("./");
+        let mut scored: Vec<(i64, usize)> = self
+            .candidates
+            .iter()
+            .enumerate()
+            .filter_map(|(i, c)| fuzzy_score(query, &c.path).map(|s| (s, i)))
+            .collect();
+        // Higher score first; ties break by shorter path then alphabetical.
+        scored.sort_by(|a, b| {
+            b.0.cmp(&a.0)
+                .then_with(|| self.candidates[a.1].path.cmp(&self.candidates[b.1].path))
+        });
+        self.filtered = scored
+            .into_iter()
+            .map(|(_, i)| i)
+            .take(MAX_FILTERED)
+            .collect();
+        self.selected = 0;
+    }
+
+    /// Enter: if a directory is highlighted, descend (stay in popup); if a
+    /// file is highlighted, select it; otherwise accept typed text verbatim.
+    fn handle_submit(&mut self) -> Option<FileMentionOutcome> {
+        if let Some(&idx) = self.filtered.get(self.selected) {
+            let cand = self.candidates[idx].clone();
+            if cand.is_dir {
+                // Descend: seed the query with the directory path and refresh.
+                self.query = cand.path;
+                self.cursor = self.query.len();
+                self.update_filtered();
+                return None;
+            }
+            return Some(FileMentionOutcome::Selected(cand.path));
+        }
+        // No matching candidate: accept the typed query verbatim if non-empty.
+        let typed = self.query.trim();
+        if typed.is_empty() {
+            Some(FileMentionOutcome::Cancelled)
+        } else {
+            Some(FileMentionOutcome::Selected(typed.to_string()))
+        }
+    }
+
+    /// Tab: extend the shared prefix among filtered paths, otherwise behave
+    /// like submit (descend into / select the highlighted entry).
+    fn handle_tab_complete(&mut self) -> Option<FileMentionOutcome> {
+        if self.filtered.is_empty() {
+            return None;
+        }
+        if self.filtered.len() == 1 {
+            return self.handle_submit();
+        }
+        let names: Vec<&str> = self
+            .filtered
+            .iter()
+            .map(|&i| self.candidates[i].path.as_str())
+            .collect();
+        let lcp = longest_common_prefix(&names);
+        if lcp.len() > self.query.len() {
+            self.query = lcp.to_string();
+            self.cursor = self.query.len();
+            self.update_filtered();
+            return None;
+        }
+        self.handle_submit()
+    }
+
+    fn handle_event(&mut self, event: Event) -> Option<FileMentionOutcome> {
+        let Event::Key(key) = event else {
+            return None;
+        };
+        if key.kind != KeyEventKind::Press && key.kind != KeyEventKind::Repeat {
+            return None;
+        }
+        if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            return Some(FileMentionOutcome::Cancelled);
+        }
+
+        match key.code {
+            KeyCode::Char(ch)
+                if !key.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                self.query.insert(self.cursor, ch);
+                self.cursor += ch.len_utf8();
+                self.update_filtered();
+                None
+            }
+            KeyCode::Backspace => {
+                if self.cursor == 0 {
+                    // Backspace past `@`: cancel and hand control back to readline.
+                    return Some(FileMentionOutcome::Cancelled);
+                }
+                let prev = self.query[..self.cursor]
+                    .char_indices()
+                    .last()
+                    .map(|(i, _)| i)
+                    .unwrap_or(0);
+                self.query.drain(prev..self.cursor);
+                self.cursor = prev;
+                self.update_filtered();
+                None
+            }
+            KeyCode::Up => {
+                if !self.filtered.is_empty() && self.selected > 0 {
+                    self.selected -= 1;
+                }
+                None
+            }
+            KeyCode::Down => {
+                if !self.filtered.is_empty() {
+                    self.selected = (self.selected + 1).min(self.filtered.len() - 1);
+                }
+                None
+            }
+            KeyCode::Enter => self.handle_submit(),
+            KeyCode::Tab => self.handle_tab_complete(),
+            KeyCode::Home => {
+                self.cursor = 0;
+                None
+            }
+            KeyCode::End => {
+                self.cursor = self.query.len();
+                None
+            }
+            KeyCode::Left => {
+                if self.cursor > 0 {
+                    self.cursor = self.query[..self.cursor]
+                        .char_indices()
+                        .last()
+                        .map(|(i, _)| i)
+                        .unwrap_or(0);
+                }
+                None
+            }
+            KeyCode::Right => {
+                if self.cursor < self.query.len() {
+                    self.cursor += self.query[self.cursor..]
+                        .chars()
+                        .next()
+                        .map(|c| c.len_utf8())
+                        .unwrap_or(0);
+                }
+                None
+            }
+            KeyCode::Esc => Some(FileMentionOutcome::Cancelled),
+            _ => None,
+        }
+    }
+
+    fn render(&self, frame: &mut ratatui::Frame<'_>, area: Rect) {
+        let input_area = Rect::new(area.x, area.y, area.width, 1);
+        let list_area = Rect::new(
+            area.x,
+            area.y + 1,
+            area.width,
+            area.height.saturating_sub(1),
+        );
+        self.render_input_line(frame, input_area);
+        self.render_file_list(frame, list_area);
+    }
+
+    fn render_input_line(&self, frame: &mut ratatui::Frame<'_>, area: Rect) {
+        let prompt_style = Style::default().fg(Color::Green);
+        let prefix_style = Style::default().fg(Color::White);
+        let at_style = Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD);
+        let input_style = Style::default().fg(Color::White);
+        let cursor_style = Style::default()
+            .fg(Color::Black)
+            .bg(Color::White)
+            .add_modifier(Modifier::BOLD);
+
+        let before = &self.query[..self.cursor];
+        let cursor_char = self.query[self.cursor..].chars().next();
+        let after_start = self.cursor + cursor_char.map_or(0, |c| c.len_utf8());
+        let after = &self.query[after_start..];
+
+        let mut spans = vec![
+            Span::styled(self.prompt.clone(), prompt_style),
+            Span::styled(self.prefix.clone(), prefix_style),
+            Span::styled("@", at_style),
+            Span::styled(before.to_string(), input_style),
+        ];
+        if let Some(ch) = cursor_char {
+            spans.push(Span::styled(ch.to_string(), cursor_style));
+            spans.push(Span::styled(after.to_string(), input_style));
+        } else {
+            spans.push(Span::styled(" ", cursor_style));
+        }
+        frame.render_widget(Paragraph::new(Line::from(spans)), area);
+    }
+
+    fn render_file_list(&self, frame: &mut ratatui::Frame<'_>, area: Rect) {
+        if self.filtered.is_empty() || area.height == 0 {
+            return;
+        }
+        let max_visible = area.height as usize;
+        let scroll = self.scroll_offset(max_visible);
+        let end = (scroll + max_visible).min(self.filtered.len());
+        let lines: Vec<Line> = self.filtered[scroll..end]
+            .iter()
+            .enumerate()
+            .map(|(row, &idx)| {
+                let absolute_row = scroll + row;
+                let cand = &self.candidates[idx];
+                let is_selected = absolute_row == self.selected;
+                let marker = if is_selected { "▸ " } else { "  " };
+                let marker_style = if is_selected {
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(Color::DarkGray)
+                };
+                let name_style = if is_selected {
+                    Style::default()
+                        .fg(Color::LightCyan)
+                        .add_modifier(Modifier::BOLD)
+                } else if cand.is_dir {
+                    Style::default().fg(Color::Blue)
+                } else {
+                    Style::default().fg(Color::White)
+                };
+                Line::from(vec![
+                    Span::styled(marker, marker_style),
+                    Span::styled(cand.path.clone(), name_style),
+                ])
+            })
+            .collect();
+
+        frame.render_widget(Paragraph::new(lines), area);
+    }
+
+    fn scroll_offset(&self, max_visible: usize) -> usize {
+        if self.selected >= max_visible {
+            self.selected - max_visible + 1
+        } else {
+            0
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Directory scan + fuzzy scoring
+// ---------------------------------------------------------------------------
+
+/// Recursively scan `cwd` for files and directories, returning relative
+/// paths. Hidden entries, `IGNORED_DIRS`, and symlinked directories are
+/// skipped. The result is sorted by path for stable ordering.
+pub(crate) fn scan_files(cwd: &Path) -> Vec<FileCandidate> {
+    let mut out = Vec::new();
+    let mut visited: HashSet<PathBuf> = HashSet::new();
+    if let Ok(canon) = cwd.canonicalize() {
+        visited.insert(canon);
+    }
+    scan_dir(cwd, cwd, 0, &mut out, &mut visited);
+    out.sort_by(|a, b| a.path.cmp(&b.path));
+    out
+}
+
+fn scan_dir(
+    root: &Path,
+    dir: &Path,
+    depth: usize,
+    out: &mut Vec<FileCandidate>,
+    visited: &mut HashSet<PathBuf>,
+) {
+    if depth > MAX_SCAN_DEPTH || out.len() >= MAX_FILES_SCANNED {
+        return;
+    }
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries {
+        if out.len() >= MAX_FILES_SCANNED {
+            return;
+        }
+        let Ok(entry) = entry else { continue };
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        if name_str.starts_with('.') {
+            continue;
+        }
+        let path = entry.path();
+        let ft = match entry.file_type() {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        // Skip symlinks to avoid walking into unrelated trees or cycles.
+        if ft.is_symlink() {
+            continue;
+        }
+        let rel = match path.strip_prefix(root) {
+            Ok(r) => r.to_string_lossy().replace('\\', "/"),
+            Err(_) => continue,
+        };
+        if ft.is_dir() {
+            if IGNORED_DIRS.contains(&name_str) {
+                continue;
+            }
+            // Cycle guard: track canonicalized directory paths.
+            if let Ok(canon) = path.canonicalize() {
+                if !visited.insert(canon) {
+                    continue;
+                }
+            }
+            out.push(FileCandidate {
+                path: format!("{rel}/"),
+                is_dir: true,
+            });
+            scan_dir(root, &path, depth + 1, out, visited);
+        } else if ft.is_file() {
+            out.push(FileCandidate {
+                path: rel,
+                is_dir: false,
+            });
+        }
+    }
+}
+
+/// Fuzzy subsequence score. Returns `None` when `query` is not a subsequence
+/// of `target` (case-insensitive). Matching is case-insensitive; exact-case
+/// matches, contiguous runs, and word-start positions score higher, while
+/// longer targets are penalized so specific short paths win.
+pub(crate) fn fuzzy_score(query: &str, target: &str) -> Option<i64> {
+    if query.is_empty() {
+        return Some(0);
+    }
+    let query: Vec<char> = query.chars().collect();
+    let target: Vec<char> = target.chars().collect();
+    let mut qi = 0usize;
+    let mut score: i64 = 0;
+    let mut prev_matched = false;
+    let mut prev_char = '\0';
+    for (pi, &pc) in target.iter().enumerate() {
+        if qi >= query.len() {
+            break;
+        }
+        let qc = query[qi];
+        if pc.eq_ignore_ascii_case(&qc) {
+            let mut s = 10i64;
+            if pc == qc {
+                s += 5; // exact-case bonus
+            }
+            if prev_matched {
+                s += 15; // contiguous run
+            }
+            if pi == 0 || matches!(prev_char, '/' | '.' | '_' | '-' | ' ') {
+                s += 30; // word-start
+            }
+            // Leading-position bonus: matches near the front rank higher.
+            s -= (pi as i64) / 4;
+            score += s;
+            qi += 1;
+            prev_matched = true;
+        } else {
+            prev_matched = false;
+        }
+        prev_char = pc;
+    }
+    if qi < query.len() {
+        return None;
+    }
+    // Prefer shorter targets (more specific match).
+    score -= (target.len() as i64) / 4;
+    Some(score)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    fn key(code: KeyCode, mods: KeyModifiers) -> Event {
+        Event::Key(KeyEvent::new(code, mods))
+    }
+
+    fn type_str(session: &mut FileMentionSession, s: &str) {
+        for ch in s.chars() {
+            session.dispatch_event(key(KeyCode::Char(ch), KeyModifiers::NONE));
+        }
+    }
+
+    /// Build a unique temp directory under the system temp dir so parallel
+    /// test processes never collide.
+    fn scratch_dir(name: &str) -> PathBuf {
+        let id = TEST_SEQ.fetch_add(1, Ordering::SeqCst);
+        let dir = std::env::temp_dir().join(format!(
+            "aish_file_mention_{name}_{}_{}",
+            std::process::id(),
+            id
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn cleanup(dir: &Path) {
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    // -- fuzzy_score ---------------------------------------------------------
+
+    #[test]
+    fn fuzzy_score_rejects_non_subsequence() {
+        assert!(fuzzy_score("xyz", "src/main.rs").is_none());
+    }
+
+    #[test]
+    fn fuzzy_score_accepts_subsequence() {
+        assert!(fuzzy_score("main", "src/main.rs").is_some());
+    }
+
+    #[test]
+    fn fuzzy_score_prefers_word_start_and_short_target() {
+        // `main` matches `main.rs` at position 0 (word start) and the path
+        // is shorter, so it must outrank `src/main.rs`.
+        let direct = fuzzy_score("main", "main.rs").unwrap();
+        let nested = fuzzy_score("main", "src/main.rs").unwrap();
+        assert!(direct > nested);
+    }
+
+    #[test]
+    fn fuzzy_score_case_insensitive_with_exact_bonus() {
+        let lower = fuzzy_score("read", "README.md").unwrap();
+        let exact = fuzzy_score("READ", "README.md").unwrap();
+        assert!(exact > lower);
+    }
+
+    // -- scan_files ----------------------------------------------------------
+
+    #[test]
+    fn scan_files_skips_hidden_and_ignored() {
+        let dir = scratch_dir("scan");
+        fs::write(dir.join("a.txt"), b"x").unwrap();
+        fs::create_dir_all(dir.join("sub")).unwrap();
+        fs::write(dir.join("sub").join("b.rs"), b"x").unwrap();
+        fs::create_dir_all(dir.join(".git")).unwrap();
+        fs::write(dir.join(".git").join("config"), b"x").unwrap();
+        fs::create_dir_all(dir.join("target")).unwrap();
+        fs::write(dir.join("target").join("bin"), b"x").unwrap();
+
+        let files = scan_files(&dir);
+        let paths: Vec<&str> = files.iter().map(|c| c.path.as_str()).collect();
+        assert!(paths.contains(&"a.txt"));
+        assert!(paths.contains(&"sub/"));
+        assert!(paths.contains(&"sub/b.rs"));
+        assert!(!paths.iter().any(|p| p.starts_with(".git")));
+        assert!(!paths.iter().any(|p| p.starts_with("target")));
+
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn scan_files_marks_directories_with_trailing_slash() {
+        let dir = scratch_dir("dirs");
+        fs::create_dir_all(dir.join("pkg")).unwrap();
+        fs::write(dir.join("pkg").join("f.rs"), b"x").unwrap();
+        let files = scan_files(&dir);
+        let pkg = files.iter().find(|c| c.path == "pkg/").unwrap();
+        assert!(pkg.is_dir);
+        let f = files.iter().find(|c| c.path == "pkg/f.rs").unwrap();
+        assert!(!f.is_dir);
+        cleanup(&dir);
+    }
+
+    // -- FileMentionSession behavior ----------------------------------------
+
+    fn session_in(dir: &Path, prefix: &str) -> FileMentionSession {
+        FileMentionSession::new(dir, "aish> ".into(), prefix.into())
+    }
+
+    #[test]
+    fn typing_filters_and_enter_selects_file() {
+        let dir = scratch_dir("select");
+        fs::write(dir.join("main.rs"), b"x").unwrap();
+        fs::write(dir.join("other.rs"), b"x").unwrap();
+        let mut s = session_in(&dir, "; analyze ");
+        type_str(&mut s, "main");
+        let outcome = s.dispatch_event(key(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(
+            outcome,
+            Some(FileMentionOutcome::Selected("main.rs".into()))
+        );
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn fuzzy_matches_substring_in_nested_path() {
+        // Typing `main` must surface `src/main.rs` even though the match
+        // starts mid-path — the core oh-my-pi parity requirement.
+        let dir = scratch_dir("fuzzy");
+        fs::create_dir_all(dir.join("src")).unwrap();
+        fs::write(dir.join("src").join("main.rs"), b"x").unwrap();
+        fs::write(dir.join("README.md"), b"x").unwrap();
+        let mut s = session_in(&dir, "; ");
+        type_str(&mut s, "main");
+        // The filtered list must contain src/main.rs in the top hit.
+        assert!(s
+            .filtered
+            .iter()
+            .any(|&i| s.candidates[i].path == "src/main.rs"));
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn enter_on_directory_descends_instead_of_selecting() {
+        let dir = scratch_dir("descend");
+        fs::create_dir_all(dir.join("src")).unwrap();
+        fs::write(dir.join("src").join("main.rs"), b"x").unwrap();
+        let mut s = session_in(&dir, "; ");
+        type_str(&mut s, "src");
+        // `src/` is the highlighted directory; Enter descends.
+        let outcome = s.dispatch_event(key(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(outcome, None); // session continues
+        assert_eq!(s.query, "src/");
+        // Now the list is scoped under src/.
+        assert!(s
+            .filtered
+            .iter()
+            .any(|&i| s.candidates[i].path == "src/main.rs"));
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn tab_extends_shared_prefix() {
+        let dir = scratch_dir("tab");
+        fs::write(dir.join("config.toml"), b"x").unwrap();
+        fs::write(dir.join("config.yaml"), b"x").unwrap();
+        let mut s = session_in(&dir, "; ");
+        type_str(&mut s, "con");
+        let outcome = s.dispatch_event(key(KeyCode::Tab, KeyModifiers::NONE));
+        // Shared prefix is `config.`; popup stays open.
+        assert_eq!(outcome, None);
+        assert_eq!(s.query, "config.");
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn backspace_past_at_cancels() {
+        let dir = scratch_dir("cancel");
+        fs::write(dir.join("a.txt"), b"x").unwrap();
+        let mut s = session_in(&dir, "; ");
+        let outcome = s.dispatch_event(key(KeyCode::Backspace, KeyModifiers::NONE));
+        assert_eq!(outcome, Some(FileMentionOutcome::Cancelled));
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn escape_cancels() {
+        let dir = scratch_dir("esc");
+        fs::write(dir.join("a.txt"), b"x").unwrap();
+        let mut s = session_in(&dir, "; ");
+        type_str(&mut s, "a");
+        let outcome = s.dispatch_event(key(KeyCode::Esc, KeyModifiers::NONE));
+        assert_eq!(outcome, Some(FileMentionOutcome::Cancelled));
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn enter_on_empty_query_with_no_match_cancels() {
+        let dir = scratch_dir("empty");
+        fs::write(dir.join("a.txt"), b"x").unwrap();
+        let mut s = session_in(&dir, "; ");
+        let outcome = s.dispatch_event(key(KeyCode::Enter, KeyModifiers::NONE));
+        // Empty query, first highlighted candidate is a file → selects it.
+        // The cancellation branch fires only when nothing matches at all.
+        assert!(matches!(outcome, Some(FileMentionOutcome::Selected(_))));
+        cleanup(&dir);
+    }
+}

--- a/crates/aish-ui/src/lib.rs
+++ b/crates/aish-ui/src/lib.rs
@@ -1,5 +1,6 @@
 mod choice;
 mod expand;
+mod file_mention;
 mod history;
 mod runtime;
 mod select;
@@ -8,6 +9,7 @@ mod slash_input;
 
 pub use choice::{ChoiceOutcome, ChoicePanel};
 pub use expand::ExpandPanel;
+pub use file_mention::{FileMentionOutcome, FileMentionSession};
 pub use history::{HistoryOutcome, HistoryPanel, HistoryRecord};
 pub use runtime::{PanelComponent, PanelError, PanelEvent, PanelOutcome, PanelRuntime};
 pub use select::{SearchSelectItem, SearchSelectOutcome, SearchSelectPanel};

--- a/crates/aish-ui/src/slash_input.rs
+++ b/crates/aish-ui/src/slash_input.rs
@@ -445,10 +445,10 @@ impl SlashInputSession {
     }
 }
 
-struct RawModeGuard;
+pub(crate) struct RawModeGuard;
 
 impl RawModeGuard {
-    fn enter() -> io::Result<Self> {
+    pub(crate) fn enter() -> io::Result<Self> {
         terminal::enable_raw_mode()?;
         if let Err(err) = execute!(io::stdout(), cursor::Hide) {
             let _ = terminal::disable_raw_mode();
@@ -466,14 +466,16 @@ impl Drop for RawModeGuard {
     }
 }
 
-fn drain_pending_events() -> io::Result<()> {
+pub(crate) fn drain_pending_events() -> io::Result<()> {
     while event::poll(std::time::Duration::from_millis(0))? {
         let _ = event::read()?;
     }
     Ok(())
 }
 
-fn open_inline_terminal(height: u16) -> io::Result<Terminal<CrosstermBackend<io::Stdout>>> {
+pub(crate) fn open_inline_terminal(
+    height: u16,
+) -> io::Result<Terminal<CrosstermBackend<io::Stdout>>> {
     Terminal::with_options(
         CrosstermBackend::new(io::stdout()),
         TerminalOptions {
@@ -482,7 +484,7 @@ fn open_inline_terminal(height: u16) -> io::Result<Terminal<CrosstermBackend<io:
     )
 }
 
-fn longest_common_prefix(names: &[&str]) -> String {
+pub(crate) fn longest_common_prefix(names: &[&str]) -> String {
     if names.is_empty() {
         return String::new();
     }
@@ -501,7 +503,7 @@ fn longest_common_prefix(names: &[&str]) -> String {
 }
 
 /// Strip ANSI CSI/OSC escape sequences from a string.
-fn strip_ansi(s: &str) -> String {
+pub(crate) fn strip_ansi(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut chars = s.chars().peekable();
     while let Some(ch) = chars.next() {


### PR DESCRIPTION
## 概述

- 问题: AI 回复的 Markdown 表格在 CJK 内容下列宽溢出 / inline 样式显示为字面量；AI 模式引用文件需手打路径；inline completion spinner 在 CJK 终端导致 `aish` 徽标位移；LLM 请求遇 429/5xx 直接失败
- 改动: 新增 `aish-md-table` crate + `md_render` 模块重构 Markdown 渲染；新增 `@path` 文件提及弹出框；spinner 只重写 `◆` 单元格；OpenAI/Anthropic/Codex 三 provider 加 HTTP 重试
- 关联 Issue: #377 #378 #379 #380

## 改动类型

- [x] Bug 修复
- [x] 新功能
- [ ] 重构
- [ ] 文档
- [ ] 其他

## 涉及范围

- [ ] 核心 Shell / PTY
- [x] AI 代理 / LLM
- [ ] 技能 / 工具
- [ ] 安全模块
- [ ] 配置系统
- [x] CLI / 界面
- [ ] 打包 / 安装
- [ ] CI/CD
- [ ] 文档

## 详细改动

### #377 Markdown 表格渲染重构
- 新增 `aish-md-table` crate：CJK 宽度感知的管道表格渲染器，单元格按列宽换行（超长 token 逐字断行），解析 inline markdown（`**bold**` / `` `code` `` / `*italic*`），递归支持嵌套
- 新增 `aish-shell::md_render`：基于 `pulldown-cmark` 的段落渲染器，段落按终端宽度折行、嵌套列表逐级缩进 + hanging indent
- `renderer.rs` 委托给新模块，移除旧的 `richrs::table` / `richrs::markdown` 路径

### #378 @path 文件提及弹出框
- 新增 `aish-ui::file_mention::FileMentionSession`：AI 模式 `;` 行内 `@`（token 边界）触发模糊文件选择，递归扫描 cwd（跳过 `.git` / `node_modules` / `target` 等），`Tab` 补全最长公共前缀，选中目录下钻
- `readline.rs`：`AtFileHandler` 在 `@` 按下时置标志 + `Cmd::Interrupt` 跳出 `read_line`
- `app.rs`：主循环识别 popup 恢复路径，splice 选中的路径回缓冲区，支持嵌套 `@` / `/`

### #379 inline completion spinner CJK 修复
- spinner 每帧只向第 1 列写单个 1 格 Braille 字符，绝不重写 `aish` 及其后内容
- 加 `debug_assert!` 保证 `MODE_ICON` 与每个 `SPINNER_STATUS` 字符都是单字符

### #380 LLM HTTP 重试机制
- `aish-llm::api` 新增共享 helper：`MAX_HTTP_RETRIES=3`、`is_retryable_status`（429/500/502/503/504）、`is_retryable_network_err`（connect/timeout）、`retry_backoff_delay`（0/500ms/1s/2s 指数退避）
- `client.rs`（OpenAI）、`anthropic_messages.rs`、`codex.rs`（两条 Codex HTTP 路径）接入
- `session.rs`：移除工具执行的盲重试（`ToolResult::error` 都是确定性的）

## 用户可见变更

- AI 回复的 Markdown 表格正确换行、inline 样式正常显示，长段落不溢出，嵌套列表缩进正确
- AI 模式输入 `@` 弹出文件选择框，可模糊搜索并插入路径
- CJK 终端下 inline completion 动画不再导致提示符抖动
- LLM 请求遇到 429/5xx/网络错误时自动重试（最多 3 次），而非直接失败

## 兼容性

- 向后兼容? 是
- 配置变更? 否

## 测试验证

- `cargo build --workspace` 通过（0.3.7）
- `cargo clippy --workspace --all-targets -- -D warnings` 通过（零 warning）
- `aish-md-table` 含 155 行单元测试覆盖管道解析、inline 样式、换行、宽度分配
- `file_mention` 含模糊打分与目录扫描测试

## 检查清单

- [x] 代码风格符合项目规范
- [x] 已添加必要的测试
- [x] 文档已更新（如需要）

## 备注

按 AGENTS.md 约定 Rust 重构通常走 `upstream/rust`，本次应维护者要求提到 `main`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `@path` file-mention popups in AI prompts, with fuzzy search, nested selector UI, keyboard navigation, tab completion, and cancellation.
  * Introduced a new Markdown rendering pipeline with improved table support, width-aware wrapping, nested lists, blockquotes, headings, links, and inline code styling.
* **Bug Fixes**
  * Improved LLM reliability by adding shared retry + exponential backoff for transient HTTP/network failures (including Codex and OpenAI-compatible calls).
  * Tool execution now runs exactly once (no retry on non-OK failures).
  * Fixed the inline completion spinner to only update the intended icon cell. 
* **Chores**
  * Added retry backoff to web fetch for connect/timeout errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->