### PR TITLE
fix(update): CDN-only checks and in-shell confirm echo

### DIFF
--- a/crates/aish-cli/src/update.rs
+++ b/crates/aish-cli/src/update.rs
@@ -197,7 +197,10 @@ fn build_update_info(
     let latest = tag_name.strip_prefix('v').unwrap_or(tag_name);
     let current = current_version.strip_prefix('v').unwrap_or(current_version);
 
-    if compare_versions(latest, current) != std::cmp::Ordering::Greater {
+    // Stable channel must not offer a prerelease even if CDN /latest is mis-tagged.
+    if (!include_pre_release && is_prerelease_version(latest))
+        || compare_versions(latest, current) != std::cmp::Ordering::Greater
+    {
         return None;
     }
 
@@ -849,6 +852,12 @@ mod tests {
     #[test]
     fn test_build_update_info_already_latest() {
         assert!(build_update_info("v0.3.8", "0.3.8", false).is_none());
+    }
+
+    #[test]
+    fn test_build_update_info_rejects_prerelease_for_stable_channel() {
+        assert!(build_update_info("v0.3.0-beta.1", "0.2.0", false).is_none());
+        assert!(build_update_info("v0.3.0-beta.1", "0.2.0", true).is_some());
     }
 
     #[test]

--- a/crates/aish-cli/src/update.rs
+++ b/crates/aish-cli/src/update.rs
@@ -1,7 +1,7 @@
 //! Self-update via CDN release metadata and bundles.
 //!
-//! Supports platform-aware download, progress display, GitHub asset fallback,
-//! archive extraction with install.sh execution, and automatic cleanup.
+//! Version discovery and downloads use `cdn.aishell.ai` only (Claude Code–style
+//! `/latest` text + versioned release paths). No GitHub API dependency.
 
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -15,11 +15,6 @@ use crate::install_channel::{current_install_channel, InstallChannel, PipChannel
 
 const DEFAULT_DOWNLOAD_BASE_URL: &str = "https://cdn.aishell.ai/download";
 const DEFAULT_BETA_DOWNLOAD_BASE_URL: &str = "https://cdn.aishell.ai/download/beta";
-const GITHUB_API_RELEASE_TAG_BASE: &str =
-    "https://api.github.com/repos/AI-Shell-Team/aish/releases/tags";
-const GITHUB_RELEASES_PAGE_BASE: &str = "https://github.com/AI-Shell-Team/aish/releases";
-const GITHUB_RELEASES_DOWNLOAD_BASE: &str =
-    "https://github.com/AI-Shell-Team/aish/releases/download";
 const CONNECTION_TIMEOUT_SECS: u64 = 10;
 const DOWNLOAD_TIMEOUT_SECS: u64 = 300;
 
@@ -193,46 +188,30 @@ fn normalize_tag(version_value: &str) -> Result<String, AishError> {
     Ok(format!("v{normalized}"))
 }
 
-fn get_release_by_tag(
-    client: &reqwest::blocking::Client,
+/// Build update info from a CDN `/latest` tag when `latest > current`.
+fn build_update_info(
     tag_name: &str,
-) -> Result<serde_json::Value, AishError> {
-    let resp = client
-        .get(format!("{}/{}", GITHUB_API_RELEASE_TAG_BASE, tag_name))
-        .send()
-        .map_err(|e| {
-            AishError::Config({
-                let mut args = std::collections::HashMap::new();
-                args.insert("error".to_string(), e.to_string());
-                t_with_args("cli.update.check_failed", &args)
-            })
-        })?;
+    current_version: &str,
+    include_pre_release: bool,
+) -> Option<UpdateInfo> {
+    let latest = tag_name.strip_prefix('v').unwrap_or(tag_name);
+    let current = current_version.strip_prefix('v').unwrap_or(current_version);
 
-    if !resp.status().is_success() {
-        return Err(AishError::Config({
-            let mut args = std::collections::HashMap::new();
-            args.insert("status".to_string(), resp.status().to_string());
-            t_with_args("cli.update.github_api_error", &args)
-        }));
+    if compare_versions(latest, current) != std::cmp::Ordering::Greater {
+        return None;
     }
 
-    let release: serde_json::Value = resp.json().map_err(|e| {
-        AishError::Config({
-            let mut args = std::collections::HashMap::new();
-            args.insert("error".to_string(), e.to_string());
-            t_with_args("cli.update.parse_release_failed", &args)
-        })
-    })?;
-
-    if release.get("tag_name").and_then(|v| v.as_str()) != Some(tag_name) {
-        return Err(AishError::Config(format!(
-            "GitHub release metadata mismatch for {tag_name}"
-        )));
-    }
-
-    Ok(release)
+    let base = resolve_download_base_url(include_pre_release, get_env_var);
+    Some(UpdateInfo {
+        tag_name: tag_name.to_string(),
+        current_version: current.to_string(),
+        latest_version: latest.to_string(),
+        html_url: format!("{base}/releases/{latest}"),
+        release_notes: String::new(),
+    })
 }
 
+/// Check CDN `/latest` for a newer version. No GitHub API calls.
 pub fn check_for_updates(
     current_version: &str,
     include_pre_release: bool,
@@ -262,41 +241,12 @@ pub fn check_for_updates(
             t_with_args("cli.update.check_failed", &args)
         })
     })?)?;
-    let release = get_release_by_tag(&client, &tag_name)?;
 
-    extract_update_info(&release, current_version)
-}
-
-fn extract_update_info(
-    release: &serde_json::Value,
-    current_version: &str,
-) -> Result<Option<UpdateInfo>, AishError> {
-    let tag = release
-        .get("tag_name")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let latest = tag.strip_prefix('v').unwrap_or(tag);
-    let current = current_version.strip_prefix('v').unwrap_or(current_version);
-
-    if compare_versions(latest, current) == std::cmp::Ordering::Greater {
-        return Ok(Some(UpdateInfo {
-            tag_name: tag.to_string(),
-            current_version: current.to_string(),
-            latest_version: latest.to_string(),
-            html_url: release
-                .get("html_url")
-                .and_then(|v| v.as_str())
-                .unwrap_or(&format!("{}/tag/{}", GITHUB_RELEASES_PAGE_BASE, tag))
-                .to_string(),
-            release_notes: release
-                .get("body")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string(),
-        }));
-    }
-
-    Ok(None)
+    Ok(build_update_info(
+        &tag_name,
+        current_version,
+        include_pre_release,
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -317,8 +267,11 @@ fn download_with_progress(url: &str, dest: &Path, label: &str) -> Result<(), Ais
     if !resp.status().is_success() {
         return Err(AishError::Config({
             let mut args = std::collections::HashMap::new();
-            args.insert("status".to_string(), resp.status().to_string());
-            t_with_args("cli.update.github_api_error", &args)
+            args.insert(
+                "error".to_string(),
+                format!("HTTP {} for {url}", resp.status()),
+            );
+            t_with_args("cli.update.download_failed", &args)
         }));
     }
 
@@ -421,7 +374,7 @@ fn sha256_file(path: &Path) -> Result<String, AishError> {
 }
 
 // ---------------------------------------------------------------------------
-// Download release (CDN → GitHub fallback)
+// Download release (CDN only)
 // ---------------------------------------------------------------------------
 
 fn download_release(tag_name: &str) -> Result<PathBuf, AishError> {
@@ -439,25 +392,9 @@ fn download_release(tag_name: &str) -> Result<PathBuf, AishError> {
     })?;
 
     let dest_path = temp_dir.join(&filename);
-
     let cdn_url = get_release_download_url(tag_name, &filename);
     println!("\x1b[1;36mDownloading release bundle...\x1b[0m");
-    if download_with_progress(&cdn_url, &dest_path, &filename).is_ok() {
-        let path_str = dest_path.display().to_string();
-        println!("\x1b[32m{}\x1b[0m", {
-            let mut args = std::collections::HashMap::new();
-            args.insert("path".to_string(), path_str);
-            t_with_args("cli.update.downloaded", &args)
-        });
-        return Ok(dest_path);
-    }
-
-    let github_url = format!(
-        "{}/{}/{}",
-        GITHUB_RELEASES_DOWNLOAD_BASE, tag_name, filename
-    );
-    println!("\x1b[33mCDN download failed, trying GitHub release asset...\x1b[0m");
-    download_with_progress(&github_url, &dest_path, &format!("{} (GitHub)", filename))?;
+    download_with_progress(&cdn_url, &dest_path, &filename)?;
     let path_str = dest_path.display().to_string();
     println!("\x1b[32m{}\x1b[0m", {
         let mut args = std::collections::HashMap::new();
@@ -830,7 +767,6 @@ pub fn run_update(check_only: bool, pre_release: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
 
     #[test]
     fn test_compare_versions_equal() {
@@ -897,20 +833,22 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_update_info_beta_to_stable() {
-        let release = json!({
-            "tag_name": "v0.3.0",
-            "html_url": "https://github.com/AI-Shell-Team/aish/releases/tag/v0.3.0",
-            "body": "Stable release"
-        });
-
-        let info = extract_update_info(&release, "0.3.0-beta.3")
-            .unwrap()
+    fn test_build_update_info_beta_to_stable() {
+        let info = build_update_info("v0.3.0", "0.3.0-beta.3", false)
             .expect("expected update from beta to stable");
 
         assert_eq!(info.current_version, "0.3.0-beta.3");
         assert_eq!(info.latest_version, "0.3.0");
         assert_eq!(info.tag_name, "v0.3.0");
+        assert_eq!(
+            info.html_url,
+            "https://cdn.aishell.ai/download/releases/0.3.0"
+        );
+    }
+
+    #[test]
+    fn test_build_update_info_already_latest() {
+        assert!(build_update_info("v0.3.8", "0.3.8", false).is_none());
     }
 
     #[test]

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -62,7 +62,6 @@ cli:
     install_script_failed: "Failed to run install script: {error}"
     unsupported_platform: "Unsupported platform: {platform}"
     unsupported_arch: "Unsupported architecture: {arch}"
-    github_api_error: "GitHub API returned status {status}"
     extraction_failed: "Extraction failed: {error}"
     installation_failed: "Installation failed: {error}"
     checking: "Checking for updates..."

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -62,7 +62,6 @@ cli:
     install_script_failed: "运行安装脚本失败: {error}"
     unsupported_platform: "不支持的平台: {platform}"
     unsupported_arch: "不支持的架构: {arch}"
-    github_api_error: "GitHub API 返回状态码 {status}"
     extraction_failed: "解压失败: {error}"
     installation_failed: "安装失败: {error}"
     checking: "正在检查更新..."

--- a/crates/aish-pty/src/bash_rc_wrapper.sh
+++ b/crates/aish-pty/src/bash_rc_wrapper.sh
@@ -190,33 +190,20 @@ __aish_on_debug() {
             ;;
     esac
 
-    # Re-enable echo for interactive session commands (ssh, telnet, etc.)
-    # so that the remote PTY inherits normal terminal settings.  The
-    # local PTY has -echo set by this wrapper, and SSH propagates these
-    # settings to the remote server, which can confuse the remote shell's
-    # readline.
+    # Re-enable echo for the duration of the user command.
     #
-    # Also re-enable echo for interactive sub-shells (bash, sh, zsh, ...)
-    # started by the user.  When the user runs e.g. `bash`, the child
-    # shell inherits the PTY termios with ECHO off.  Bash's readline
-    # normally renders input itself, but when the child is launched in a
-    # context where readline is disabled (e.g. inheriting `set +o emacs`
-    # via the rcfile, or non-readline shells like dash), the user's
-    # keystrokes never appear on screen — commands execute "blind".
-    # Restoring ECHO before the child takes the foreground makes
-    # keystrokes visible again.  __aish_prompt_command re-disables ECHO
-    # when the child exits and the aish prompt returns.
-    local __aish_cmd_name="$BASH_COMMAND"
-    while [[ "$__aish_cmd_name" =~ ^[A-Za-z_][A-Za-z_0-9]*= ]]; do
-        __aish_cmd_name="${__aish_cmd_name#* }"
-    done
-    __aish_cmd_name="${__aish_cmd_name%% *}"
-    __aish_cmd_name="${__aish_cmd_name##*/}"
-    case "$__aish_cmd_name" in
-        ssh|telnet|mosh|nc|netcat|ftp|sftp|bash|sh|zsh|ksh|mksh|dash|rbash|fish|csh|tcsh)
-            stty echo 2>/dev/null || true
-            ;;
-    esac
+    # The local PTY keeps -echo at the aish prompt so the frontend owns
+    # display (injected command lines must not bounce back via master_fd).
+    # Once a real command starts, cooked-mode children need kernel ECHO:
+    # `aish update`'s read_line confirm, bash `read`, python input(), ssh
+    # remote readline inheritance, nested shells without their own
+    # echo, etc.  Without this, keystrokes are accepted but invisible —
+    # users report "无法输入".
+    #
+    # Programs that need silent input (sudo/passwd) turn ECHO off
+    # themselves.  __aish_prompt_command re-disables ECHO when the
+    # command finishes and the aish prompt returns.
+    stty echo 2>/dev/null || true
 
     __AISH_AT_PROMPT=0
     __aish_emit_command_started "$BASH_COMMAND"
@@ -233,8 +220,8 @@ __aish_prompt_command() {
     fi
     # Keep PS1 empty — prompt rendering is handled by the Python frontend.
     PS1=''
-    # Re-disable echo in case a session command (ssh, telnet) re-enabled
-    # it via the DEBUG trap.  The frontend handles all display itself.
+    # Re-disable echo after the user command (DEBUG trap re-enabled it).
+    # The frontend handles all display at the aish prompt itself.
     stty -echo -echonl 2>/dev/null || true
     __AISH_AT_PROMPT=1
     __aish_emit_prompt_ready "$exit_code"

--- a/crates/aish-pty/src/persistent.rs
+++ b/crates/aish-pty/src/persistent.rs
@@ -8203,6 +8203,37 @@ mod tests {
         pty.stop();
     }
 
+    /// Regression: user commands must run with PTY ECHO on.
+    ///
+    /// The bash rc wrapper keeps `-echo` at the aish prompt (frontend
+    /// owns display), but `__aish_on_debug` must restore ECHO before a
+    /// foreground child starts.  Without that, cooked-mode prompts
+    /// (`aish update` confirm, `read`, `input()`) accept keys with no
+    /// visible feedback — reported as "无法输入".
+    #[test]
+    fn test_user_command_re_enables_pty_echo() {
+        let cwd = std::env::current_dir()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| "/tmp".to_string());
+        let mut pty = PersistentPty::start(&cwd, 24, 80).expect("start should succeed");
+
+        let (output, exit_code, _) = pty
+            .execute_command(
+                r#"python3 -c "import termios,sys; f=termios.tcgetattr(0); print('ECHO', int(bool(f[3]&termios.ECHO)))""#,
+                Duration::from_secs(10),
+                None,
+                false,
+            )
+            .expect("execute should succeed");
+        assert_eq!(exit_code, 0, "output was: {output}");
+        assert!(
+            output.contains("ECHO 1"),
+            "expected PTY ECHO on during user command, got: {output}"
+        );
+
+        pty.stop();
+    }
+
     #[test]
     fn test_execute_multiple_commands() {
         let cwd = std::env::current_dir()


### PR DESCRIPTION
## Summary

- Problem: `aish update` confirm prompts showed no echo inside aish; version checks could fail with GitHub API 403 even when CDN `/latest` worked.
- Changes: CDN-only update discovery/download; re-enable PTY echo for all user commands; reject prerelease tags on the stable channel.
- Related Issue: #396

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Other

## Scope

- [x] Core shell / PTY
- [ ] AI agent / LLM
- [ ] Skills / Tools
- [ ] Security
- [ ] Configuration
- [x] CLI / Interface
- [x] Packaging / Installation
- [ ] CI/CD
- [ ] Documentation

## User-visible Changes

- Inside aish, cooked-mode confirms (including `aish update` `[y/N]`) now echo typed characters.
- `aish update` no longer calls GitHub Releases API; checks and downloads use CDN only, so anonymous GitHub rate limits no longer break update checks.
- Update available links point at CDN release paths (e.g. `https://cdn.aishell.ai/download/releases/0.3.8`).

## Compatibility

- Backward compatible? Yes
- Config changes? No (existing `AISH_LATEST_URL` / `AISH_DOWNLOAD_BASE_URL` overrides still work)

## Testing

- `make format && make format-check && make lint`
- `cargo test -p aish-cli update::`
- `cargo test -p aish-pty re_enables_pty_echo`
- Temporary embedded version `0.3.7`: `./target/debug/aish update` showed `0.3.7 → 0.3.8` with CDN URL and confirm prompt
- Restored `0.3.8`: reports already latest without GitHub 403

## Checklist

- [x] Code follows project style
- [x] Tests added if needed
- [ ] Documentation updated if needed

Closes #396

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update checks and downloads by switching to a CDN-only delivery path.
  * Tightened update channel behavior by rejecting prereleases on stable.
  * Enhanced update download failure messaging with `HTTP {status} for {url}`.
  * Fixed terminal echo behavior for interactive user commands.
* **Tests**
  * Added a regression test to verify PTY terminal echo is restored during command execution.
* **Localization**
  * Removed obsolete GitHub update error message strings from English and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->