### PR TITLE
feat(session): /fork — branch a session, preserving the original

### DIFF
--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -184,6 +184,7 @@ shell:
     forget-approvals: "Gemerkte Befehlsgenehmigungen löschen (diese Sitzung)"
     skill: "Skills suchen, installieren, prüfen; Registries verwalten"
     export: "Aktuelle Sitzung als Markdown exportieren"
+    fork: "Aktuelle Sitzung abzweigen"
 
   feedback:
     select_type: "Feedback-Typ auswählen"
@@ -665,6 +666,12 @@ shell:
     store_unavailable: "Sitzungsspeicher nicht verfügbar; Export nicht möglich"
     not_found: "aktuelle Sitzung im Speicher nicht gefunden"
     load_failed: "Laden der Sitzung fehlgeschlagen: {error}"
+  fork:
+    forked: "Sitzung verzweigt {short} (von {parent})"
+    switch_failed: "Verzweigung erstellt, aber Wechsel fehlgeschlagen: {error}"
+    switch_manual: "verwende `/resume {session_id}` zum manuellen Wechseln"
+    failed: "Verzweigung fehlgeschlagen: {error}"
+    store_unavailable: "Sitzungsspeicher nicht verfügbar; Verzweigung nicht möglich"
 
   live_sessions:
     daemon_disabled: "PTY-Daemon ist deaktiviert. In config.yaml aktivieren:"

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -369,6 +369,7 @@ shell:
     forget-approvals: "Clear remembered command approvals (this session)"
     skill: "Search, install, verify skills; manage registries"
     export: "Export the current session to Markdown"
+    fork: "Branch the current session"
 
   record:
     started: "⏺ Recording started: {path}"
@@ -564,6 +565,12 @@ shell:
     store_unavailable: "session store unavailable; cannot export"
     not_found: "current session not found in store"
     load_failed: "failed to load session: {error}"
+  fork:
+    forked: "forked session {short} (from {parent})"
+    switch_failed: "fork created but switch failed: {error}"
+    switch_manual: "use `/resume {session_id}` to switch manually"
+    failed: "fork failed: {error}"
+    store_unavailable: "session store unavailable; cannot fork"
 
   live_sessions:
     daemon_disabled: "PTY daemon is disabled. Enable it in config.yaml:"

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -184,6 +184,7 @@ shell:
     forget-approvals: "Borrar aprobaciones de comandos recordadas (esta sesión)"
     skill: "Buscar, instalar, verificar skills; gestionar registros"
     export: "Exportar la sesión actual a Markdown"
+    fork: "Bifurcar la sesión actual"
 
   feedback:
     select_type: "Seleccionar tipo de comentario"
@@ -665,6 +666,12 @@ shell:
     store_unavailable: "almacén de sesiones no disponible; no se puede exportar"
     not_found: "sesión actual no encontrada en el almacén"
     load_failed: "fallo al cargar la sesión: {error}"
+  fork:
+    forked: "sesión bifurcada {short} (de {parent})"
+    switch_failed: "bifurcación creada pero el cambio falló: {error}"
+    switch_manual: "usa `/resume {session_id}` para cambiar manualmente"
+    failed: "bifurcación fallida: {error}"
+    store_unavailable: "almacén de sesiones no disponible; no se puede bifurcar"
 
   live_sessions:
     daemon_disabled: "Demonio PTY deshabilitado. Habilitar en config.yaml:"

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -184,6 +184,7 @@ shell:
     forget-approvals: "Effacer les approbations mémorisées (cette session)"
     skill: "Rechercher, installer, vérifier des skills; gérer les registres"
     export: "Exporter la session actuelle en Markdown"
+    fork: "Créer une branche de la session actuelle"
 
   feedback:
     select_type: "Sélectionner le type de commentaire"
@@ -665,6 +666,12 @@ shell:
     store_unavailable: "stockage de session indisponible ; export impossible"
     not_found: "session actuelle introuvable dans le stockage"
     load_failed: "échec du chargement de la session : {error}"
