### PR TITLE
feat(security): session-scoped command approval memory

### DIFF
--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -128,6 +128,16 @@ status:
   na: "k.A."
 
 shell:
+  confirm_dialog_title: "Tool-Ausführung"
+  confirm_dialog_tool: "Tool:"
+  confirm_dialog_command: "Befehl:"
+  confirm_dialog_options: "[y] Einmal erlauben   [a] Diese Sitzung merken   [r] KI um anderen Weg bitten   [n] Ablehnen"
+  confirm_dialog_question: "Deine Wahl (Standard n):"
+  confirm_choice_once: "Einmal erlauben"
+  confirm_choice_remember: "Diese Sitzung merken"
+  confirm_choice_reply: "KI um anderen Weg bitten"
+  confirm_choice_deny: "Ablehnen"
+  forget_approvals_cleared: "{count} gespeicherte Genehmigung(en) für diese Sitzung gelöscht"
   welcome2:
     header: ">_ AI Shell {version}"
     model_hint: "(mit /model wechseln)"
@@ -168,6 +178,7 @@ shell:
     live_sessions: "Aktive PTY-Sitzungen auflisten"
     kill_live_sessions: "PTY-Sitzung(en) nach ID beenden"
     audit: "Audit-Protokoll abfragen (wer/wann/was/KI-Vorschlag/Bestaetigung)"
+    forget-approvals: "Gemerkte Befehlsgenehmigungen löschen (diese Sitzung)"
 
   feedback:
     select_type: "Feedback-Typ auswählen"

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -367,6 +367,7 @@ shell:
     live_sessions: "List live PTY sessions"
     kill_live_sessions: "Kill live PTY session(s) by ID"
     audit: "Query audit log (who/when/what/AI suggestion/confirm)"
+    forget-approvals: "Clear remembered command approvals (this session)"
 
   record:
     started: "⏺ Recording started: {path}"
@@ -441,7 +442,14 @@ shell:
   # Confirm dialog
   confirm_dialog_title: "Tool Execution"
   confirm_dialog_tool: "Tool:"
-  confirm_dialog_question: "Allow? [y/N]"
+  confirm_dialog_command: "Command:"
+  confirm_dialog_options: "[y] Allow once   [a] Remember this session   [r] Reply to AI (try another way)   [n] Deny"
+  confirm_dialog_question: "Your choice (default n):"
+  confirm_choice_once: "Allow once"
+  confirm_choice_remember: "Remember this session"
+  confirm_choice_reply: "Reply to AI (try another way)"
+  confirm_choice_deny: "Deny"
+  forget_approvals_cleared: "Cleared {count} remembered approval(s) for this session"
 
   # Prompt
   prompt_prefix: "Execute"

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -128,6 +128,16 @@ status:
   na: "N/D"
 
 shell:
+  confirm_dialog_title: "Ejecución de herramienta"
+  confirm_dialog_tool: "Herramienta:"
+  confirm_dialog_command: "Comando:"
+  confirm_dialog_options: "[y] Permitir una vez   [a] Recordar esta sesión   [r] Pedir a la IA otra opción   [n] Denegar"
+  confirm_dialog_question: "Tu elección (predeterminado n):"
+  confirm_choice_once: "Permitir una vez"
+  confirm_choice_remember: "Recordar esta sesión"
+  confirm_choice_reply: "Pedir a la IA otra opción"
+  confirm_choice_deny: "Denegar"
+  forget_approvals_cleared: "Se borraron {count} autorización(es) recordadas de esta sesión"
   welcome2:
     header: ">_ AI Shell {version}"
     model_hint: "(escribe /model para cambiar)"
@@ -168,6 +178,7 @@ shell:
     live_sessions: "Listar sesiones PTY activas"
     kill_live_sessions: "Terminar sesion(es) PTY por ID"
     audit: "Consultar el registro de auditoría (quién/cuándo/qué/sugerencia de IA/confirmación)"
+    forget-approvals: "Borrar aprobaciones de comandos recordadas (esta sesión)"
 
   feedback:
     select_type: "Seleccionar tipo de comentario"

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -128,6 +128,16 @@ status:
   na: "N/A"
 
 shell:
+  confirm_dialog_title: "Exécution d'outil"
+  confirm_dialog_tool: "Outil :"
+  confirm_dialog_command: "Commande :"
+  confirm_dialog_options: "[y] Autoriser une fois   [a] Mémoriser cette session   [r] Demander à l'IA une autre approche   [n] Refuser"
+  confirm_dialog_question: "Votre choix (défaut n) :"
+  confirm_choice_once: "Autoriser une fois"
+  confirm_choice_remember: "Mémoriser cette session"
+  confirm_choice_reply: "Demander à l'IA une autre approche"
+  confirm_choice_deny: "Refuser"
+  forget_approvals_cleared: "{count} autorisation(s) mémorisée(s) effacée(s) pour cette session"
   welcome2:
     header: ">_ AI Shell {version}"
     model_hint: "(tapez /model pour changer)"
@@ -168,6 +178,7 @@ shell:
     live_sessions: "Lister les sessions PTY actives"
     kill_live_sessions: "Terminer session(s) PTY par ID"
     audit: "Consulter le journal d'audit (qui/quand/quoi/suggestion IA/confirmation)"
+    forget-approvals: "Effacer les approbations mémorisées (cette session)"
 
   feedback:
     select_type: "Sélectionner le type de commentaire"

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -128,6 +128,16 @@ status:
   na: "なし"
 
 shell:
+  confirm_dialog_title: "ツール実行"
+  confirm_dialog_tool: "ツール:"
+  confirm_dialog_command: "コマンド:"
+  confirm_dialog_options: "[y] 一回許可   [a] セッション記憶   [r] AIに別案を相談   [n] 拒否"
+  confirm_dialog_question: "選択（デフォルト n）："
+  confirm_choice_once: "一回許可"
+  confirm_choice_remember: "セッション記憶"
+  confirm_choice_reply: "AIに別案を相談"
+  confirm_choice_deny: "拒否"
+  forget_approvals_cleared: "このセッションの記憶された承認 {count} 件を削除しました"
   welcome2:
     header: ">_ AI Shell {version}"
     model_hint: "(/model で切り替え)"
@@ -168,6 +178,7 @@ shell:
     live_sessions: "アクティブPTYセッション一覧"
     kill_live_sessions: "IDでPTYセッション終了"
     audit: "監査ログを照会（誰/いつ/何/AI提案/確認）"
