### PR TITLE
fix(cli): improve aish uninstall sudo auth UX

### DIFF
--- a/crates/aish-cli/src/uninstall.rs
+++ b/crates/aish-cli/src/uninstall.rs
@@ -145,6 +145,9 @@ enum EnsureSudoOutcome {
 }
 
 /// True when stderr is empty or only sudo's cancel / "password required" noise.
+///
+/// Matching assumes `ensure_sudo` runs sudo with `LC_ALL=C` so these English
+/// strings are stable across host locales.
 fn is_sudo_cancel_noise(stderr: &str) -> bool {
     let trimmed = stderr.trim();
     if trimmed.is_empty() {
@@ -153,7 +156,6 @@ fn is_sudo_cancel_noise(stderr: &str) -> bool {
     trimmed.lines().all(|line| {
         let line = line.trim();
         line.is_empty()
-            || line == "sudo: 需要密码"
             || line == "sudo: no password was provided"
             || line == "sudo: a password is required"
             || line.starts_with("sudo: a terminal is required")
@@ -165,15 +167,17 @@ fn is_sudo_cancel_noise(stderr: &str) -> bool {
 ///
 /// Ignores SIGINT in the parent while waiting so Ctrl+C only stops `sudo`.
 /// Stdin is inherited so PAM shows the normal TTY password prompt (piped stdin
-/// yields the bare "请输入密码" form). Stderr is piped so cancel noise can be
-/// filtered while real diagnostics are kept. Do not use `Command::output()`:
-/// it forces piped stdin.
+/// yields a degraded prompt). Stderr is piped and drained concurrently to avoid
+/// pipe-buffer deadlocks; cancel noise is filtered while real diagnostics are
+/// kept. `LC_ALL=C` keeps sudo's stderr locale-stable for matching. Do not use
+/// `Command::output()`: it forces piped stdin.
 fn ensure_sudo() -> EnsureSudoOutcome {
     unsafe {
         libc::signal(libc::SIGINT, libc::SIG_IGN);
     }
     let mut child = match std::process::Command::new("sudo")
         .arg("-v")
+        .env("LC_ALL", "C")
         .stdin(Stdio::inherit())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
@@ -188,6 +192,11 @@ fn ensure_sudo() -> EnsureSudoOutcome {
         }
     };
     let mut stderr_pipe = child.stderr.take().expect("stderr was piped");
+    let reader = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = stderr_pipe.read_to_end(&mut buf);
+        buf
+    });
     let status = child.wait();
     unsafe {
         libc::signal(libc::SIGINT, libc::SIG_DFL);
@@ -196,8 +205,8 @@ fn ensure_sudo() -> EnsureSudoOutcome {
         Ok(status) => status,
         Err(e) => return EnsureSudoOutcome::Failed(format!("Failed to wait for sudo: {e}")),
     };
-    let mut stderr = String::new();
-    let _ = stderr_pipe.read_to_string(&mut stderr);
+    let stderr_bytes = reader.join().unwrap_or_default();
+    let stderr = String::from_utf8_lossy(&stderr_bytes);
     if status.success() {
         return EnsureSudoOutcome::Ready;
     }
@@ -662,9 +671,12 @@ mod tests {
     #[test]
     fn test_is_sudo_cancel_noise() {
         assert!(is_sudo_cancel_noise(""));
-        assert!(is_sudo_cancel_noise("sudo: 需要密码\n"));
+        assert!(is_sudo_cancel_noise("sudo: no password was provided\n"));
         assert!(is_sudo_cancel_noise(
-            "sudo: no password was provided\nsudo: 需要密码\n"
+            "sudo: no password was provided\nsudo: a password is required\n"
+        ));
+        assert!(is_sudo_cancel_noise(
+            "sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper\n"
         ));
         assert!(!is_sudo_cancel_noise(
             "lixin is not in the sudoers file.  This incident will be reported.\n"
@@ -672,6 +684,8 @@ mod tests {
         assert!(!is_sudo_cancel_noise(
             "sudo: 3 incorrect password attempts\n"
         ));
+        // Localized strings are not matched; ensure_sudo pins LC_ALL=C.
+        assert!(!is_sudo_cancel_noise("sudo: 需要密码\n"));
     }
 
     #[test]

--- a/crates/aish-cli/src/uninstall.rs
+++ b/crates/aish-cli/src/uninstall.rs
@@ -4,7 +4,9 @@
 //! and runs the appropriate uninstall procedure. With `--purge`, also
 //! removes user config/data/cache and system-level config files.
 
+use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 
 use aish_core::AishError;
 use aish_i18n::{t, t_with_args};
@@ -128,6 +130,83 @@ fn which_exists(cmd: &str) -> bool {
 // ---------------------------------------------------------------------------
 // Uninstall by method
 // ---------------------------------------------------------------------------
+
+fn method_needs_sudo(method: InstallMethod) -> bool {
+    matches!(method, InstallMethod::Archive | InstallMethod::System)
+}
+
+/// Outcome of pre-uninstall `sudo -v`.
+enum EnsureSudoOutcome {
+    Ready,
+    /// User cancelled / no password entered — show only "Cancelled."
+    Cancelled,
+    /// Real sudo failure (sudoers, retries exhausted, etc.) — surface stderr.
+    Failed(String),
+}
+
+/// True when stderr is empty or only sudo's cancel / "password required" noise.
+fn is_sudo_cancel_noise(stderr: &str) -> bool {
+    let trimmed = stderr.trim();
+    if trimmed.is_empty() {
+        return true;
+    }
+    trimmed.lines().all(|line| {
+        let line = line.trim();
+        line.is_empty()
+            || line == "sudo: 需要密码"
+            || line == "sudo: no password was provided"
+            || line == "sudo: a password is required"
+            || line.starts_with("sudo: a terminal is required")
+    })
+}
+
+/// Cache sudo credentials (`sudo -v`) so the password prompt happens before we
+/// announce uninstall progress.
+///
+/// Ignores SIGINT in the parent while waiting so Ctrl+C only stops `sudo`.
+/// Stdin is inherited so PAM shows the normal TTY password prompt (piped stdin
+/// yields the bare "请输入密码" form). Stderr is piped so cancel noise can be
+/// filtered while real diagnostics are kept. Do not use `Command::output()`:
+/// it forces piped stdin.
+fn ensure_sudo() -> EnsureSudoOutcome {
+    unsafe {
+        libc::signal(libc::SIGINT, libc::SIG_IGN);
+    }
+    let mut child = match std::process::Command::new("sudo")
+        .arg("-v")
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(e) => {
+            unsafe {
+                libc::signal(libc::SIGINT, libc::SIG_DFL);
+            }
+            return EnsureSudoOutcome::Failed(format!("Failed to run sudo: {e}"));
+        }
+    };
+    let mut stderr_pipe = child.stderr.take().expect("stderr was piped");
+    let status = child.wait();
+    unsafe {
+        libc::signal(libc::SIGINT, libc::SIG_DFL);
+    }
+    let status = match status {
+        Ok(status) => status,
+        Err(e) => return EnsureSudoOutcome::Failed(format!("Failed to wait for sudo: {e}")),
+    };
+    let mut stderr = String::new();
+    let _ = stderr_pipe.read_to_string(&mut stderr);
+    if status.success() {
+        return EnsureSudoOutcome::Ready;
+    }
+    if is_sudo_cancel_noise(&stderr) {
+        EnsureSudoOutcome::Cancelled
+    } else {
+        EnsureSudoOutcome::Failed(stderr.trim().to_string())
+    }
+}
 
 fn run_sudo(args: &[&str]) -> Result<(), AishError> {
     let output = std::process::Command::new("sudo")
@@ -484,6 +563,26 @@ pub fn run_uninstall(purge: bool) {
         }
     }
 
+    // Authenticate before announcing progress so we never print "Uninstalling..."
+    // while still waiting for a password.
+    if method_needs_sudo(method) {
+        match ensure_sudo() {
+            EnsureSudoOutcome::Ready => {}
+            EnsureSudoOutcome::Cancelled => {
+                println!("{}", t("cli.uninstall.cancelled"));
+                return;
+            }
+            EnsureSudoOutcome::Failed(error) => {
+                eprintln!("\x1b[31m{}\x1b[0m", {
+                    let mut args = std::collections::HashMap::new();
+                    args.insert("error".to_string(), error);
+                    t_with_args("cli.uninstall.uninstall_failed", &args)
+                });
+                return;
+            }
+        }
+    }
+
     println!("{}", t("cli.uninstall.uninstalling"));
 
     let result = match method {
@@ -550,6 +649,30 @@ fn remove_current_binary() -> Result<(), AishError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_method_needs_sudo_for_privileged_installs() {
+        assert!(method_needs_sudo(InstallMethod::Archive));
+        assert!(method_needs_sudo(InstallMethod::System));
+        assert!(!method_needs_sudo(InstallMethod::Cargo));
+        assert!(!method_needs_sudo(InstallMethod::Pip));
+        assert!(!method_needs_sudo(InstallMethod::Unknown));
+    }
+
+    #[test]
+    fn test_is_sudo_cancel_noise() {
+        assert!(is_sudo_cancel_noise(""));
+        assert!(is_sudo_cancel_noise("sudo: 需要密码\n"));
+        assert!(is_sudo_cancel_noise(
+            "sudo: no password was provided\nsudo: 需要密码\n"
+        ));
+        assert!(!is_sudo_cancel_noise(
+            "lixin is not in the sudoers file.  This incident will be reported.\n"
+        ));
+        assert!(!is_sudo_cancel_noise(
+            "sudo: 3 incorrect password attempts\n"
+        ));
+    }
 
     #[test]
     fn test_is_elf_binary_nonexistent() {

--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -9,6 +9,9 @@ cli:
   detach_hint: "Getrennt. `aish -c` ausfuehren, um wieder zu verbinden."
   resume_failed: "Sitzung konnte nicht fortgesetzt werden: {error}"
 
+  uninstall:
+    cancelled: "Abgebrochen."
+
   option:
     model: "Zu verwendendes LLM-Modell; kann auch über AISH_MODEL oder die Konfigurationsdatei gesetzt werden."
     api_key: "API-Schlüssel für den LLM-Anbieter; kann auch über AISH_API_KEY oder Anbieter-Umgebungsvariablen gesetzt werden."

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -9,6 +9,9 @@ cli:
   detach_hint: "Sesión desconectada. Ejecuta `aish -c` para reconectar."
   resume_failed: "No se pudo reanudar la sesión: {error}"
 
+  uninstall:
+    cancelled: "Cancelado."
+
   option:
     model: "Modelo LLM que se va a usar; también puede definirse mediante AISH_MODEL o el archivo de configuración."
     api_key: "Clave API del proveedor LLM; también puede definirse mediante AISH_API_KEY o variables de entorno del proveedor."

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -9,6 +9,9 @@ cli:
   detach_hint: "Session détachée. Lancez `aish -c` pour vous reconnecter."
   resume_failed: "Echec de la reprise de session : {error}"
 
+  uninstall:
+    cancelled: "Annule."
+
   option:
     model: "Modele LLM a utiliser ; peut aussi etre defini via AISH_MODEL ou le fichier de configuration."
     api_key: "Cle API du fournisseur LLM ; peut aussi etre definie via AISH_API_KEY ou les variables d'environnement du fournisseur."

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -10,7 +10,7 @@ cli:
   resume_failed: "Echec de la reprise de session : {error}"
 
   uninstall:
-    cancelled: "Annule."
+    cancelled: "Annulé."
 
   option:
     model: "Modele LLM a utiliser ; peut aussi etre defini via AISH_MODEL ou le fichier de configuration."

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -9,6 +9,9 @@ cli:
   detach_hint: "セッションを切り離しました。`aish -c` で再接続できます。"
   resume_failed: "セッションの復元に失敗しました: {error}"
 
+  uninstall:
+    cancelled: "キャンセルしました。"
+
   option:
     model: "使用する LLM モデル。AISH_MODEL または設定ファイルでも指定できます。"
     api_key: "LLM プロバイダーの API キー。AISH_API_KEY または各プロバイダーの環境変数でも指定できます。"

--- a/crates/aish-pty/src/persistent.rs
+++ b/crates/aish-pty/src/persistent.rs
@@ -1888,9 +1888,12 @@ impl PersistentPty {
 
                         // Non-session: original passthrough behavior
                         if !is_session {
-                            if data.contains(&0x03) {
-                                let _ = kill_pg(self.child_pid, Signal::SIGINT);
-                            }
+                            // Ctrl+C: only forward 0x03 so the PTY line discipline
+                            // delivers SIGINT to the *foreground* job. Do not
+                            // `kill_pg(self.child_pid)` — that signals bash's own
+                            // process group and makes bash emit a blank line before
+                            // the next aish prompt (see force_cancel_pty_foreground
+                            // / execute_command which intentionally never signal bash).
                             write_buf.extend_from_slice(data);
                             continue;
                         }


### PR DESCRIPTION
## Summary
- Authenticate with `sudo -v` before printing "Uninstalling..." for archive/system installs, so password entry no longer looks like uninstall already started (#398).
- Keep the normal PAM TTY password prompt; on cancel suppress sudo "password required" noise and show "Cancelled.", while still surfacing real sudo failures (sudoers / retries).
- Stop signaling bash's process group on Ctrl+C in the non-session PTY path, avoiding an extra blank line before the next aish prompt.

## Test plan
- [ ] Archive install: `aish uninstall` → password prompt appears **before** "Uninstalling..."; PAM prompt looks normal (e.g. `请输入密码：`)
- [ ] Ctrl+C at password prompt → only `已取消。` / `Cancelled.` (no `sudo: 需要密码` noise)
- [ ] Real sudo failure (e.g. not in sudoers) → `卸载失败:` includes useful stderr
- [ ] Successful auth → "Uninstalling..." then uninstall proceeds
- [ ] From inside aish shell: Ctrl+C during password prompt → no extra blank line before next prompt
- [ ] `cargo test -p aish-cli uninstall` / `make lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved uninstall behavior for privileged scenarios with more reliable administrator authentication and clearer outcomes for user cancellation vs real failures.
  * Adjusted Ctrl+C handling for interactive commands so interrupts are delivered to the foreground job via the PTY.
* **Localization**
  * Added uninstall cancellation messaging to German, Spanish, French, and Japanese CLI translations.
* **Tests**
  * Added unit test coverage for the administrator-auth requirement logic and sudo cancellation classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->