### PR TITLE
feat(shell): /export — export a session to Markdown

### DIFF
--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -183,6 +183,7 @@ shell:
     audit: "Audit-Protokoll abfragen (wer/wann/was/KI-Vorschlag/Bestaetigung)"
     forget-approvals: "Gemerkte Befehlsgenehmigungen löschen (diese Sitzung)"
     skill: "Skills suchen, installieren, prüfen; Registries verwalten"
+    export: "Aktuelle Sitzung als Markdown exportieren"
 
   feedback:
     select_type: "Feedback-Typ auswählen"
@@ -647,6 +648,23 @@ shell:
     no_matches: "Keine passenden Sitzungen."
     current_marker: "(aktuell)"
     selector_footer: "Tippen zum Suchen · ↑/↓ zum Auswählen · Enter zum Fortsetzen · Esc zum Abbrechen"
+
+  export:
+    md_header: "# aish Sitzungsexport"
+    session_label: "- **Sitzung**: `{uuid}`"
+    model_label: "- **Modell**: {model}"
+    api_base_label: "- **api_base**: {base}"
+    forked_label: "- **verzweigt von**: `{parent}`"
+    created_label: "- **erstellt**: {created}"
+    working_dir: "**Arbeitsverzeichnis**: `{cwd}`"
+    conversation_header: "## Unterhaltung"
+    history_header: "## Befehlsverlauf"
+    exported: "exportiert {file} ({msgs} Nachrichten, {cmds} Befehle)"
+    write_failed: "Schreiben von {file} fehlgeschlagen: {error}"
+    usage: "Verwendung: /export [md]  (nur markdown wird unterstützt)"
+    store_unavailable: "Sitzungsspeicher nicht verfügbar; Export nicht möglich"
+    not_found: "aktuelle Sitzung im Speicher nicht gefunden"
+    load_failed: "Laden der Sitzung fehlgeschlagen: {error}"
 
   live_sessions:
     daemon_disabled: "PTY-Daemon ist deaktiviert. In config.yaml aktivieren:"

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -368,6 +368,7 @@ shell:
     audit: "Query audit log (who/when/what/AI suggestion/confirm)"
     forget-approvals: "Clear remembered command approvals (this session)"
     skill: "Search, install, verify skills; manage registries"
+    export: "Export the current session to Markdown"
 
   record:
     started: "⏺ Recording started: {path}"
@@ -546,6 +547,23 @@ shell:
     no_matches: "No matching sessions."
     current_marker: "(current)"
     selector_footer: "Type to search · ↑/↓ to select · Enter to resume · Esc to cancel"
+
+  export:
+    md_header: "# aish session export"
+    session_label: "- **session**: `{uuid}`"
+    model_label: "- **model**: {model}"
+    api_base_label: "- **api_base**: {base}"
+    forked_label: "- **forked from**: `{parent}`"
+    created_label: "- **created**: {created}"
+    working_dir: "**working dir**: `{cwd}`"
+    conversation_header: "## Conversation"
+    history_header: "## Command history"
+    exported: "exported {file} ({msgs} messages, {cmds} commands)"
+    write_failed: "failed to write {file}: {error}"
+    usage: "usage: /export [md]  (only markdown is supported)"
+    store_unavailable: "session store unavailable; cannot export"
+    not_found: "current session not found in store"
+    load_failed: "failed to load session: {error}"
 
   live_sessions:
     daemon_disabled: "PTY daemon is disabled. Enable it in config.yaml:"

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -183,6 +183,7 @@ shell:
     audit: "Consultar el registro de auditoría (quién/cuándo/qué/sugerencia de IA/confirmación)"
     forget-approvals: "Borrar aprobaciones de comandos recordadas (esta sesión)"
     skill: "Buscar, instalar, verificar skills; gestionar registros"
+    export: "Exportar la sesión actual a Markdown"
 
   feedback:
     select_type: "Seleccionar tipo de comentario"
@@ -647,6 +648,23 @@ shell:
     no_matches: "No hay sesiones coincidentes."
     current_marker: "(actual)"
     selector_footer: "Escribe para buscar · ↑/↓ para seleccionar · Enter para reanudar · Esc para cancelar"
