### PR TITLE
feat: 响应 footer ctx→req 语义澄清 + 自动压缩标记

### DIFF
--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -83,6 +83,11 @@ pub struct LlmSession {
     /// Updated every iteration — reflects actual context window consumption
     /// regardless of whether the API reports prompt_tokens in streaming mode.
     last_prompt_estimate: std::sync::atomic::AtomicU64,
+    /// Compaction mode applied during the current turn
+    /// ("microcompact" | "full_compact"). Reset at the start of each
+    /// `process_input` call; surfaced via the response footer so a shrinking
+    /// ctx bar can be attributed to compaction rather than a miscount.
+    last_turn_compaction: std::sync::Mutex<Option<&'static str>>,
     /// Per-session tool execution policy (read-only bash enforcement, etc.).
     tool_execution_policy: crate::tool_context::ToolExecutionPolicy,
     /// True for sessions created via [`Self::create_subsession`].
@@ -142,6 +147,7 @@ impl LlmSession {
             plan_state: Arc::new(Mutex::new(PlanModeState::default())),
             token_stats: std::sync::Mutex::new(crate::usage::TokenStats::default()),
             last_prompt_estimate: std::sync::atomic::AtomicU64::new(0),
+            last_turn_compaction: std::sync::Mutex::new(None),
             tool_execution_policy: crate::tool_context::ToolExecutionPolicy::default(),
             is_sub_agent: false,
             #[cfg(test)]
@@ -337,6 +343,13 @@ impl LlmSession {
             .load(std::sync::atomic::Ordering::Relaxed)
     }
 
+    /// Return the compaction mode applied during the current turn, if any.
+    /// `Some("full_compact")` — history was summarized down;
+    /// `Some("microcompact")` — only stale tool output was cleared.
+    pub fn last_turn_compaction(&self) -> Option<&'static str> {
+        *self.last_turn_compaction.lock().unwrap()
+    }
+
     /// Return a snapshot of cumulative token usage statistics.
     pub fn token_stats(&self) -> crate::usage::TokenStats {
         self.token_stats.lock().unwrap().clone()
@@ -472,6 +485,7 @@ impl LlmSession {
         stream: bool,
     ) -> Result<crate::types::ProcessResult, AishError> {
         self.cancellation_token.reset();
+        self.last_turn_compaction.lock().unwrap().take();
 
         // Emit operation start event
         self.emit_event(LlmEvent {
@@ -1423,6 +1437,7 @@ impl LlmSession {
             plan_state: Arc::new(Mutex::new(PlanModeState::default())),
             token_stats: std::sync::Mutex::new(crate::usage::TokenStats::default()),
             last_prompt_estimate: std::sync::atomic::AtomicU64::new(0),
+            last_turn_compaction: std::sync::Mutex::new(None),
             tool_execution_policy: self.tool_execution_policy,
             is_sub_agent: true,
             #[cfg(test)]
@@ -1604,9 +1619,11 @@ impl LlmSession {
             let report = microcompact_chat_messages(&mut messages, policy);
             if report.changed_messages > 0 {
                 compaction_changed = true;
+                *self.last_turn_compaction.lock().unwrap() = Some("microcompact");
                 tracing::info!(
                     changed_messages = report.changed_messages,
                     reclaimed_tokens = report.reclaimed_tokens,
+                    compaction = "microcompact",
                     "send-path context microcompact completed"
                 );
             }
@@ -1629,10 +1646,15 @@ impl LlmSession {
                     .full_compact_chat_messages_with_model(messages.clone(), policy)
                     .await
                 {
-                    Ok(compacted) => {
+                    Ok(_compacted) => {
                         *self.compact_consecutive_failures.lock().unwrap() = 0;
                         compaction_changed = true;
-                        messages = compacted;
+                        *self.last_turn_compaction.lock().unwrap() = Some("full_compact");
+                        tracing::info!(
+                            compaction = "full_compact",
+                            "send-path full compact completed, compaction flag set"
+                        );
+                        messages = _compacted;
                     }
                     Err(err) => {
                         let mut guard = self.compact_consecutive_failures.lock().unwrap();

--- a/crates/aish-shell/src/ai_handler.rs
+++ b/crates/aish-shell/src/ai_handler.rs
@@ -345,6 +345,11 @@ impl AiHandler {
         self.llm_session.last_prompt_estimate()
     }
 
+    /// Return the compaction mode applied during the current turn, if any.
+    pub fn last_turn_compaction(&self) -> Option<&'static str> {
+        self.llm_session.last_turn_compaction()
+    }
+
     /// Return current context budget state (estimated tokens, pressure, %).
     pub fn context_budget_state(&self) -> aish_context::ContextBudgetState {
         self.context_manager.budget_state()

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -2389,11 +2389,13 @@ impl AishShell {
                                     } else {
                                         0
                                     };
+                                    let compaction = self.ai_handler.last_turn_compaction();
                                     let footer = theme::response_footer(
                                         &self.config.model,
                                         delta_in,
                                         delta_out,
                                         ctx_percent,
+                                        compaction,
                                         Some(ai_elapsed),
                                     );
                                     crate::recorder::shared_record_output(

--- a/crates/aish-shell/src/theme.rs
+++ b/crates/aish-shell/src/theme.rs
@@ -410,12 +410,20 @@ pub fn context_bar(percent: u8) -> String {
 }
 
 /// Render a one-line response metadata footer:
-/// `◉ model │ 3.2k in 1.1k out │ 3.2s │ ctx [████████░░] 23%`
+/// `◉ model │ 3.2k in 1.1k out │ 3.2s │ req [████████░░] 23%`
+///
+/// `req` is the current request's share of the context window — NOT the
+/// cumulative conversation size. Tool calls from prior turns are not
+/// persisted into the context manager, so a short follow-up after a
+/// tool-heavy turn legitimately shows a much smaller `req`. When
+/// `compaction` is `Some`, a trailing `⟳compacted` / `⟳micro` hint marks
+/// that the bar shrank because history was compacted this turn.
 pub fn response_footer(
     model: &str,
     input_tokens: u64,
     output_tokens: u64,
     ctx_percent: u8,
+    compaction: Option<&str>,
     elapsed_secs: Option<f64>,
 ) -> String {
     let sep = dim("│");
@@ -423,8 +431,13 @@ pub fn response_footer(
         Some(secs) => format!(" {} {} ", dim("·"), muted(&format!("{:.1}s", secs))),
         None => " ".to_string(),
     };
+    let compaction_part = match compaction {
+        Some("full_compact") => format!(" {}", dim("⟳compacted")),
+        Some("microcompact") => format!(" {}", dim("⟳micro")),
+        _ => String::new(),
+    };
     format!(
-        "{} {} {} {} {}{}{} ctx {}",
+        "{} {} {} {} {}{}{} req {}{}",
         gold("◉"),
         gold(model),
         sep,
@@ -432,7 +445,8 @@ pub fn response_footer(
         warning(&format!("{} out", format_tokens(output_tokens))),
         time_part,
         sep,
-        context_bar(ctx_percent)
+        context_bar(ctx_percent),
+        compaction_part,
     )
 }
 
@@ -646,7 +660,7 @@ mod diff_tests {
 
     #[test]
     fn response_footer_without_elapsed_has_space_before_sep() {
-        let footer = strip_ansi(&response_footer("gpt-4", 1000, 500, 23, None));
+        let footer = strip_ansi(&response_footer("gpt-4", 1000, 500, 23, None, None));
         assert!(
             footer.contains("out │"),
             "separator must have space before it when elapsed is None: {footer:?}"
@@ -655,7 +669,7 @@ mod diff_tests {
 
     #[test]
     fn response_footer_with_elapsed_has_time_segment() {
-        let footer = strip_ansi(&response_footer("gpt-4", 1000, 500, 23, Some(1.5)));
+        let footer = strip_ansi(&response_footer("gpt-4", 1000, 500, 23, None, Some(1.5)));
         assert!(
             footer.contains("1.5s"),
             "elapsed time must appear in footer: {footer:?}"


### PR DESCRIPTION
## 背景

Closes #382

当前 footer 的 `ctx%` 指标语义模糊：它反映的是**最后一次 API 请求**的 prompt token 估算占窗口比例，而非累积对话历史占比。由于 `context_manager` 不持久化工具调用（`tool_call` / `tool_result`），带工具的复杂任务后下一轮 `ctx%` 会骤降（如 35% → 4%），用户易误解为计数 bug。

同时，`prepare_messages_for_send` 触发 `microcompact` / `full_compact` 时 `ctx%` 也会骤降，但 footer 没有任何提示，用户无法区分"正常请求变小"和"历史被压缩"。

## 改动

### 1. footer 标签 `ctx` → `req`
明确表示"本次请求占窗口的比例"，doc 注释说明语义与工具历史不持久化的设计。

### 2. 自动压缩标记提示
当 `prepare_messages_for_send` 触发压缩时，footer 追加标记：
- `⟳compacted` — full_compact（LLM 摘要旧消息）
- `⟳micro` — microcompact（清空旧工具输出）

标记用 `dim()` 渲染，淡灰色不抢眼；无压缩时 footer 与之前一致（除标签）。

### 3. 实现细节
- `LlmSession` 新增 `last_turn_compaction: Mutex<Option<&'static str>>`，`process_input` 每轮 reset
- `prepare_messages_for_send` 在 microcompact / full_compact 触发时记录模式
- `response_footer` 新增 `compaction: Option<&str>` 参数
- `AiHandler` 透传 getter，`app.rs` 调用处传入压缩状态

## 验证

- ✅ `cargo fmt --all -- --check`
- ✅ `cargo clippy --all-targets -- -D warnings`（0 warnings）
- ✅ `cargo test --workspace`（全过）

## 改动文件

- `crates/aish-llm/src/session.rs` — 压缩跟踪字段 + 记录逻辑
- `crates/aish-shell/src/ai_handler.rs` — getter 透传
- `crates/aish-shell/src/app.rs` — footer 调用处传入压缩状态
- `crates/aish-shell/src/theme.rs` — footer 标签 `ctx→req` + compaction 参数 + doc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context compaction indicators to AI response footers.
  * Footers now distinguish between micro-compaction and full compaction when applied during a turn.
  * Updated token usage labeling for clearer request information.

* **Tests**
  * Updated response footer tests to cover the new compaction indicator input and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->