### PR TITLE
Release v0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.9] - 2026-07-27
+
+### Added
+
+- Added session-scoped command approval memory when the sandbox is enabled: choosing "allow and don't ask again" remembers the same host + command for the rest of the session (`[a]`), with `/forget-approvals` to clear. Path-bearing commands hide the remember option; denials are never persisted, and `sudo` is not stripped during normalization so a non-root approval cannot auto-authorize the root variant.
+
+### Changed
+
+- Dropped unused crate dependencies, centralized local version pins under `workspace.dependencies`, and set MSRV to `1.89`.
+- `aish update` now relies on CDN `/latest` instead of hard-depending on the GitHub Releases API after the CDN check, so rate-limit `403` responses no longer fail updates.
 
 ### Fixed
 
 - Fixed packaged skills so they are compile-time embedded in the `aish` binary and loaded for every user (including bare-root installs), instead of seeding `~/.config/aish/skills` at install time (which skipped root and could leave root-owned config dirs).
-- Hardened the packaging smoke test to assert the installer/bundle no longer ship or invoke skill seeding.
+- Made builtin skill materialization race-safe with unique staging directories and a `.complete` marker before rename.
+- Hardened packaging smoke tests to assert the installer/bundle no longer ship or invoke skill seeding, and to fail closed when `build_bundle.sh` is missing.
 - Show a one-line terminal tip on the interactive session that performs the temporary legacy seed migration (only when skills were actually moved).
+- Fixed `/setting` sandbox and security toggles so they take effect immediately and sync to `security_policy.yaml` (atomic write with fallback when the policy directory is not writable).
+- Fixed welcome panel label formatting (no duplicated colon) and right-border alignment under CJK locales / WeTTY.
+- Restored PTY echo for cooked-mode user prompts so typed input is visible for confirms such as `aish update [y/N]`.
+- Reject prerelease tags on the stable CDN channel so a mis-tagged stable `/latest` cannot offer beta builds when `include_pre_release` is false.
+- Improved `aish uninstall` sudo authentication UX: authenticate before printing progress, suppress cancel-only sudo noise while surfacing real failures, avoid blank-line side effects on Ctrl+C, and localize the cancelled message (including French `Annulé`).
 
 ### Removed
 
@@ -22,10 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - The one-shot migration of pre-embed install-seeded skills (`migrate_seeded`, backup dir `~/.config/aish/migrated-seeded-skills/`, marker `.skills-seed-migrated-v1`) is temporary and will be removed in a future release once leftover seeds are uncommon.
-
-### Notes for releasers
-
-- Review whether to remove `crates/aish-skills/src/migrate_seeded.rs` (one-shot legacy install-seed migration). If keeping it another cycle, mention the deprecation again in that release's notes; if removing, list it under Removed and delete the module + call site in `SkillManager::load_all_skills`.
 
 ## [0.3.8] - 2026-07-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "aish-cli"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "aish-config"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "aish-context"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "aish-core",
  "serde",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "aish-core"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aish-hosts"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "aish-i18n"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "aish-llm"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "aish-context",
  "aish-core",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "aish-md-table"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "richrs",
  "unicode-width",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "aish-memory"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "aish-core",
  "chrono",
@@ -157,14 +157,14 @@ dependencies = [
 
 [[package]]
 name = "aish-prompts"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "dirs 5.0.1",
 ]
 
 [[package]]
 name = "aish-pty"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "aish-scripts"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "dirs 5.0.1",
  "regex",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "aish-security"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "libc",
  "regex",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "aish-session"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "aish-core",
  "chrono",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "aish-shell"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "aish-config",
  "aish-context",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "aish-skills"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "aish-tools"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "aish-core",
  "aish-i18n",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "aish-ui"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "crossterm 0.28.1",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.89"


### PR DESCRIPTION
## Summary
- Bump version to `0.3.9` (`Cargo.toml` / `Cargo.lock`)
- Add `CHANGELOG.md` section for 0.3.9 covering changes since 0.3.8

### Highlights
- **Added**: session-scoped command approval memory (`[a]` / `/forget-approvals`)
- **Changed**: CDN-only `aish update` path; deps cleanup + MSRV 1.89
- **Fixed**: embed packaged skills (no install-time seeding); `/setting` security live sync; update PTY echo + prerelease guard; uninstall sudo UX; welcome panel CJK border
- **Removed**: `seed-skills.sh`
- **Deprecated**: temporary legacy seed migration (`migrate_seeded`)

## Local checks
- [x] `python3 packaging/tests/test_resolve_release_pr.py -q`
- [x] `python3 packaging/scripts/release_metadata.py --expected-version 0.3.9`
- [x] `make ci-check`

## Release prep
Please run **Release Preparation** with this PR number before merge:
```bash
gh workflow run release-preparation.yml \
  --repo AI-Shell-Team/aish \
  --ref main \
  -f pr_number=<PR_NUMBER>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release documentation for version 0.3.9, including new packaging, CDN, settings synchronization, and migration updates.

* **Bug Fixes**
  * Improved embedded skill loading reliability and packaging smoke tests.
  * Fixed UI prompt formatting, stable-channel prerelease handling, and uninstall authentication guidance.
  * Ensured settings and security changes sync immediately.

* **Deprecated**
  * Marked the temporary pre-embed seed migration as deprecated and removed the legacy seed helper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->