+  fork:
+    forked: "session bifurquée {short} (depuis {parent})"
+    switch_failed: "bifurcation créée mais le changement a échoué : {error}"
+    switch_manual: "utilisez `/resume {session_id}` pour changer manuellement"
+    failed: "échec de la bifurcation : {error}"
+    store_unavailable: "stockage de session indisponible ; bifurcation impossible"
 
   live_sessions:
     daemon_disabled: "Daemon PTY desactive. Activer dans config.yaml :"

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -184,6 +184,7 @@ shell:
     forget-approvals: "記憶されたコマンド承認を削除（このセッション）"
     skill: "スキルの検索・インストール・検証;レジストリ管理"
     export: "現在のセッションを Markdown にエクスポート"
+    fork: "現在のセッションを分岐"
 
   feedback:
     select_type: "フィードバックの種類を選択"
@@ -665,6 +666,12 @@ shell:
     store_unavailable: "セッションストアが利用できません；エクスポートできません"
     not_found: "ストアに現在のセッションが見つかりません"
     load_failed: "セッションの読み込みに失敗しました: {error}"
+  fork:
+    forked: "セッションをフォークしました {short}（親 {parent}）"
+    switch_failed: "フォークを作成しましたが切り替えに失敗しました: {error}"
+    switch_manual: "`/resume {session_id}` で手動切り替えしてください"
+    failed: "フォーク失敗: {error}"
+    store_unavailable: "セッションストアが利用できません；フォークできません"
 
   live_sessions:
     daemon_disabled: "PTYデーモンが無効です。config.yaml で有効にしてください："

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -369,6 +369,7 @@ shell:
     forget-approvals: "清除本会话记住的命令审批"
     skill: "搜索、安装、校验技能；管理 registry 源"
     export: "导出当前会话为 Markdown"
+    fork: "分支当前会话"
 
   record:
     started: "⏺ 录制已开始: {path}"
@@ -564,6 +565,12 @@ shell:
     store_unavailable: "会话存储不可用；无法导出"
     not_found: "在存储中找不到当前会话"
     load_failed: "加载会话失败：{error}"
+  fork:
+    forked: "已分叉会话 {short}（来自 {parent}）"
+    switch_failed: "分叉已创建但切换失败：{error}"
+    switch_manual: "使用 `/resume {session_id}` 手动切换"
+    failed: "分叉失败：{error}"
+    store_unavailable: "会话存储不可用；无法分叉"
 
   live_sessions:
     daemon_disabled: "PTY 守护进程未启用，请在 config.yaml 中开启："

