### PR TITLE
feat(shell): /sessions — browse the session tree and switch

### DIFF
--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -185,6 +185,7 @@ shell:
     skill: "Skills suchen, installieren, prüfen; Registries verwalten"
     export: "Aktuelle Sitzung als Markdown exportieren"
     fork: "Aktuelle Sitzung abzweigen"
+    sessions: "Sitzungsbaum anzeigen"
 
   feedback:
     select_type: "Feedback-Typ auswählen"
@@ -672,6 +673,11 @@ shell:
     switch_manual: "verwende `/resume {session_id}` zum manuellen Wechseln"
     failed: "Verzweigung fehlgeschlagen: {error}"
     store_unavailable: "Sitzungsspeicher nicht verfügbar; Verzweigung nicht möglich"
+
+  sessions:
+    none: "(keine gespeicherten Sitzungen)"
+    switch_failed: "Sitzungswechsel fehlgeschlagen: {error}"
+    list_failed: "Sitzungen auflisten fehlgeschlagen: {error}"
 
   live_sessions:
     daemon_disabled: "PTY-Daemon ist deaktiviert. In config.yaml aktivieren:"

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -370,6 +370,7 @@ shell:
     skill: "Search, install, verify skills; manage registries"
     export: "Export the current session to Markdown"
     fork: "Branch the current session"
+    sessions: "Show the session tree"
 
   record:
     started: "⏺ Recording started: {path}"
@@ -571,6 +572,11 @@ shell:
     switch_manual: "use `/resume {session_id}` to switch manually"
     failed: "fork failed: {error}"
     store_unavailable: "session store unavailable; cannot fork"
+
+  sessions:
+    none: "(no saved sessions)"
+    switch_failed: "failed to switch session: {error}"
+    list_failed: "failed to list sessions: {error}"
 
   live_sessions:
     daemon_disabled: "PTY daemon is disabled. Enable it in config.yaml:"

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -185,6 +185,7 @@ shell:
     skill: "Buscar, instalar, verificar skills; gestionar registros"
     export: "Exportar la sesión actual a Markdown"
     fork: "Bifurcar la sesión actual"
+    sessions: "Mostrar el árbol de sesiones"
 
   feedback:
     select_type: "Seleccionar tipo de comentario"
@@ -672,6 +673,11 @@ shell:
     switch_manual: "usa `/resume {session_id}` para cambiar manualmente"
     failed: "bifurcación fallida: {error}"
     store_unavailable: "almacén de sesiones no disponible; no se puede bifurcar"
+
+  sessions:
+    none: "(sin sesiones guardadas)"
+    switch_failed: "fallo al cambiar de sesión: {error}"
+    list_failed: "fallo al listar sesiones: {error}"
 
   live_sessions:
     daemon_disabled: "Demonio PTY deshabilitado. Habilitar en config.yaml:"

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -185,6 +185,7 @@ shell:
     skill: "Rechercher, installer, vérifier des skills; gérer les registres"
     export: "Exporter la session actuelle en Markdown"
     fork: "Créer une branche de la session actuelle"
+    sessions: "Afficher l'arborescence des sessions"
 
   feedback:
     select_type: "Sélectionner le type de commentaire"
@@ -672,6 +673,11 @@ shell:
     switch_manual: "utilisez `/resume {session_id}` pour changer manuellement"
     failed: "échec de la bifurcation : {error}"
     store_unavailable: "stockage de session indisponible ; bifurcation impossible"
+
+  sessions:
+    none: "(aucune session enregistrée)"
+    switch_failed: "échec du changement de session : {error}"
+    list_failed: "échec de la liste des sessions : {error}"
 
   live_sessions:
     daemon_disabled: "Daemon PTY desactive. Activer dans config.yaml :"

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -185,6 +185,7 @@ shell:
     skill: "スキルの検索・インストール・検証;レジストリ管理"
     export: "現在のセッションを Markdown にエクスポート"
     fork: "現在のセッションを分岐"
