### PR TITLE
fix(security): /setting 沙箱/安全配置即时生效并同步到 security_policy.yaml

### DIFF
--- a/crates/aish-security/src/lib.rs
+++ b/crates/aish-security/src/lib.rs
@@ -13,8 +13,8 @@ pub use decision::{RiskLevel, SandboxOffAction, SecurityAnalysis, SecurityDecisi
 pub use fallback::{FallbackRuleAssessment, FallbackRuleEngine};
 pub use manager::{SecurityManager, SecurityRequest};
 pub use policy::{
-    load_policy, resolve_security_policy_path, InvalidFallbackRule, PolicyRule, SecurityPolicy,
-    ValidationIssue,
+    load_policy, resolve_security_policy_path, save_policy_globals, InvalidFallbackRule,
+    PolicyRule, SecurityPolicy, ValidationIssue,
 };
 pub use sandbox::{run_sandbox_daemon, run_sandbox_worker, SandboxClient};
 pub use types::{FsChange, MatchedRuleSummary};

--- a/crates/aish-security/src/manager.rs
+++ b/crates/aish-security/src/manager.rs
@@ -119,6 +119,24 @@ impl SecurityManager {
         self
     }
 
+    /// Replace the active policy and rebuild derived state (fallback engine,
+    /// sandbox runner). The secret scanner is intentionally **preserved** —
+    /// `/setting` only edits the global fields (`enable_sandbox`,
+    /// `default_risk_level`, `sandbox_off_action`,
+    /// `sandbox_timeout_seconds`, `input_guard.enabled`), never
+    /// `secret_patterns`. Callers that need to swap secret patterns must
+    /// construct a fresh `SecurityManager` instead, or the scanner will miss
+    /// the new patterns.
+    pub fn set_policy(&mut self, policy: SecurityPolicy) {
+        let sandbox_runner = policy.enable_sandbox.then(|| {
+            Arc::new(SandboxClient::new(DEFAULT_SANDBOX_SOCKET_PATH)) as Arc<dyn SandboxRunner>
+        });
+        let fallback_engine = FallbackRuleEngine::new(policy.clone());
+        self.policy = policy;
+        self.fallback_engine = fallback_engine;
+        self.sandbox_runner = sandbox_runner;
+    }
+
     #[cfg(test)]
     fn with_sandbox_runner(mut self, runner: impl SandboxRunner + 'static) -> Self {
         self.sandbox_runner = Some(Arc::new(runner));
@@ -362,6 +380,34 @@ mod tests {
         assert_eq!(decision.level, RiskLevel::Low);
         assert!(decision.allow);
         assert!(!decision.require_confirmation);
+    }
+
+    /// `set_policy` must rebuild the sandbox runner when `enable_sandbox`
+    /// flips on, so a live `/setting` toggle takes effect immediately.
+    #[test]
+    fn set_policy_rebuilds_sandbox_runner_when_enabled() {
+        let mut manager = SecurityManager::new(SecurityPolicy::default());
+        // Starts disabled (no sandbox runner).
+        assert!(!manager.policy().enable_sandbox);
+        assert!(manager.sandbox_runner.is_none());
+
+        manager.set_policy(SecurityPolicy {
+            enable_sandbox: true,
+            default_risk_level: RiskLevel::Medium,
+            ..SecurityPolicy::default()
+        });
+
+        assert!(manager.policy().enable_sandbox);
+        assert_eq!(manager.policy().default_risk_level, RiskLevel::Medium);
+        assert!(
+            manager.sandbox_runner.is_some(),
+            "enabling sandbox must construct a runner"
+        );
+
+        // Flipping back off drops the runner.
+        manager.set_policy(SecurityPolicy::default());
+        assert!(!manager.policy().enable_sandbox);
+        assert!(manager.sandbox_runner.is_none());
     }
 
     #[test]

--- a/crates/aish-security/src/policy.rs
+++ b/crates/aish-security/src/policy.rs
@@ -549,15 +549,17 @@ pub fn save_policy_globals(path: &Path, updates: &[(&str, &str)]) -> Result<(), 
     for (field, value) in updates {
         updated = update_global_field(&updated, field, value);
     }
-    // Write to a temp file in the same directory, then rename for atomicity.
-    // A plain fs::write can leave the file truncated on crash/ENOSPC, which
-    // would make load_policy silently fall back to the fail-open default.
+    // Prefer atomic write (temp + rename in the same directory) to avoid
+    // truncation on crash/ENOSPC. Fall back to direct fs::write when the
+    // directory isn't writable (common for /etc/aish/ where the file is
+    // user-owned but the directory is root-owned) — direct write only needs
+    // file-level write permission.
     let tmp_path = path.with_extension("yaml.tmp");
-    fs::write(&tmp_path, updated)
-        .map_err(|e| format!("failed to write {}: {e}", tmp_path.display()))?;
-    if let Err(e) = fs::rename(&tmp_path, path) {
+    let atomic_ok = fs::write(&tmp_path, &updated).is_ok() && fs::rename(&tmp_path, path).is_ok();
+    if !atomic_ok {
         let _ = fs::remove_file(&tmp_path);
-        return Err(format!("failed to replace {}: {e}", path.display()));
+        fs::write(path, &updated)
+            .map_err(|e| format!("failed to write {}: {e}", path.display()))?;
     }
     Ok(())
 }

--- a/crates/aish-security/src/policy.rs
+++ b/crates/aish-security/src/policy.rs
@@ -532,6 +532,110 @@ pub fn load_policy(config_path: Option<&Path>) -> SecurityPolicy {
     }
 }
 
+/// Update one or more `global:` fields in a `security_policy.yaml` file
+/// **in place**, preserving all comments, blank lines, and other sections.
+///
+/// Each entry in `updates` is `(field_name, new_value)`. If a field already
+/// exists under `global:`, its value is replaced (inline comments kept). If
+/// it is absent, it is inserted into the `global:` block. If `global:` itself
+/// is missing, a minimal section is appended.
+///
+/// Used by the `/setting` panel so security toggles are visible in the file
+/// users consider authoritative — not just in `config.yaml`.
+pub fn save_policy_globals(path: &Path, updates: &[(&str, &str)]) -> Result<(), String> {
+    let text =
+        fs::read_to_string(path).map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    let mut updated = text;
+    for (field, value) in updates {
+        updated = update_global_field(&updated, field, value);
+    }
+    fs::write(path, updated).map_err(|e| format!("failed to write {}: {e}", path.display()))?;
+    Ok(())
+}
+
+/// Replace `field` under the top-level `global:` mapping with `value`, or
+/// insert it if absent. Preserves comments, indentation, and all other content.
+fn update_global_field(text: &str, field: &str, value: &str) -> String {
+    let lines: Vec<&str> = text.split('\n').collect();
+    let mut out: Vec<String> = Vec::with_capacity(lines.len());
+    let mut in_global = false;
+    let mut global_line_idx: Option<usize> = None;
+    let mut last_indent: String = String::from("  ");
+    let mut last_global_child_idx: Option<usize> = None;
+    let mut done = false;
+
+    for (i, raw) in lines.iter().enumerate() {
+        // A top-level key: no leading whitespace, not blank, not a comment,
+        // not a list-item dash.
+        let is_top_level = !raw.is_empty()
+            && !raw.starts_with(' ')
+            && !raw.starts_with('\t')
+            && !raw.starts_with('#')
+            && !raw.starts_with('-');
+        if is_top_level {
+            in_global = raw.trim_start().starts_with("global:");
+            if in_global {
+                global_line_idx = Some(i);
+            }
+        }
+
+        if in_global && !done {
+            let stripped = raw.trim_start();
+            let indent_len = raw.len() - stripped.len();
+            if indent_len > 0 && !stripped.starts_with('#') && !stripped.is_empty() {
+                // Track the indentation used inside global: so an insertion
+                // (if needed) matches the surrounding style.
+                last_indent = raw[..indent_len].to_string();
+                last_global_child_idx = Some(i);
+            }
+            // Match `  field:` exactly (the ':' terminator prevents
+            // `enable_sandbox_extra:` from matching `enable_sandbox`).
+            let needle = format!("{}:", field);
+            if stripped.starts_with(&needle) {
+                let after = &stripped[needle.len()..];
+                // Preserve a trailing inline comment, e.g. `field: VALUE  # note`.
+                let comment = after.find('#').map(|pos| &after[pos..]);
+                out.push(format!(
+                    "{}{}: {}{}",
+                    &raw[..indent_len],
+                    field,
+                    value,
+                    comment.map(|c| format!("  {}", c)).unwrap_or_default()
+                ));
+                done = true;
+                continue;
+            }
+        }
+
+        out.push(raw.to_string());
+    }
+
+    // Field not found under global: — insert it.
+    if !done {
+        if let Some(gidx) = global_line_idx {
+            // Insert after the last existing child of global: (or right
+            // after `global:` if the section is empty).
+            let insert_at = last_global_child_idx.map(|c| c + 1).unwrap_or(gidx + 1);
+            // Find where `out` currently has the corresponding line — since
+            // we pushed every line, indices match `lines`.
+            out.insert(insert_at, format!("{}{}: {}", last_indent, field, value));
+        } else {
+            // No global: section at all — append a minimal one.
+            if !out.is_empty() && out.last().map(|l| !l.is_empty()).unwrap_or(false) {
+                out.push(String::new());
+            }
+            out.push("global:".to_string());
+            out.push(format!("  {}: {}", field, value));
+        }
+    }
+
+    let mut result = out.join("\n");
+    if text.ends_with('\n') && !result.ends_with('\n') {
+        result.push('\n');
+    }
+    result
+}
+
 pub fn default_rules() -> Vec<PolicyRule> {
     vec![PolicyRule {
         pattern: "/**/security_policy.yaml".to_string(),
@@ -756,5 +860,163 @@ rules: []
         assert!(policy.input_guard.enabled);
         assert!(policy.input_guard.custom_block_rules.is_empty());
         assert!(policy.input_guard.custom_confirm_rules.is_empty());
+    }
+
+    // ---- save_policy_globals / update_global_field ----
+
+    #[test]
+    fn update_global_field_replaces_existing_value() {
+        let yaml = "global:\n  enable_sandbox: true\n  default_risk_level: LOW\n";
+        let out = super::update_global_field(yaml, "enable_sandbox", "false");
+        assert!(out.contains("enable_sandbox: false"));
+        assert!(out.contains("default_risk_level: LOW"));
+        assert!(!out.contains("enable_sandbox: true"));
+    }
+
+    #[test]
+    fn update_global_field_preserves_inline_comment() {
+        let yaml = "global:\n  enable_sandbox: false  # toggle me\n";
+        let out = super::update_global_field(yaml, "enable_sandbox", "true");
+        assert!(out.contains("enable_sandbox: true  # toggle me"));
+    }
+
+    #[test]
+    fn update_global_field_preserves_block_comments_and_other_sections() {
+        let yaml = "# header comment\n\
+                    global:\n\
+                    # enable sandbox?\n\
+                    enable_sandbox: false\n\
+                    default_risk_level: LOW\n\
+                    \n\
+                    audit:\n\
+                    enabled: true\n";
+        let out = super::update_global_field(yaml, "enable_sandbox", "true");
+        assert!(out.contains("# header comment"));
+        assert!(out.contains("# enable sandbox?"));
+        assert!(out.contains("enable_sandbox: true"));
+        assert!(out.contains("default_risk_level: LOW"));
+        assert!(out.contains("audit:"));
+        assert!(out.contains("enabled: true"));
+    }
+
+    #[test]
+    fn update_global_field_does_not_match_prefix() {
+        // `enable_sandbox` must NOT match `enable_sandbox_extra`.
+        let yaml = "global:\n  enable_sandbox: true\n  enable_sandbox_extra: keep\n";
+        let out = super::update_global_field(yaml, "enable_sandbox", "false");
+        assert!(out.contains("enable_sandbox: false"));
+        assert!(out.contains("enable_sandbox_extra: keep"));
+    }
+
+    #[test]
+    fn update_global_field_inserts_missing_field() {
+        let yaml = "global:\n  default_risk_level: LOW\n";
+        let out = super::update_global_field(yaml, "enable_sandbox", "true");
+        assert!(out.contains("enable_sandbox: true"));
+        assert!(out.contains("default_risk_level: LOW"));
+        // Inserted with the same indent as the existing child.
+        assert!(out.contains("  enable_sandbox: true"));
+    }
+
+    #[test]
+    fn update_global_field_creates_global_section_if_absent() {
+        let yaml = "audit:\n  enabled: true\n";
+        let out = super::update_global_field(yaml, "enable_sandbox", "true");
+        assert!(out.contains("global:"));
+        assert!(out.contains("enable_sandbox: true"));
+        assert!(out.contains("audit:"));
+    }
+
+    #[test]
+    fn save_policy_globals_round_trips_through_load_policy() {
+        let dir = tempdir().unwrap();
+        let policy_path = dir.path().join("security_policy.yaml");
+        fs::write(
+            &policy_path,
+            "# comment\nglobal:\n  enable_sandbox: true\n  default_risk_level: LOW\nrules: []\n",
+        )
+        .unwrap();
+        super::save_policy_globals(
+            &policy_path,
+            &[
+                ("enable_sandbox", "false"),
+                ("default_risk_level", "MEDIUM"),
+            ],
+        )
+        .unwrap();
+
+        let policy = load_policy(Some(&policy_path));
+        assert!(!policy.enable_sandbox);
+        assert_eq!(policy.default_risk_level, RiskLevel::Medium);
+
+        // Comment preserved.
+        let on_disk = fs::read_to_string(&policy_path).unwrap();
+        assert!(on_disk.contains("# comment"));
+    }
+
+    /// Verifies the real-world `/etc/aish/security_policy.yaml` layout
+    /// (block comments above each field, inline comments on some lines,
+    /// multi-language content) survives a `/setting` sync intact.
+    #[test]
+    fn save_policy_globals_preserves_production_template_comments() {
+        let dir = tempdir().unwrap();
+        let policy_path = dir.path().join("security_policy.yaml");
+        // Mirrors the installed template with CJK comments and inline notes.
+        let template = concat!(
+            "# AI-Shell Security Policy\n",
+            "# Installed by `make install`.\n",
+            "\n",
+            "# 全局配置\n",
+            "global:\n",
+            "  # 未命中任何规则时的默认风险\n",
+            "  default_risk_level: LOW\n",
+            "\n",
+            "  # 是否开启沙箱预跑\n",
+            "  enable_sandbox: true\n",
+            "\n",
+            "  # 沙箱关闭时的处理动作\n",
+            "  sandbox_off_action: ALLOW      # ALLOW | CONFIRM | BLOCK\n",
+            "  sandbox_timeout_seconds: 10\n",
+            "\n",
+            "audit:\n",
+            "  enabled: false\n",
+            "\n",
+            "rules: []\n",
+        );
+        fs::write(&policy_path, template).unwrap();
+
+        super::save_policy_globals(
+            &policy_path,
+            &[
+                ("enable_sandbox", "false"),
+                ("default_risk_level", "MEDIUM"),
+                ("sandbox_off_action", "BLOCK"),
+                ("sandbox_timeout_seconds", "15"),
+            ],
+        )
+        .unwrap();
+
+        let result = fs::read_to_string(&policy_path).unwrap();
+
+        // Block comments preserved.
+        assert!(result.contains("# AI-Shell Security Policy"));
+        assert!(result.contains("# 全局配置"));
+        assert!(result.contains("# 未命中任何规则时的默认风险"));
+        assert!(result.contains("# 是否开启沙箱预跑"));
+        assert!(result.contains("# 沙箱关闭时的处理动作"));
+
+        // Values updated.
+        assert!(result.contains("enable_sandbox: false"));
+        assert!(!result.contains("enable_sandbox: true"));
+        assert!(result.contains("default_risk_level: MEDIUM"));
+        assert!(result.contains("sandbox_off_action: BLOCK"));
+        assert!(result.contains("sandbox_timeout_seconds: 15"));
+
+        // Inline comment on sandbox_off_action line preserved.
+        assert!(result.contains("# ALLOW | CONFIRM | BLOCK"));
+
+        // Other sections untouched.
+        assert!(result.contains("audit:"));
+        assert!(result.contains("rules: []"));
     }
 }

--- a/crates/aish-security/src/policy.rs
+++ b/crates/aish-security/src/policy.rs
@@ -549,7 +549,16 @@ pub fn save_policy_globals(path: &Path, updates: &[(&str, &str)]) -> Result<(), 
     for (field, value) in updates {
         updated = update_global_field(&updated, field, value);
     }
-    fs::write(path, updated).map_err(|e| format!("failed to write {}: {e}", path.display()))?;
+    // Write to a temp file in the same directory, then rename for atomicity.
+    // A plain fs::write can leave the file truncated on crash/ENOSPC, which
+    // would make load_policy silently fall back to the fail-open default.
+    let tmp_path = path.with_extension("yaml.tmp");
+    fs::write(&tmp_path, updated)
+        .map_err(|e| format!("failed to write {}: {e}", tmp_path.display()))?;
+    if let Err(e) = fs::rename(&tmp_path, path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(format!("failed to replace {}: {e}", path.display()));
+    }
     Ok(())
 }
 
@@ -882,18 +891,24 @@ rules: []
 
     #[test]
     fn update_global_field_preserves_block_comments_and_other_sections() {
-        let yaml = "# header comment\n\
-                    global:\n\
-                    # enable sandbox?\n\
-                    enable_sandbox: false\n\
-                    default_risk_level: LOW\n\
-                    \n\
-                    audit:\n\
-                    enabled: true\n";
+        let yaml = concat!(
+            "# header comment\n",
+            "global:\n",
+            "  # enable sandbox?\n",
+            "  enable_sandbox: false\n",
+            "  default_risk_level: LOW\n",
+            "\n",
+            "audit:\n",
+            "  enabled: true\n",
+        );
         let out = super::update_global_field(yaml, "enable_sandbox", "true");
         assert!(out.contains("# header comment"));
         assert!(out.contains("# enable sandbox?"));
         assert!(out.contains("enable_sandbox: true"));
+        assert!(
+            !out.contains("enable_sandbox: false"),
+            "old value must be replaced, not duplicated"
+        );
         assert!(out.contains("default_risk_level: LOW"));
         assert!(out.contains("audit:"));
         assert!(out.contains("enabled: true"));

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -152,6 +152,33 @@ fn setting_desc(def: &crate::settings_panel::SettingDef) -> String {
     t(&format!("shell.setting.k.{}.desc", def.key.name()))
 }
 
+/// Mirror the security-relevant fields of `config.yaml` onto `policy`.
+///
+/// `config.yaml` overrides `security_policy.yaml` for the globals the
+/// `/setting` panel exposes (`enable_sandbox`, `default_risk_level`,
+/// `sandbox_off_action`, `sandbox_timeout_seconds`, and the InputGuard
+/// master switch). Centralized here so the startup path and the live
+/// `/setting` update path cannot drift.
+fn apply_config_security_overrides(
+    policy: &mut aish_security::SecurityPolicy,
+    config: &ConfigModel,
+) {
+    use aish_security::decision::{RiskLevel, SandboxOffAction};
+    policy.input_guard.enabled = config.input_guard_enabled;
+    policy.enable_sandbox = config.enable_sandbox;
+    policy.default_risk_level = match config.default_risk_level.to_lowercase().as_str() {
+        "medium" => RiskLevel::Medium,
+        "high" => RiskLevel::High,
+        _ => RiskLevel::Low,
+    };
+    policy.sandbox_off_action = match config.sandbox_off_action.to_lowercase().as_str() {
+        "confirm" => SandboxOffAction::Confirm,
+        "block" => SandboxOffAction::Block,
+        _ => SandboxOffAction::Allow,
+    };
+    policy.sandbox_timeout_seconds = config.sandbox_timeout_seconds;
+}
+
 /// Human-readable current value for the setting-list row.
 fn setting_display_current(cfg: &ConfigModel, def: &crate::settings_panel::SettingDef) -> String {
     use crate::settings_panel::{current_raw, SettingKind};
@@ -780,19 +807,7 @@ impl AishShell {
         // config.yaml mirrors several security_policy.yaml fields and takes
         // precedence, so users can toggle them from the familiar config file
         // (and via /setting) without editing security_policy.yaml.
-        policy.input_guard.enabled = config.input_guard_enabled;
-        policy.enable_sandbox = config.enable_sandbox;
-        policy.default_risk_level = match config.default_risk_level.to_lowercase().as_str() {
-            "medium" => aish_security::decision::RiskLevel::Medium,
-            "high" => aish_security::decision::RiskLevel::High,
-            _ => aish_security::decision::RiskLevel::Low,
-        };
-        policy.sandbox_off_action = match config.sandbox_off_action.to_lowercase().as_str() {
-            "confirm" => aish_security::decision::SandboxOffAction::Confirm,
-            "block" => aish_security::decision::SandboxOffAction::Block,
-            _ => aish_security::decision::SandboxOffAction::Allow,
-        };
-        policy.sandbox_timeout_seconds = config.sandbox_timeout_seconds;
+        apply_config_security_overrides(&mut policy, &config);
         let security_manager = SecurityManager::new(policy);
         let input_guard =
             aish_security::input_guard::InputGuard::from_policy(security_manager.policy());
@@ -4557,6 +4572,22 @@ impl AishShell {
                 self.input_guard
                     .set_enabled(self.config.input_guard_enabled);
             }
+            LiveEffect::SecurityPolicy => {
+                // Re-apply the security globals mirrored from config.yaml to
+                // the running SecurityManager so changes take effect now,
+                // not on next launch. `set_policy` rebuilds the sandbox
+                // runner when `enable_sandbox` flips.
+                let mut policy = self.security_manager.policy().clone();
+                apply_config_security_overrides(&mut policy, &self.config);
+                self.security_manager.set_policy(policy);
+
+                // Also persist to security_policy.yaml (the file users
+                // consider authoritative) so the change is visible there and
+                // survives a restart. Writes to the resolved policy path;
+                // a permission failure is logged but does not revert the
+                // live update.
+                self.sync_security_policy_file();
+            }
             LiveEffect::None => {}
         }
 
@@ -4593,6 +4624,47 @@ impl AishShell {
             *restart_changes += 1;
         }
         Ok(())
+    }
+
+    /// Persist the current security globals to the resolved
+    /// `security_policy.yaml` so `/setting` changes are visible in the file
+    /// users consider authoritative and survive a restart. A write failure
+    /// (e.g. root-owned system policy) is logged but does not revert the
+    /// live update or block the `/setting` flow.
+    fn sync_security_policy_file(&self) {
+        let Some(path) = aish_security::resolve_security_policy_path(None) else {
+            return;
+        };
+        let risk = match self.config.default_risk_level.to_lowercase().as_str() {
+            "medium" => "MEDIUM",
+            "high" => "HIGH",
+            _ => "LOW",
+        };
+        let action = match self.config.sandbox_off_action.to_lowercase().as_str() {
+            "confirm" => "CONFIRM",
+            "block" => "BLOCK",
+            _ => "ALLOW",
+        };
+        let timeout_str = self.config.sandbox_timeout_seconds.to_string();
+        let updates: &[(&str, &str)] = &[
+            (
+                "enable_sandbox",
+                if self.config.enable_sandbox {
+                    "true"
+                } else {
+                    "false"
+                },
+            ),
+            ("default_risk_level", risk),
+            ("sandbox_off_action", action),
+            ("sandbox_timeout_seconds", &timeout_str),
+        ];
+        if let Err(e) = aish_security::save_policy_globals(&path, updates) {
+            eprintln!(
+                "{}",
+                theme::warning(&format!("could not write {}: {e}", path.display()))
+            );
+        }
     }
 
     /// Build the panel data from the live config. Pure function so it stays

--- a/crates/aish-shell/src/settings_panel.rs
+++ b/crates/aish-shell/src/settings_panel.rs
@@ -28,6 +28,11 @@ pub enum LiveEffect {
     /// `input_guard_enabled` changes, so `screen_input()` honors it without a
     /// restart.
     InputGuard,
+    /// Re-apply the mirrored security globals (`enable_sandbox`,
+    /// `default_risk_level`, `sandbox_off_action`, `sandbox_timeout_seconds`)
+    /// to the live `SecurityManager` via `set_policy`, so sandbox pre-runs and
+    /// risk gating honor the new values without a restart.
+    SecurityPolicy,
     /// Re-initialize the whole LLM session + tools + inline completer — needed
     /// when `model` / `api_base` / `api_key` change.
     ModelSession,
@@ -775,13 +780,16 @@ pub fn apply(cfg: &mut ConfigModel, key: SettingKey, value: &str) -> Result<(), 
     }
     Ok(())
 }
-
 /// What live side-effect the shell must run after `key` changes.
 pub fn live_effect(key: SettingKey) -> LiveEffect {
     match key {
         SettingKey::Model | SettingKey::ApiBase | SettingKey::ApiKey => LiveEffect::ModelSession,
         SettingKey::Temperature | SettingKey::MaxTokens => LiveEffect::ToolsRefresh,
         SettingKey::InputGuardEnabled => LiveEffect::InputGuard,
+        SettingKey::EnableSandbox
+        | SettingKey::DefaultRiskLevel
+        | SettingKey::SandboxOffAction
+        | SettingKey::SandboxTimeout => LiveEffect::SecurityPolicy,
         _ => LiveEffect::None,
     }
 }
@@ -789,8 +797,9 @@ pub fn live_effect(key: SettingKey) -> LiveEffect {
 /// Whether the running session must be restarted for `key`'s new value to take
 /// effect. The model/credential fields are applied live via `update_model`,
 /// temperature/max_tokens rebuild tools live, `input_guard_enabled` toggles the
-/// cached InputGuard live, and `prompt_style` is read from `self.config` on
-/// each render — everything else is consumed only at startup.
+/// cached InputGuard live, the security globals (`enable_sandbox`, etc.) are
+/// pushed into the running `SecurityManager`, and `prompt_style` is read from
+/// `self.config` on each render — everything else is consumed only at startup.
 pub fn requires_restart(key: SettingKey) -> bool {
     match key {
         SettingKey::Model
@@ -799,6 +808,10 @@ pub fn requires_restart(key: SettingKey) -> bool {
         | SettingKey::Temperature
         | SettingKey::MaxTokens
         | SettingKey::InputGuardEnabled
+        | SettingKey::EnableSandbox
+        | SettingKey::DefaultRiskLevel
+        | SettingKey::SandboxOffAction
+        | SettingKey::SandboxTimeout
         | SettingKey::PromptStyle => false,
         _ => true,
     }
@@ -1017,9 +1030,13 @@ mod tests {
         assert!(!requires_restart(SettingKey::Model));
         assert!(!requires_restart(SettingKey::InputGuardEnabled));
         assert!(!requires_restart(SettingKey::PromptStyle));
+        // Security globals are pushed live into the SecurityManager.
+        assert!(!requires_restart(SettingKey::EnableSandbox));
+        assert!(!requires_restart(SettingKey::DefaultRiskLevel));
+        assert!(!requires_restart(SettingKey::SandboxOffAction));
+        assert!(!requires_restart(SettingKey::SandboxTimeout));
         // Startup-only settings do require a restart.
         assert!(requires_restart(SettingKey::LogLevel));
-        assert!(requires_restart(SettingKey::EnableSandbox));
         assert!(requires_restart(SettingKey::HistorySize));
     }
 
@@ -1054,12 +1071,24 @@ mod tests {
         assert_eq!(live_effect(SettingKey::Model), LiveEffect::ModelSession);
         assert_eq!(live_effect(SettingKey::ApiKey), LiveEffect::ModelSession);
         assert_eq!(
-            live_effect(SettingKey::Temperature),
-            LiveEffect::ToolsRefresh
-        );
-        assert_eq!(
             live_effect(SettingKey::InputGuardEnabled),
             LiveEffect::InputGuard
+        );
+        assert_eq!(
+            live_effect(SettingKey::EnableSandbox),
+            LiveEffect::SecurityPolicy
+        );
+        assert_eq!(
+            live_effect(SettingKey::DefaultRiskLevel),
+            LiveEffect::SecurityPolicy
+        );
+        assert_eq!(
+            live_effect(SettingKey::SandboxOffAction),
+            LiveEffect::SecurityPolicy
+        );
+        assert_eq!(
+            live_effect(SettingKey::SandboxTimeout),
+            LiveEffect::SecurityPolicy
         );
     }
 


### PR DESCRIPTION
Closes #386.

## 问题

在 `/setting` 面板切换沙箱或其他安全全局字段后存在两个问题：

1. **不即时生效**：`requires_restart(EnableSandbox)` 返回 `true`，用户必须重启才能应用更改。
2. **不同步到 `security_policy.yaml`**：`/setting` 只写 `~/.config/aish/config.yaml`，用户检查实际加载的 `security_policy.yaml`（如 `/etc/aish/security_policy.yaml`）发现值没变。

## 修复

### 即时生效

| 变更 | 文件 |
|------|------|
| `SecurityManager::set_policy(policy)` — 替换活动策略，重建 fallback engine + sandbox runner | `manager.rs` |
| `LiveEffect::SecurityPolicy` 新变体，映射 4 个安全键 | `settings_panel.rs` |
| `requires_restart()` 对安全键返回 `false` | `settings_panel.rs` |
| `apply_config_security_overrides()` 公共助手，启动路径和实时更新共用 | `app.rs` |

### 同步到 security_policy.yaml

| 变更 | 文件 |
|------|------|
| `save_policy_globals(path, updates)` — 保留注释的文本级 YAML 编辑器 | `policy.rs` |
| `sync_security_policy_file()` — 写 4 个 global 到 resolved policy path | `app.rs` |

`save_policy_globals` 保留 CJK 注释、inline 注释（`field: value  # note`）、block 注释和其他 section。写失败（root-owned）打 warning 不阻断实时更新。

## 测试

新增 9 个单元测试：

- `set_policy_rebuilds_sandbox_runner_when_enabled` — sandbox runner 重建
- `update_global_field_replaces_existing_value` — 基本替换
- `update_global_field_preserves_inline_comment` — inline 注释保留
- `update_global_field_preserves_block_comments_and_other_sections` — 多 section + 注释保留
- `update_global_field_does_not_match_prefix` — `enable_sandbox` 不误匹配 `enable_sandbox_extra`
- `update_global_field_inserts_missing_field` — 字段缺失时插入
- `update_global_field_creates_global_section_if_absent` — `global:` 不存在时创建
- `save_policy_globals_round_trips_through_load_policy` — 写后读回一致
- `save_policy_globals_preserves_production_template_comments` — 生产模板（CJK 注释）完整性

## 验证

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓（0 failures）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Security policy-related settings now apply immediately without requiring a restart.
  * Live updates adjust sandbox enablement, default risk level, sandbox-off action, and sandbox timeout.
  * Updated security-policy globals are saved back to `security_policy.yaml`, preserving existing comments/formatting while modifying only the targeted `global` fields.
* **Bug Fixes**
  * Policy changes now rebuild sandbox behavior instantly (including proper sandbox runner enable/disable).
  * Secret scanner configuration is preserved across policy updates.
* **Tests**
  * Added coverage for immediate sandbox rebuild behavior and policy-file save/preservation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->