--- a/crates/aish-session/src/models.rs
+++ b/crates/aish-session/src/models.rs
@@ -11,6 +11,12 @@ pub struct SessionRecord {
     pub api_base: Option<String>,
     pub run_user: Option<String>,
     pub state: serde_json::Value,
+    /// UUID of the session this one was forked from (`None` for a root session).
+    #[serde(default)]
+    pub parent_session_uuid: Option<String>,
+    /// History row id within the parent at which this branch diverges.
+    #[serde(default)]
+    pub branch_point_message_id: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/aish-session/src/store.rs
+++ b/crates/aish-session/src/store.rs
@@ -13,12 +13,14 @@ use crate::models::{
 
 const SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS sessions (
-    session_uuid TEXT PRIMARY KEY,
-    created_at   TEXT NOT NULL,
-    model        TEXT NOT NULL,
-    api_base     TEXT,
-    run_user     TEXT,
-    state        TEXT DEFAULT '{}'
+    session_uuid         TEXT PRIMARY KEY,
+    created_at           TEXT NOT NULL,
+    model                TEXT NOT NULL,
+    api_base             TEXT,
+    run_user             TEXT,
+    state                TEXT DEFAULT '{}',
+    parent_session_uuid  TEXT,
+    branch_point_message_id INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS history (
@@ -105,6 +107,8 @@ impl SessionStore {
         // Create tables.
         conn.execute_batch(SCHEMA)
             .map_err(|e| AishError::Session(format!("failed to create schema: {e}")))?;
+        // Apply additive migrations for databases created by older builds.
+        migrate_schema(&conn)?;
 
         debug!(path = ?db_path, "opened session store");
 
@@ -138,6 +142,8 @@ impl SessionStore {
             api_base: api_base.map(|s| s.to_string()),
             run_user: user,
             state,
+            parent_session_uuid: None,
+            branch_point_message_id: None,
         })
     }
 
@@ -170,6 +176,17 @@ impl SessionStore {
 
         tx.execute("DELETE FROM history WHERE session_uuid = ?1", params![uuid])
             .map_err(|e| AishError::Session(format!("failed to delete session history: {e}")))?;
+        // Reparent any children so deleting a forked parent does not orphan
+        // them out of session_roots()/list_children(); they resurface as roots.
+        // Clear branch_point_message_id too — it references the parent's now-
+        // deleted history, so a promoted root must not carry a dangling branch.
+        tx.execute(
+            "UPDATE sessions
+                SET parent_session_uuid = NULL, branch_point_message_id = NULL
+              WHERE parent_session_uuid = ?1",
+            params![uuid],
+        )
+        .map_err(|e| AishError::Session(format!("failed to reparent child sessions: {e}")))?;
         tx.execute(
             "DELETE FROM sessions WHERE session_uuid = ?1",
             params![uuid],
@@ -185,22 +202,13 @@ impl SessionStore {
         let mut stmt = self
             .conn
             .prepare(
-                "SELECT session_uuid, created_at, model, api_base, run_user, state
+                "SELECT session_uuid, created_at, model, api_base, run_user, state,
+                        parent_session_uuid, branch_point_message_id
              FROM sessions WHERE session_uuid = ?1",
             )
             .map_err(|e| AishError::Session(format!("failed to prepare get_session: {e}")))?;
 
-        let result = stmt.query_row(params![uuid], |row| {
-            Ok(SessionRecord {
-                session_uuid: row.get(0)?,
-                created_at: parse_datetime(&row.get::<_, String>(1)?),
-                model: row.get(2)?,
-                api_base: row.get(3)?,
-                run_user: row.get(4)?,
-                state: serde_json::from_str(&row.get::<_, String>(5)?)
-                    .unwrap_or(serde_json::Value::Object(Default::default())),
-            })
-        });
+        let result = stmt.query_row(params![uuid], row_to_session_record);
 
         match result {
             Ok(record) => Ok(Some(record)),
@@ -214,23 +222,14 @@ impl SessionStore {
         let mut stmt = self
             .conn
             .prepare(
-                "SELECT session_uuid, created_at, model, api_base, run_user, state
+                "SELECT session_uuid, created_at, model, api_base, run_user, state,
+                        parent_session_uuid, branch_point_message_id
              FROM sessions",
             )
             .map_err(|e| AishError::Session(format!("failed to prepare list_sessions: {e}")))?;
 
         let rows = stmt
-            .query_map([], |row| {
-                Ok(SessionRecord {
-                    session_uuid: row.get(0)?,
-                    created_at: parse_datetime(&row.get::<_, String>(1)?),
-                    model: row.get(2)?,
-                    api_base: row.get(3)?,
-                    run_user: row.get(4)?,
-                    state: serde_json::from_str(&row.get::<_, String>(5)?)
-                        .unwrap_or(serde_json::Value::Object(Default::default())),
-                })
-            })
+            .query_map([], row_to_session_record)
             .map_err(|e| AishError::Session(format!("failed to query sessions: {e}")))?;
 
         let mut sessions = Vec::new();
@@ -248,6 +247,106 @@ impl SessionStore {
         sessions.truncate(limit);
 
         Ok(sessions)
+    }
+    /// Fork a new session from an existing one.
+    ///
+    /// The new session copies the parent's persisted `state` snapshot plus its
+    /// `model`/`api_base`/`run_user` metadata, and records `parent_uuid` plus
+    /// the optional `branch_point_message_id` (the history row at which the
+    /// branch diverges). The fork's `created_at` is the current time.
+    pub fn fork_session(
+        &self,
+        parent_uuid: &str,
+        branch_point_message_id: Option<i64>,
+        new_uuid: &str,
+    ) -> Result<SessionRecord> {
+        let parent = self.get_session(parent_uuid)?.ok_or_else(|| {
+            AishError::Session(format!("parent session not found: {parent_uuid}"))
+        })?;
+
+        let now = Utc::now();
+        let now_str = now.to_rfc3339();
+        let state_str = serde_json::to_string(&parent.state)?;
+
+        self.conn
+            .execute(
+                "INSERT INTO sessions
+                    (session_uuid, created_at, model, api_base, run_user, state,
+                     parent_session_uuid, branch_point_message_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    new_uuid,
+                    now_str,
+                    parent.model,
+                    parent.api_base,
+                    parent.run_user,
+                    state_str,
+                    parent_uuid,
+                    branch_point_message_id,
+                ],
+            )
+            .map_err(|e| AishError::Session(format!("failed to fork session: {e}")))?;
+
+        Ok(SessionRecord {
+            session_uuid: new_uuid.to_string(),
+            created_at: now,
+            model: parent.model,
+            api_base: parent.api_base,
+            run_user: parent.run_user,
+            state: parent.state,
+            parent_session_uuid: Some(parent_uuid.to_string()),
+            branch_point_message_id,
+        })
+    }
+
+    /// List the direct child sessions forked from `parent_uuid`, oldest first.
+    pub fn list_children(&self, parent_uuid: &str) -> Result<Vec<SessionRecord>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT session_uuid, created_at, model, api_base, run_user, state,
+                        parent_session_uuid, branch_point_message_id
+                 FROM sessions WHERE parent_session_uuid = ?1
+                 ORDER BY created_at ASC",
+            )
+            .map_err(|e| AishError::Session(format!("failed to prepare list_children: {e}")))?;
+
+        let rows = stmt
+            .query_map(params![parent_uuid], row_to_session_record)
+            .map_err(|e| AishError::Session(format!("failed to query children: {e}")))?;
+
+        let mut children = Vec::new();
+        for row in rows {
+            children.push(
+                row.map_err(|e| AishError::Session(format!("failed to read child row: {e}")))?,
+            );
+        }
+        Ok(children)
+    }
+
+    /// List all root sessions (those without a parent), newest first.
+    pub fn session_roots(&self) -> Result<Vec<SessionRecord>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT session_uuid, created_at, model, api_base, run_user, state,
+                        parent_session_uuid, branch_point_message_id
+                 FROM sessions WHERE parent_session_uuid IS NULL
+                 ORDER BY created_at DESC",
+            )
+            .map_err(|e| AishError::Session(format!("failed to prepare session_roots: {e}")))?;
+
+        let rows = stmt
+            .query_map([], row_to_session_record)
+            .map_err(|e| AishError::Session(format!("failed to query session roots: {e}")))?;
+
+        let mut roots = Vec::new();
+        for row in rows {
+            roots.push(
+                row.map_err(|e| AishError::Session(format!("failed to read root row: {e}")))?,
+            );
+        }
+        Ok(roots)
     }
 
     /// Add a command history entry and return its row id.
@@ -479,6 +578,76 @@ impl AuditSink for AuditStore {
     }
 }
 
+/// Build a [`SessionRecord`] from a query row in the canonical column order:
+/// `session_uuid, created_at, model, api_base, run_user, state,
+/// parent_session_uuid, branch_point_message_id`.
+fn row_to_session_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRecord> {
+    Ok(SessionRecord {
+        session_uuid: row.get(0)?,
+        created_at: parse_datetime(&row.get::<_, String>(1)?),
+        model: row.get(2)?,
+        api_base: row.get(3)?,
+        run_user: row.get(4)?,
+        state: serde_json::from_str(&row.get::<_, String>(5)?)
+            .unwrap_or(serde_json::Value::Object(Default::default())),
+        parent_session_uuid: row.get(6)?,
+        branch_point_message_id: row.get(7)?,
+    })
+}
+
+/// Add columns introduced after the initial schema (`parent_session_uuid`,
+/// `branch_point_message_id`) to databases created by older builds. Idempotent:
+/// each column is added only when missing, detected via `PRAGMA table_info`.
+fn migrate_schema(conn: &rusqlite::Connection) -> Result<()> {
+    add_column_if_missing(
+        conn,
+        "parent_session_uuid",
+        "ALTER TABLE sessions ADD COLUMN parent_session_uuid TEXT DEFAULT NULL;",
+    )?;
+    add_column_if_missing(
+        conn,
+        "branch_point_message_id",
+        "ALTER TABLE sessions ADD COLUMN branch_point_message_id INTEGER DEFAULT NULL;",
+    )?;
+    Ok(())
+}
+
+/// Apply an `ALTER TABLE ... ADD COLUMN` idempotently. The column's presence is
+/// probed via `PRAGMA table_info` before the alter runs; a `duplicate column
+/// name` error is still treated as success so a concurrent `SessionStore::open`
+/// that won the race between probe and alter cannot break startup. Any other
+/// error propagates unchanged.
+fn add_column_if_missing(conn: &rusqlite::Connection, column: &str, sql: &str) -> Result<()> {
+    if column_exists(conn, column)? {
+        return Ok(());
+    }
+    match conn.execute_batch(sql) {
+        Ok(()) => Ok(()),
+        Err(e) if e.to_string().contains("duplicate column") => Ok(()),
+        Err(e) => Err(AishError::Session(format!(
+            "failed to apply session schema migration: {e}"
+        ))),
+    }
+}
+
+/// Whether `sessions` has a column named `column`, via `PRAGMA table_info`.
+fn column_exists(conn: &rusqlite::Connection, column: &str) -> Result<bool> {
+    let mut stmt = conn
+        .prepare("PRAGMA table_info(sessions)")
+        .map_err(|e| AishError::Session(format!("failed to probe session columns: {e}")))?;
+    let names = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|e| AishError::Session(format!("failed to probe session columns: {e}")))?;
+    for name in names {
+        if name.map_err(|e| AishError::Session(format!("failed to read column row: {e}")))?
+            == column
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 /// Parse an RFC 3339 datetime string, falling back to UTC now on failure.
 fn parse_datetime(s: &str) -> chrono::DateTime<chrono::Utc> {
     let normalized = if let Some(prefix) = s.strip_suffix('Z') {
@@ -646,5 +815,191 @@ mod tests {
             })
             .unwrap();
         assert!(other_user.is_empty());
+    }
+    fn temp_store() -> (tempfile::TempDir, SessionStore) {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("sessions.db");
+        let store = SessionStore::open(Some(&db_path)).unwrap();
+        (temp, store)
+    }
+
+    #[test]
+    fn fork_session_copies_state_and_links_parent() {
+        let (_temp, store) = temp_store();
+        let parent = store
+            .create_session("gpt-4o", Some("http://localhost:11434"))
+            .unwrap();
+        let snapshot = SessionStateSnapshot {
+            cwd: Some("/srv".to_string()),
+            summary_preview: Some("parent summary".to_string()),
+            context_messages_snapshot: vec![SessionContextMessage {
+                role: "user".to_string(),
+                content: "hello".to_string(),
+                memory_type: MemoryType::Llm,
+                name: None,
+                tool_call_id: None,
+            }],
+            updated_at: Some(Utc::now()),
+        };
+        store
+            .update_session_state(&parent.session_uuid, &snapshot)
+            .unwrap();
+
+        let child_uuid = "forked-uuid-1234";
+        let forked = store
+            .fork_session(&parent.session_uuid, Some(42), child_uuid)
+            .unwrap();
+
+        // Metadata is copied from the parent.
+        assert_eq!(forked.model, "gpt-4o");
+        assert_eq!(forked.api_base.as_deref(), Some("http://localhost:11434"));
+        assert_eq!(forked.run_user, parent.run_user);
+        assert_eq!(forked.session_uuid, child_uuid);
+
+        // Branch linkage is recorded on the returned record.
+        assert_eq!(
+            forked.parent_session_uuid.as_deref(),
+            Some(parent.session_uuid.as_str())
+        );
+        assert_eq!(forked.branch_point_message_id, Some(42));
+
+        // The persisted child must carry the parent's state and linkage.
+        let reloaded = store.get_session(child_uuid).unwrap().unwrap();
+        let reloaded_parent = store.get_session(&parent.session_uuid).unwrap().unwrap();
+        assert_eq!(reloaded.state, reloaded_parent.state);
+        let child_snapshot = reloaded.state_snapshot();
+        assert_eq!(child_snapshot.cwd.as_deref(), Some("/srv"));
+        assert_eq!(
+            child_snapshot.summary_preview.as_deref(),
+            Some("parent summary")
+        );
+        assert_eq!(child_snapshot.context_messages_snapshot.len(), 1);
+        assert_eq!(
+            reloaded.parent_session_uuid.as_deref(),
+            Some(parent.session_uuid.as_str())
+        );
+        assert_eq!(reloaded.branch_point_message_id, Some(42));
+
+        // The parent is the only root; the child is not a root.
+        let roots = store.session_roots().unwrap();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].session_uuid, parent.session_uuid);
+    }
+
+    #[test]
+    fn list_children_returns_only_direct_descendants() {
+        let (_temp, store) = temp_store();
+        let parent = store.create_session("m", None).unwrap();
+
+        let first = store
+            .fork_session(&parent.session_uuid, None, "child-1")
+            .unwrap();
+        let second = store
+            .fork_session(&parent.session_uuid, Some(7), "child-2")
+            .unwrap();
+        // A grandchild belongs to a child, not the parent.
+        let _grand = store.fork_session("child-1", None, "grand-1").unwrap();
+
+        let children = store.list_children(&parent.session_uuid).unwrap();
+        assert_eq!(children.len(), 2);
+        // Ordered oldest-first by created_at.
+        assert_eq!(children[0].session_uuid, first.session_uuid);
+        assert_eq!(children[1].session_uuid, second.session_uuid);
+        for child in &children {
+            assert_eq!(
+                child.parent_session_uuid.as_deref(),
+                Some(parent.session_uuid.as_str())
+            );
+        }
+
+        // The grandchild shows up only under its own parent.
+        let grandchildren = store.list_children("child-1").unwrap();
+        assert_eq!(grandchildren.len(), 1);
+        assert_eq!(grandchildren[0].session_uuid, "grand-1");
+    }
+
+    #[test]
+    fn delete_session_reparents_children_to_root() {
+        let (_temp, store) = temp_store();
+        let parent = store.create_session("m", None).unwrap();
+        let _child = store
+            .fork_session(&parent.session_uuid, Some(42), "child-1")
+            .unwrap();
+        let _grand = store.fork_session("child-1", None, "grand-1").unwrap();
+
+        // Sanity: parent is the only root before deletion.
+        assert_eq!(store.session_roots().unwrap().len(), 1);
+
+        store.delete_session(&parent.session_uuid).unwrap();
+
+        // The deleted parent is gone...
+        assert!(store.get_session(&parent.session_uuid).unwrap().is_none());
+        // ...and its child was reparented to root instead of being orphaned.
+        let roots = store.session_roots().unwrap();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].session_uuid, "child-1");
+        assert!(roots[0].parent_session_uuid.is_none());
+        // The dangling branch point (into the deleted parent's history) is cleared.
+        assert!(roots[0].branch_point_message_id.is_none());
+        // The grandchild is still nested under the reparented child.
+        assert_eq!(store.list_children("child-1").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn fork_session_missing_parent_errors() {
+        let (_temp, store) = temp_store();
+        let err = store.fork_session("does-not-exist", None, "x").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("parent session not found"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn migrate_schema_is_backward_compatible_with_legacy_db() {
+        // Create a database that predates the branch columns, then re-open it
+        // through SessionStore which must transparently add them.
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("legacy.db");
+        {
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE sessions (
+                    session_uuid TEXT PRIMARY KEY,
+                    created_at   TEXT NOT NULL,
+                    model        TEXT NOT NULL,
+                    api_base     TEXT,
+                    run_user     TEXT,
+                    state        TEXT DEFAULT '{}'
+                );
+                INSERT INTO sessions (session_uuid, created_at, model, api_base, run_user, state)
+                VALUES ('legacy-1',
+                        '2026-01-01T00:00:00+00:00',
+                        'old-model', '', '', '{}');",
+            )
+            .unwrap();
+        }
+
+        // Re-opening triggers migrate_schema; the legacy row round-trips and
+        // the new columns default to NULL.
+        let store = SessionStore::open(Some(&db_path)).unwrap();
+        let record = store.get_session("legacy-1").unwrap().unwrap();
+        assert_eq!(record.model, "old-model");
+        assert!(record.parent_session_uuid.is_none());
+        assert!(record.branch_point_message_id.is_none());
+
+        // Forking off the migrated legacy row must now work.
+        let forked = store
+            .fork_session("legacy-1", Some(3), "legacy-fork")
+            .unwrap();
+        assert_eq!(forked.parent_session_uuid.as_deref(), Some("legacy-1"));
+        assert_eq!(forked.branch_point_message_id, Some(3));
+        assert_eq!(store.list_children("legacy-1").unwrap().len(), 1);
+
+        // The legacy row is a root; the fork is not.
+        let roots = store.session_roots().unwrap();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].session_uuid, "legacy-1");
     }
 }

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -3464,6 +3464,7 @@ impl AishShell {
             Some("/forget-approvals") => self.handle_forget_approvals(),
             Some("/skill") => self.handle_skill_command(&parts),
             Some("/export") => self.handle_export_command(&parts),
+            Some("/fork") => self.handle_fork_command(),
             _ => {
                 eprintln!("{}", {
                     let mut args = std::collections::HashMap::new();
@@ -3656,6 +3657,67 @@ impl AishShell {
                 t_with_args("shell.export.write_failed", &{
                     let mut args = std::collections::HashMap::new();
                     args.insert("file".to_string(), fname);
+                    args.insert("error".to_string(), e.to_string());
+                    args
+                })
+            ),
+        }
+    }
+
+    /// `/fork` — branch the current session into a new one (copied context),
+    /// then switch into the fork so the original is preserved at its branch point.
+    fn handle_fork_command(&mut self) {
+        // Persist the current context first so the fork copies the latest state.
+        self.persist_session_snapshot();
+        let parent_uuid = self.session_uuid.clone();
+        let new_uuid = uuid::Uuid::new_v4().to_string();
+
+        // fork_session borrows the store immutably; keep that borrow in a block so
+        // the later `&mut self` resume call is not blocked by the live reference.
+        let fork_result = {
+            let Some(store) = self.session_store.as_ref() else {
+                eprintln!("{}", t("shell.fork.store_unavailable"));
+                return;
+            };
+            store.fork_session(&parent_uuid, None, &new_uuid)
+        };
+
+        let new_short = &new_uuid[..8.min(new_uuid.len())];
+        let parent_short = &parent_uuid[..8.min(parent_uuid.len())];
+        match fork_result {
+            Ok(_) => {
+                println!(
+                    "\x1b[32m{}\x1b[0m",
+                    t_with_args("shell.fork.forked", &{
+                        let mut args = std::collections::HashMap::new();
+                        args.insert("short".to_string(), new_short.to_string());
+                        args.insert("parent".to_string(), parent_short.to_string());
+                        args
+                    })
+                );
+                if let Err(e) = self.resume_session_with_options(&new_uuid, false, true) {
+                    eprintln!(
+                        "{}",
+                        t_with_args("shell.fork.switch_failed", &{
+                            let mut args = std::collections::HashMap::new();
+                            args.insert("error".to_string(), e.to_string());
+                            args
+                        })
+                    );
+                    eprintln!(
+                        "{}",
+                        t_with_args("shell.fork.switch_manual", &{
+                            let mut args = std::collections::HashMap::new();
+                            args.insert("session_id".to_string(), new_uuid.clone());
+                            args
+                        })
+                    );
+                }
+            }
+            Err(e) => eprintln!(
+                "{}",
+                t_with_args("shell.fork.failed", &{
+                    let mut args = std::collections::HashMap::new();
                     args.insert("error".to_string(), e.to_string());
                     args
                 })

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -50,6 +50,10 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
         "Search, install, verify skills; manage registries",
     ),
     ("/export", "Export current session to Markdown"),
+    (
+        "/fork",
+        "Branch the current session into a new one (copied context)",
+    ),
 ];
 
 // ---------------------------------------------------------------------------
@@ -828,6 +832,6 @@ mod tests {
                 cmd
             );
         }
-        assert_eq!(SLASH_COMMANDS.len(), 19);
+        assert_eq!(SLASH_COMMANDS.len(), 20);
     }
 }