+    sessions: "セッションツリーを表示"
 
   feedback:
     select_type: "フィードバックの種類を選択"
@@ -672,6 +673,11 @@ shell:
     switch_manual: "`/resume {session_id}` で手動切り替えしてください"
     failed: "フォーク失敗: {error}"
     store_unavailable: "セッションストアが利用できません；フォークできません"
+
+  sessions:
+    none: "（保存済みセッションはありません）"
+    switch_failed: "セッションの切り替えに失敗しました: {error}"
+    list_failed: "セッション一覧の取得に失敗しました: {error}"
 
   live_sessions:
     daemon_disabled: "PTYデーモンが無効です。config.yaml で有効にしてください："

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -370,6 +370,7 @@ shell:
     skill: "搜索、安装、校验技能；管理 registry 源"
     export: "导出当前会话为 Markdown"
     fork: "分支当前会话"
+    sessions: "显示会话树"
 
   record:
     started: "⏺ 录制已开始: {path}"
@@ -571,6 +572,11 @@ shell:
     switch_manual: "使用 `/resume {session_id}` 手动切换"
     failed: "分叉失败：{error}"
     store_unavailable: "会话存储不可用；无法分叉"
+
+  sessions:
+    none: "（无已保存会话）"
+    switch_failed: "切换会话失败：{error}"
+    list_failed: "列出会话失败：{error}"
 
   live_sessions:
     daemon_disabled: "PTY 守护进程未启用，请在 config.yaml 中开启："

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -3465,6 +3465,7 @@ impl AishShell {
             Some("/skill") => self.handle_skill_command(&parts),
             Some("/export") => self.handle_export_command(&parts),
             Some("/fork") => self.handle_fork_command(),
+            Some("/sessions") => self.handle_sessions_command(),
             _ => {
                 eprintln!("{}", {
                     let mut args = std::collections::HashMap::new();
@@ -3722,6 +3723,116 @@ impl AishShell {
                     args
                 })
             ),
+        }
+    }
+
+    /// `/sessions` — browse the session tree in an interactive panel (instead of
+    /// flooding the screen) and switch to the chosen session on submit.
+    fn handle_sessions_command(&mut self) {
+        let Some(store) = self.session_store.as_ref() else {
+            eprintln!("{}", t("shell.resume.session_store_unavailable"));
+            return;
+        };
+        let roots = match store.session_roots() {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!(
+                    "{}",
+                    t_with_args("shell.sessions.list_failed", &{
+                        let mut args = std::collections::HashMap::new();
+                        args.insert("error".to_string(), e.to_string());
+                        args
+                    })
+                );
+                return;
+            }
+        };
+        if roots.is_empty() {
+            println!("{}", t("shell.sessions.none"));
+            return;
+        }
+
+        // Walk the full session forest depth-first so nested forks stay visible
+        // without dumping every node to stdout.
+        let mut items: Vec<aish_ui::SearchSelectItem> = Vec::new();
+        for root in &roots {
+            self.collect_session_tree(store, root, 0, &mut items);
+        }
+
+        let panel = aish_ui::SearchSelectPanel::new(
+            aish_i18n::t("shell.resume.selector_title"),
+            aish_i18n::t("shell.resume.search_placeholder"),
+            items,
+        );
+        if let Ok(aish_ui::PanelOutcome::Submitted(aish_ui::SearchSelectOutcome::Selected(id))) =
+            aish_ui::PanelRuntime::new().run(panel)
+        {
+            if id != self.session_uuid {
+                if let Err(e) = self.resume_session_with_options(&id, true, true) {
+                    eprintln!(
+                        "{}",
+                        t_with_args("shell.sessions.switch_failed", &{
+                            let mut args = std::collections::HashMap::new();
+                            args.insert("error".to_string(), e.to_string());
+                            args
+                        })
+                    );
+                }
+            }
+        }
+    }
+
+    /// Build one panel row for a session node, indenting forks beneath roots.
+    fn session_tree_item(
+        &self,
+        session: &aish_session::SessionRecord,
+        depth: usize,
+    ) -> aish_ui::SearchSelectItem {
+        let indent = if depth > 0 {
+            format!("{}└ ", "  ".repeat(depth))
+        } else {
+            String::new()
+        };
+        let short = &session.session_uuid[..8.min(session.session_uuid.len())];
+        let when = session.created_at.format("%m-%d %H:%M");
+        let cur = if session.session_uuid == self.session_uuid {
+            " *"
+        } else {
+            ""
+        };
+        let label = format!("{}{} {} {}{}", indent, short, session.model, when, cur);
+        let snap = session.state_snapshot();
+        let preview: String = snap
+            .summary_preview
+            .as_deref()
+            .unwrap_or("")
+            .chars()
+            .take(60)
+            .collect();
+        let search = format!("{} {} {}", short, session.model, preview);
+        let mut item = aish_ui::SearchSelectItem::new(session.session_uuid.clone(), label)
+            .with_search_text(search);
+        if !preview.is_empty() {
+            item = item.with_detail(preview);
+        }
+        item
+    }
+
+    /// Depth-first walk of the session tree: push `node` then recurse into its
+    /// children. The fork model guarantees acyclic parent links (a parent always
+    /// exists before its fork), so recursion terminates without a visited set.
+    fn collect_session_tree(
+        &self,
+        store: &aish_session::SessionStore,
+        node: &aish_session::SessionRecord,
+        depth: usize,
+        items: &mut Vec<aish_ui::SearchSelectItem>,
+    ) {
+        items.push(self.session_tree_item(node, depth));
+        if let Ok(children) = store.list_children(&node.session_uuid) {
+            for child in &children {
+                self.collect_session_tree(store, child, depth + 1, items);
+            }
         }
     }
 

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -54,6 +54,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
         "/fork",
         "Branch the current session into a new one (copied context)",
     ),