+    forget-approvals: "記憶されたコマンド承認を削除（このセッション）"
 
   feedback:
     select_type: "フィードバックの種類を選択"

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -367,6 +367,7 @@ shell:
     live_sessions: "列出活跃 PTY 会话"
     kill_live_sessions: "按 ID 终止活跃 PTY 会话"
     audit: "查询审计日志（谁/何时/什么/AI建议/确认）"
+    forget-approvals: "清除本会话记住的命令审批"
 
   record:
     started: "⏺ 录制已开始: {path}"
@@ -441,7 +442,14 @@ shell:
   # 确认对话框
   confirm_dialog_title: "工具执行"
   confirm_dialog_tool: "工具："
-  confirm_dialog_question: "允许? [y/N]"
+  confirm_dialog_command: "命令："
+  confirm_dialog_options: "[y] 允许一次   [a] 本会话记住   [r] 回复 AI 换方案   [n] 拒绝"
+  confirm_dialog_question: "你的选择（默认 n）："
+  confirm_choice_once: "允许一次"
+  confirm_choice_remember: "本会话记住"
+  confirm_choice_reply: "回复 AI 换方案"
+  confirm_choice_deny: "拒绝"
+  forget_approvals_cleared: "已清除本会话的命令审批记忆（{count} 项）"
 
   # 提示符
   prompt_prefix: "执行"