--- a/crates/aish-shell/tests/slash_popup_commands.rs
+++ b/crates/aish-shell/tests/slash_popup_commands.rs
@@ -30,7 +30,7 @@ fn each_builtin_command_enter_executes() {
 
 #[test]
 fn slash_commands_table_has_expected_count() {
-    assert_eq!(SLASH_COMMANDS.len(), 19);
+    assert_eq!(SLASH_COMMANDS.len(), 20);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds the `/fork` built-in command: branch the current session into a new one (copied context), then switch into the fork so the original is preserved at its branch point.

Closes #413

## What it does

- Persists the current snapshot, then `fork_session` copies the parent's state + metadata into a new session, recording `parent_session_uuid` + `branch_point_message_id`, and switches into it.

## Data layer (`aish-session`)

- `SessionRecord` gains `parent_session_uuid` + `branch_point_message_id`.
- `fork_session` / `session_roots` / `list_children`; `migrate_schema` adds the columns additively (idempotent, backward compatible with legacy DBs).
- `delete_session` reparents children to root (clearing the dangling branch point) so deleting a forked parent never orphans its descendants.

## Scope

Reuses the existing `persist_session_snapshot` + `resume_session_with_options`. Self-contained to `aish-session` (store + models) + the `/fork` command in `aish-shell` + i18n.

> `/sessions` (the tree browser) builds on this data layer and will follow in a separate PR.

## Verification

- `cargo clippy -p aish-session -p aish-shell --all-targets -- -D warnings` clean.
- `aish-session` tests pass (9), including `fork_session_*`, `list_children_*`, `migrate_schema_*`, `delete_session_reparents_children_to_root`.
- `slash_popup_commands` tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `/fork` slash command to branch the current session into a new session while preserving context.
  * The app automatically switches to the forked session and shows success/failure outcomes, including manual resume guidance if switching fails.
  * Added session forking support with parent/branch-point tracking and updated localized UI strings (EN, DE, ES, FR, JA, ZH).

* **Bug Fixes**
  * Added automatic compatibility migration for existing session databases.
  * Prevented deleted sessions from leaving invalid branch references (child sessions are safely re-linked).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->