### PR TITLE
fix(security): make security_policy.yaml the sole SSOT (#407)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 
 PREFIX ?= /usr
 BINDIR ?= $(PREFIX)/bin
-SYSCONFDIR ?= /etc
 SHAREDIR ?= $(PREFIX)/share
 DATADIR ?= $(SHAREDIR)/aish
 SYSTEMD_UNITDIR ?= /etc/systemd/system
@@ -69,8 +68,8 @@ install:
 	@echo "Installing built artifacts into $(DESTDIR)"
 	install -d "$(DESTDIR)$(BINDIR)"
 	install -m 0755 target/$(TARGET)/release/aish "$(DESTDIR)$(BINDIR)/aish"
-	install -d "$(DESTDIR)$(SYSCONFDIR)/aish"
-	install -m 0644 config/security_policy.yaml "$(DESTDIR)$(SYSCONFDIR)/aish/security_policy.yaml"
+	# security_policy.yaml is compile-time embedded / seeded under ~/.config/aish
+	# at runtime; do not install a system copy under /etc/aish.
 	install -d "$(DESTDIR)$(SYSTEMD_UNITDIR)"
 	sed 's|@AISH_BINDIR@|$(BINDIR)|g' packaging/systemd/aish-sandbox.service.in > "$(DESTDIR)$(SYSTEMD_UNITDIR)/aish-sandbox.service"
 	chmod 0644 "$(DESTDIR)$(SYSTEMD_UNITDIR)/aish-sandbox.service"

--- a/config/security_policy.yaml
+++ b/config/security_policy.yaml
@@ -1,129 +1,57 @@
-# -AI-Shell Security Policy
-# Installed by `make install` to /etc/aish/security_policy.yaml (system-level).
-# User-level fallback at ~/.config/aish/security_policy.yaml is auto-seeded on
-# first launch from EMPTY_POLICY_TEMPLATE in crates/aish-security/src/policy.rs.
+# AI-Shell Security Policy
+# Seeded to ~/.config/aish/security_policy.yaml on first use.
+# First matching rule wins. Paths are absolute; * = one level, ** = recursive.
 
-# - global: 全局默认行为配置
-#   - default_risk_level: 未命中任何 rules 时的默认风险等级。
-#     可选值通常为：LOW | MEDIUM | HIGH（具体以实现侧枚举为准）。
-#   - enable_sandbox: 是否启用沙箱预跑/受控执行（如实现侧支持，可映射到对应开关）。
-#   - sandbox_off_action: 当沙箱关闭、不可用或执行失败时，系统无法根据 rules 评估命令实际的文件变更，
-#     将采用该配置指定的动作进行处理：BLOCK=阻断，CONFIRM=需确认，ALLOW=直接放行。
-#   - sandbox_timeout_seconds: 沙箱预执行/预评估的超时时间（秒）。超时后不会阻止真实命令，
-#     但会降级为”无法可靠评估风险，请确认后执行”。
-#
-# - audit: 审计日志开关。enabled: false 时不记录；启用后建议同步配置 log_path。
-#          include_commands: true 时同时记录用户输入的 shell 命令（默认仅记录
-#          AI 工具调用和安全决策）。
-#
-# - input_guard: 在命令/提示送入 shell 执行前进行正则预筛查。
-#   - enabled: 总开关。
-#   - max_analyzable_bytes: 超过该长度的输入强制确认（防止粘贴海量内容绕过筛查）。
-#   - custom_block_rules / custom_confirm_rules: 自定义正则规则，覆盖或追加到内置规则。
-#     内置规则见 crates/aish-security/src/input_guard/patterns.rs。
-#   每条自定义规则字段：
-#   - name: 规则唯一标识；与内置规则同名会覆盖之。
-#   - pattern: 正则表达式（字符串）。
-#   - message: 命中时展示给用户的说明文案。
-#
-# - rules: 资源规则列表（自上而下匹配，命中第一条即生效）
-#   每条规则字段：
-#   - id: 规则唯一标识（建议稳定且可追踪，如 H-001）。
-#   - name: 规则名称（用于展示/日志）。
-#   - path: 资源路径模式列表。
-#     - 支持绝对路径；支持通配符 “*”（单级）与 “**”（递归）。
-#     - 目录语义示例：”/boot”、”/boot/*”、”/boot/**”。
-#   - exclude:（可选）排除路径模式列表；命中 exclude 的路径不适用该规则。
-#   - operations: 允许该规则匹配的操作类型列表。
-#     典型值：WRITE | DELETE（具体以实现侧枚举为准）。
-#   - risk: 该规则对应的风险等级：LOW | MEDIUM | HIGH。
-#   - reason: 风险原因说明（用于提示用户）。
-#   - confirm_message:（可选）当该规则命中且需要二次确认时展示的提示文案。
-#   - suggestion:（可选）建议/替代方案（可使用多行文本 “|”）。
-
-# 资源对象（path）规范：
-# 1) 路径格式：仅支持绝对路径；支持通配符 “*” 和 “**”。
-# 2) 目录区分：
-#    - “/boot”   ：目录本身
-#    - “/boot/*” ：目录下一级内容
-#    - “/boot/**”:目录下递归所有内容
-# 3) 变量：支持在路径中使用环境/命令变量（由实现侧在加载或匹配时展开）。例如：
-#    - “$PWD”、”$HOME”、”$(uname -r)”
-# 4) 排除规则：通过 exclude 字段排除特定路径（同样支持通配符与变量）。
-
-# 全局配置
 global:
-  # 未命中任何规则时的默认风险
-  default_risk_level: LOW
-
-  # 是否开启沙箱预跑（若当前实现已支持，可映射到现有 enable_sandbox 逻辑）
+  default_risk_level: LOW        # LOW | MEDIUM | HIGH
   enable_sandbox: false
-
-  # 沙箱关闭、不可用或执行失败时的处理动作（BLOCK=阻断，CONFIRM=需确认，ALLOW=直接放行）
-  sandbox_off_action: ALLOW
-
-  # 沙箱预执行超时时间（秒）
+  sandbox_off_action: ALLOW      # ALLOW | CONFIRM | BLOCK
   sandbox_timeout_seconds: 10
 
-# 审计日志（默认关闭；启用时建议同步设置 log_path）
 audit:
   enabled: false
-  # include_commands: false   # 设为 true 同时记录用户输入的 shell 命令
+  # include_commands: false
   # log_path: /var/log/aish/audit.log
 
-# InputGuard 预执行筛查（在命令送入 shell 之前按正则阻断或要求确认）
+# Pre-screen commands before execution.
+# Built-ins: crates/aish-security/src/input_guard/patterns.rs
 input_guard:
   enabled: true
-  # max_analyzable_bytes: 4096    # 超过该长度的输入强制确认
-  # 自定义规则示例（被注释；按需放开）：
+  # max_analyzable_bytes: 4096
   # custom_block_rules:
   #   - name: no_rm_data
   #     pattern: "rm\\s+-rf\\s+/data"
-  #     message: 禁止删除 /data
-  # custom_confirm_rules:
-  #   - name: confirm_docker_push
-  #     pattern: "docker\\s+push"
-  #     message: 推送镜像 — 请确认 tag
+  #     message: deleting /data is forbidden
 
-# 规则列表：从上到下匹配，第一条命中生效
 rules:
-  # ===== 高风险：系统核心目录，禁止 AI 修改 =====
   - id: H-001
-    name: "系统配置目录保护"
-    command_list: ["rm"] # 仅在沙箱关闭时生效
+    name: Protect /etc
+    command_list: ["rm"]  # sandbox-off fallback only
     path: ["/etc/**"]
     operations: [WRITE, DELETE]
     risk: HIGH
-    reason: "系统配置目录，误修改会导致严重故障"
-    suggestion: |
-      如确需修改 /etc 下文件，建议由人工完成变更并使用变更管理/备份策略。
+    reason: System config changes can break the host
+    suggestion: Edit /etc manually with a backup/change process.
 
-  # ===== 中风险： /home目录 =====
   - id: M-001
-    name: "家目录保护"
-    command_list: ["rm"] # 仅在沙箱关闭时生效
+    name: Protect /home
+    command_list: ["rm"]
     path: ["/home/**"]
     operations: [WRITE, DELETE]
     risk: MEDIUM
-    reason: "家目录文件，误删可能造成数据丢失"
-    confirm_message: "将对 /home/ 下文件执行写入/删除操作，是否继续？"
+    reason: Home-directory writes/deletes can lose user data
+    confirm_message: Write/delete under /home — continue?
 
-  # ===== 低风险：工作区 =====
   - id: L-001
-    name: "临时区可写"
-    command_list: ["rm"] # 仅在沙箱关闭时生效
+    name: Allow /tmp
+    command_list: ["rm"]
     path: ["/tmp/**"]
     operations: [WRITE, DELETE]
     risk: LOW
-    reason: "临时区代码和项目文件，允许 AI 修改"
+    reason: Temporary files are generally safe for AI edits
 
-# Secret detection patterns (optional).
-# Uncomment and customize to add your own patterns.
-# Built-in patterns cover: OpenAI, Anthropic, AWS, Google, GitHub, Stripe,
-# Slack, Fireworks API keys; JWT tokens; URL-embedded passwords.
-#
+# Optional custom secret patterns (built-ins already cover common API keys).
 # secret_patterns:
-#   - name: "My Internal Token"
+#   - name: My Internal Token
 #     pattern: "int_[a-zA-Z0-9]{32}"
 #     secret_type: api_key
-

--- a/crates/aish-cli/src/uninstall.rs
+++ b/crates/aish-cli/src/uninstall.rs
@@ -17,6 +17,7 @@ use crate::install_channel::{current_install_channel, InstallChannel, PipChannel
 const ARCHIVE_BIN_DIR: &str = "/usr/local/bin";
 const ARCHIVE_BINARY_NAMES: &[&str] = &["aish", "aish-uninstall"];
 const ARCHIVE_SHARE_DIR: &str = "/usr/local/share/aish";
+// Legacy path from older installers; current releases seed policy under ~/.config/aish.
 const SYSTEM_CONFIG_DIR: &str = "/etc/aish";
 const SYSTEMD_UNIT_DIR: &str = "/etc/systemd/system";
 const PIP_PACKAGE_NAMES: &[&str] = &["aish-rust", "aish"];
@@ -438,6 +439,8 @@ fn uninstall_system(purge: bool) -> Result<(), AishError> {
     ))
 }
 
+/// Remove leftover `/etc/aish` from older installers. Current releases no
+/// longer place files there; runtime policy lives under `~/.config/aish`.
 fn purge_system_config() {
     let etc_aish = Path::new(SYSTEM_CONFIG_DIR);
     if etc_aish.exists() {

--- a/crates/aish-config/src/loader.rs
+++ b/crates/aish-config/src/loader.rs
@@ -17,9 +17,10 @@ impl ConfigLoader {
     /// If the file exists, any fields missing relative to the current
     /// `ConfigModel` schema are auto-inserted with their default values
     /// and the file is rewritten in place. This lets new config options
-    /// (e.g. `input_guard_enabled`) show up in existing users' yaml
+    /// (e.g. `enable_token_estimation`) show up in existing users' yaml
     /// without manual editing. User-set values and field ordering are
-    /// preserved; only missing keys are appended.
+    /// preserved; only missing keys are appended. Legacy security keys
+    /// that now live in `security_policy.yaml` are stripped on load.
     pub fn load(config_path: Option<&Path>) -> Result<ConfigModel> {
         let path = match config_path {
             Some(p) => p.to_path_buf(),
@@ -46,7 +47,16 @@ impl ConfigLoader {
                 serde_yaml::to_value(ConfigModel::default())
                     .expect("ConfigModel::default() must serialize")
             });
-            let changed = Self::merge_missing(&mut value, default_value);
+            let mut changed = Self::merge_missing(&mut value, default_value);
+            let stripped = Self::strip_legacy_security_keys(&mut value);
+            if !stripped.is_empty() {
+                changed = true;
+                eprintln!(
+                    "warning: removed legacy security keys from {}: [{}]. These settings now live in ~/.config/aish/security_policy.yaml — use /setting or edit that file.",
+                    path.display(),
+                    stripped.join(", ")
+                );
+            }
             // Deserialize BEFORE writing — if the merged Value still
             // fails to deserialize (e.g. user has a field with an
             // invalid type that migration didn't touch), surface the
@@ -118,6 +128,34 @@ impl ConfigLoader {
             }
         }
         changed
+    }
+
+    /// Remove security fields that used to live in `config.yaml` but are now
+    /// owned exclusively by `security_policy.yaml` (issue #407).
+    ///
+    /// Returns the names of keys that were actually present and removed so
+    /// callers can warn the user once.
+    fn strip_legacy_security_keys(value: &mut serde_yaml::Value) -> Vec<String> {
+        const LEGACY_KEYS: &[&str] = &[
+            "enable_sandbox",
+            "sandbox_off_action",
+            "sandbox_timeout_seconds",
+            "default_risk_level",
+            "input_guard_enabled",
+        ];
+        let Some(map) = value.as_mapping_mut() else {
+            return Vec::new();
+        };
+        let mut removed = Vec::new();
+        for key in LEGACY_KEYS {
+            if map
+                .remove(serde_yaml::Value::String((*key).to_string()))
+                .is_some()
+            {
+                removed.push((*key).to_string());
+            }
+        }
+        removed
     }
 
     /// Return the default config path following XDG conventions.
@@ -195,14 +233,14 @@ mod tests {
         let config = ConfigLoader::load(Some(&path)).unwrap();
         assert_eq!(config.model, "glm-4.7");
         assert_eq!(config.api_key, "secret");
-        // input_guard_enabled wasn't in the yaml; default true should
+        // enable_token_estimation wasn't in the yaml; default true should
         // have been both applied AND persisted.
-        assert!(config.input_guard_enabled);
+        assert!(config.enable_token_estimation);
 
         let on_disk = std::fs::read_to_string(&path).unwrap();
         assert!(on_disk.contains("model: glm-4.7"));
         assert!(on_disk.contains("api_key: secret"));
-        assert!(on_disk.contains("input_guard_enabled: true"));
+        assert!(on_disk.contains("enable_token_estimation: true"));
     }
 
     #[test]
@@ -223,25 +261,55 @@ mod tests {
             "unknown user-extension keys must survive migration; got:\n{on_disk}"
         );
         // New schema key also added.
-        assert!(on_disk.contains("input_guard_enabled:"));
+        assert!(on_disk.contains("enable_token_estimation:"));
     }
 
     #[test]
     fn load_preserves_user_overrides_during_migration() {
-        // User explicitly set input_guard_enabled: false. Migration
-        // must NOT overwrite it with the default true.
+        // User explicitly set auto_suggest: true (default is false).
+        // Migration must NOT overwrite it with the default.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.yaml");
-        std::fs::write(&path, "model: glm-4.7\ninput_guard_enabled: false\n").unwrap();
+        std::fs::write(&path, "model: glm-4.7\nauto_suggest: true\n").unwrap();
 
         let config = ConfigLoader::load(Some(&path)).unwrap();
-        assert!(!config.input_guard_enabled);
+        assert!(config.auto_suggest);
 
         let on_disk = std::fs::read_to_string(&path).unwrap();
-        // Should still be false, not overwritten with true.
-        assert!(on_disk.contains("input_guard_enabled: false"));
+        // Should still be true, not overwritten with false.
+        assert!(on_disk.contains("auto_suggest: true"));
         // Other missing fields should have been added.
         assert!(on_disk.contains("api_key:"));
+    }
+
+    #[test]
+    fn load_strips_legacy_security_keys() {
+        // Security settings moved to security_policy.yaml (#407). Old keys
+        // left in config.yaml must be removed on load so they stop confusing
+        // users / docs.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(
+            &path,
+            "model: glm-4.7\nenable_sandbox: true\ninput_guard_enabled: false\nsandbox_off_action: block\n",
+        )
+        .unwrap();
+
+        let _config = ConfigLoader::load(Some(&path)).unwrap();
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert!(on_disk.contains("model: glm-4.7"));
+        assert!(
+            !on_disk.contains("enable_sandbox:"),
+            "legacy enable_sandbox must be stripped; got:\n{on_disk}"
+        );
+        assert!(
+            !on_disk.contains("input_guard_enabled:"),
+            "legacy input_guard_enabled must be stripped; got:\n{on_disk}"
+        );
+        assert!(
+            !on_disk.contains("sandbox_off_action:"),
+            "legacy sandbox_off_action must be stripped; got:\n{on_disk}"
+        );
     }
 
     #[test]