--- a/crates/aish-llm/src/approval_memory.rs
+++ b/crates/aish-llm/src/approval_memory.rs
@@ -1,0 +1,378 @@
+//! Session-scoped approval memory for tool preflight confirmations.
+//!
+//! When the sandbox is enabled, the shell remembers a user's "allow and don't
+//! ask again" decision for the same host + command within the current session.
+//! This avoids re-prompting on repeated equivalent commands (e.g. restarting
+//! the same service) while still confirming every distinct command.
+//!
+//! Design decisions locked with the user:
+//! - Only `Allow` decisions are remembered. Denials are never persisted, so a
+//!   refused command is re-confirmed if the AI retries it. Repeated denials are
+//!   avoided in practice by offering "reply to AI" feedback that steers the
+//!   model toward a different approach.
+//! - Memory lives in-process for the session only. Nothing is written to disk.
+//! - Path arguments are kept intact during normalization: the memory key is
+//!   the full command text, so `rm /a` and `rm /b` are distinct keys and a
+//!   remembered approval never replays against a different path.
+
+use std::collections::HashSet;
+
+/// The user's choice when asked to confirm a tool execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApprovalChoice {
+    /// Allow this single execution; do not remember.
+    Once,
+    /// Allow and remember for the rest of the session (same host + command).
+    RememberSession,
+    /// Deny and ask the AI to try a different approach.
+    ReplyToAi,
+    /// Deny this execution only; do not remember.
+    Deny,
+}
+
+/// Session-scoped memory of approved commands.
+///
+/// The key is `(host_key, normalized_command)`. Looking up or recording a
+/// command always re-derives its key from the raw text, so callers never need
+/// to normalize themselves.
+#[derive(Debug, Default)]
+pub struct ApprovalMemory {
+    allowed: HashSet<(String, String)>,
+}
+
+impl ApprovalMemory {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Derive the memory key for a command: normalize once, drop empty, and
+    /// compute the host from the *normalized* text so a leading wrapper such
+    /// as `nohup` does not fragment remote commands between localhost and
+    /// their real host.
+    fn key(command: &str) -> Option<(String, String)> {
+        let normalized = normalize_command(command);
+        if normalized.is_empty() {
+            return None;
+        }
+        Some((command_host_key(&normalized), normalized))
+    }
+
+    /// Returns true if this command was previously approved for the session
+    /// on its target host.
+    pub fn is_allowed(&self, command: &str) -> bool {
+        match Self::key(command) {
+            Some(key) => self.allowed.contains(&key),
+            None => false,
+        }
+    }
+
+    /// Record an approval so subsequent equivalent commands skip the prompt.
+    /// Empty commands are ignored.
+    pub fn remember(&mut self, command: &str) {
+        if let Some(key) = Self::key(command) {
+            self.allowed.insert(key);
+        }
+    }
+
+    /// Forget all remembered approvals for this session.
+    pub fn clear(&mut self) {
+        self.allowed.clear();
+    }
+
+    /// Number of remembered approvals (mainly for diagnostics/tests).
+    pub fn len(&self) -> usize {
+        self.allowed.len()
+    }
+
+    /// Whether no approvals are currently remembered.
+    pub fn is_empty(&self) -> bool {
+        self.allowed.is_empty()
+    }
+}
+
+/// Identify the host a command targets.
+///
+/// Remote commands (`ssh user@host ...`, `telnet host`, ...) target the
+/// extracted host; everything else targets the local machine. This mirrors
+/// aish-shell's `extract_remote_host` but is duplicated here so this crate
+/// stays free of a downstream dependency.
+pub fn command_host_key(command: &str) -> String {
+    extract_remote_host(command).unwrap_or_else(|| "localhost".to_string())
+}
+
+/// Normalize a command so wrapper differences don't fragment the memory,
+/// while keeping every meaningful byte intact.
+///
+/// Strips leading/trailing whitespace and a leading bare `nohup` wrapper,
+/// then preserves the rest **verbatim**. Whitespace is deliberately NOT
+/// collapsed: collapsing it would make two distinct quoted paths such as
+/// `rm '/tmp/a  b'` (two spaces) and `rm '/tmp/a b'` (one space) share a
+/// key, letting a remembered approval skip confirmation for a different
+/// command.
+///
+/// `sudo` is intentionally NOT stripped: a non-root approval must never
+/// auto-authorize the sudo (root) variant of the same command, since sudo
+/// elevates privileges.
+pub fn normalize_command(command: &str) -> String {
+    let mut rest = command.trim();
+    while let Some(after) = rest.strip_prefix("nohup") {
+        // Bare trailing `nohup` with nothing after it: no real command.
+        if after.is_empty() {
+            return String::new();
+        }
+        // `nohup` must be followed by whitespace to be the wrapper, not a
+        // command whose name starts with "nohup" (e.g. `nohupyter`).
+        match after.strip_prefix([' ', '\t']) {
+            Some(followed) => rest = followed.trim_start(),
+            None => break,
+        }
+    }
+    rest.to_owned()
+}
+
+fn extract_remote_host(command: &str) -> Option<String> {
+    let mut parts = command.split_whitespace();
+    let cmd = parts.next()?;
+    if !matches!(cmd, "ssh" | "telnet" | "mosh" | "sftp" | "nc" | "netcat") {
+        return None;
+    }
+    const OPTS_WITH_ARG: &[&str] = &[
+        "-D", "-E", "-F", "-I", "-J", "-L", "-O", "-Q", "-R", "-S", "-W", "-b", "-c", "-e", "-i",
+        "-l", "-m", "-o", "-p", "-w",
+    ];
+    let mut iter = parts.peekable();
+    while let Some(part) = iter.next() {
+        if part.starts_with('-') {
+            let opt_name = if let Some(eq) = part.find('=') {
+                &part[..eq]
+            } else {
+                part
+            };
+            if OPTS_WITH_ARG.contains(&opt_name) && !part.contains('=') {
+                iter.next();
+            }
+            continue;
+        }
+        return Some(part.to_string());
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_memory_allows_nothing() {
+        let mem = ApprovalMemory::new();
+        assert!(mem.is_empty());
+        assert!(!mem.is_allowed("systemctl restart nginx"));
+    }
+
+    #[test]
+    fn remembers_equivalent_commands() {
+        let mut mem = ApprovalMemory::new();
+        mem.remember("systemctl restart nginx");
+        // Identical text matches.
+        assert!(mem.is_allowed("systemctl restart nginx"));
+        // nohup wrapper is stripped, so it matches the bare command.
+        assert!(mem.is_allowed("nohup systemctl restart nginx"));
+        // Decorative whitespace is NOT collapsed (preserves quoted paths),
+        // so a multi-space variant stays distinct.
+        assert!(!mem.is_allowed("systemctl  restart nginx"));
+        assert_eq!(mem.len(), 1);
+    }
+
+    #[test]
+    fn sudo_variant_is_not_authorized_by_non_root_approval() {
+        let mut mem = ApprovalMemory::new();
+        mem.remember("systemctl restart nginx");
+        // A non-root approval must NOT silently authorize the sudo (root)
+        // variant — that would escalate privileges and skip the sandbox.
+        assert!(!mem.is_allowed("sudo systemctl restart nginx"));
+        // Reverse direction must also hold.
+        let mut mem2 = ApprovalMemory::new();
+        mem2.remember("sudo systemctl restart nginx");
+        assert!(!mem2.is_allowed("systemctl restart nginx"));
+        assert!(mem2.is_allowed("sudo systemctl restart nginx"));
+    }
+
+    #[test]
+    fn distinguishes_hosts() {
+        let mut mem = ApprovalMemory::new();
+        mem.remember("ssh root@host-a systemctl restart nginx");
+        assert!(mem.is_allowed("ssh root@host-a systemctl restart nginx"));
+        // Same command text but a different host must not be auto-approved.
+        assert!(!mem.is_allowed("ssh root@host-b systemctl restart nginx"));
+    }
+
+    #[test]
+    fn nohup_wrapped_remote_matches_unwrapped() {
+        // Regression: the host key must be derived from the *normalized*
+        // command. Otherwise `nohup ssh root@host ...` would store localhost
+        // and never match the bare `ssh root@host ...` (real host).
+        let mut mem = ApprovalMemory::new();
+        mem.remember("nohup ssh root@host uptime");
+        assert!(mem.is_allowed("ssh root@host uptime"));
+        assert!(mem.is_allowed("nohup ssh root@host uptime"));
+        assert!(!mem.is_allowed("ssh root@other uptime"));
+        // Normalizes-to-empty inputs (nohup-only / whitespace) record nothing.
+        let mut mem2 = ApprovalMemory::new();
+        mem2.remember("nohup");
+        assert!(mem2.is_empty());
+        mem2.remember("   ");
+        assert!(mem2.is_empty());
+    }
+
+    #[test]
+    fn local_commands_share_localhost_key() {
+        let mut mem = ApprovalMemory::new();
+        mem.remember("systemctl restart nginx");
+        // Same command text (no sudo) matches on localhost.
+        assert!(mem.is_allowed("systemctl restart nginx"));
+        assert!(mem.is_allowed("nohup systemctl restart nginx"));
+    }
+
+    #[test]
+    fn distinct_commands_are_not_implicitly_approved() {
+        let mut mem = ApprovalMemory::new();
+        mem.remember("systemctl restart nginx");
+        assert!(!mem.is_allowed("systemctl restart mysql"));
+        assert!(!mem.is_allowed("systemctl stop nginx"));
+    }
+    #[test]
+    fn path_distinct_commands_are_not_cross_authorized() {
+        // After removing the path-bearing guard, the safety argument for
+        // remembering path commands rests on the memory key being the full
+        // command text. Different paths must stay distinct so a remembered
+        // approval never replays against a different path.
+        let mut mem = ApprovalMemory::new();
+        mem.remember("rm /tmp/a");
+        assert!(mem.is_allowed("rm /tmp/a"));
+        assert!(!mem.is_allowed("rm /tmp/b"));
+        assert!(!mem.is_allowed("rm /tmp/a/x"));
+        // A path prefix must not authorize a longer path either.
+        mem.remember("rm /var/log");
+        assert!(!mem.is_allowed("rm /var/log/app.log"));
+    }
+
+    #[test]
+    fn quoted_whitespace_paths_stay_distinct() {
+        // Whitespace inside quotes is semantically meaningful (part of the
+        // path). normalize_command preserves it verbatim, so two paths that
+        // differ only in internal spacing must NOT share an approval key.
+        let mut mem = ApprovalMemory::new();
+        mem.remember("rm '/tmp/a  b'");
+        assert!(mem.is_allowed("rm '/tmp/a  b'"));
+        assert!(!mem.is_allowed("rm '/tmp/a b'"));
+        // Reverse direction.
+        let mut mem2 = ApprovalMemory::new();
+        mem2.remember("rm '/tmp/a b'");
+        assert!(!mem2.is_allowed("rm '/tmp/a  b'"));
+    }
+
+    #[test]
+    fn clear_wipes_memory() {
+        let mut mem = ApprovalMemory::new();
+        mem.remember("systemctl restart nginx");
+        assert!(mem.is_allowed("systemctl restart nginx"));
+        mem.clear();
+        assert!(mem.is_empty());
+        assert!(!mem.is_allowed("systemctl restart nginx"));
+    }
+
+    #[test]
+    fn empty_command_is_ignored() {
+        let mut mem = ApprovalMemory::new();
+        mem.remember("");
+        assert!(mem.is_empty());
+        assert!(!mem.is_allowed(""));
+    }
+
+    #[test]
+    fn strips_leading_wrappers() {
+        // nohup is stripped (no privilege change).
+        assert_eq!(
+            normalize_command("nohup systemctl restart nginx"),
+            "systemctl restart nginx"
+        );
+        // sudo is NOT stripped — it changes privileges.
+        assert_eq!(
+            normalize_command("sudo systemctl restart nginx"),
+            "sudo systemctl restart nginx"
+        );
+        // Whitespace is preserved verbatim (no collapsing) so quoted paths
+        // with different internal spacing stay distinct keys.
+        assert_eq!(
+            normalize_command("systemctl  restart   nginx"),
+            "systemctl  restart   nginx"
+        );
+        assert_eq!(normalize_command(""), "");
+        assert_eq!(normalize_command("nohup"), "");
+        assert_eq!(normalize_command("nohup   nohup ls"), "ls");
+        // A command whose name merely starts with "nohup" is not stripped.
+        assert_eq!(normalize_command("nohupyter run"), "nohupyter run");
+    }
+
+    #[test]
+    fn extract_remote_host_basics() {
+        assert_eq!(
+            extract_remote_host("ssh root@host"),
+            Some("root@host".into())
+        );
+        assert_eq!(
+            extract_remote_host("ssh -p 2222 user@host ls"),
+            Some("user@host".into())
+        );
+        assert_eq!(
+            extract_remote_host("ssh -o StrictHostKeyChecking=no root@host uptime"),
+            Some("root@host".into())
+        );
+        assert_eq!(extract_remote_host("systemctl restart nginx"), None);
+        assert_eq!(extract_remote_host(""), None);
+    }
+
+    #[test]
+    fn ssh_quiet_flag_does_not_consume_host() {
+        // Regression: ssh -q is the quiet flag (no argument). Treating -q as
+        // an option-with-arg caused `ssh -q host` to skip `host`, returning
+        // None and misclassifying the remote command as localhost. This
+        // mirrors the same regression test in aish-shell's extract_remote_host.
+        assert_eq!(
+            extract_remote_host("ssh -q root@host uptime"),
+            Some("root@host".into())
+        );
+        assert_eq!(
+            extract_remote_host("ssh -q user@host"),
+            Some("user@host".into())
+        );
+    }
+
+    #[test]
+    fn ssh_argument_options_consume_their_value() {
+        // -K is a flag (GSSAPI auth, no argument) — host is found.
+        assert_eq!(
+            extract_remote_host("ssh -K root@host uptime"),
+            Some("root@host".into())
+        );
+        // -Q takes a query_option argument, so the following host is found.
+        assert_eq!(
+            extract_remote_host("ssh -Q cipher root@host"),
+            Some("root@host".into())
+        );
+        // -D (dynamic forward) takes a port argument.
+        assert_eq!(
+            extract_remote_host("ssh -D 1080 root@host"),
+            Some("root@host".into())
+        );
+    }
+
+    #[test]
+    fn host_key_falls_back_to_localhost() {
+        assert_eq!(command_host_key("systemctl restart nginx"), "localhost");
+        assert_eq!(
+            command_host_key("ssh root@web-1 systemctl restart nginx"),
+            "root@web-1"
+        );
+    }
+}

--- a/crates/aish-llm/src/lib.rs
+++ b/crates/aish-llm/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod agents;
 pub mod api;
+pub mod approval_memory;
 pub mod client;
 pub mod langfuse;
 pub mod llm_stream;
@@ -43,6 +44,7 @@ pub use api::{
     resolve_anthropic_messages_url, resolve_api_dialect, stream_simple,
     test_connection as test_api_connection, ApiDialect, StreamContext,
 };
+pub use approval_memory::{ApprovalChoice, ApprovalMemory};
 pub use client::{LlmClient, LlmResponse, DEFAULT_MAX_TOKENS};
 pub use langfuse::{LangfuseClient, LangfuseConfig};
 pub use model_id::{normalize_model_for_provider, resolve_model_for_api, trim_model_name};

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -7,6 +7,7 @@ use aish_core::{
 };
 
 use crate::api::{resolve_api_dialect, stream_simple, ApiDialect, StreamContext};
+use crate::approval_memory::{ApprovalChoice, ApprovalMemory};
 use crate::client::LlmResponse;
 use crate::langfuse::LangfuseClient;
 use crate::streaming::{extract_message_text, SseEvent, StreamParser};
@@ -50,8 +51,13 @@ pub struct LlmSession {
     tools: HashMap<String, Arc<dyn Tool>>,
     cancellation_token: Arc<CancellationToken>,
     event_callback: Option<Arc<dyn Fn(LlmEvent) -> Option<LlmCallbackResult> + Send + Sync>>,
-    confirmation_callback: Option<Arc<dyn Fn(&PreflightSecurityContext) -> bool + Send + Sync>>,
+    confirmation_callback:
+        Option<Arc<dyn Fn(&PreflightSecurityContext) -> ApprovalChoice + Send + Sync>>,
     security_notice_callback: Option<Arc<dyn Fn(&PreflightSecurityContext) + Send + Sync>>,
+    /// Session-scoped approval memory. When set, commands the user approved
+    /// with "remember" skip confirmation (and the sandbox preflight) for the
+    /// rest of the session on the same host.
+    approval_memory: Option<Arc<Mutex<ApprovalMemory>>>,
     /// Callback invoked when the tool-call iteration limit is reached.
     /// Receives the current iteration count and returns true to reset and continue.
     iteration_limit_callback: Option<Arc<dyn Fn(u32) -> bool + Send + Sync>>,
@@ -129,6 +135,7 @@ impl LlmSession {
             cancellation_token: Arc::new(CancellationToken::new()),
             event_callback: None,
             confirmation_callback: None,
+            approval_memory: None,
             security_notice_callback: None,
             iteration_limit_callback: None,
             audit_sink: None,
@@ -202,13 +209,21 @@ impl LlmSession {
         self.event_callback.clone()
     }
 
-    /// Set the confirmation callback invoked when a tool's preflight returns Confirm.
-    /// The callback receives raw security context and returns true to approve.
+    /// Set the confirmation callback invoked when a tool's preflight returns
+    /// Confirm. The callback receives the security context and returns the
+    /// user's approval choice (allow once, allow + remember, reply to AI, deny).
     pub fn set_confirmation_callback(
         &mut self,
-        cb: Arc<dyn Fn(&PreflightSecurityContext) -> bool + Send + Sync>,
+        cb: Arc<dyn Fn(&PreflightSecurityContext) -> ApprovalChoice + Send + Sync>,
     ) {
         self.confirmation_callback = Some(cb);
+    }
+
+    /// Install session-scoped approval memory. When present, commands approved
+    /// with "remember" skip confirmation (and sandbox preflight) for the rest
+    /// of the session.
+    pub fn set_approval_memory(&mut self, memory: Arc<Mutex<ApprovalMemory>>) {
+        self.approval_memory = Some(memory);
     }
 
     /// Set the callback invoked when a tool's preflight returns a display-only security notice.
@@ -1417,6 +1432,7 @@ impl LlmSession {
             cancellation_token: Arc::new(CancellationToken::new()),
             event_callback: self.event_callback.clone(),
             confirmation_callback: self.confirmation_callback.clone(),
+            approval_memory: self.approval_memory.clone(),
             security_notice_callback: self.security_notice_callback.clone(),
             iteration_limit_callback: self.iteration_limit_callback.clone(),
             audit_sink: self.audit_sink.clone(),
@@ -1457,6 +1473,27 @@ impl LlmSession {
             )));
         }
 
+        // Approval memory: if this command was previously approved for the
+        // session, skip the whole preflight (including the sandbox pre-run).
+        let memory_command = args.get("command").and_then(|value| value.as_str());
+        if memory_command.is_some_and(|command| {
+            self.approval_memory
+                .as_ref()
+                .is_some_and(|memory| memory.lock().unwrap().is_allowed(command))
+        }) {
+            self.emit_audit(AuditEvent::security_decision(
+                chrono::Utc::now(),
+                self.audit_session_uuid.clone(),
+                None,
+                None,
+                memory_command.map(|c| self.redact(c)),
+                "allow".to_string(),
+                Some("remembered".to_string()),
+                None,
+                Some("LOW".to_string()),
+            ));
+            return None;
+        }
         let ctx = crate::tool_context::ToolContext::for_session(self);
         match tool.preflight_with_context(args, &ctx) {
             PreflightResult::Allow => {
@@ -1482,12 +1519,25 @@ impl LlmSession {
                         SecurityPanelMode::Confirm,
                     )
                 });
-                let approved = if let Some(ref cb) = self.confirmation_callback {
+                let choice = if let Some(ref cb) = self.confirmation_callback {
                     cb(&security)
                 } else {
-                    true
+                    // No callback = allow once (backward compatible).
+                    ApprovalChoice::Once
                 };
+                if matches!(choice, ApprovalChoice::RememberSession) {
+                    if let Some(memory) = &self.approval_memory {
+                        if let Some(command) = memory_command {
+                            memory.lock().unwrap().remember(command);
+                        }
+                    }
+                }
                 let (matched_rule, risk_level) = audit_security_info(&security);
+                let audit_response = match choice {
+                    ApprovalChoice::Once | ApprovalChoice::RememberSession => "yes",
+                    ApprovalChoice::ReplyToAi => "reply",
+                    ApprovalChoice::Deny => "no",
+                };
                 self.emit_audit(AuditEvent::security_decision(
                     chrono::Utc::now(),
                     self.audit_session_uuid.clone(),
@@ -1495,21 +1545,20 @@ impl LlmSession {
                     None,
                     security.target.as_ref().map(|t| self.redact(t)),
                     "confirm".to_string(),
-                    Some(if approved {
-                        "yes".to_string()
-                    } else {
-                        "no".to_string()
-                    }),
+                    Some(audit_response.to_string()),
                     matched_rule,
                     risk_level,
                 ));
-                if approved {
-                    None
-                } else {
-                    Some(ToolResult::error(format!(
+                match choice {
+                    ApprovalChoice::Once | ApprovalChoice::RememberSession => None,
+                    ApprovalChoice::ReplyToAi => Some(ToolResult::error(format!(
+                        "User declined and asked for a different approach: {}",
+                        message
+                    ))),
+                    ApprovalChoice::Deny => Some(ToolResult::error(format!(
                         "Tool execution denied: {}",
                         message
-                    )))
+                    ))),
                 }
             }
             PreflightResult::Block { message, security } => {
@@ -3041,5 +3090,100 @@ mod tests {
             event.data["tool_args"]["command"].as_str(),
             Some("sudo ls /root")
         );
+    }
+
+    // Tool whose preflight always returns Confirm and counts how many times
+    // preflight runs, so tests can verify the approval-memory short-circuit.
+    struct ConfirmCountingTool {
+        preflight_calls: std::sync::Arc<std::sync::atomic::AtomicU32>,
+    }
+
+    impl ConfirmCountingTool {
+        fn new(counter: std::sync::Arc<std::sync::atomic::AtomicU32>) -> Self {
+            Self {
+                preflight_calls: counter,
+            }
+        }
+    }
+
+    impl Tool for ConfirmCountingTool {
+        fn name(&self) -> &str {
+            "bash"
+        }
+        fn description(&self) -> &str {
+            "confirm-counting test tool"
+        }
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {}})
+        }
+        fn preflight(&self, _args: &serde_json::Value) -> PreflightResult {
+            self.preflight_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            PreflightResult::Confirm {
+                message: "test confirmation".to_string(),
+                security: None,
+            }
+        }
+        fn execute(&self, _args: serde_json::Value) -> ToolResult {
+            ToolResult::success("executed")
+        }
+    }
+
+    #[tokio::test]
+    async fn approval_memory_skips_preflight_on_remembered_command() {
+        let mut session = LlmSession::new("http://localhost", "key", "model", None, None);
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        session.register_tool(Box::new(ConfirmCountingTool::new(counter.clone())));
+        // Callback always chooses "remember for this session".
+        session.set_confirmation_callback(std::sync::Arc::new(
+            |_ctx: &PreflightSecurityContext| ApprovalChoice::RememberSession,
+        ));
+        session.set_approval_memory(std::sync::Arc::new(std::sync::Mutex::new(
+            ApprovalMemory::new(),
+        )));
+
+        let tool_call = ToolCall {
+            id: "call_1".into(),
+            name: "bash".into(),
+            arguments: serde_json::json!({ "command": "systemctl restart nginx" }).to_string(),
+        };
+
+        // First call: preflight runs (Confirm), user remembers, command executes.
+        let result = session.execute_tool_external(&tool_call).await;
+        assert!(result.ok);
+        assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+        // Second call: memory hit, preflight must NOT run again.
+        let result2 = session.execute_tool_external(&tool_call).await;
+        assert!(result2.ok);
+        assert_eq!(
+            counter.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "remembered command must skip preflight entirely"
+        );
+    }
+
+    #[tokio::test]
+    async fn approval_reply_to_ai_denies_execution() {
+        let mut session = LlmSession::new("http://localhost", "key", "model", None, None);
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        session.register_tool(Box::new(ConfirmCountingTool::new(counter.clone())));
+        session.set_confirmation_callback(std::sync::Arc::new(
+            |_ctx: &PreflightSecurityContext| ApprovalChoice::ReplyToAi,
+        ));
+        session.set_approval_memory(std::sync::Arc::new(std::sync::Mutex::new(
+            ApprovalMemory::new(),
+        )));
+
+        let tool_call = ToolCall {
+            id: "call_1".into(),
+            name: "bash".into(),
+            arguments: serde_json::json!({ "command": "rm -rf /tmp/x" }).to_string(),
+        };
+        let result = session.execute_tool_external(&tool_call).await;
+        assert!(!result.ok);
+        assert!(result.output.contains("different approach"));
+        // Preflight still ran once (memory miss → confirm → reply).
+        assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 1);
     }
 }

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -509,6 +509,9 @@ pub struct AishShell {
     /// Inline AI completer (None when disabled). Stored so `/model` can
     /// update its model at runtime without restarting the shell.
     inline_ai: Option<Arc<crate::inline_completion::InlineCompleter>>,
+    /// Session-scoped approval memory shared with the LLM session. Kept on the
+    /// shell so slash commands (e.g. `/forget-approvals`) can reset it.
+    approval_memory: Arc<Mutex<aish_llm::ApprovalMemory>>,
 }
 
 impl AishShell {
@@ -780,10 +783,7 @@ impl AishShell {
         // Honor config.output_language for AI responses (overrides LANG).
         crate::ai_handler::set_output_language_override(config.output_language.clone());
 
-        let mut state = ShellState::new();
-        for cmd in &config.approved_ai_commands {
-            state.approved_ai_commands.insert(cmd.clone());
-        }
+        let state = ShellState::new();
 
         // Initialize LLM session
         let mut llm_session = llm_session_from_config(&config);
@@ -1679,7 +1679,7 @@ impl AishShell {
 
         // Set up confirmation callback for tool approval flow
         let confirmation_callback: Arc<
-            dyn Fn(&aish_llm::PreflightSecurityContext) -> bool + Send + Sync,
+            dyn Fn(&aish_llm::PreflightSecurityContext) -> aish_llm::ApprovalChoice + Send + Sync,
         > = Arc::new(|ctx: &aish_llm::PreflightSecurityContext| {
             let width = std::env::var("COLUMNS")
                 .ok()
@@ -1697,6 +1697,19 @@ impl AishShell {
                 &format!("  {}   {}", tool_label, ctx.tool_name),
                 inner_width,
             );
+            let command = ctx.target.as_deref().unwrap_or("");
+            if !command.is_empty() {
+                let cmd_label = theme::bold(&theme::accent(&t("shell.confirm_dialog_command")));
+                let safe_command = sanitize_for_display(command);
+                let cmd_lines = wrap_text(&safe_command, width.saturating_sub(14));
+                print_panel_line(
+                    &format!("  {} {}", cmd_label, cmd_lines.lines().next().unwrap_or("")),
+                    inner_width,
+                );
+                for line in cmd_lines.lines().skip(1) {
+                    print_panel_line(&format!("         {}", line), inner_width);
+                }
+            }
             let reason_lines = wrap_text(&ctx.message, width.saturating_sub(14));
             let reason_label = theme::bold(&theme::accent("Reason:"));
             print_panel_line(
@@ -1712,17 +1725,49 @@ impl AishShell {
             }
             print_panel_line("", inner_width);
             print_panel_line(
-                &format!("  {}", theme::accent(&t("shell.confirm_dialog_question"))),
+                &format!("  {}", theme::accent(&t("shell.confirm_dialog_options"))),
                 inner_width,
             );
-            println!("{}", theme::warning(&format!("╰{}╯", border)));
-            print!("  ");
+            // Input line lives inside the panel so it stays visually attached
+            // to the question and the pressed key is echoed back to the user.
+            let prompt_text = t("shell.confirm_dialog_question");
+            let prompt_vis = ansi_display_width(&prompt_text);
+            print!(
+                "{}  {} ",
+                theme::warning("│"),
+                theme::bold(&theme::accent(&prompt_text))
+            );
             let _ = std::io::stdout().flush();
-
-            read_raw_confirmation()
+            let (pressed, choice) = read_approval_choice();
+            let echo_ch = match pressed {
+                b'\r' | b'\n' => '↵',
+                0 => '?',
+                c if (c as char).is_ascii_graphic() => c as char,
+                _ => '·',
+            };
+            print!("{}", theme::accent(&echo_ch.to_string()));
+            let used = 2 + prompt_vis + 1 + 1;
+            let pad = inner_width.saturating_sub(used);
+            println!("{}{}", " ".repeat(pad), theme::warning("│"));
+            println!("{}", theme::warning(&format!("╰{}╯", border)));
+            let verdict_key = match choice {
+                aish_llm::ApprovalChoice::Once => "shell.confirm_choice_once",
+                aish_llm::ApprovalChoice::RememberSession => "shell.confirm_choice_remember",
+                aish_llm::ApprovalChoice::ReplyToAi => "shell.confirm_choice_reply",
+                aish_llm::ApprovalChoice::Deny => "shell.confirm_choice_deny",
+            };
+            println!("  {} {}", theme::accent("→"), theme::bold(&t(verdict_key)));
+            choice
         });
 
         llm_session.set_confirmation_callback(confirmation_callback);
+
+        // Session-scoped approval memory: when the user approves a command with
+        // "remember", equivalent commands (same host + normalized text) skip
+        // confirmation — and the sandbox preflight — for the rest of the session.
+        let approval_memory: Arc<Mutex<aish_llm::ApprovalMemory>> =
+            Arc::new(Mutex::new(aish_llm::ApprovalMemory::new()));
+        llm_session.set_approval_memory(approval_memory.clone());
 
         if let Some(ref audit) = audit_store {
             let scanner = security_manager.secret_scanner().clone();
@@ -1880,6 +1925,7 @@ impl AishShell {
             expand_history,
             shared_recorder,
             inline_ai: None,
+            approval_memory,
         })
     }
 
@@ -3209,6 +3255,7 @@ impl AishShell {
             Some("/live_sessions") => self.handle_live_sessions_command(),
             Some("/kill_live_sessions") => self.handle_kill_live_sessions_command(&parts),
             Some("/audit") => self.handle_audit_command(&parts),
+            Some("/forget-approvals") => self.handle_forget_approvals(),
             _ => {
                 eprintln!("{}", {
                     let mut args = std::collections::HashMap::new();
@@ -3218,6 +3265,23 @@ impl AishShell {
             }
         }
         true
+    }
+
+    /// Handle `/forget-approvals` — clear all session-scoped command approvals
+    /// so previously "remembered" commands prompt for confirmation again.
+    fn handle_forget_approvals(&mut self) {
+        let count = {
+            let mut memory = self.approval_memory.lock().unwrap();
+            let n = memory.len();
+            memory.clear();
+            n
+        };
+        let mut args = std::collections::HashMap::new();
+        args.insert("count".to_string(), count.to_string());
+        println!(
+            "\x1b[36m{}\x1b[0m",
+            t_with_args("shell.forget_approvals_cleared", &args)
+        );
     }
 
     fn handle_audit_command(&self, parts: &[&str]) {
@@ -5192,30 +5256,6 @@ impl AishShell {
     pub fn reset_interruption(&mut self) {
         self.interruption = InterruptionState::Normal;
         self.last_ctrl_c = None;
-    }
-
-    /// Check if a command is pre-approved and should skip confirmation.
-    pub fn is_command_approved(&self, command: &str) -> bool {
-        self.state.approved_ai_commands.contains(command)
-    }
-
-    /// Remember a command as approved for future use.
-    pub fn remember_approved_command(&mut self, command: &str) {
-        if command.is_empty() {
-            return;
-        }
-        self.state.approved_ai_commands.insert(command.to_string());
-
-        // Persist to config if not already tracked
-        if !self
-            .config
-            .approved_ai_commands
-            .contains(&command.to_string())
-        {
-            self.config.approved_ai_commands.push(command.to_string());
-            let config_path = aish_config::ConfigLoader::default_config_path();
-            let _ = aish_config::ConfigLoader::save(&self.config, &config_path);
-        }
     }
 
     /// Execute a .aish script file.
@@ -8112,6 +8152,56 @@ fn format_number(n: u64) -> String {
     result.chars().rev().collect()
 }
 
+/// Strip terminal control sequences (CSI/OSC/SS3 and other C0 control bytes)
+/// from tool-provided text before rendering it, so a command containing
+/// escape sequences cannot alter the terminal (clipboard, hyperlink, title)
+/// before the user approves it. Common whitespace (`\n`, `\r`, `\t`) and all
+/// printable characters are preserved.
+fn sanitize_for_display(s: &str) -> String {
+    static RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(concat!(
+            // OSC: ESC ] ... (BEL | ST)
+            r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)",
+            // CSI: ESC [ params letter
+            r"|\x1b\[[0-9;?]*[A-Za-z]",
+            // Other single-char ESC sequences
+            r"|\x1b[@-Z\\-_]",
+            // Stray C0 control bytes (excluding \t \n \r) and DEL
+            r"|[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]",
+        ))
+        .unwrap()
+    });
+    RE.replace_all(s, "").to_string()
+}
+
+#[cfg(test)]
+mod sanitize_for_display_tests {
+    use super::sanitize_for_display;
+
+    #[test]
+    fn strips_csi_color_sequences() {
+        assert_eq!(sanitize_for_display("\x1b[31mrm\x1b[0m /tmp"), "rm /tmp");
+    }
+
+    #[test]
+    fn strips_osc_clipboard_sequence() {
+        // OSC 52 (clipboard) must not execute on display.
+        assert_eq!(
+            sanitize_for_display("\x1b]52;c;Zm1lbQ==\x07echo hi"),
+            "echo hi"
+        );
+    }
+
+    #[test]
+    fn preserves_common_whitespace_and_plain_text() {
+        assert_eq!(sanitize_for_display("a\tb\nc\rd"), "a\tb\nc\rd");
+        assert_eq!(
+            sanitize_for_display("systemctl restart nginx"),
+            "systemctl restart nginx"
+        );
+    }
+}
+
 /// Read a single-byte confirmation from stdin in raw mode.
 ///
 /// Acquires the interactive input guard (pauses esc_watcher), reads one
@@ -8162,6 +8252,63 @@ fn read_raw_confirmation() -> bool {
     approved
 }
 
+/// Read a single-byte approval choice from stdin in raw mode.
+///
+/// Returns the raw byte the user pressed plus the mapped [`ApprovalChoice`].
+/// The caller owns echo and newline rendering so the choice can be shown
+/// inside the confirmation panel. Reads exactly one byte, then drains any
+/// trailing bytes (e.g. \r after 'y') with a short timeout, like
+/// [`read_raw_confirmation`].
+fn read_approval_choice() -> (u8, aish_llm::ApprovalChoice) {
+    let _ig = aish_tools::bash::acquire_interactive_input_guard();
+
+    let mut byte = [0u8; 1];
+    let (pressed, choice) = match io::stdin().read(&mut byte) {
+        Ok(1) => {
+            let ch = byte[0];
+            let choice = match ch {
+                b'y' | b'Y' => aish_llm::ApprovalChoice::Once,
+                b'a' | b'A' => aish_llm::ApprovalChoice::RememberSession,
+                b'r' | b'R' => aish_llm::ApprovalChoice::ReplyToAi,
+                _ => aish_llm::ApprovalChoice::Deny,
+            };
+            (ch, choice)
+        }
+        _ => (0, aish_llm::ApprovalChoice::Deny),
+    };
+    // Drain trailing bytes with timeout (e.g. \r after 'y').
+    let mut drain_buf = [0u8; 64];
+    let stdin_fd = libc::STDIN_FILENO;
+    loop {
+        let mut fds: libc::fd_set = unsafe { std::mem::zeroed() };
+        unsafe {
+            libc::FD_ZERO(&mut fds);
+            libc::FD_SET(stdin_fd, &mut fds);
+        }
+        let mut tv = libc::timeval {
+            tv_sec: 0,
+            tv_usec: 10_000,
+        };
+        let sel = unsafe {
+            libc::select(
+                stdin_fd + 1,
+                &mut fds,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut tv,
+            )
+        };
+        if sel <= 0 {
+            break;
+        }
+        match io::stdin().read(&mut drain_buf) {
+            Ok(0) | Err(_) => break,
+            Ok(_) => continue,
+        }
+    }
+    (pressed, choice)
+}
+
 /// Render markdown-formatted text to the terminal using richrs.
 /// Print markdown with recording support.
 fn print_md_with_recording(text: &str, shared_recorder: &crate::recorder::SharedRecorder) {
@@ -8186,7 +8333,8 @@ fn extract_remote_host(command: &str) -> Option<String> {
         return None;
     }
     let opts_with_arg: &[&str] = &[
-        "-p", "-l", "-i", "-o", "-L", "-R", "-S", "-W", "-J", "-b", "-c", "-F", "-I", "-K", "-m",
+        "-D", "-E", "-F", "-I", "-J", "-L", "-O", "-Q", "-R", "-S", "-W", "-b", "-c", "-e", "-i",
+        "-l", "-m", "-o", "-p", "-w",
     ];
     let mut iter = parts.iter().skip(1).peekable();
     while let Some(part) = iter.next() {
@@ -8230,6 +8378,25 @@ mod extract_remote_host_tests {
         assert_eq!(
             extract_remote_host("ssh -p 2222 user@host"),
             Some("user@host".to_string())
+        );
+    }
+
+    #[test]
+    fn ssh_flags_and_argument_options_parse_host() {
+        // -K (GSSAPI auth) is a flag — host must be found, not consumed.
+        assert_eq!(
+            extract_remote_host("ssh -K root@host uptime"),
+            Some("root@host".to_string())
+        );
+        // -Q takes a query_option argument.
+        assert_eq!(
+            extract_remote_host("ssh -Q cipher root@host"),
+            Some("root@host".to_string())
+        );
+        // -D (dynamic forward) takes a port argument.
+        assert_eq!(
+            extract_remote_host("ssh -D 1080 root@host"),
+            Some("root@host".to_string())
         );
     }
 }

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -41,6 +41,10 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
         "/audit",
         "Query audit log (who/when/what/AI suggestion/confirm)",
     ),
+    (
+        "/forget-approvals",
+        "Clear remembered command approvals (this session)",
+    ),
 ];
 
 // ---------------------------------------------------------------------------
@@ -819,6 +823,6 @@ mod tests {
                 cmd
             );
         }
-        assert_eq!(SLASH_COMMANDS.len(), 16);
+        assert_eq!(SLASH_COMMANDS.len(), 17);
     }
 }

