### PR TITLE
Release v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.8] - 2026-07-22
+
+### Added
+
+- Added `@path` file-mention popup in AI mode with fuzzy search, Tab longest-common-prefix completion, and directory drill-down.
+- Added a CJK-aware Markdown rendering pipeline (`aish-md-table` + `md_render`) for width-aware tables, inline styles, nested lists, and terminal wrapping.
+- Added response-footer compaction markers (`⟳compacted` / `⟳micro`) when automatic context compaction runs during a turn.
+
+### Changed
+
+- Renamed the response-footer token label from `ctx` to `req` to reflect per-request window usage rather than cumulative conversation history.
+- Added shared HTTP retry with exponential backoff for transient 429/5xx and network errors across OpenAI, Anthropic, and Codex providers.
+
+### Fixed
+
+- Fixed the inline completion spinner so CJK terminals no longer shift the `aish` mode icon.
+- Fixed PTY detach after session exit to skip the Detach write and avoid Broken-pipe WARN noise (Ctrl+Q still sends Detach).
+- Fixed packaged skills seeding to write into `~/.config/aish/skills` as the target user (no `/usr/local` install + leaf-only chown), including a one-shot repair for leftover root-owned config trees from older installers.
+- Hardened the packaging ownership smoke test to require seed/install scripts and assert privilege drop instead of fakeroot ownership checks.
+
 ## [0.3.7] - 2026-07-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "aish-cli"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "aish-config"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "aish-context"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "aish-core",
  "serde",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "aish-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "aish-hosts"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "aish-i18n"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "aish-llm"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "aish-context",
  "aish-core",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "aish-md-table"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "richrs",
  "unicode-width",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "aish-memory"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "aish-core",
  "chrono",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "aish-prompts"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "aish-pty"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "aish-scripts"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "aish-security"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "libc",
  "regex",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "aish-session"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "aish-core",
  "chrono",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "aish-shell"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "aish-config",
  "aish-context",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "aish-skills"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "aish-tools"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "aish-core",
  "aish-i18n",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "aish-ui"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "crossterm 0.28.1",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"


### PR DESCRIPTION
## Summary

- Bump workspace version to **0.3.8** and add CHANGELOG notes for the release.
- Includes `@path` file mention, CJK-aware Markdown tables, footer `ctx→req` + compaction markers, LLM HTTP retry, PTY detach WARN fix, and packaging skills seed ownership fixes (#381, #383, #375, #384).

## Changelog highlights

### Added
- `@path` file-mention popup (fuzzy search / Tab LCP / directory drill-down)
- CJK-aware Markdown rendering (`aish-md-table` + `md_render`)
- Response-footer compaction markers (`⟳compacted` / `⟳micro`)

### Changed
- Footer token label `ctx` → `req` (per-request window usage)
- Shared HTTP retry + exponential backoff for 429/5xx/network errors

### Fixed
- Inline completion spinner CJK icon shift
- PTY detach after session exit (Broken-pipe WARN)
- Packaged skills seed into user config as target user (no `/usr/local` + leaf chown)

## Local verification

- [x] `python3 packaging/tests/test_resolve_release_pr.py -q`
- [x] `make format-check` / `make lint` (via `make ci-check`)
- [x] `make test` (completion_query timing flaked once under load, passed on retry + full re-run)

## Release checklist

- [ ] CI green
- [ ] Manually run **Release Preparation** with this PR number
- [ ] Merge after Preparation ✅
- [ ] Tag `v0.3.8` on merged `main` and push to upstream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `@path` file mentions with fuzzy search and completion.
  * Improved Markdown rendering for CJK text, including width-aware tables and styling.
  * Added compaction markers to response footers during automatic context compaction.

* **Improvements**
  * Renamed the response-footer token label from `ctx` to `req`.
  * Added automatic retries with exponential backoff for transient provider and network errors.

* **Bug Fixes**
  * Corrected CJK completion spinner alignment.
  * Reduced broken-pipe warnings after terminal session exit.
  * Fixed packaged skill installation and configuration ownership handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->