+    ("/sessions", "Show the session tree (roots + forks)"),
 ];
 
 // ---------------------------------------------------------------------------
@@ -832,6 +833,6 @@ mod tests {
                 cmd
             );
         }
-        assert_eq!(SLASH_COMMANDS.len(), 20);
+        assert_eq!(SLASH_COMMANDS.len(), 21);
     }
 }

--- a/crates/aish-shell/tests/slash_popup_commands.rs
+++ b/crates/aish-shell/tests/slash_popup_commands.rs
@@ -30,7 +30,7 @@ fn each_builtin_command_enter_executes() {
 
 #[test]
 fn slash_commands_table_has_expected_count() {
-    assert_eq!(SLASH_COMMANDS.len(), 20);
+    assert_eq!(SLASH_COMMANDS.len(), 21);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds the `/sessions` built-in command: an interactive panel that browses the session tree (roots + all descendants, indented by depth) and switches to the chosen session on submit.

Closes #412

## What it does

- Walks the full session forest depth-first (`collect_session_tree`) so nested forks stay visible, not just roots + direct children.
- Submit switches to the selected session, persisting the current state first (`persist_current=true`, like `/resume`) so no cwd is lost.

## Stacked on #418 (`/fork`)

This builds on the session data layer introduced by the `/fork` PR — `session_roots` / `list_children` / `parent_session_uuid`. **Merge #418 first.** The diff below includes that PR's commit until it lands.

## Scope

Reuses the existing `SearchSelectPanel` + `resume_session_with_options`; no new UI primitives. Self-contained to the `/sessions` command + i18n.

## Verification

- `cargo clippy -p aish-shell --all-targets -- -D warnings` clean.
- `aish-session` tests pass (9); `slash_popup_commands` tests pass (count + i18n).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `/sessions` command to browse the session tree, including roots and forks.
  * Added an interactive session selector with details such as model, timestamp, current session, and summary.
  * Enabled switching to a selected saved session.
* **Localization**
  * Added translations for the new command and session browsing messages in German, Spanish, French, Japanese, Simplified Chinese, and English.
  * Added messages for empty session lists and session loading or switching failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->