--- a/crates/aish-shell/src/types.rs
+++ b/crates/aish-shell/src/types.rs
@@ -51,8 +51,6 @@ pub struct ShellState {
     pub can_correct_error: bool,
     /// Captured output (stdout+stderr combined) from last executed command.
     pub last_output: String,
-    /// Pre-approved AI commands that skip future confirmation dialogs.
-    pub approved_ai_commands: std::collections::HashSet<String>,
 }
 
 impl ShellState {
@@ -72,7 +70,6 @@ impl ShellState {
             last_exit_code: 0,
             can_correct_error: false,
             last_output: String::new(),
-            approved_ai_commands: std::collections::HashSet::new(),
         }
     }
 }

--- a/crates/aish-shell/tests/slash_popup_commands.rs
+++ b/crates/aish-shell/tests/slash_popup_commands.rs
@@ -30,7 +30,7 @@ fn each_builtin_command_enter_executes() {
 
 #[test]
 fn slash_commands_table_has_expected_count() {
-    assert_eq!(SLASH_COMMANDS.len(), 16);
+    assert_eq!(SLASH_COMMANDS.len(), 17);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Session-scoped command approval memory for tool preflight confirmations. When the sandbox is enabled, the shell remembers a user's "allow and don't ask again" decision for the same host + command within the session, so repeated equivalent commands (e.g. restarting the same service) no longer re-prompt.

Confirmation options:
- `[y]` allow once
- `[a]` remember for this session (same host + command)
- `[r]` deny and ask the AI for a different approach
- `[n]` deny this execution

Only `Allow` decisions are remembered; denials are never persisted. Memory lives in-process for the session only — nothing is written to disk.

**Key safety property:** `normalize_command` does NOT strip `sudo`, so a non-root approval can never auto-authorize the sudo (root) variant of the same command. Path arguments are kept intact, so `rm /a` and `rm /b` stay distinct keys.

Implementation:
- `aish-llm`: new `approval_memory` module; `LlmSession` gains an `approval_memory` field and `run_tool_preflight` skips the entire preflight (including the sandbox pre-run) when a command is remembered.
- `aish-shell`: `confirmation_callback` returns `ApprovalChoice` and renders the four-option UI; `/forget-approvals` clears the session memory.
- Removed the old config-persisted `approved_ai_commands` dead code, superseded by session-scoped memory.

Fixes #391 — `approval_memory::extract_remote_host` misclassified `ssh -q` (the quiet flag, which takes no argument) as an option-with-arg, swallowing the following host token and breaking host partitioning for quiet ssh commands. Now aligned with `aish-shell`'s already-correct version, with a mirroring regression test.

## Test plan

- `cargo test -p aish-llm --lib` → 278 passed
- `cargo test -p aish-shell --lib extract_remote_host` → 2 passed (both copies now behave identically)
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a richer tool-execution confirmation dialog with selectable outcomes: allow once, remember for this session, ask the AI for an alternative, or deny.
  * Added `/forget-approvals` to clear remembered command approvals for the current session.
* **Localization**
  * Updated the confirmation dialog and “forget approvals” strings for English, German, Spanish, French, Japanese, and Simplified Chinese.
* **Bug Fixes**
  * Improved remembered-approval matching and isolation (including host/command/path handling and elevated variants).
  * Fixed remote-host parsing edge cases (e.g., certain SSH flags) used for approval scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->