+
+  export:
+    md_header: "# exportación de sesión aish"
+    session_label: "- **sesión**: `{uuid}`"
+    model_label: "- **modelo**: {model}"
+    api_base_label: "- **api_base**: {base}"
+    forked_label: "- **bifurcada de**: `{parent}`"
+    created_label: "- **creada**: {created}"
+    working_dir: "**directorio de trabajo**: `{cwd}`"
+    conversation_header: "## Conversación"
+    history_header: "## Historial de comandos"
+    exported: "exportado {file} ({msgs} mensajes, {cmds} comandos)"
+    write_failed: "fallo al escribir {file}: {error}"
+    usage: "uso: /export [md]  (solo se admite markdown)"
+    store_unavailable: "almacén de sesiones no disponible; no se puede exportar"
+    not_found: "sesión actual no encontrada en el almacén"
+    load_failed: "fallo al cargar la sesión: {error}"
 
   live_sessions:
     daemon_disabled: "Demonio PTY deshabilitado. Habilitar en config.yaml:"

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -183,6 +183,7 @@ shell:
     audit: "Consulter le journal d'audit (qui/quand/quoi/suggestion IA/confirmation)"
     forget-approvals: "Effacer les approbations mémorisées (cette session)"
     skill: "Rechercher, installer, vérifier des skills; gérer les registres"
+    export: "Exporter la session actuelle en Markdown"
 
   feedback:
     select_type: "Sélectionner le type de commentaire"
@@ -647,6 +648,23 @@ shell:
     no_matches: "Aucune session correspondante."
     current_marker: "(actuelle)"
     selector_footer: "Tapez pour rechercher · ↑/↓ pour selectionner · Enter pour reprendre · Esc pour annuler"
+
+  export:
+    md_header: "# exportation de session aish"
+    session_label: "- **session** : `{uuid}`"
+    model_label: "- **modèle** : {model}"
+    api_base_label: "- **api_base** : {base}"
+    forked_label: "- **bifurquée de** : `{parent}`"
+    created_label: "- **créée** : {created}"
+    working_dir: "**répertoire de travail** : `{cwd}`"
+    conversation_header: "## Conversation"
+    history_header: "## Historique des commandes"
+    exported: "exporté {file} ({msgs} messages, {cmds} commandes)"
+    write_failed: "échec d'écriture de {file} : {error}"
+    usage: "usage : /export [md]  (seul markdown est pris en charge)"
+    store_unavailable: "stockage de session indisponible ; export impossible"
+    not_found: "session actuelle introuvable dans le stockage"
+    load_failed: "échec du chargement de la session : {error}"
 
   live_sessions:
     daemon_disabled: "Daemon PTY desactive. Activer dans config.yaml :"

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -183,6 +183,7 @@ shell:
     audit: "監査ログを照会（誰/いつ/何/AI提案/確認）"
     forget-approvals: "記憶されたコマンド承認を削除（このセッション）"
     skill: "スキルの検索・インストール・検証;レジストリ管理"
+    export: "現在のセッションを Markdown にエクスポート"
 
   feedback:
     select_type: "フィードバックの種類を選択"
@@ -647,6 +648,23 @@ shell:
     no_matches: "一致するセッションはありません。"
     current_marker: "(現在)"
     selector_footer: "入力して検索 · ↑/↓ で選択 · Enter で復元 · Esc でキャンセル"
+
+  export:
+    md_header: "# aish セッションエクスポート"
+    session_label: "- **セッション**: `{uuid}`"
+    model_label: "- **モデル**: {model}"
+    api_base_label: "- **api_base**: {base}"
+    forked_label: "- **フォーク元**: `{parent}`"
+    created_label: "- **作成**: {created}"
+    working_dir: "**作業ディレクトリ**: `{cwd}`"
+    conversation_header: "## 会話"
+    history_header: "## コマンド履歴"
+    exported: "エクスポートしました {file}（{msgs} メッセージ、{cmds} コマンド）"
+    write_failed: "{file} の書き込みに失敗しました: {error}"
+    usage: "使い方: /export [md]  （markdown のみ対応）"
+    store_unavailable: "セッションストアが利用できません；エクスポートできません"
+    not_found: "ストアに現在のセッションが見つかりません"
+    load_failed: "セッションの読み込みに失敗しました: {error}"
 
   live_sessions:
     daemon_disabled: "PTYデーモンが無効です。config.yaml で有効にしてください："

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -368,6 +368,7 @@ shell:
     audit: "查询审计日志（谁/何时/什么/AI建议/确认）"
     forget-approvals: "清除本会话记住的命令审批"
     skill: "搜索、安装、校验技能；管理 registry 源"
+    export: "导出当前会话为 Markdown"
 
   record:
     started: "⏺ 录制已开始: {path}"
@@ -546,6 +547,23 @@ shell:
     no_matches: "没有匹配的会话。"
     current_marker: "(当前)"
     selector_footer: "输入以搜索 · ↑/↓ 选择 · Enter 恢复 · Esc 取消"