@@ -272,7 +340,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("nonexistent.yaml");
         let config = ConfigLoader::load(Some(&path)).unwrap();
-        assert!(config.input_guard_enabled);
+        assert!(config.enable_token_estimation);
         assert!(!path.exists());
     }
 

--- a/crates/aish-config/src/model.rs
+++ b/crates/aish-config/src/model.rs
@@ -364,7 +364,6 @@ pub struct ConfigModel {
     pub pty_output_keep_bytes: usize,
     pub memory: Option<MemoryConfig>,
     pub session_db_path: Option<String>,
-    pub enable_sandbox: bool,
 
     /// Inject git branch awareness into remote bash prompts during SSH/telnet
     /// sessions. When true, aish prepends a `|branch` marker (magenta, matching
@@ -406,16 +405,6 @@ pub struct ConfigModel {
     #[serde(default = "default_true")]
     pub remote_show_kube: bool,
 
-    pub sandbox_off_action: String,
-    pub sandbox_timeout_seconds: f64,
-    pub default_risk_level: String,
-
-    /// Master switch for InputGuard (BLOCKED / Confirm prompts).
-    /// When false, all input passes through unchecked. Mirrors the
-    /// `input_guard.enabled` field in security_policy.yaml so users
-    /// can toggle it from the more familiar config.yaml.
-    #[serde(default = "default_true")]
-    pub input_guard_enabled: bool,
     pub langfuse_public_key: Option<String>,
     pub langfuse_secret_key: Option<String>,
     pub langfuse_host: Option<String>,
@@ -518,17 +507,12 @@ impl Default for ConfigModel {
             pty_output_keep_bytes: 4096,
             memory: None,
             session_db_path: None,
-            enable_sandbox: false,
             enable_remote_git_prompt: true,
             remote_rich_prompt: default_true(),
             remote_danger_patterns: default_remote_danger_patterns(),
             remote_show_venv: default_true(),
             remote_show_container: default_true(),
             remote_show_kube: default_true(),
-            sandbox_off_action: "allow".to_string(),
-            sandbox_timeout_seconds: 10.0,
-            default_risk_level: "low".to_string(),
-            input_guard_enabled: default_true(),
             langfuse_public_key: None,
             langfuse_secret_key: None,
             langfuse_host: None,

--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -982,10 +982,11 @@ help:
 
         ## Speicherort
 
-        Priorität:
+        Pfad:
         1. Explizit angegebener Pfad
-        2. `/etc/aish/security_policy.yaml`
-        3. `~/.config/aish/security_policy.yaml`
+        2. `~/.config/aish/security_policy.yaml` (fehlt sie, wird die mitgelieferte Vorlage erzeugt)
+
+        `/etc/aish` wird zur Laufzeit nicht gelesen.
 
         ## Risikostufen
 

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -1386,10 +1386,11 @@ help:
 
         ## Config Location
 
-        Priority:
+        Path:
         1. Explicit path (if configured)
-        2. `/etc/aish/security_policy.yaml`
-        3. `~/.config/aish/security_policy.yaml`
+        2. `~/.config/aish/security_policy.yaml` (seeded from the shipped template if missing)
+
+        `/etc/aish` is not read at runtime.
 
         ## Risk Levels
 

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -982,10 +982,11 @@ help:
 
         ## Ubicación de configuración
 
-        Prioridad：
+        Ruta:
         1. Ruta explícita especificada
-        2. `/etc/aish/security_policy.yaml`
-        3. `~/.config/aish/security_policy.yaml`
+        2. `~/.config/aish/security_policy.yaml` (si falta, se genera desde la plantilla incluida)
+
+        `/etc/aish` no se lee en tiempo de ejecución.
 
         ## Niveles de riesgo
 

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -982,10 +982,11 @@ help:
 
         ## Emplacement de la configuration
 
-        Priorité :
+        Chemin :
         1. Chemin explicitement spécifié
-        2. `/etc/aish/security_policy.yaml`
-        3. `~/.config/aish/security_policy.yaml`
+        2. `~/.config/aish/security_policy.yaml` (généré depuis le modèle embarqué si absent)
+
+        `/etc/aish` n'est pas lu à l'exécution.
 
         ## Niveaux de risque
 

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -982,10 +982,11 @@ help:
 
         ## 設定場所
 
-        優先順位：
+        パス：
         1. 明示的に指定されたパス
-        2. `/etc/aish/security_policy.yaml`
-        3. `~/.config/aish/security_policy.yaml`
+        2. `~/.config/aish/security_policy.yaml`（無い場合は同梱テンプレートから生成）
+
+        実行時に `/etc/aish` は読みません。
 
         ## リスクレベル
 

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -1384,10 +1384,11 @@ help:
 
         ## 配置位置
 
-        优先级：
+        路径：
         1. 显式指定的路径
-        2. `/etc/aish/security_policy.yaml`
-        3. `~/.config/aish/security_policy.yaml`
+        2. `~/.config/aish/security_policy.yaml`（不存在时从内置模板生成）
+
+        运行时不再读取 `/etc/aish`。
 
         ## 风险等级
 

--- a/crates/aish-pty/src/session_interceptor.rs
+++ b/crates/aish-pty/src/session_interceptor.rs
@@ -208,9 +208,9 @@ impl SessionInterceptor {
     /// `ai_callback` is None -> interceptor is disabled (pure passthrough).
     /// `ai_callback` is Some -> interceptor will intercept `;` input.
     /// `status_callback` is Some -> interceptor will intercept `/status` input.
-    /// `input_guard_enabled` mirrors `config.yaml`'s `input_guard_enabled`
-    /// and overrides the same-named field in security_policy.yaml so the
-    /// user-facing toggle applies uniformly to local and PTY screening.
+    /// `input_guard_enabled` comes from the live security policy
+    /// (`security_policy.yaml` / `/setting`) so local and PTY screening
+    /// share the same toggle without rebuilding the rule set.
     pub fn new(
         ai_callback: Option<Box<AiCallback>>,
         status_callback: Option<Box<StatusCallback>>,

--- a/crates/aish-security/src/input_guard/mod.rs
+++ b/crates/aish-security/src/input_guard/mod.rs
@@ -127,9 +127,9 @@ impl InputGuard {
         self.enabled
     }
 
-    /// Override the enabled flag. Used when the caller wants to mirror an
-    /// external toggle (e.g. `config.yaml`'s `input_guard_enabled`) onto a
-    /// cached `InputGuard` instance without rebuilding the rule set.
+    /// Override the enabled flag. Used when the caller wants to apply a
+    /// live `/setting` toggle onto a cached `InputGuard` instance without
+    /// rebuilding the rule set.
     pub fn set_enabled(&mut self, enabled: bool) {
         self.enabled = enabled;
     }

--- a/crates/aish-security/src/lib.rs
+++ b/crates/aish-security/src/lib.rs
@@ -13,8 +13,9 @@ pub use decision::{RiskLevel, SandboxOffAction, SecurityAnalysis, SecurityDecisi
 pub use fallback::{FallbackRuleAssessment, FallbackRuleEngine};
 pub use manager::{SecurityManager, SecurityRequest};
 pub use policy::{
-    load_policy, resolve_security_policy_path, save_policy_globals, InvalidFallbackRule,
-    PolicyRule, SecurityPolicy, ValidationIssue,
+    load_policy, resolve_security_policy_path, save_policy_ui_fields,
+    writable_security_policy_path, InvalidFallbackRule, PolicyRule, SecurityPolicy,
+    ValidationIssue,
 };
 pub use sandbox::{run_sandbox_daemon, run_sandbox_worker, SandboxClient};
 pub use types::{FsChange, MatchedRuleSummary};

--- a/crates/aish-security/src/lib.rs
+++ b/crates/aish-security/src/lib.rs
@@ -13,9 +13,9 @@ pub use decision::{RiskLevel, SandboxOffAction, SecurityAnalysis, SecurityDecisi
 pub use fallback::{FallbackRuleAssessment, FallbackRuleEngine};
 pub use manager::{SecurityManager, SecurityRequest};
 pub use policy::{
-    load_policy, resolve_security_policy_path, save_policy_ui_fields,
-    writable_security_policy_path, InvalidFallbackRule, PolicyRule, SecurityPolicy,
-    ValidationIssue,
+    load_policy, resolve_security_policy_path, save_policy_ui_fields, try_load_policy,
+    writable_security_policy_path, InvalidFallbackRule, PolicyLoadError, PolicyRule,
+    SecurityPolicy, ValidationIssue,
 };
 pub use sandbox::{run_sandbox_daemon, run_sandbox_worker, SandboxClient};
 pub use types::{FsChange, MatchedRuleSummary};

--- a/crates/aish-security/src/policy.rs
+++ b/crates/aish-security/src/policy.rs
@@ -110,8 +110,9 @@ fn user_security_policy_path() -> PathBuf {
 }
 
 /// Seed `~/.config/aish/security_policy.yaml` if missing from the compile-time
-/// default template. Uses `create_new` so concurrent first-launch races do not
-/// clobber an existing user file.
+/// default template. Writes the full template to a temp file first, then
+/// installs with `create_new` so concurrent races cannot clobber a user file
+/// and a failed seed cannot leave an empty destination.
 fn ensure_user_policy_template(path: &Path) {
     if path.exists() {
         return;
@@ -120,11 +121,32 @@ fn ensure_user_policy_template(path: &Path) {
         let _ = fs::create_dir_all(parent);
     }
 
-    let _ = fs::OpenOptions::new()
+    // Write the full template first. Only then create the destination so a
+    // failed seed cannot leave an empty file that suppresses later retries.
+    let tmp_path = path.with_extension("yaml.seed.tmp");
+    if fs::write(&tmp_path, DEFAULT_POLICY_TEMPLATE).is_err() {
+        let _ = fs::remove_file(&tmp_path);
+        return;
+    }
+
+    use std::io::Write;
+    match fs::OpenOptions::new()
         .write(true)
         .create_new(true)
         .open(path)
-        .and_then(|_| fs::write(path, DEFAULT_POLICY_TEMPLATE));
+    {
+        Ok(mut file) => {
+            if file.write_all(DEFAULT_POLICY_TEMPLATE.as_bytes()).is_err() {
+                drop(file);
+                let _ = fs::remove_file(path);
+            }
+        }
+        Err(_) => {
+            // Lost the create_new race, or open failed — leave an existing
+            // user file alone.
+        }
+    }
+    let _ = fs::remove_file(&tmp_path);
 }
 
 /// Resolve the policy file used for **reads**.
@@ -567,7 +589,11 @@ fn update_section_field(text: &str, section: &str, field: &str, value: &str) -> 
     let mut out: Vec<String> = Vec::with_capacity(lines.len());
     let mut in_section = false;
     let mut section_line_idx: Option<usize> = None;
-    let mut last_indent: String = String::from("  ");
+    // Indentation of direct children under `section:` (min indent seen).
+    // Nested list/map lines must not overwrite this, or a missing-field
+    // insert lands inside the nested block.
+    let mut child_indent: String = String::from("  ");
+    let mut saw_child_indent = false;
     let mut last_section_child_idx: Option<usize> = None;
     let mut done = false;
 
@@ -590,10 +616,13 @@ fn update_section_field(text: &str, section: &str, field: &str, value: &str) -> 
             let stripped = raw.trim_start();
             let indent_len = raw.len() - stripped.len();
             if indent_len > 0 && !stripped.starts_with('#') && !stripped.is_empty() {
-                // Track the indentation used inside the section so an insertion
-                // (if needed) matches the surrounding style.
-                last_indent = raw[..indent_len].to_string();
+                // Always advance the insert cursor past every descendant line,
+                // but only learn direct-child indent from the shallowest level.
                 last_section_child_idx = Some(i);
+                if !saw_child_indent || indent_len < child_indent.len() {
+                    child_indent = raw[..indent_len].to_string();
+                    saw_child_indent = true;
+                }
             }
             // Match `  field:` exactly (the ':' terminator prevents
             // `enable_sandbox_extra:` from matching `enable_sandbox`).
@@ -625,7 +654,7 @@ fn update_section_field(text: &str, section: &str, field: &str, value: &str) -> 
             let insert_at = last_section_child_idx.map(|c| c + 1).unwrap_or(sidx + 1);
             // Find where `out` currently has the corresponding line — since
             // we pushed every line, indices match `lines`.
-            out.insert(insert_at, format!("{}{}: {}", last_indent, field, value));
+            out.insert(insert_at, format!("{}{}: {}", child_indent, field, value));
         } else {
             // No section at all — append a minimal one.
             if !out.is_empty() && out.last().map(|l| !l.is_empty()).unwrap_or(false) {
@@ -668,6 +697,13 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{load_policy, resolve_security_policy_path, SecurityPolicy};
+
+    /// Serialize tests that mutate process-global env vars (cargo runs them
+    /// in parallel threads of one process).
+    fn xdg_env_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
 
     /// RAII env var restore for path-resolution tests.
     struct EnvGuard {
@@ -729,6 +765,9 @@ mod tests {
         let user_path = xdg.join("aish").join("security_policy.yaml");
         fs::write(&user_path, "global:\n  enable_sandbox: true\nrules: []\n").unwrap();
 
+        let _lock = xdg_env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let _guard = EnvGuard::set("XDG_CONFIG_HOME", Some(xdg.to_str().unwrap()));
         let resolved = resolve_security_policy_path(None);
         assert_eq!(resolved.as_deref(), Some(user_path.as_path()));
@@ -741,6 +780,9 @@ mod tests {
         let dir = tempdir().unwrap();
         let xdg = dir.path().join("xdg");
         fs::create_dir_all(&xdg).unwrap();
+        let _lock = xdg_env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let _guard = EnvGuard::set("XDG_CONFIG_HOME", Some(xdg.to_str().unwrap()));
 
         let resolved = resolve_security_policy_path(None).expect("user policy");
@@ -754,6 +796,9 @@ mod tests {
         let dir = tempdir().unwrap();
         let xdg = dir.path().join("xdg");
         fs::create_dir_all(&xdg).unwrap();
+        let _lock = xdg_env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let _guard = EnvGuard::set("XDG_CONFIG_HOME", Some(xdg.to_str().unwrap()));
 
         let path = super::writable_security_policy_path().expect("user path");
@@ -1010,6 +1055,29 @@ rules: []
         assert!(out.contains("default_risk_level: LOW"));
         // Inserted with the same indent as the existing child.
         assert!(out.contains("  enable_sandbox: true"));
+    }
+
+    #[test]
+    fn update_section_field_inserts_at_direct_child_indent_with_nested() {
+        // Nested custom rules must not steal the indent used for a missing
+        // top-level field under the same section.
+        let yaml = concat!(
+            "input_guard:\n",
+            "  custom_block_rules:\n",
+            "    - name: no_rm_data\n",
+            "      pattern: \"rm\"\n",
+            "      message: nope\n",
+        );
+        let out = super::update_section_field(yaml, "input_guard", "enabled", "false");
+        let enabled_line = out
+            .lines()
+            .find(|l| l.trim_start().starts_with("enabled:"))
+            .expect("enabled field missing");
+        assert_eq!(
+            enabled_line, "  enabled: false",
+            "enabled must be a direct child of input_guard; got:\n{out}"
+        );
+        assert!(out.contains("custom_block_rules:"));
     }
 
     #[test]

--- a/crates/aish-security/src/policy.rs
+++ b/crates/aish-security/src/policy.rs
@@ -412,18 +412,80 @@ fn parse_invalid_fallback_rules(
     (invalid_rules, issues)
 }
 
+/// Errors from an authoritative security policy load (no silent defaults).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PolicyLoadError {
+    /// Policy path could not be resolved / seeded.
+    Missing { path: PathBuf },
+    /// Policy file exists but could not be read.
+    Read { path: PathBuf, message: String },
+    /// Policy file is not valid YAML.
+    Parse { path: PathBuf, message: String },
+}
+
+impl std::fmt::Display for PolicyLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Missing { path } => write!(
+                f,
+                "security policy missing or could not be seeded: {}",
+                path.display()
+            ),
+            Self::Read { path, message } => {
+                write!(
+                    f,
+                    "cannot read security policy {}: {message}",
+                    path.display()
+                )
+            }
+            Self::Parse { path, message } => {
+                write!(
+                    f,
+                    "invalid security policy YAML {}: {message}",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for PolicyLoadError {}
+
+/// Load the security policy, reporting missing/unreadable/invalid files.
+///
+/// Unlike [`load_policy`], this does **not** fall back to
+/// [`SecurityPolicy::default`] on I/O or parse failure — callers that need to
+/// surface diagnostics (e.g. `aish doctor`) should use this entry point.
+pub fn try_load_policy(config_path: Option<&Path>) -> Result<SecurityPolicy, PolicyLoadError> {
+    let effective_path = match resolve_security_policy_path(config_path) {
+        Some(path) => path,
+        None => {
+            return Err(PolicyLoadError::Missing {
+                path: config_path
+                    .map(Path::to_path_buf)
+                    .unwrap_or_else(user_security_policy_path),
+            });
+        }
+    };
+
+    let text = fs::read_to_string(&effective_path).map_err(|e| PolicyLoadError::Read {
+        path: effective_path.clone(),
+        message: e.to_string(),
+    })?;
+    let data = serde_yaml::from_str::<Value>(&text).map_err(|e| PolicyLoadError::Parse {
+        path: effective_path,
+        message: e.to_string(),
+    })?;
+    Ok(policy_from_value(data))
+}
+
+/// Load security policy for runtime use. On missing/unreadable/invalid files,
+/// falls back to [`SecurityPolicy::default`] (same historical behavior).
 pub fn load_policy(config_path: Option<&Path>) -> SecurityPolicy {
-    let Some(effective_path) = resolve_security_policy_path(config_path) else {
-        return SecurityPolicy::default();
-    };
+    try_load_policy(config_path).unwrap_or_else(|_| SecurityPolicy::default())
+}
 
-    let Ok(text) = fs::read_to_string(&effective_path) else {
-        return SecurityPolicy::default();
-    };
-    let Ok(data) = serde_yaml::from_str::<Value>(&text) else {
-        return SecurityPolicy::default();
-    };
-
+fn policy_from_value(data: Value) -> SecurityPolicy {
     let root = data.as_mapping();
     let global_cfg = root.and_then(|m| as_mapping(mapping_get(m, "global")));
     let audit_cfg = root.and_then(|m| as_mapping(mapping_get(m, "audit")));
@@ -820,6 +882,23 @@ mod tests {
             .chars()
             .any(|c| ('\u{4e00}'..='\u{9fff}').contains(&c));
         assert!(!has_cjk, "seeded policy must not contain CJK comments");
+    }
+
+    #[test]
+    fn try_load_policy_reports_parse_errors() {
+        let dir = tempdir().unwrap();
+        let policy_path = dir.path().join("security_policy.yaml");
+        fs::write(&policy_path, "global: [\n").unwrap();
+        let err = super::try_load_policy(Some(&policy_path)).expect_err("parse");
+        match err {
+            super::PolicyLoadError::Parse { path, message } => {
+                assert_eq!(path, policy_path);
+                assert!(!message.is_empty());
+            }
+            other => panic!("expected Parse, got {other:?}"),
+        }
+        // Runtime loader still falls back instead of panicking.
+        let _ = load_policy(Some(&policy_path));
     }
 
     #[test]

--- a/crates/aish-security/src/policy.rs
+++ b/crates/aish-security/src/policy.rs
@@ -774,10 +774,7 @@ mod tests {
         let has_cjk = seeded
             .chars()
             .any(|c| ('\u{4e00}'..='\u{9fff}').contains(&c));
-        assert_eq!(
-            has_cjk, false,
-            "seeded policy must not contain CJK comments"
-        );
+        assert!(!has_cjk, "seeded policy must not contain CJK comments");
     }
 
     #[test]

--- a/crates/aish-security/src/policy.rs
+++ b/crates/aish-security/src/policy.rs
@@ -92,41 +92,10 @@ impl Default for SecurityPolicy {
     }
 }
 
-const EMPTY_POLICY_TEMPLATE: &str = "# AI-Shell Security Policy\n\
-\n\
-# Lines below ship aish defaults. Edit to tighten or relax; removing a\n\
-# key restores its default value. System location: /etc/aish/security_policy.yaml.\n\
-# User fallback (~/.config/aish/security_policy.yaml) is auto-seeded from this\n\
-# template on first launch.\n\
-\n\
-global:\n\
-  default_risk_level: LOW        # LOW | MEDIUM | HIGH\n\
-  enable_sandbox: false\n\
-  sandbox_off_action: ALLOW      # ALLOW | CONFIRM | BLOCK\n\
-  sandbox_timeout_seconds: 10\n\
-\n\
-audit:\n\
-  enabled: false\n\
-  # include_commands: false   # set true to also audit regular shell commands\n\
-  # log_path: /var/log/aish/audit.log\n\
-\n\
-# InputGuard pre-screens shell commands and AI prompts before execution.\n\
-# Built-in rules: crates/aish-security/src/input_guard/patterns.rs.\n\
-# Custom rules below are merged on top of built-ins; a custom rule with\n\
-# the same `name` as a built-in overrides it.\n\
-input_guard:\n\
-  enabled: true\n\
-  # max_analyzable_bytes: 4096    # inputs longer than this force-confirm\n\
-  # custom_block_rules:\n\
-  #   - name: no_rm_data\n\
-  #     pattern: \"rm\\s+-rf\\s+/data\"\n\
-  #     message: deleting /data is forbidden\n\
-  # custom_confirm_rules:\n\
-  #   - name: confirm_docker_push\n\
-  #     pattern: \"docker\\s+push\"\n\
-  #     message: pushing image — confirm tag\n\
-\n\
-rules: []\n";
+/// Default policy content shipped with aish. Seeded into
+/// `~/.config/aish/security_policy.yaml` on first use — runtime never reads
+/// `/etc/aish`.
+const DEFAULT_POLICY_TEMPLATE: &str = include_str!("../../../config/security_policy.yaml");
 
 fn user_security_policy_path() -> PathBuf {
     let base_dir = env::var_os("XDG_CONFIG_HOME")
@@ -140,7 +109,13 @@ fn user_security_policy_path() -> PathBuf {
     base_dir.join("aish").join("security_policy.yaml")
 }
 
+/// Seed `~/.config/aish/security_policy.yaml` if missing from the compile-time
+/// default template. Uses `create_new` so concurrent first-launch races do not
+/// clobber an existing user file.
 fn ensure_user_policy_template(path: &Path) {
+    if path.exists() {
+        return;
+    }
     if let Some(parent) = path.parent() {
         let _ = fs::create_dir_all(parent);
     }
@@ -149,19 +124,23 @@ fn ensure_user_policy_template(path: &Path) {
         .write(true)
         .create_new(true)
         .open(path)
-        .and_then(|_| fs::write(path, EMPTY_POLICY_TEMPLATE));
+        .and_then(|_| fs::write(path, DEFAULT_POLICY_TEMPLATE));
 }
 
+/// Resolve the policy file used for **reads**.
+///
+/// Priority:
+/// 1. Explicit `config_path` (tests / overrides)
+/// 2. `~/.config/aish/security_policy.yaml` (auto-seeded from the shipped
+///    template when missing)
+///
+/// `/etc/aish` is never consulted — all runtime policy I/O is under the user
+/// config directory.
 pub fn resolve_security_policy_path(config_path: Option<&Path>) -> Option<PathBuf> {
     if let Some(path) = config_path {
         if path.exists() {
             return Some(path.to_path_buf());
         }
-    }
-
-    let system_path = PathBuf::from("/etc/aish/security_policy.yaml");
-    if system_path.exists() {
-        return Some(system_path);
     }
 
     let user_path = user_security_policy_path();
@@ -173,6 +152,19 @@ pub fn resolve_security_policy_path(config_path: Option<&Path>) -> Option<PathBu
     }
 
     None
+}
+
+/// Path `/setting` (and other UI writers) must use — always
+/// `~/.config/aish/security_policy.yaml`. Seeds the shipped template when
+/// missing.
+pub fn writable_security_policy_path() -> Option<PathBuf> {
+    let user_path = user_security_policy_path();
+    ensure_user_policy_template(&user_path);
+    if user_path.exists() {
+        Some(user_path)
+    } else {
+        None
+    }
 }
 
 fn mapping_get<'a>(mapping: &'a Mapping, key: &str) -> Option<&'a Value> {
@@ -532,28 +524,31 @@ pub fn load_policy(config_path: Option<&Path>) -> SecurityPolicy {
     }
 }
 
-/// Update one or more `global:` fields in a `security_policy.yaml` file
-/// **in place**, preserving all comments, blank lines, and other sections.
-///
-/// Each entry in `updates` is `(field_name, new_value)`. If a field already
-/// exists under `global:`, its value is replaced (inline comments kept). If
-/// it is absent, it is inserted into the `global:` block. If `global:` itself
-/// is missing, a minimal section is appended.
-///
-/// Used by the `/setting` panel so security toggles are visible in the file
-/// users consider authoritative — not just in `config.yaml`.
-pub fn save_policy_globals(path: &Path, updates: &[(&str, &str)]) -> Result<(), String> {
+/// Persist `/setting` Security fields in one read/modify/write: `global:`
+/// updates plus optional `input_guard.enabled`. Preserves comments.
+pub fn save_policy_ui_fields(
+    path: &Path,
+    global_updates: &[(&str, &str)],
+    input_guard_enabled: Option<bool>,
+) -> Result<(), String> {
     let text =
         fs::read_to_string(path).map_err(|e| format!("failed to read {}: {e}", path.display()))?;
     let mut updated = text;
-    for (field, value) in updates {
-        updated = update_global_field(&updated, field, value);
+    for (field, value) in global_updates {
+        updated = update_section_field(&updated, "global", field, value);
+    }
+    if let Some(enabled) = input_guard_enabled {
+        updated = update_section_field(
+            &updated,
+            "input_guard",
+            "enabled",
+            if enabled { "true" } else { "false" },
+        );
     }
     // Prefer atomic write (temp + rename in the same directory) to avoid
     // truncation on crash/ENOSPC. Fall back to direct fs::write when the
-    // directory isn't writable (common for /etc/aish/ where the file is
-    // user-owned but the directory is root-owned) — direct write only needs
-    // file-level write permission.
+    // directory isn't writable — uncommon for ~/.config, but kept for
+    // callers that still pass an explicit path.
     let tmp_path = path.with_extension("yaml.tmp");
     let atomic_ok = fs::write(&tmp_path, &updated).is_ok() && fs::rename(&tmp_path, path).is_ok();
     if !atomic_ok {
@@ -564,15 +559,16 @@ pub fn save_policy_globals(path: &Path, updates: &[(&str, &str)]) -> Result<(), 
     Ok(())
 }
 
-/// Replace `field` under the top-level `global:` mapping with `value`, or
+/// Replace `field` under a top-level YAML `section:` mapping with `value`, or
 /// insert it if absent. Preserves comments, indentation, and all other content.
-fn update_global_field(text: &str, field: &str, value: &str) -> String {
+fn update_section_field(text: &str, section: &str, field: &str, value: &str) -> String {
+    let section_key = format!("{}:", section);
     let lines: Vec<&str> = text.split('\n').collect();
     let mut out: Vec<String> = Vec::with_capacity(lines.len());
-    let mut in_global = false;
-    let mut global_line_idx: Option<usize> = None;
+    let mut in_section = false;
+    let mut section_line_idx: Option<usize> = None;
     let mut last_indent: String = String::from("  ");
-    let mut last_global_child_idx: Option<usize> = None;
+    let mut last_section_child_idx: Option<usize> = None;
     let mut done = false;
 
     for (i, raw) in lines.iter().enumerate() {
@@ -584,20 +580,20 @@ fn update_global_field(text: &str, field: &str, value: &str) -> String {
             && !raw.starts_with('#')
             && !raw.starts_with('-');
         if is_top_level {
-            in_global = raw.trim_start().starts_with("global:");
-            if in_global {
-                global_line_idx = Some(i);
+            in_section = raw.trim_start().starts_with(&section_key);
+            if in_section {
+                section_line_idx = Some(i);
             }
         }
 
-        if in_global && !done {
+        if in_section && !done {
             let stripped = raw.trim_start();
             let indent_len = raw.len() - stripped.len();
             if indent_len > 0 && !stripped.starts_with('#') && !stripped.is_empty() {
-                // Track the indentation used inside global: so an insertion
+                // Track the indentation used inside the section so an insertion
                 // (if needed) matches the surrounding style.
                 last_indent = raw[..indent_len].to_string();
-                last_global_child_idx = Some(i);
+                last_section_child_idx = Some(i);
             }
             // Match `  field:` exactly (the ':' terminator prevents
             // `enable_sandbox_extra:` from matching `enable_sandbox`).
@@ -621,21 +617,21 @@ fn update_global_field(text: &str, field: &str, value: &str) -> String {
         out.push(raw.to_string());
     }
 
-    // Field not found under global: — insert it.
+    // Field not found under section: — insert it.
     if !done {
-        if let Some(gidx) = global_line_idx {
-            // Insert after the last existing child of global: (or right
-            // after `global:` if the section is empty).
-            let insert_at = last_global_child_idx.map(|c| c + 1).unwrap_or(gidx + 1);
+        if let Some(sidx) = section_line_idx {
+            // Insert after the last existing child of the section (or right
+            // after `section:` if the section is empty).
+            let insert_at = last_section_child_idx.map(|c| c + 1).unwrap_or(sidx + 1);
             // Find where `out` currently has the corresponding line — since
             // we pushed every line, indices match `lines`.
             out.insert(insert_at, format!("{}{}: {}", last_indent, field, value));
         } else {
-            // No global: section at all — append a minimal one.
+            // No section at all — append a minimal one.
             if !out.is_empty() && out.last().map(|l| !l.is_empty()).unwrap_or(false) {
                 out.push(String::new());
             }
-            out.push("global:".to_string());
+            out.push(format!("{}:", section));
             out.push(format!("  {}: {}", field, value));
         }
     }
@@ -672,6 +668,31 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{load_policy, resolve_security_policy_path, SecurityPolicy};
+
+    /// RAII env var restore for path-resolution tests.
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<std::ffi::OsString>,
+    }
+    impl EnvGuard {
+        fn set(key: &'static str, value: Option<&str>) -> Self {
+            let prev = std::env::var_os(key);
+            match value {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+            Self { key, prev }
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
     use crate::decision::{RiskLevel, SandboxOffAction};
 
     #[test]
@@ -698,6 +719,64 @@ mod tests {
         let resolved = resolve_security_policy_path(Some(&policy_path));
 
         assert_eq!(resolved.as_deref(), Some(policy_path.as_path()));
+    }
+
+    #[test]
+    fn resolve_security_policy_path_uses_user_config() {
+        let dir = tempdir().unwrap();
+        let xdg = dir.path().join("xdg");
+        fs::create_dir_all(xdg.join("aish")).unwrap();
+        let user_path = xdg.join("aish").join("security_policy.yaml");
+        fs::write(
+            &user_path,
+            "global:\n  enable_sandbox: true\nrules: []\n",
+        )
+        .unwrap();
+
+        let _guard = EnvGuard::set("XDG_CONFIG_HOME", Some(xdg.to_str().unwrap()));
+        let resolved = resolve_security_policy_path(None);
+        assert_eq!(resolved.as_deref(), Some(user_path.as_path()));
+        let policy = load_policy(None);
+        assert!(policy.enable_sandbox);
+    }
+
+    #[test]
+    fn resolve_security_policy_path_seeds_user_and_ignores_etc() {
+        let dir = tempdir().unwrap();
+        let xdg = dir.path().join("xdg");
+        fs::create_dir_all(&xdg).unwrap();
+        let _guard = EnvGuard::set("XDG_CONFIG_HOME", Some(xdg.to_str().unwrap()));
+
+        let resolved = resolve_security_policy_path(None).expect("user policy");
+        assert!(resolved.starts_with(&xdg));
+        assert!(!resolved.starts_with("/etc"));
+        assert!(resolved.exists());
+    }
+
+    #[test]
+    fn writable_security_policy_path_seeds_user_file() {
+        let dir = tempdir().unwrap();
+        let xdg = dir.path().join("xdg");
+        fs::create_dir_all(&xdg).unwrap();
+        let _guard = EnvGuard::set("XDG_CONFIG_HOME", Some(xdg.to_str().unwrap()));
+
+        let path = super::writable_security_policy_path().expect("user path");
+        assert!(path.exists());
+        assert!(path.starts_with(&xdg));
+        assert_eq!(
+            path.file_name().and_then(|s| s.to_str()),
+            Some("security_policy.yaml")
+        );
+
+        let seeded = fs::read_to_string(&path).unwrap();
+        assert!(seeded.contains("# AI-Shell Security Policy"));
+        assert!(seeded.contains("Protect /etc"));
+        assert!(seeded.contains("id: H-001"));
+        assert!(seeded.contains("id: M-001"));
+        assert!(seeded.contains("id: L-001"));
+        // Shipped seed is English-only (no CJK comments).
+        let has_cjk = seeded.chars().any(|c| ('\u{4e00}'..='\u{9fff}').contains(&c));
+        assert_eq!(has_cjk, false, "seeded policy must not contain CJK comments");
     }
 
     #[test]
@@ -873,26 +952,26 @@ rules: []
         assert!(policy.input_guard.custom_confirm_rules.is_empty());
     }
 
-    // ---- save_policy_globals / update_global_field ----
+    // ---- save_policy_ui_fields / update_section_field ----
 
     #[test]
-    fn update_global_field_replaces_existing_value() {
+    fn update_section_field_global_replaces_existing_value() {
         let yaml = "global:\n  enable_sandbox: true\n  default_risk_level: LOW\n";
-        let out = super::update_global_field(yaml, "enable_sandbox", "false");
+        let out = super::update_section_field(yaml, "global", "enable_sandbox", "false");
         assert!(out.contains("enable_sandbox: false"));
         assert!(out.contains("default_risk_level: LOW"));
         assert!(!out.contains("enable_sandbox: true"));
     }
 
     #[test]
-    fn update_global_field_preserves_inline_comment() {
+    fn update_section_field_global_preserves_inline_comment() {
         let yaml = "global:\n  enable_sandbox: false  # toggle me\n";
-        let out = super::update_global_field(yaml, "enable_sandbox", "true");
+        let out = super::update_section_field(yaml, "global", "enable_sandbox", "true");
         assert!(out.contains("enable_sandbox: true  # toggle me"));
     }
 
     #[test]
-    fn update_global_field_preserves_block_comments_and_other_sections() {
+    fn update_section_field_global_preserves_block_comments_and_other_sections() {
         let yaml = concat!(
             "# header comment\n",
             "global:\n",
@@ -903,7 +982,7 @@ rules: []
             "audit:\n",
             "  enabled: true\n",
         );
-        let out = super::update_global_field(yaml, "enable_sandbox", "true");
+        let out = super::update_section_field(yaml, "global", "enable_sandbox", "true");
         assert!(out.contains("# header comment"));
         assert!(out.contains("# enable sandbox?"));
         assert!(out.contains("enable_sandbox: true"));
@@ -917,18 +996,18 @@ rules: []
     }
 
     #[test]
-    fn update_global_field_does_not_match_prefix() {
+    fn update_section_field_global_does_not_match_prefix() {
         // `enable_sandbox` must NOT match `enable_sandbox_extra`.
         let yaml = "global:\n  enable_sandbox: true\n  enable_sandbox_extra: keep\n";
-        let out = super::update_global_field(yaml, "enable_sandbox", "false");
+        let out = super::update_section_field(yaml, "global", "enable_sandbox", "false");
         assert!(out.contains("enable_sandbox: false"));
         assert!(out.contains("enable_sandbox_extra: keep"));
     }
 
     #[test]
-    fn update_global_field_inserts_missing_field() {
+    fn update_section_field_global_inserts_missing_field() {
         let yaml = "global:\n  default_risk_level: LOW\n";
-        let out = super::update_global_field(yaml, "enable_sandbox", "true");
+        let out = super::update_section_field(yaml, "global", "enable_sandbox", "true");
         assert!(out.contains("enable_sandbox: true"));
         assert!(out.contains("default_risk_level: LOW"));
         // Inserted with the same indent as the existing child.
@@ -936,16 +1015,16 @@ rules: []
     }
 
     #[test]
-    fn update_global_field_creates_global_section_if_absent() {
+    fn update_section_field_global_creates_global_section_if_absent() {
         let yaml = "audit:\n  enabled: true\n";
-        let out = super::update_global_field(yaml, "enable_sandbox", "true");
+        let out = super::update_section_field(yaml, "global", "enable_sandbox", "true");
         assert!(out.contains("global:"));
         assert!(out.contains("enable_sandbox: true"));
         assert!(out.contains("audit:"));
     }
 
     #[test]
-    fn save_policy_globals_round_trips_through_load_policy() {
+    fn save_policy_ui_fields_round_trips_through_load_policy() {
         let dir = tempdir().unwrap();
         let policy_path = dir.path().join("security_policy.yaml");
         fs::write(
@@ -953,12 +1032,13 @@ rules: []
             "# comment\nglobal:\n  enable_sandbox: true\n  default_risk_level: LOW\nrules: []\n",
         )
         .unwrap();
-        super::save_policy_globals(
+        super::save_policy_ui_fields(
             &policy_path,
             &[
                 ("enable_sandbox", "false"),
                 ("default_risk_level", "MEDIUM"),
             ],
+            None,
         )
         .unwrap();
 
@@ -971,27 +1051,27 @@ rules: []
         assert!(on_disk.contains("# comment"));
     }
 
-    /// Verifies the real-world `/etc/aish/security_policy.yaml` layout
+    /// Verifies the shipped `config/security_policy.yaml` layout
     /// (block comments above each field, inline comments on some lines,
     /// multi-language content) survives a `/setting` sync intact.
     #[test]
-    fn save_policy_globals_preserves_production_template_comments() {
+    fn save_policy_ui_fields_preserves_production_template_comments() {
         let dir = tempdir().unwrap();
         let policy_path = dir.path().join("security_policy.yaml");
-        // Mirrors the installed template with CJK comments and inline notes.
+        // Mirrors the shipped English template shape with block + inline comments.
         let template = concat!(
             "# AI-Shell Security Policy\n",
-            "# Installed by `make install`.\n",
+            "# Seeded to ~/.config/aish/security_policy.yaml on first use.\n",
             "\n",
-            "# 全局配置\n",
+            "# Global defaults\n",
             "global:\n",
-            "  # 未命中任何规则时的默认风险\n",
+            "  # Default risk when no rules match\n",
             "  default_risk_level: LOW\n",
             "\n",
-            "  # 是否开启沙箱预跑\n",
+            "  # Sandbox pre-run toggle\n",
             "  enable_sandbox: true\n",
             "\n",
-            "  # 沙箱关闭时的处理动作\n",
+            "  # Action when sandbox is off/unavailable\n",
             "  sandbox_off_action: ALLOW      # ALLOW | CONFIRM | BLOCK\n",
             "  sandbox_timeout_seconds: 10\n",
             "\n",
@@ -1002,7 +1082,7 @@ rules: []
         );
         fs::write(&policy_path, template).unwrap();
 
-        super::save_policy_globals(
+        super::save_policy_ui_fields(
             &policy_path,
             &[
                 ("enable_sandbox", "false"),
@@ -1010,6 +1090,7 @@ rules: []
                 ("sandbox_off_action", "BLOCK"),
                 ("sandbox_timeout_seconds", "15"),
             ],
+            None,
         )
         .unwrap();
 
@@ -1017,10 +1098,10 @@ rules: []
 
         // Block comments preserved.
         assert!(result.contains("# AI-Shell Security Policy"));
-        assert!(result.contains("# 全局配置"));
-        assert!(result.contains("# 未命中任何规则时的默认风险"));
-        assert!(result.contains("# 是否开启沙箱预跑"));
-        assert!(result.contains("# 沙箱关闭时的处理动作"));
+        assert!(result.contains("# Global defaults"));
+        assert!(result.contains("# Default risk when no rules match"));
+        assert!(result.contains("# Sandbox pre-run toggle"));
+        assert!(result.contains("# Action when sandbox is off/unavailable"));
 
         // Values updated.
         assert!(result.contains("enable_sandbox: false"));
@@ -1035,5 +1116,31 @@ rules: []
         // Other sections untouched.
         assert!(result.contains("audit:"));
         assert!(result.contains("rules: []"));
+    }
+
+    #[test]
+    fn save_policy_ui_fields_updates_input_guard_enabled() {
+        let dir = tempdir().unwrap();
+        let policy_path = dir.path().join("security_policy.yaml");
+        fs::write(
+            &policy_path,
+            "global:\n  enable_sandbox: false\n\ninput_guard:\n  enabled: true\nrules: []\n",
+        )
+        .unwrap();
+
+        super::save_policy_ui_fields(
+            &policy_path,
+            &[("enable_sandbox", "true")],
+            Some(false),
+        )
+        .unwrap();
+
+        let policy = load_policy(Some(&policy_path));
+        assert!(policy.enable_sandbox);
+        assert!(!policy.input_guard.enabled);
+
+        let on_disk = fs::read_to_string(&policy_path).unwrap();
+        assert!(on_disk.contains("enable_sandbox: true"));
+        assert!(on_disk.contains("enabled: false"));
     }
 }

--- a/crates/aish-security/src/policy.rs
+++ b/crates/aish-security/src/policy.rs
@@ -727,11 +727,7 @@ mod tests {
         let xdg = dir.path().join("xdg");
         fs::create_dir_all(xdg.join("aish")).unwrap();
         let user_path = xdg.join("aish").join("security_policy.yaml");
-        fs::write(
-            &user_path,
-            "global:\n  enable_sandbox: true\nrules: []\n",
-        )
-        .unwrap();
+        fs::write(&user_path, "global:\n  enable_sandbox: true\nrules: []\n").unwrap();
 
         let _guard = EnvGuard::set("XDG_CONFIG_HOME", Some(xdg.to_str().unwrap()));
         let resolved = resolve_security_policy_path(None);
@@ -775,8 +771,13 @@ mod tests {
         assert!(seeded.contains("id: M-001"));
         assert!(seeded.contains("id: L-001"));
         // Shipped seed is English-only (no CJK comments).
-        let has_cjk = seeded.chars().any(|c| ('\u{4e00}'..='\u{9fff}').contains(&c));
-        assert_eq!(has_cjk, false, "seeded policy must not contain CJK comments");
+        let has_cjk = seeded
+            .chars()
+            .any(|c| ('\u{4e00}'..='\u{9fff}').contains(&c));
+        assert_eq!(
+            has_cjk, false,
+            "seeded policy must not contain CJK comments"
+        );
     }
 
     #[test]
@@ -1128,12 +1129,8 @@ rules: []
         )
         .unwrap();
 
-        super::save_policy_ui_fields(
-            &policy_path,
-            &[("enable_sandbox", "true")],
-            Some(false),
-        )
-        .unwrap();
+        super::save_policy_ui_fields(&policy_path, &[("enable_sandbox", "true")], Some(false))
+            .unwrap();
 
         let policy = load_policy(Some(&policy_path));
         assert!(policy.enable_sandbox);

--- a/crates/aish-security/src/policy.rs
+++ b/crates/aish-security/src/policy.rs
@@ -121,29 +121,32 @@ fn ensure_user_policy_template(path: &Path) {
         let _ = fs::create_dir_all(parent);
     }
 
-    // Write the full template first. Only then create the destination so a
-    // failed seed cannot leave an empty file that suppresses later retries.
+    // Write the complete template to a temp file first, then publish it with a
+    // no-clobber install so concurrent readers never observe a partial dest and
+    // an existing user file is never overwritten.
     let tmp_path = path.with_extension("yaml.seed.tmp");
     if fs::write(&tmp_path, DEFAULT_POLICY_TEMPLATE).is_err() {
         let _ = fs::remove_file(&tmp_path);
         return;
     }
 
-    use std::io::Write;
-    match fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(path)
-    {
-        Ok(mut file) => {
-            if file.write_all(DEFAULT_POLICY_TEMPLATE.as_bytes()).is_err() {
-                drop(file);
-                let _ = fs::remove_file(path);
-            }
-        }
+    match fs::hard_link(&tmp_path, path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
         Err(_) => {
-            // Lost the create_new race, or open failed — leave an existing
-            // user file alone.
+            // Fallback when hard links are unavailable: create_new + full write,
+            // removing the destination if that write fails.
+            use std::io::Write;
+            if let Ok(mut file) = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(path)
+            {
+                if file.write_all(DEFAULT_POLICY_TEMPLATE.as_bytes()).is_err() {
+                    drop(file);
+                    let _ = fs::remove_file(path);
+                }
+            }
         }
     }
     let _ = fs::remove_file(&tmp_path);
@@ -191,10 +194,6 @@ pub fn writable_security_policy_path() -> Option<PathBuf> {
 
 fn mapping_get<'a>(mapping: &'a Mapping, key: &str) -> Option<&'a Value> {
     mapping.get(Value::String(key.to_string()))
-}
-
-fn as_mapping(value: Option<&Value>) -> Option<&Mapping> {
-    value.and_then(Value::as_mapping)
 }
 
 fn ensure_list(value: Option<&Value>) -> Vec<&Value> {
@@ -421,6 +420,8 @@ pub enum PolicyLoadError {
     Read { path: PathBuf, message: String },
     /// Policy file is not valid YAML.
     Parse { path: PathBuf, message: String },
+    /// YAML parsed, but required sections have the wrong shape.
+    Invalid { path: PathBuf, message: String },
 }
 
 impl std::fmt::Display for PolicyLoadError {
@@ -442,6 +443,13 @@ impl std::fmt::Display for PolicyLoadError {
                 write!(
                     f,
                     "invalid security policy YAML {}: {message}",
+                    path.display()
+                )
+            }
+            Self::Invalid { path, message } => {
+                write!(
+                    f,
+                    "invalid security policy structure {}: {message}",
                     path.display()
                 )
             }
@@ -473,10 +481,13 @@ pub fn try_load_policy(config_path: Option<&Path>) -> Result<SecurityPolicy, Pol
         message: e.to_string(),
     })?;
     let data = serde_yaml::from_str::<Value>(&text).map_err(|e| PolicyLoadError::Parse {
-        path: effective_path,
+        path: effective_path.clone(),
         message: e.to_string(),
     })?;
-    Ok(policy_from_value(data))
+    policy_from_value(data).map_err(|message| PolicyLoadError::Invalid {
+        path: effective_path,
+        message,
+    })
 }
 
 /// Load security policy for runtime use. On missing/unreadable/invalid files,
@@ -485,10 +496,25 @@ pub fn load_policy(config_path: Option<&Path>) -> SecurityPolicy {
     try_load_policy(config_path).unwrap_or_else(|_| SecurityPolicy::default())
 }
 
-fn policy_from_value(data: Value) -> SecurityPolicy {
-    let root = data.as_mapping();
-    let global_cfg = root.and_then(|m| as_mapping(mapping_get(m, "global")));
-    let audit_cfg = root.and_then(|m| as_mapping(mapping_get(m, "audit")));
+fn optional_section_mapping<'a>(
+    root: &'a Mapping,
+    key: &str,
+) -> Result<Option<&'a Mapping>, String> {
+    match mapping_get(root, key) {
+        None => Ok(None),
+        Some(value) => value
+            .as_mapping()
+            .map(Some)
+            .ok_or_else(|| format!("`{key}` must be a mapping")),
+    }
+}
+
+fn policy_from_value(data: Value) -> Result<SecurityPolicy, String> {
+    let root = data
+        .as_mapping()
+        .ok_or_else(|| "root document must be a mapping".to_string())?;
+    let global_cfg = optional_section_mapping(root, "global")?;
+    let audit_cfg = optional_section_mapping(root, "audit")?;
 
     let default_risk_level = parse_risk(
         global_cfg.and_then(|m| mapping_get(m, "default_risk_level")),
@@ -532,11 +558,15 @@ fn policy_from_value(data: Value) -> SecurityPolicy {
         false,
     );
 
-    let rule_mappings: Vec<&Mapping> = root
-        .and_then(|m| mapping_get(m, "rules"))
-        .and_then(Value::as_sequence)
-        .map(|seq| seq.iter().filter_map(Value::as_mapping).collect())
-        .unwrap_or_default();
+    let rule_mappings: Vec<&Mapping> = match mapping_get(root, "rules") {
+        None => Vec::new(),
+        Some(value) => {
+            let seq = value
+                .as_sequence()
+                .ok_or_else(|| "`rules` must be a sequence".to_string())?;
+            seq.iter().filter_map(Value::as_mapping).collect()
+        }
+    };
 
     let v2_items: Vec<&Mapping> = rule_mappings
         .into_iter()
@@ -563,36 +593,41 @@ fn policy_from_value(data: Value) -> SecurityPolicy {
     let mut rules = default_rules();
     rules.extend(parse_v2_rules(&valid_items));
 
-    let secret_patterns: Vec<crate::secret::CustomPattern> = root
-        .and_then(|m| mapping_get(m, "secret_patterns"))
-        .and_then(Value::as_sequence)
-        .map(|seq| {
-            seq.iter()
-                .filter_map(|v| {
-                    let yaml_str = serde_yaml::to_string(v).unwrap_or_default();
-                    match serde_yaml::from_value(v.clone()) {
-                        Ok(pattern) => Some(pattern),
-                        Err(e) => {
-                            validation_issues.push(ValidationIssue {
-                                rule_id: None,
-                                field: "secret_patterns".to_string(),
-                                value: Some(yaml_str.trim().to_string()),
-                                message: Some(format!("Invalid custom pattern: {e}")),
-                            });
-                            None
+    let secret_patterns: Vec<crate::secret::CustomPattern> =
+        match mapping_get(root, "secret_patterns") {
+            None => Vec::new(),
+            Some(value) => {
+                let seq = value
+                    .as_sequence()
+                    .ok_or_else(|| "`secret_patterns` must be a sequence".to_string())?;
+                seq.iter()
+                    .filter_map(|v| {
+                        let yaml_str = serde_yaml::to_string(v).unwrap_or_default();
+                        match serde_yaml::from_value(v.clone()) {
+                            Ok(pattern) => Some(pattern),
+                            Err(e) => {
+                                validation_issues.push(ValidationIssue {
+                                    rule_id: None,
+                                    field: "secret_patterns".to_string(),
+                                    value: Some(yaml_str.trim().to_string()),
+                                    message: Some(format!("Invalid custom pattern: {e}")),
+                                });
+                                None
+                            }
                         }
-                    }
-                })
-                .collect()
-        })
-        .unwrap_or_default();
+                    })
+                    .collect()
+            }
+        };
 
-    let input_guard: crate::input_guard::config::InputGuardConfig = root
-        .and_then(|m| mapping_get(m, "input_guard"))
-        .and_then(|v| serde_yaml::from_value(v.clone()).ok())
-        .unwrap_or_default();
+    let input_guard: crate::input_guard::config::InputGuardConfig =
+        match mapping_get(root, "input_guard") {
+            None => crate::input_guard::config::InputGuardConfig::default(),
+            Some(value) => serde_yaml::from_value(value.clone())
+                .map_err(|e| format!("invalid `input_guard`: {e}"))?,
+        };
 
-    SecurityPolicy {
+    Ok(SecurityPolicy {
         enable_sandbox,
         sandbox_off_action,
         sandbox_timeout_seconds,
@@ -605,7 +640,7 @@ fn policy_from_value(data: Value) -> SecurityPolicy {
         validation_issues,
         secret_patterns,
         input_guard,
-    }
+    })
 }
 
 /// Persist `/setting` Security fields in one read/modify/write: `global:`
@@ -899,6 +934,38 @@ mod tests {
         }
         // Runtime loader still falls back instead of panicking.
         let _ = load_policy(Some(&policy_path));
+    }
+
+    #[test]
+    fn try_load_policy_rejects_invalid_global_shape() {
+        let dir = tempdir().unwrap();
+        let policy_path = dir.path().join("security_policy.yaml");
+        // Valid YAML, invalid policy structure: global must be a mapping.
+        fs::write(&policy_path, "global: []\nrules: []\n").unwrap();
+        let err = super::try_load_policy(Some(&policy_path)).expect_err("invalid");
+        match err {
+            super::PolicyLoadError::Invalid { path, message } => {
+                assert_eq!(path, policy_path);
+                assert!(message.contains("`global`"), "{message}");
+            }
+            other => panic!("expected Invalid, got {other:?}"),
+        }
+        let _ = load_policy(Some(&policy_path));
+    }
+
+    #[test]
+    fn try_load_policy_rejects_invalid_input_guard_shape() {
+        let dir = tempdir().unwrap();
+        let policy_path = dir.path().join("security_policy.yaml");
+        fs::write(&policy_path, "global: {}\ninput_guard: []\nrules: []\n").unwrap();
+        let err = super::try_load_policy(Some(&policy_path)).expect_err("invalid");
+        match err {
+            super::PolicyLoadError::Invalid { path, message } => {
+                assert_eq!(path, policy_path);
+                assert!(message.contains("`input_guard`"), "{message}");
+            }
+            other => panic!("expected Invalid, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -5043,7 +5043,8 @@ impl AishShell {
             // Rebuild items every iteration so values refresh after each edit.
             // `last_key` restores the cursor; `last_category` keeps the user on
             // the same chip instead of bouncing back to "All" after each edit.
-            let (cats, items) = Self::build_settings_items(&self.config, self.security_manager.policy());
+            let (cats, items) =
+                Self::build_settings_items(&self.config, self.security_manager.policy());
             let panel = SettingsPanel::new(t("shell.setting.title").to_string(), cats, items)
                 .with_search_placeholder(t("shell.setting.search_placeholder"))
                 .with_footer_idle(t("shell.setting.footer_idle"))
@@ -5107,7 +5108,11 @@ impl AishShell {
                     let def = settings_panel::find(k);
                     let label = setting_label(def);
                     let desc = setting_desc(def);
-                    let cur_raw = crate::settings_panel::raw_value(&self.config, self.security_manager.policy(), k);
+                    let cur_raw = crate::settings_panel::raw_value(
+                        &self.config,
+                        self.security_manager.policy(),
+                        k,
+                    );
                     let secret = matches!(def.kind, SettingKind::Secret);
                     let submitted = prompt_edit_value(&label, &desc, &cur_raw, secret);
                     let skip = secret && submitted.as_deref().is_some_and(|v| v.is_empty());
@@ -5568,7 +5573,8 @@ impl AishShell {
             SettingKind::Choice(o) => o,
             _ => return None,
         };
-        let cur = crate::settings_panel::raw_value(&self.config, self.security_manager.policy(), key);
+        let cur =
+            crate::settings_panel::raw_value(&self.config, self.security_manager.policy(), key);
         let label = setting_label(def);
         let desc = setting_desc(def);
         let options: Vec<DialogOption> = opts
@@ -5739,11 +5745,9 @@ impl AishShell {
             ("sandbox_off_action", policy.sandbox_off_action.as_str()),
             ("sandbox_timeout_seconds", &timeout_str),
         ];
-        if let Err(e) = aish_security::save_policy_ui_fields(
-            &path,
-            updates,
-            Some(policy.input_guard.enabled),
-        ) {
+        if let Err(e) =
+            aish_security::save_policy_ui_fields(&path, updates, Some(policy.input_guard.enabled))
+        {
             eprintln!(
                 "{}",
                 theme::warning(&format!("could not write {}: {e}", path.display()))

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -5603,9 +5603,6 @@ impl AishShell {
             .map(|d| d.key)
     }
 
-    /// Current raw value for a setting. Security keys read from the live
-    /// policy SSOT; everything else from `config.yaml`.
-
     /// Apply `new_val` to `key` and either clear `pending_error` (on success)
     /// or replace it with the localized validation message (on failure).
     /// Centralizing this here guarantees the error shown always reflects the

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -164,37 +164,13 @@ fn setting_desc(def: &crate::settings_panel::SettingDef) -> String {
     t(&format!("shell.setting.k.{}.desc", def.key.name()))
 }
 
-/// Mirror the security-relevant fields of `config.yaml` onto `policy`.
-///
-/// `config.yaml` overrides `security_policy.yaml` for the globals the
-/// `/setting` panel exposes (`enable_sandbox`, `default_risk_level`,
-/// `sandbox_off_action`, `sandbox_timeout_seconds`, and the InputGuard
-/// master switch). Centralized here so the startup path and the live
-/// `/setting` update path cannot drift.
-fn apply_config_security_overrides(
-    policy: &mut aish_security::SecurityPolicy,
-    config: &ConfigModel,
-) {
-    use aish_security::decision::{RiskLevel, SandboxOffAction};
-    policy.input_guard.enabled = config.input_guard_enabled;
-    policy.enable_sandbox = config.enable_sandbox;
-    policy.default_risk_level = match config.default_risk_level.to_lowercase().as_str() {
-        "medium" => RiskLevel::Medium,
-        "high" => RiskLevel::High,
-        _ => RiskLevel::Low,
-    };
-    policy.sandbox_off_action = match config.sandbox_off_action.to_lowercase().as_str() {
-        "confirm" => SandboxOffAction::Confirm,
-        "block" => SandboxOffAction::Block,
-        _ => SandboxOffAction::Allow,
-    };
-    policy.sandbox_timeout_seconds = config.sandbox_timeout_seconds;
-}
-
 /// Human-readable current value for the setting-list row.
-fn setting_display_current(cfg: &ConfigModel, def: &crate::settings_panel::SettingDef) -> String {
-    use crate::settings_panel::{current_raw, SettingKey, SettingKind};
-    let raw = current_raw(cfg, def.key);
+fn setting_display_current(
+    cfg: &ConfigModel,
+    def: &crate::settings_panel::SettingDef,
+    raw: &str,
+) -> String {
+    use crate::settings_panel::{SettingKey, SettingKind};
     match def.kind {
         SettingKind::Bool => {
             let label = if raw == "true" {
@@ -257,7 +233,7 @@ fn setting_display_current(cfg: &ConfigModel, def: &crate::settings_panel::Setti
             if raw.is_empty() {
                 t("shell.setting.not_set")
             } else {
-                raw
+                raw.to_string()
             }
         }
     }
@@ -527,6 +503,8 @@ pub struct AishShell {
     pub config: ConfigModel,
     pub ai_handler: AiHandler,
     pub security_manager: SecurityManager,
+    /// Shared with BashTool so preflight sees `/setting` live policy updates.
+    policy_slot: aish_tools::bash::PolicySlot,
     input_guard: aish_security::input_guard::InputGuard,
     secret_check_closure:
         std::sync::Arc<dyn Fn(&str) -> Option<aish_pty::SshSecretCheckResult> + Send + Sync>,
@@ -857,15 +835,16 @@ impl AishShell {
             }
         }
 
-        // Initialize security manager (before tool registration)
-        let mut policy = load_policy(None);
-        // config.yaml mirrors several security_policy.yaml fields and takes
-        // precedence, so users can toggle them from the familiar config file
-        // (and via /setting) without editing security_policy.yaml.
-        apply_config_security_overrides(&mut policy, &config);
-        let security_manager = SecurityManager::new(policy);
+        // Initialize security manager (before tool registration).
+        // security_policy.yaml is the sole authority for security globals.
+        let policy = load_policy(None);
+        let security_manager = SecurityManager::new(policy.clone());
         let input_guard =
             aish_security::input_guard::InputGuard::from_policy(security_manager.policy());
+        // Live policy slot shared with BashTool preflight (same effective values
+        // as SecurityManager; updated again on `/setting` Security edits).
+        let policy_slot: aish_tools::bash::PolicySlot =
+            std::sync::Arc::new(std::sync::Mutex::new(Some(policy)));
 
         // Register tools
         let mut tool_registry = ToolRegistry::new();
@@ -874,6 +853,7 @@ impl AishShell {
         let mut bash_tool = aish_tools::bash::BashTool::new();
         bash_tool.set_cancellation_token(llm_session.cancellation_token_arc());
         bash_tool.set_pty_slot(pty_slot.clone());
+        bash_tool.set_policy_slot(policy_slot.clone());
 
         // Shared secret vault slot — populated after AishShell construction.
         let vault_slot: aish_tools::bash::VaultSlot =
@@ -1998,6 +1978,7 @@ impl AishShell {
             config,
             ai_handler,
             security_manager,
+            policy_slot,
             input_guard,
             secret_check_closure,
             secret_vault,
@@ -5062,7 +5043,7 @@ impl AishShell {
             // Rebuild items every iteration so values refresh after each edit.
             // `last_key` restores the cursor; `last_category` keeps the user on
             // the same chip instead of bouncing back to "All" after each edit.
-            let (cats, items) = Self::build_settings_items(&self.config);
+            let (cats, items) = Self::build_settings_items(&self.config, self.security_manager.policy());
             let panel = SettingsPanel::new(t("shell.setting.title").to_string(), cats, items)
                 .with_search_placeholder(t("shell.setting.search_placeholder"))
                 .with_footer_idle(t("shell.setting.footer_idle"))
@@ -5126,7 +5107,7 @@ impl AishShell {
                     let def = settings_panel::find(k);
                     let label = setting_label(def);
                     let desc = setting_desc(def);
-                    let cur_raw = settings_panel::current_raw(&self.config, k);
+                    let cur_raw = crate::settings_panel::raw_value(&self.config, self.security_manager.policy(), k);
                     let secret = matches!(def.kind, SettingKind::Secret);
                     let submitted = prompt_edit_value(&label, &desc, &cur_raw, secret);
                     let skip = secret && submitted.as_deref().is_some_and(|v| v.is_empty());
@@ -5587,7 +5568,7 @@ impl AishShell {
             SettingKind::Choice(o) => o,
             _ => return None,
         };
-        let cur = settings_panel::current_raw(&self.config, key);
+        let cur = crate::settings_panel::raw_value(&self.config, self.security_manager.policy(), key);
         let label = setting_label(def);
         let desc = setting_desc(def);
         let options: Vec<DialogOption> = opts
@@ -5615,6 +5596,9 @@ impl AishShell {
             .find(|d| d.key.name() == name)
             .map(|d| d.key)
     }
+
+    /// Current raw value for a setting. Security keys read from the live
+    /// policy SSOT; everything else from `config.yaml`.
 
     /// Apply `new_val` to `key` and either clear `pending_error` (on success)
     /// or replace it with the localized validation message (on failure).
@@ -5649,60 +5633,52 @@ impl AishShell {
     ) -> Result<(), String> {
         use crate::settings_panel::{self, LiveEffect, SettingKind};
 
-        // Validate against a clone so a bad value can't partially mutate
-        // the live config; only commit on success.
-        let mut trial = self.config.clone();
-        settings_panel::apply(&mut trial, key, new_val)?;
-        self.config = trial;
+        if settings_panel::is_security_setting(key) {
+            // Security SSOT is security_policy.yaml — never write these to
+            // config.yaml. Validate on a policy clone, then commit live.
+            let mut trial = self.security_manager.policy().clone();
+            settings_panel::apply_security(&mut trial, key, new_val)?;
+            self.security_manager.set_policy(trial.clone());
+            aish_tools::bash::BashTool::publish_live_policy(&self.policy_slot, trial);
+            self.input_guard
+                .set_enabled(self.security_manager.policy().input_guard.enabled);
+            self.sync_security_policy_file();
+        } else {
+            // Validate against a clone so a bad value can't partially mutate
+            // the live config; only commit on success.
+            let mut trial = self.config.clone();
+            settings_panel::apply(&mut trial, key, new_val)?;
+            self.config = trial;
 
-        // Persist to disk.
-        let config_path = aish_config::ConfigLoader::default_config_path();
-        if let Err(e) = aish_config::ConfigLoader::save(&self.config, &config_path) {
-            eprintln!(
-                "{}",
-                theme::warning(&{
-                    let mut a = std::collections::HashMap::new();
-                    a.insert("error".to_string(), e.to_string());
-                    t_with_args("shell.config_save_warning", &a)
-                })
-            );
-        }
-
-        // Live side-effects so the change is felt without restart.
-        match settings_panel::live_effect(key) {
-            LiveEffect::ModelSession => {
-                self.ai_handler.update_model(
-                    &self.config.model,
-                    Some(&self.config.api_base),
-                    Some(&self.config.api_key),
+            // Persist to disk.
+            let config_path = aish_config::ConfigLoader::default_config_path();
+            if let Err(e) = aish_config::ConfigLoader::save(&self.config, &config_path) {
+                eprintln!(
+                    "{}",
+                    theme::warning(&{
+                        let mut a = std::collections::HashMap::new();
+                        a.insert("error".to_string(), e.to_string());
+                        t_with_args("shell.config_save_warning", &a)
+                    })
                 );
-                if let Some(ai) = &self.inline_ai {
-                    ai.update_model(&self.config.model);
-                }
-                self.refresh_config_dependent_tools();
             }
-            LiveEffect::ToolsRefresh => self.refresh_config_dependent_tools(),
-            LiveEffect::InputGuard => {
-                self.input_guard
-                    .set_enabled(self.config.input_guard_enabled);
-            }
-            LiveEffect::SecurityPolicy => {
-                // Re-apply the security globals mirrored from config.yaml to
-                // the running SecurityManager so changes take effect now,
-                // not on next launch. `set_policy` rebuilds the sandbox
-                // runner when `enable_sandbox` flips.
-                let mut policy = self.security_manager.policy().clone();
-                apply_config_security_overrides(&mut policy, &self.config);
-                self.security_manager.set_policy(policy);
 
-                // Also persist to security_policy.yaml (the file users
-                // consider authoritative) so the change is visible there and
-                // survives a restart. Writes to the resolved policy path;
-                // a permission failure is logged but does not revert the
-                // live update.
-                self.sync_security_policy_file();
+            // Live side-effects so the change is felt without restart.
+            match settings_panel::live_effect(key) {
+                LiveEffect::ModelSession => {
+                    self.ai_handler.update_model(
+                        &self.config.model,
+                        Some(&self.config.api_base),
+                        Some(&self.config.api_key),
+                    );
+                    if let Some(ai) = &self.inline_ai {
+                        ai.update_model(&self.config.model);
+                    }
+                    self.refresh_config_dependent_tools();
+                }
+                LiveEffect::ToolsRefresh => self.refresh_config_dependent_tools(),
+                LiveEffect::None => {}
             }
-            LiveEffect::None => {}
         }
 
         // Confirmation line below the panel.
@@ -5740,40 +5716,34 @@ impl AishShell {
         Ok(())
     }
 
-    /// Persist the current security globals to the resolved
-    /// `security_policy.yaml` so `/setting` changes are visible in the file
-    /// users consider authoritative and survive a restart. A write failure
-    /// (e.g. root-owned system policy) is logged but does not revert the
-    /// live update or block the `/setting` flow.
+    /// Persist the live SecurityManager globals to
+    /// `~/.config/aish/security_policy.yaml` (SSOT for `/setting`). Missing
+    /// files are seeded from the shipped template. A write failure is logged
+    /// but does not revert the live update.
     fn sync_security_policy_file(&self) {
-        let Some(path) = aish_security::resolve_security_policy_path(None) else {
+        let Some(path) = aish_security::writable_security_policy_path() else {
             return;
         };
-        let risk = match self.config.default_risk_level.to_lowercase().as_str() {
-            "medium" => "MEDIUM",
-            "high" => "HIGH",
-            _ => "LOW",
-        };
-        let action = match self.config.sandbox_off_action.to_lowercase().as_str() {
-            "confirm" => "CONFIRM",
-            "block" => "BLOCK",
-            _ => "ALLOW",
-        };
-        let timeout_str = self.config.sandbox_timeout_seconds.to_string();
+        let policy = self.security_manager.policy();
+        let timeout_str = policy.sandbox_timeout_seconds.to_string();
         let updates: &[(&str, &str)] = &[
             (
                 "enable_sandbox",
-                if self.config.enable_sandbox {
+                if policy.enable_sandbox {
                     "true"
                 } else {
                     "false"
                 },
             ),
-            ("default_risk_level", risk),
-            ("sandbox_off_action", action),
+            ("default_risk_level", policy.default_risk_level.as_str()),
+            ("sandbox_off_action", policy.sandbox_off_action.as_str()),
             ("sandbox_timeout_seconds", &timeout_str),
         ];
-        if let Err(e) = aish_security::save_policy_globals(&path, updates) {
+        if let Err(e) = aish_security::save_policy_ui_fields(
+            &path,
+            updates,
+            Some(policy.input_guard.enabled),
+        ) {
             eprintln!(
                 "{}",
                 theme::warning(&format!("could not write {}: {e}", path.display()))
@@ -5785,6 +5755,7 @@ impl AishShell {
     /// easy to test and avoids borrow conflicts against `self`.
     fn build_settings_items(
         config: &ConfigModel,
+        policy: &aish_security::SecurityPolicy,
     ) -> (
         Vec<aish_ui::SettingsCategoryInfo>,
         Vec<aish_ui::SettingsItem>,
@@ -5811,8 +5782,8 @@ impl AishShell {
         let items: Vec<SettingsItem> = SETTINGS
             .iter()
             .map(|def| {
-                let cur_raw = settings_panel::current_raw(config, def.key);
-                let display = setting_display_current(config, def);
+                let cur_raw = settings_panel::raw_value(config, policy, def.key);
+                let display = setting_display_current(config, def, &cur_raw);
                 let (kind, options) = match def.kind {
                     SettingKind::Bool => (SettingsValueKind::Bool, Vec::new()),
                     SettingKind::Choice(opts) => (
@@ -6081,7 +6052,7 @@ impl AishShell {
                 Some(self.secret_check_closure.clone()),
                 Some(self.secret_vault.clone()),
                 on_output,
-                self.config.input_guard_enabled,
+                self.input_guard.enabled(),
                 self.config.enable_remote_git_prompt,
                 self.config.remote_rich_prompt,
                 self.config.remote_danger_patterns.clone(),
@@ -6469,7 +6440,7 @@ impl AishShell {
                 None,
                 None,
                 None,
-                self.config.input_guard_enabled,
+                self.input_guard.enabled(),
                 false, // not an SSH session, no git prompt injection
                 self.config.remote_rich_prompt,
                 self.config.remote_danger_patterns.clone(),

--- a/crates/aish-shell/src/doctor/config.rs
+++ b/crates/aish-shell/src/doctor/config.rs
@@ -50,12 +50,16 @@ impl ConfigChecker {
             );
         }
 
-        if !config.enable_sandbox && config.sandbox_off_action != "allow" {
+        // Sandbox globals live in security_policy.yaml (not config.yaml).
+        let policy = aish_security::load_policy(None);
+        if !policy.enable_sandbox
+            && policy.sandbox_off_action != aish_security::SandboxOffAction::Allow
+        {
             items.push(CheckItem::warn(
                 "sandbox_config",
                 format!(
-                    "Sandbox disabled but sandbox_off_action is '{}' (expected 'allow')",
-                    config.sandbox_off_action
+                    "Sandbox disabled but sandbox_off_action is '{}' (expected 'ALLOW')",
+                    policy.sandbox_off_action
                 ),
             ));
         }

--- a/crates/aish-shell/src/doctor/config.rs
+++ b/crates/aish-shell/src/doctor/config.rs
@@ -51,17 +51,31 @@ impl ConfigChecker {
         }
 
         // Sandbox globals live in security_policy.yaml (not config.yaml).
-        let policy = aish_security::load_policy(None);
-        if !policy.enable_sandbox
-            && policy.sandbox_off_action != aish_security::SandboxOffAction::Allow
-        {
-            items.push(CheckItem::warn(
-                "sandbox_config",
-                format!(
-                    "Sandbox disabled but sandbox_off_action is '{}' (expected 'ALLOW')",
-                    policy.sandbox_off_action
-                ),
-            ));
+        // Use the fallible loader so a missing/broken policy is visible instead
+        // of silently evaluating SecurityPolicy::default().
+        match aish_security::try_load_policy(None) {
+            Ok(policy) => {
+                items.push(CheckItem::pass(
+                    "security_policy",
+                    "security_policy.yaml loaded",
+                ));
+                if !policy.enable_sandbox
+                    && policy.sandbox_off_action != aish_security::SandboxOffAction::Allow
+                {
+                    items.push(CheckItem::warn(
+                        "sandbox_config",
+                        format!(
+                            "Sandbox disabled but sandbox_off_action is '{}' (expected 'ALLOW')",
+                            policy.sandbox_off_action
+                        ),
+                    ));
+                }
+            }
+            Err(e) => {
+                items.push(CheckItem::fail("security_policy", e.to_string()).hint(
+                    "Fix or recreate ~/.config/aish/security_policy.yaml (or delete it to reseed)",
+                ));
+            }
         }
 
         items

--- a/crates/aish-shell/src/settings_panel.rs
+++ b/crates/aish-shell/src/settings_panel.rs
@@ -624,7 +624,9 @@ pub fn security_current_raw(policy: &SecurityPolicy, key: SettingKey) -> String 
         SettingKey::InputGuardEnabled => bool_str(policy.input_guard.enabled),
         SettingKey::EnableSandbox => bool_str(policy.enable_sandbox),
         SettingKey::DefaultRiskLevel => risk_level_raw(policy.default_risk_level).to_string(),
-        SettingKey::SandboxOffAction => sandbox_off_action_raw(policy.sandbox_off_action).to_string(),
+        SettingKey::SandboxOffAction => {
+            sandbox_off_action_raw(policy.sandbox_off_action).to_string()
+        }
         SettingKey::SandboxTimeout => format!("{}", policy.sandbox_timeout_seconds),
         _ => unreachable!("non-security key rejected above"),
     };

--- a/crates/aish-shell/src/settings_panel.rs
+++ b/crates/aish-shell/src/settings_panel.rs
@@ -10,6 +10,7 @@
 //! this module is intentionally free of terminal I/O so it stays unit-testable.
 
 use aish_config::ConfigModel;
+use aish_security::{RiskLevel, SandboxOffAction, SecurityPolicy};
 
 // ---------------------------------------------------------------------------
 // Live-effect signal
@@ -20,19 +21,12 @@ use aish_config::ConfigModel;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LiveEffect {
     /// No live action needed; the field is read on demand from `self.config`.
+    /// Security keys also map here — they are applied via the dedicated
+    /// `is_security_setting` path in `app.rs`, not through this enum.
     None,
     /// Rebuild the model-dependent tools (WebFetch) — e.g. after temperature or
     /// `max_tokens` changes.
     ToolsRefresh,
-    /// Toggle the cached InputGuard's enabled flag — after
-    /// `input_guard_enabled` changes, so `screen_input()` honors it without a
-    /// restart.
-    InputGuard,
-    /// Re-apply the mirrored security globals (`enable_sandbox`,
-    /// `default_risk_level`, `sandbox_off_action`, `sandbox_timeout_seconds`)
-    /// to the live `SecurityManager` via `set_policy`, so sandbox pre-runs and
-    /// risk gating honor the new values without a restart.
-    SecurityPolicy,
     /// Re-initialize the whole LLM session + tools + inline completer — needed
     /// when `model` / `api_base` / `api_key` change.
     ModelSession,
@@ -550,20 +544,131 @@ pub fn find(key: SettingKey) -> &'static SettingDef {
         .expect("SettingKey is exhaustive over SETTINGS")
 }
 
-/// The factory-default raw value for `key`, derived from `ConfigModel::default()`.
+/// The factory-default raw value for `key`.
 ///
-/// Deriving (rather than hand-mirroring the defaults) eliminates drift: if a
-/// default changes in `aish-config`, this function tracks it automatically.
-/// Used to mark a row as "changed" (current != default) and to power the
-/// reset-to-default action.
+/// Security keys derive from `SecurityPolicy::default()` (policy SSOT);
+/// everything else from `ConfigModel::default()`.
 pub fn default_raw_of(key: SettingKey) -> String {
-    let cfg = ConfigModel::default();
-    current_raw(&cfg, key)
+    raw_value(&ConfigModel::default(), &SecurityPolicy::default(), key)
 }
 
 /// Whether the current raw value differs from the factory default.
 pub fn is_changed(key: SettingKey, current_raw: &str) -> bool {
     current_raw != default_raw_of(key)
+}
+
+// ---------------------------------------------------------------------------
+// Security settings (security_policy.yaml SSOT)
+// ---------------------------------------------------------------------------
+
+/// Security category keys live in `security_policy.yaml`, not `config.yaml`.
+pub fn is_security_setting(key: SettingKey) -> bool {
+    matches!(
+        key,
+        SettingKey::InputGuardEnabled
+            | SettingKey::EnableSandbox
+            | SettingKey::DefaultRiskLevel
+            | SettingKey::SandboxOffAction
+            | SettingKey::SandboxTimeout
+    )
+}
+
+/// Read the current raw value from the correct SSOT (`SecurityPolicy` or
+/// `ConfigModel`).
+pub fn raw_value(cfg: &ConfigModel, policy: &SecurityPolicy, key: SettingKey) -> String {
+    if is_security_setting(key) {
+        security_current_raw(policy, key)
+    } else {
+        current_raw(cfg, key)
+    }
+}
+
+/// Read a Security setting from the live policy.
+fn risk_level_raw(level: RiskLevel) -> &'static str {
+    match level {
+        RiskLevel::Low => "low",
+        RiskLevel::Medium => "medium",
+        RiskLevel::High => "high",
+    }
+}
+
+fn sandbox_off_action_raw(action: SandboxOffAction) -> &'static str {
+    match action {
+        SandboxOffAction::Allow => "allow",
+        SandboxOffAction::Confirm => "confirm",
+        SandboxOffAction::Block => "block",
+    }
+}
+
+fn parse_risk_level(value: &str) -> RiskLevel {
+    match value {
+        "medium" => RiskLevel::Medium,
+        "high" => RiskLevel::High,
+        _ => RiskLevel::Low,
+    }
+}
+
+fn parse_sandbox_off_action(value: &str) -> SandboxOffAction {
+    match value {
+        "confirm" => SandboxOffAction::Confirm,
+        "block" => SandboxOffAction::Block,
+        _ => SandboxOffAction::Allow,
+    }
+}
+
+pub fn security_current_raw(policy: &SecurityPolicy, key: SettingKey) -> String {
+    if !is_security_setting(key) {
+        panic!("security_current_raw called with non-security key {key:?}");
+    }
+    let raw = match key {
+        SettingKey::InputGuardEnabled => bool_str(policy.input_guard.enabled),
+        SettingKey::EnableSandbox => bool_str(policy.enable_sandbox),
+        SettingKey::DefaultRiskLevel => risk_level_raw(policy.default_risk_level).to_string(),
+        SettingKey::SandboxOffAction => sandbox_off_action_raw(policy.sandbox_off_action).to_string(),
+        SettingKey::SandboxTimeout => format!("{}", policy.sandbox_timeout_seconds),
+        _ => unreachable!("non-security key rejected above"),
+    };
+    if let SettingKind::Choice(options) = find(key).kind {
+        if let Some(canonical) = options.iter().find(|o| o.eq_ignore_ascii_case(&raw)) {
+            return (*canonical).to_string();
+        }
+    }
+    raw
+}
+
+/// Apply a validated Security setting onto a policy in memory.
+pub fn apply_security(
+    policy: &mut SecurityPolicy,
+    key: SettingKey,
+    value: &str,
+) -> Result<(), String> {
+    if !is_security_setting(key) {
+        return Err(format!("not a security setting: {key:?}"));
+    }
+    if let SettingKind::Choice(options) = find(key).kind {
+        if !options.contains(&value) {
+            return Err(format!("expected one of {:?}, got `{value}`", options));
+        }
+    }
+    match key {
+        SettingKey::InputGuardEnabled => {
+            policy.input_guard.enabled = parse_bool(value)?;
+        }
+        SettingKey::EnableSandbox => {
+            policy.enable_sandbox = parse_bool(value)?;
+        }
+        SettingKey::DefaultRiskLevel => {
+            policy.default_risk_level = parse_risk_level(value);
+        }
+        SettingKey::SandboxOffAction => {
+            policy.sandbox_off_action = parse_sandbox_off_action(value);
+        }
+        SettingKey::SandboxTimeout => {
+            policy.sandbox_timeout_seconds = parse_f64(value, 1.0..=300.0)?;
+        }
+        _ => unreachable!("non-security key rejected above"),
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -592,11 +697,13 @@ pub fn current_raw(cfg: &ConfigModel, key: SettingKey) -> String {
         SettingKey::InlineEnforceJson => bool_str(cfg.inline_completion.enforce_json),
         SettingKey::MaxLlmMessages => cfg.max_llm_messages.to_string(),
         SettingKey::EnableTokenEstimation => bool_str(cfg.enable_token_estimation),
-        SettingKey::InputGuardEnabled => bool_str(cfg.input_guard_enabled),
-        SettingKey::EnableSandbox => bool_str(cfg.enable_sandbox),
-        SettingKey::DefaultRiskLevel => cfg.default_risk_level.clone(),
-        SettingKey::SandboxOffAction => cfg.sandbox_off_action.clone(),
-        SettingKey::SandboxTimeout => format!("{}", cfg.sandbox_timeout_seconds),
+        SettingKey::InputGuardEnabled
+        | SettingKey::EnableSandbox
+        | SettingKey::DefaultRiskLevel
+        | SettingKey::SandboxOffAction
+        | SettingKey::SandboxTimeout => {
+            panic!("security setting {key:?} must use security_current_raw")
+        }
         SettingKey::MemoryAutoRecall => cfg
             .memory
             .as_ref()
@@ -728,11 +835,13 @@ pub fn apply(cfg: &mut ConfigModel, key: SettingKey, value: &str) -> Result<(), 
         }
         SettingKey::MaxLlmMessages => cfg.max_llm_messages = parse_usize(value)?,
         SettingKey::EnableTokenEstimation => cfg.enable_token_estimation = parse_bool(value)?,
-        SettingKey::InputGuardEnabled => cfg.input_guard_enabled = parse_bool(value)?,
-        SettingKey::EnableSandbox => cfg.enable_sandbox = parse_bool(value)?,
-        SettingKey::DefaultRiskLevel => cfg.default_risk_level = value.to_string(),
-        SettingKey::SandboxOffAction => cfg.sandbox_off_action = value.to_string(),
-        SettingKey::SandboxTimeout => cfg.sandbox_timeout_seconds = parse_f64(value, 1.0..=300.0)?,
+        SettingKey::InputGuardEnabled
+        | SettingKey::EnableSandbox
+        | SettingKey::DefaultRiskLevel
+        | SettingKey::SandboxOffAction
+        | SettingKey::SandboxTimeout => {
+            panic!("security setting {key:?} must use apply_security")
+        }
         SettingKey::MemoryAutoRecall => {
             ensure_memory(cfg).auto_recall = parse_bool(value)?;
         }
@@ -810,33 +919,26 @@ pub fn live_effect(key: SettingKey) -> LiveEffect {
     match key {
         SettingKey::Model | SettingKey::ApiBase | SettingKey::ApiKey => LiveEffect::ModelSession,
         SettingKey::Temperature | SettingKey::MaxTokens => LiveEffect::ToolsRefresh,
-        SettingKey::InputGuardEnabled => LiveEffect::InputGuard,
-        SettingKey::EnableSandbox
-        | SettingKey::DefaultRiskLevel
-        | SettingKey::SandboxOffAction
-        | SettingKey::SandboxTimeout => LiveEffect::SecurityPolicy,
+        // Security keys are applied via `is_security_setting` in app.rs.
         _ => LiveEffect::None,
     }
 }
 
 /// Whether the running session must be restarted for `key`'s new value to take
 /// effect. The model/credential fields are applied live via `update_model`,
-/// temperature/max_tokens rebuild tools live, `input_guard_enabled` toggles the
-/// cached InputGuard live, the security globals (`enable_sandbox`, etc.) are
-/// pushed into the running `SecurityManager`, and `prompt_style` is read from
+/// temperature/max_tokens rebuild tools live, Security settings are pushed into
+/// the running `SecurityManager` + InputGuard, and `prompt_style` is read from
 /// `self.config` on each render — everything else is consumed only at startup.
 pub fn requires_restart(key: SettingKey) -> bool {
+    if is_security_setting(key) {
+        return false;
+    }
     match key {
         SettingKey::Model
         | SettingKey::ApiBase
         | SettingKey::ApiKey
         | SettingKey::Temperature
         | SettingKey::MaxTokens
-        | SettingKey::InputGuardEnabled
-        | SettingKey::EnableSandbox
-        | SettingKey::DefaultRiskLevel
-        | SettingKey::SandboxOffAction
-        | SettingKey::SandboxTimeout
         | SettingKey::PromptStyle => false,
         // SkillAutoSearch is read once at AiHandler construction, so a change
         // only takes effect after restart (live toggling silently failed
@@ -1011,26 +1113,51 @@ mod tests {
 
     #[test]
     fn choice_current_value_is_case_normalized() {
-        // A stored uppercase value (e.g. merged from security_policy.yaml)
-        // must display as the canonical lowercase option so the "current"
-        // marker and list value line up.
+        // Security enums always render as canonical lowercase options.
+        let mut policy = SecurityPolicy::default();
+        policy.default_risk_level = RiskLevel::Low;
+        assert_eq!(
+            security_current_raw(&policy, SettingKey::DefaultRiskLevel),
+            "low"
+        );
         let mut cfg = default_cfg();
-        cfg.default_risk_level = "LOW".into();
-        assert_eq!(current_raw(&cfg, SettingKey::DefaultRiskLevel), "low");
         cfg.log_level = "DEBUG".into();
         assert_eq!(current_raw(&cfg, SettingKey::LogLevel), "debug");
         // A value outside the option set is passed through unchanged.
-        cfg.sandbox_off_action = "weird".into();
-        assert_eq!(current_raw(&cfg, SettingKey::SandboxOffAction), "weird");
+        cfg.log_level = "weird".into();
+        assert_eq!(current_raw(&cfg, SettingKey::LogLevel), "weird");
+    }
+
+    #[test]
+    fn security_sandbox_roundtrip_uses_policy_not_config() {
+        let mut policy = SecurityPolicy::default();
+        assert_eq!(
+            security_current_raw(&policy, SettingKey::EnableSandbox),
+            "false"
+        );
+        apply_security(&mut policy, SettingKey::EnableSandbox, "on").unwrap();
+        assert!(policy.enable_sandbox);
+        apply_security(&mut policy, SettingKey::SandboxOffAction, "block").unwrap();
+        assert_eq!(policy.sandbox_off_action, SandboxOffAction::Block);
+        assert_eq!(
+            security_current_raw(&policy, SettingKey::SandboxOffAction),
+            "block"
+        );
     }
 
     #[test]
     fn roundtrip_bool_toggle() {
-        let mut cfg = default_cfg();
-        assert_eq!(current_raw(&cfg, SettingKey::InputGuardEnabled), "true");
-        apply(&mut cfg, SettingKey::InputGuardEnabled, "off").unwrap();
-        assert!(!cfg.input_guard_enabled);
-        assert_eq!(current_raw(&cfg, SettingKey::InputGuardEnabled), "false");
+        let mut policy = SecurityPolicy::default();
+        assert_eq!(
+            security_current_raw(&policy, SettingKey::InputGuardEnabled),
+            "true"
+        );
+        apply_security(&mut policy, SettingKey::InputGuardEnabled, "off").unwrap();
+        assert!(!policy.input_guard.enabled);
+        assert_eq!(
+            security_current_raw(&policy, SettingKey::InputGuardEnabled),
+            "false"
+        );
     }
 
     #[test]
@@ -1047,12 +1174,13 @@ mod tests {
         // mis-grade security risk.
         let mut cfg = default_cfg();
         assert!(apply(&mut cfg, SettingKey::LogLevel, "warb").is_err());
-        assert!(apply(&mut cfg, SettingKey::DefaultRiskLevel, "banana").is_err());
+        let mut policy = SecurityPolicy::default();
+        assert!(apply_security(&mut policy, SettingKey::DefaultRiskLevel, "banana").is_err());
         // Valid values pass through.
         apply(&mut cfg, SettingKey::LogLevel, "debug").unwrap();
         assert_eq!(cfg.log_level, "debug");
-        apply(&mut cfg, SettingKey::DefaultRiskLevel, "high").unwrap();
-        assert_eq!(cfg.default_risk_level, "high");
+        apply_security(&mut policy, SettingKey::DefaultRiskLevel, "high").unwrap();
+        assert_eq!(policy.default_risk_level, RiskLevel::High);
     }
 
     #[test]
@@ -1102,42 +1230,26 @@ mod tests {
     fn model_fields_signal_session_refresh() {
         assert_eq!(live_effect(SettingKey::Model), LiveEffect::ModelSession);
         assert_eq!(live_effect(SettingKey::ApiKey), LiveEffect::ModelSession);
-        assert_eq!(
-            live_effect(SettingKey::InputGuardEnabled),
-            LiveEffect::InputGuard
-        );
-        assert_eq!(
-            live_effect(SettingKey::EnableSandbox),
-            LiveEffect::SecurityPolicy
-        );
-        assert_eq!(
-            live_effect(SettingKey::DefaultRiskLevel),
-            LiveEffect::SecurityPolicy
-        );
-        assert_eq!(
-            live_effect(SettingKey::SandboxOffAction),
-            LiveEffect::SecurityPolicy
-        );
-        assert_eq!(
-            live_effect(SettingKey::SandboxTimeout),
-            LiveEffect::SecurityPolicy
-        );
+        // Security keys are handled outside LiveEffect.
+        assert_eq!(live_effect(SettingKey::InputGuardEnabled), LiveEffect::None);
+        assert_eq!(live_effect(SettingKey::EnableSandbox), LiveEffect::None);
+        assert_eq!(live_effect(SettingKey::DefaultRiskLevel), LiveEffect::None);
+        assert_eq!(live_effect(SettingKey::SandboxOffAction), LiveEffect::None);
+        assert_eq!(live_effect(SettingKey::SandboxTimeout), LiveEffect::None);
     }
 
-    /// Regression: `default_raw_of` must match `current_raw(ConfigModel::default())`
-    /// for every key. Previously `default_raw_of(RemoteDangerPatterns)` was
-    /// hand-mirrored to `""`, which (a) flagged every fresh install as changed
-    /// and (b) made Ctrl+R reset silently wipe the production-safety patterns.
-    /// Deriving from `ConfigModel::default()` makes drift impossible.
+    /// Regression: `default_raw_of` must track factory defaults. Security keys
+    /// come from `SecurityPolicy::default()`; the rest from `ConfigModel`.
     #[test]
-    fn default_raw_of_matches_configmodel_default_for_all_keys() {
+    fn default_raw_of_matches_factory_defaults_for_all_keys() {
         let cfg = ConfigModel::default();
+        let policy = SecurityPolicy::default();
         for def in SETTINGS {
-            let expected = current_raw(&cfg, def.key);
+            let expected = raw_value(&cfg, &policy, def.key);
             let actual = default_raw_of(def.key);
             assert_eq!(
                 actual, expected,
-                "default_raw_of({:?}) drifts from ConfigModel::default()",
+                "default_raw_of({:?}) drifts from factory default",
                 def.key
             );
         }

--- a/crates/aish-tools/src/bash/bash.rs
+++ b/crates/aish-tools/src/bash/bash.rs
@@ -144,12 +144,7 @@ fn security_preflight_with_socket(
     config_path: Option<&Path>,
     sandbox_socket_path: Option<&Path>,
 ) -> PreflightResult {
-    security_preflight_with_policy(
-        command,
-        cwd,
-        load_policy(config_path),
-        sandbox_socket_path,
-    )
+    security_preflight_with_policy(command, cwd, load_policy(config_path), sandbox_socket_path)
 }
 
 fn security_preflight_with_policy(

--- a/crates/aish-tools/src/bash/bash.rs
+++ b/crates/aish-tools/src/bash/bash.rs
@@ -10,7 +10,8 @@ use aish_llm::{
 };
 use aish_pty::{BashOffloadSettings, BashOutputOffload, CancelToken, PtyExecutor};
 use aish_security::{
-    load_policy, secret::SecretVault, SecurityDecision, SecurityManager, SecurityRequest,
+    load_policy, secret::SecretVault, SecurityDecision, SecurityManager, SecurityPolicy,
+    SecurityRequest,
 };
 
 use super::prompt;
@@ -99,6 +100,10 @@ impl Drop for InteractiveInputGuard {
 /// Shared vault slot for secret placeholder restoration.
 pub type VaultSlot = Arc<Mutex<Option<Arc<Mutex<SecretVault>>>>>;
 
+/// Live security policy shared with the shell's SecurityManager (`/setting`).
+/// When set, bash preflight uses this snapshot instead of reloading from disk.
+pub type PolicySlot = Arc<Mutex<Option<SecurityPolicy>>>;
+
 /// Tool for executing bash commands via PTY.
 pub struct BashTool {
     /// Shared cancellation token from the AI handler.
@@ -109,6 +114,8 @@ pub struct BashTool {
     pty_slot: PtySlot,
     /// Shared vault for restoring $SECRET_* placeholders before command execution.
     secret_vault: VaultSlot,
+    /// Live policy from the shell; falls back to `load_policy` when empty.
+    policy_slot: PolicySlot,
 }
 
 fn timeout_secs(args: &serde_json::Value) -> Result<Option<u64>, ToolResult> {
@@ -137,7 +144,20 @@ fn security_preflight_with_socket(
     config_path: Option<&Path>,
     sandbox_socket_path: Option<&Path>,
 ) -> PreflightResult {
-    let policy = load_policy(config_path);
+    security_preflight_with_policy(
+        command,
+        cwd,
+        load_policy(config_path),
+        sandbox_socket_path,
+    )
+}
+
+fn security_preflight_with_policy(
+    command: &str,
+    cwd: Option<&Path>,
+    policy: SecurityPolicy,
+    sandbox_socket_path: Option<&Path>,
+) -> PreflightResult {
     let manager = SecurityManager::new(policy.clone());
     let mut request = SecurityRequest::ai_command()
         .with_repo_root("/")
@@ -192,7 +212,12 @@ fn bash_preflight(
     }
 
     let cwd = std::env::current_dir().ok();
-    security_preflight(&command, cwd.as_deref(), None)
+    if let Some(policy) = tool.live_policy() {
+        security_preflight_with_policy(&command, cwd.as_deref(), policy, None)
+    } else {
+        // No live slot (standalone/tests) — load from disk SSOT.
+        security_preflight(&command, cwd.as_deref(), None)
+    }
 }
 
 fn format_security_message(decision: &SecurityDecision) -> String {
@@ -265,6 +290,7 @@ impl BashTool {
             cancellation_token: None,
             pty_slot: Arc::new(Mutex::new(None)),
             secret_vault: Arc::new(Mutex::new(None)),
+            policy_slot: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -290,6 +316,7 @@ impl BashTool {
         bash.set_cancellation_token(token);
         bash.set_pty_slot(Arc::clone(&self.pty_slot));
         bash.set_secret_vault(Arc::clone(&self.secret_vault));
+        bash.set_policy_slot(Arc::clone(&self.policy_slot));
         bash
     }
 
@@ -339,6 +366,20 @@ impl BashTool {
     /// Set the shared secret vault for placeholder restoration.
     pub fn set_secret_vault(&mut self, vault: VaultSlot) {
         self.secret_vault = vault;
+    }
+
+    /// Share the shell's live security policy with bash preflight.
+    pub fn set_policy_slot(&mut self, slot: PolicySlot) {
+        self.policy_slot = slot;
+    }
+
+    /// Publish an updated live policy (used after `/setting` Security edits).
+    pub fn publish_live_policy(slot: &PolicySlot, policy: SecurityPolicy) {
+        *slot.lock().unwrap() = Some(policy);
+    }
+
+    fn live_policy(&self) -> Option<SecurityPolicy> {
+        self.policy_slot.lock().unwrap().clone()
     }
 
     /// Restore `$SECRET_*` placeholders in the command to their actual values.
@@ -651,6 +692,53 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+
+    #[test]
+    fn bash_preflight_uses_live_policy_slot_over_disk() {
+        // Isolate load_policy(None) to an ALLOW-only user policy, then prove
+        // the live slot (HIGH rm-/etc rule) wins for bash_preflight.
+        let dir = tempdir().unwrap();
+        let xdg = dir.path().join("xdg");
+        fs::create_dir_all(xdg.join("aish")).unwrap();
+        let user_policy = xdg.join("aish").join("security_policy.yaml");
+        fs::write(
+            &user_policy,
+            "global:\n  enable_sandbox: false\n  sandbox_off_action: ALLOW\n  default_risk_level: LOW\nrules: []\n",
+        )
+        .unwrap();
+        let old_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        std::env::set_var("XDG_CONFIG_HOME", &xdg);
+
+        let mut tool = BashTool::new();
+        let args = serde_json::json!({"command": "rm -rf /etc"});
+        assert_eq!(
+            bash_preflight(&tool, &args, false),
+            PreflightResult::Allow,
+            "disk policy alone should allow"
+        );
+
+        let slot: PolicySlot = Arc::new(Mutex::new(None));
+        tool.set_policy_slot(Arc::clone(&slot));
+        let live_path = dir.path().join("live_policy.yaml");
+        fs::write(
+            &live_path,
+            "global:\n  enable_sandbox: false\n  sandbox_off_action: ALLOW\n  default_risk_level: LOW\nrules:\n  - id: H-001\n    path: [/etc/**]\n    operations: [DELETE]\n    command_list: [rm]\n    risk: HIGH\n    reason: live policy blocks etc\n",
+        )
+        .unwrap();
+        BashTool::publish_live_policy(&slot, load_policy(Some(live_path.as_path())));
+
+        match bash_preflight(&tool, &args, false) {
+            PreflightResult::Block { message, .. } => {
+                assert!(message.contains("live policy blocks etc"), "{message}");
+            }
+            other => panic!("expected Block from live policy slot, got {other:?}"),
+        }
+
+        match old_xdg {
+            Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+    }
 
     #[test]
     fn test_for_sub_session_token_binds_child_not_parent() {

--- a/crates/aish-tools/src/bash/bash.rs
+++ b/crates/aish-tools/src/bash/bash.rs
@@ -688,6 +688,35 @@ mod tests {
 
     use super::*;
 
+    fn xdg_env_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    /// Restore `XDG_CONFIG_HOME` on drop (including panic/assert unwind).
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<std::ffi::OsString>,
+    }
+    impl EnvGuard {
+        fn set(key: &'static str, value: Option<&std::path::Path>) -> Self {
+            let prev = std::env::var_os(key);
+            match value {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+            Self { key, prev }
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
     #[test]
     fn bash_preflight_uses_live_policy_slot_over_disk() {
         // Isolate load_policy(None) to an ALLOW-only user policy, then prove
@@ -701,8 +730,10 @@ mod tests {
             "global:\n  enable_sandbox: false\n  sandbox_off_action: ALLOW\n  default_risk_level: LOW\nrules: []\n",
         )
         .unwrap();
-        let old_xdg = std::env::var_os("XDG_CONFIG_HOME");
-        std::env::set_var("XDG_CONFIG_HOME", &xdg);
+        let _lock = xdg_env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _guard = EnvGuard::set("XDG_CONFIG_HOME", Some(xdg.as_path()));
 
         let mut tool = BashTool::new();
         let args = serde_json::json!({"command": "rm -rf /etc"});
@@ -727,11 +758,6 @@ mod tests {
                 assert!(message.contains("live policy blocks etc"), "{message}");
             }
             other => panic!("expected Block from live policy slot, got {other:?}"),
-        }
-
-        match old_xdg {
-            Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
-            None => std::env::remove_var("XDG_CONFIG_HOME"),
         }
     }
 

--- a/packaging/scripts/install-bundle.sh
+++ b/packaging/scripts/install-bundle.sh
@@ -6,16 +6,16 @@ ROOTFS_DIR="${SCRIPT_DIR}/rootfs"
 SYSTEMD_DIR="${SCRIPT_DIR}/systemd"
 MIN_GLIBC_VERSION="2.28"
 BUNDLE_SYSTEMD_UNITDIR="/etc/systemd/system"
-FORCE_CONFIG_OVERWRITE=0
 INSTALL_ROOT="${AISH_INSTALL_ROOT:-}"
 INSTALL_PREFIX=""
 SKIP_SYSTEMD="${AISH_SKIP_SYSTEMD:-0}"
 
 usage() {
 	cat <<'EOF'
-Usage: sudo ./install.sh [--force-config] [--prefix=PATH]
+Usage: sudo ./install.sh [--prefix=PATH]
 
-Installs AI Shell binaries and the security policy.
+Installs AI Shell binaries. Security policy is seeded under
+~/.config/aish/security_policy.yaml on first run (not installed under /etc).
 
 Packaged skills are embedded in the aish binary (loaded at runtime); this
 installer does not write skills into any user's ~/.config/aish/skills.
@@ -104,17 +104,6 @@ install_file() {
 	fi
 }
 
-install_config() {
-	local source_path="$1"
-	local destination_path
-	destination_path="$(target_path "$2")"
-	if [[ -f "$destination_path" && "$FORCE_CONFIG_OVERWRITE" -ne 1 ]]; then
-		echo "Preserving existing config: ${destination_path}"
-		return
-	fi
-	install_file "$source_path" "$2" 0644
-}
-
 install_systemd_units() {
 	if [[ -n "$INSTALL_PREFIX" ]]; then
 		return
@@ -151,10 +140,6 @@ install_systemd_units() {
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
-		--force-config)
-			FORCE_CONFIG_OVERWRITE=1
-			shift
-			;;
 		--prefix=*)
 			INSTALL_PREFIX="${1#*=}"
 			shift
@@ -179,7 +164,6 @@ BIN_DIR="$(binary_target_dir)"
 
 install_file "$ROOTFS_DIR/usr/bin/aish" "${BIN_DIR}/aish" 0755
 install_file "$SCRIPT_DIR/uninstall.sh" "${BIN_DIR}/aish-uninstall" 0755
-install_config "$ROOTFS_DIR/etc/aish/security_policy.yaml" "/etc/aish/security_policy.yaml"
 
 install_systemd_units
 

--- a/packaging/scripts/uninstall-bundle.sh
+++ b/packaging/scripts/uninstall-bundle.sh
@@ -94,6 +94,8 @@ rm -rf "$(target_path "/usr/local/share/aish/skills")"
 rmdir --ignore-fail-on-non-empty "$(target_path "/usr/local/share/aish")" >/dev/null 2>&1 || true
 rm -rf "$(target_path "/usr/share/aish/skills")"
 rmdir --ignore-fail-on-non-empty "$(target_path "/usr/share/aish")" >/dev/null 2>&1 || true
+# Legacy cleanup: older installers placed security_policy.yaml under /etc/aish.
+# Current releases no longer install there (policy lives under ~/.config/aish).
 if [[ "$PURGE_CONFIG" -eq 1 ]]; then
 	rm -f "$(target_path "/etc/aish/security_policy.yaml")"
 	rmdir --ignore-fail-on-non-empty "$(target_path "/etc/aish")" >/dev/null 2>&1 || true


### PR DESCRIPTION
## 概述

- 问题: `/setting` 与 `security_policy.yaml` 双源不同步；`config.yaml` 覆盖策略文件，Bash preflight 又可能直接 `load_policy()`，导致面板显示与真实预检行为不一致。
- 改动: 以 `~/.config/aish/security_policy.yaml` 为唯一权威源；`/setting` 读写 live `SecurityManager`，并通过 `PolicySlot` 同步给 BashTool；从 `ConfigModel`/`config.yaml` 移除安全字段并在加载时 strip + 警告；安装不再写入 `/etc/aish`。
- 关联 Issue: #407

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [x] 重构
- [x] 文档
- [ ] 其他

## 涉及范围

- [x] 核心 Shell / PTY
- [ ] AI 代理 / LLM
- [x] 技能 / 工具
- [x] 安全模块
- [x] 配置系统
- [x] CLI / 界面
- [x] 打包 / 安装
- [ ] CI/CD
- [x] 文档

## 用户可见变更

- Security 设置仅来自 `~/.config/aish/security_policy.yaml`（缺失时从内置模板 seed）；运行时不再读取 `/etc/aish`。
- `/setting` 修改 Security 项即时更新 live manager 与 Bash preflight，并写回用户策略文件。
- 旧版 `config.yaml` 中的 `enable_sandbox` / `sandbox_*` / `default_risk_level` / `input_guard_enabled` 会在加载时被移除并打印一次性警告。
- 安装包不再安装 `/etc/aish/security_policy.yaml`；卸载 purge 仍清理遗留 `/etc/aish`。
- 帮助文案与默认策略模板改为英文精简版（保留 H-001/M-001/L-001）。

## 兼容性

- 向后兼容? 否（有意破坏双源兼容，换为单一 SSOT）
- 配置变更? 是
  - 安全全局项仅保留在 `security_policy.yaml`
  - `config.yaml` 遗留安全键加载时 strip，不自动迁移数值到策略文件（提示用户改策略文件或 `/setting`）
  - 系统级 `/etc/aish/security_policy.yaml` 不再作为运行时读取路径

## 测试验证

- `cargo test -p aish-config -p aish-security --lib`
- `cargo test -p aish-shell --lib settings_panel`
- `cargo test -p aish-tools --lib bash`（含 live PolicySlot 覆盖磁盘策略用例）

## 检查清单

- [x] 代码风格符合项目规范
- [x] 已添加必要的测试
- [x] 文档已更新（如需要）

## Commit 拆分

1. `fix(security): use ~/.config/aish as sole policy path`
2. `chore(packaging): stop installing security_policy under /etc`
3. `fix(config): remove security fields from ConfigModel`
4. `fix(shell): bind /setting and BashTool to live security policy`
5. `docs(i18n): document user-only security_policy path`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Security settings now apply immediately across shell and command screening, and bash preflight uses a live security-policy snapshot.
  * On first run, `security_policy.yaml` is seeded to `~/.config/aish/security_policy.yaml`.
* **Bug Fixes**
  * Runtime no longer consults legacy `/etc/aish` security policy files.
  * Legacy security keys in `config.yaml` are removed on load, with a warning and the updated file saved.
* **Documentation**
  * Installer and all localized “Security Policy / Config Location” help now point to `~/.config/aish` and clarify `/etc/aish` isn’t read at runtime.
* **Bug Fixes**
  * Health checks now report security-policy parsing/validation issues more precisely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->