+
+  export:
+    md_header: "# aish 会话导出"
+    session_label: "- **会话**：`{uuid}`"
+    model_label: "- **模型**：{model}"
+    api_base_label: "- **api_base**：{base}"
+    forked_label: "- **分叉自**：`{parent}`"
+    created_label: "- **创建时间**：{created}"
+    working_dir: "**工作目录**：`{cwd}`"
+    conversation_header: "## 对话"
+    history_header: "## 命令历史"
+    exported: "已导出 {file}（{msgs} 条消息，{cmds} 条命令）"
+    write_failed: "写入 {file} 失败：{error}"
+    usage: "用法：/export [md]  （仅支持 markdown）"
+    store_unavailable: "会话存储不可用；无法导出"
+    not_found: "在存储中找不到当前会话"
+    load_failed: "加载会话失败：{error}"
 
   live_sessions:
     daemon_disabled: "PTY 守护进程未启用，请在 config.yaml 中开启："

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -3463,6 +3463,7 @@ impl AishShell {
             Some("/audit") => self.handle_audit_command(&parts),
             Some("/forget-approvals") => self.handle_forget_approvals(),
             Some("/skill") => self.handle_skill_command(&parts),
+            Some("/export") => self.handle_export_command(&parts),
             _ => {
                 eprintln!("{}", {
                     let mut args = std::collections::HashMap::new();
@@ -3489,6 +3490,177 @@ impl AishShell {
             "\x1b[36m{}\x1b[0m",
             t_with_args("shell.forget_approvals_cleared", &args)
         );
+    }
+
+    /// `/export [md]` — export the current session (AI conversation + command
+    /// history) to a Markdown file for postmortem or sharing.
+    fn handle_export_command(&self, parts: &[&str]) {
+        let format = parts.get(1).copied().unwrap_or("md");
+        if format != "md" && format != "markdown" {
+            eprintln!("{}", t("shell.export.usage"));
+            return;
+        }
+        let Some(store) = self.session_store.as_ref() else {
+            eprintln!("{}", t("shell.export.store_unavailable"));
+            return;
+        };
+        let uuid = &self.session_uuid;
+        let record = match store.get_session(uuid) {
+            Ok(Some(r)) => r,
+            Ok(None) => {
+                eprintln!("{}", t("shell.export.not_found"));
+                return;
+            }
+            Err(e) => {
+                eprintln!(
+                    "{}",
+                    t_with_args("shell.export.load_failed", &{
+                        let mut args = std::collections::HashMap::new();
+                        args.insert("error".to_string(), e.to_string());
+                        args
+                    })
+                );
+                return;
+            }
+        };
+        // Export the full history. The 100k cap is effectively unbounded for
+        // any real session, so a long-lived archive is never silently truncated.
+        let history = match store.get_history(uuid, 100_000) {
+            Ok(h) => h,
+            Err(e) => {
+                eprintln!(
+                    "{}",
+                    t_with_args("shell.export.load_failed", &{
+                        let mut args = std::collections::HashMap::new();
+                        args.insert("error".to_string(), e.to_string());
+                        args
+                    })
+                );
+                return;
+            }
+        };
+        let snap = record.state_snapshot();
+
+        let mut md = String::new();
+        md.push_str(&format!("{}\n\n", t("shell.export.md_header")));
+        md.push_str(&format!(
+            "{}\n",
+            t_with_args("shell.export.session_label", &{
+                let mut args = std::collections::HashMap::new();
+                args.insert("uuid".to_string(), uuid.to_string());
+                args
+            })
+        ));
+        md.push_str(&format!(
+            "{}\n",
+            t_with_args("shell.export.model_label", &{
+                let mut args = std::collections::HashMap::new();
+                args.insert("model".to_string(), record.model.clone());
+                args
+            })
+        ));
+        if let Some(base) = &record.api_base {
+            md.push_str(&format!(
+                "{}\n",
+                t_with_args("shell.export.api_base_label", &{
+                    let mut args = std::collections::HashMap::new();
+                    args.insert("base".to_string(), base.clone());
+                    args
+                })
+            ));
+        }
+        md.push_str(&format!(
+            "{}\n",
+            t_with_args("shell.export.created_label", &{
+                let mut args = std::collections::HashMap::new();
+                args.insert(
+                    "created".to_string(),
+                    record
+                        .created_at
+                        .format("%Y-%m-%d %H:%M:%S UTC")
+                        .to_string(),
+                );
+                args
+            })
+        ));
+        if let Some(cwd) = &snap.cwd {
+            md.push_str(&format!(
+                "\n{}\n",
+                t_with_args("shell.export.working_dir", &{
+                    let mut args = std::collections::HashMap::new();
+                    args.insert("cwd".to_string(), cwd.clone());
+                    args
+                })
+            ));
+        }
+
+        md.push_str(&format!("\n{}\n\n", t("shell.export.conversation_header")));
+        for msg in &snap.context_messages_snapshot {
+            let role = match msg.role.as_str() {
+                "user" => "User",
+                "assistant" => "Assistant",
+                "system" => "System",
+                other => other,
+            };
+            md.push_str(&format!("**{}**\n\n{}\n\n", role, msg.content));
+        }
+
+        md.push_str(&format!("\n{}\n\n", t("shell.export.history_header")));
+        md.push_str("| # | source | rc | command |\n|---|---|---|---|\n");
+        for (i, entry) in history.iter().enumerate() {
+            let cmd = entry
+                .command
+                .replace('|', "\\|")
+                .replace('\n', " ")
+                .replace('`', "\\`");
+            let rc = entry
+                .returncode
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "-".into());
+            md.push_str(&format!(
+                "| {} | {} | {} | {} |\n",
+                i + 1,
+                entry.source,
+                rc,
+                cmd
+            ));
+        }
+
+        let fname = format!("aish-session-{}.md", &uuid[..8.min(uuid.len())]);
+        match std::fs::write(&fname, &md) {
+            Ok(_) => {
+                // Owner-only: the archive contains the full conversation and
+                // raw command history, so restrict it regardless of umask.
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    let _ =
+                        std::fs::set_permissions(&fname, std::fs::Permissions::from_mode(0o600));
+                }
+                println!(
+                    "\x1b[32m{}\x1b[0m",
+                    t_with_args("shell.export.exported", &{
+                        let mut args = std::collections::HashMap::new();
+                        args.insert("file".to_string(), fname);
+                        args.insert(
+                            "msgs".to_string(),
+                            snap.context_messages_snapshot.len().to_string(),
+                        );
+                        args.insert("cmds".to_string(), history.len().to_string());
+                        args
+                    })
+                )
+            }
+            Err(e) => eprintln!(
+                "{}",
+                t_with_args("shell.export.write_failed", &{
+                    let mut args = std::collections::HashMap::new();
+                    args.insert("file".to_string(), fname);
+                    args.insert("error".to_string(), e.to_string());
+                    args
+                })
+            ),
+        }
     }
 
     /// Handle `/skill` command — search, list, install, remove, verify.

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -49,6 +49,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
         "/skill",
         "Search, install, verify skills; manage registries",
     ),
+    ("/export", "Export current session to Markdown"),
 ];
 
 // ---------------------------------------------------------------------------
@@ -827,6 +828,6 @@ mod tests {
                 cmd
             );
         }
-        assert_eq!(SLASH_COMMANDS.len(), 18);
+        assert_eq!(SLASH_COMMANDS.len(), 19);
     }
 }

--- a/crates/aish-shell/tests/slash_popup_commands.rs
+++ b/crates/aish-shell/tests/slash_popup_commands.rs
@@ -30,7 +30,7 @@ fn each_builtin_command_enter_executes() {
 
 #[test]
 fn slash_commands_table_has_expected_count() {
-    assert_eq!(SLASH_COMMANDS.len(), 18);
+    assert_eq!(SLASH_COMMANDS.len(), 19);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds the `/export [md]` built-in command: writes the current session to a Markdown file (`aish-session-<short>.md`) for postmortem or sharing.

Closes #411

## What it does

- Exports session metadata (uuid, model, api_base, created time, working dir), the full AI conversation (by role), and the command history as a table.
- History-table cells escape `|`, newlines, and backticks so commands containing them render correctly.
- A failed session-record or history fetch surfaces a localized error instead of silently exporting an empty file.

## Scope

Self-contained: reuses the existing `SessionStore::get_session` / `get_history` and the existing session-state snapshot. No new persistence path, no other commands touched.

- `crates/aish-shell/src/app.rs` — `handle_export_command` + route.
- `crates/aish-shell/src/readline.rs` — `/export` popup entry.
- `crates/aish-i18n/locales/*` — `shell.export.*` + `shell.slash.export` (6 locales).

## Verification

- `cargo clippy -p aish-shell --all-targets -- -D warnings` clean.
- `slash_popup_commands` tests pass (count + i18n descriptions).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `/export` command to export the current session (conversation plus command history) as a Markdown file.
  * Accepts `md` or `markdown` format options and provides localized success and error messages.
* **Documentation**
  * Added new localized help text and export workflow strings for `/export` in English, German, Spanish, French, Japanese, and Simplified Chinese.
* **Tests**
  * Updated slash-command count expectations to include the new `/export` entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->