### PR TITLE
fix(skills): unified validation + transactional reinstall; rank search by relevance

### DIFF
--- a/crates/aish-shell/src/resume_selector.rs
+++ b/crates/aish-shell/src/resume_selector.rs
@@ -76,6 +76,8 @@ pub fn select_resume_session(items: &[ResumeSessionItem]) -> io::Result<Option<S
         PanelOutcome::Submitted(SearchSelectOutcome::Rename(_)) => Ok(None),
         // Quit (Ctrl+Q) is not meaningful for the resume picker; cancel.
         PanelOutcome::Submitted(SearchSelectOutcome::Quit) => Ok(None),
+        // Actions are not used by the resume picker; treat as a no-op.
+        PanelOutcome::Submitted(SearchSelectOutcome::Action(_, _)) => Ok(None),
         PanelOutcome::Cancelled => Ok(None),
     }
 }

--- a/crates/aish-skills/src/manager.rs
+++ b/crates/aish-skills/src/manager.rs
@@ -161,30 +161,8 @@ impl SkillManager {
     /// The file must start with a YAML frontmatter block delimited by `---`.
     fn parse_skill_file(&self, source: SkillSource, skill_path: &Path) -> aish_core::Result<Skill> {
         let content = std::fs::read_to_string(skill_path)?;
-        let re = regex::Regex::new(FRONTMATTER_REGEX).map_err(|e| {
-            aish_core::AishError::Skill(format!("Invalid frontmatter regex: {}", e))
-        })?;
-
-        let caps = re.captures(&content).ok_or_else(|| {
-            aish_core::AishError::Skill(
-                "Invalid skill file format: must start with YAML frontmatter".into(),
-            )
-        })?;
-
-        let frontmatter_yaml = caps.get(1).unwrap().as_str();
-        let skill_content = &content[caps.get(0).unwrap().end()..];
-        let skill_content = skill_content.trim();
-
-        let metadata: SkillMetadata = serde_yaml::from_str(frontmatter_yaml)
-            .map_err(|e| aish_core::AishError::Skill(format!("Invalid YAML frontmatter: {}", e)))?;
-        if metadata.context == crate::SkillExecutionContext::SubAgent
-            && metadata.agent.as_deref().is_none_or(str::is_empty)
-        {
-            return Err(aish_core::AishError::Skill(format!(
-                "Skill '{}' uses context=subagent but does not declare an agent",
-                metadata.name
-            )));
-        }
+        let (metadata, body) = parse_skill_metadata(&content)?;
+        let skill_content = body.trim();
 
         let base_dir = skill_path
             .parent()
@@ -319,6 +297,40 @@ impl SkillManager {
         // Default to User if we cannot determine the source.
         SkillSource::User
     }
+}
+
+/// Parse a SKILL.md document: extract the YAML frontmatter, deserialize it
+/// into [`SkillMetadata`], and enforce the loader's invariants. Returns the
+/// parsed metadata and the document body (the content after the frontmatter
+/// block, not yet trimmed).
+///
+/// This is the single source of truth for "would the loader accept this file":
+/// [`SkillManager::parse_skill_file`], the registry installer, and the verifier
+/// all route through it, so install/verify-time validation can never drift from
+/// load-time validation. A skill that fails this (e.g. one that declares
+/// `context: subagent`/`fork` without an `agent`) is rejected here rather than
+/// landing on disk only to be rejected on every hot-reload.
+pub fn parse_skill_metadata(content: &str) -> aish_core::Result<(SkillMetadata, &str)> {
+    let re = regex::Regex::new(FRONTMATTER_REGEX)
+        .map_err(|e| aish_core::AishError::Skill(format!("Invalid frontmatter regex: {}", e)))?;
+    let caps = re.captures(content).ok_or_else(|| {
+        aish_core::AishError::Skill(
+            "Invalid skill file format: must start with YAML frontmatter".into(),
+        )
+    })?;
+    let frontmatter_yaml = caps.get(1).unwrap().as_str();
+    let body = &content[caps.get(0).unwrap().end()..];
+    let metadata: SkillMetadata = serde_yaml::from_str(frontmatter_yaml)
+        .map_err(|e| aish_core::AishError::Skill(format!("Invalid YAML frontmatter: {}", e)))?;
+    if metadata.context == crate::SkillExecutionContext::SubAgent
+        && metadata.agent.as_deref().is_none_or(str::is_empty)
+    {
+        return Err(aish_core::AishError::Skill(format!(
+            "Skill '{}' uses context=subagent but does not declare an agent",
+            metadata.name
+        )));
+    }
+    Ok((metadata, body))
 }
 
 /// Walk a directory recursively, following symlinks while detecting cycles.
@@ -628,5 +640,31 @@ mod tests {
             skill.quarantined,
             "nested SKILL.md under an untrusted skill must be quarantined"
         );
+    }
+    #[test]
+    fn parse_skill_metadata_rejects_fork_without_agent() {
+        // The docker-best-practices bug: `context: fork` aliases to SubAgent,
+        // which requires a named agent. The shared parse must reject it so the
+        // installer and verifier reject it too.
+        let content = "---\nname: docker\ndescription: d\ncontext: fork\n---\nbody\n";
+        let err = parse_skill_metadata(content).expect_err("fork without agent must fail");
+        assert!(err.to_string().contains("agent"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_skill_metadata_accepts_subagent_with_agent_and_returns_body() {
+        let content = "---\nname: diag\ndescription: d\ncontext: subagent\nagent: troubleshoot\n---\n## Body\n";
+        let (metadata, body) =
+            parse_skill_metadata(content).expect("valid subagent skill must parse");
+        assert_eq!(metadata.name, "diag");
+        assert_eq!(metadata.agent.as_deref(), Some("troubleshoot"));
+        assert!(body.trim_start().starts_with("## Body"));
+    }
+
+    #[test]
+    fn parse_skill_metadata_rejects_missing_frontmatter() {
+        let err = parse_skill_metadata("no frontmatter here at all")
+            .expect_err("must require frontmatter");
+        assert!(err.to_string().contains("frontmatter"), "got: {err}");
     }
 }

--- a/crates/aish-skills/src/registry/mod.rs
+++ b/crates/aish-skills/src/registry/mod.rs
@@ -254,22 +254,7 @@ impl RegistryManager {
         let adapter = self.find_adapter(&skill.registry).ok_or_else(|| {
             aish_core::AishError::Skill(format!("No adapter for registry '{}'", skill.registry))
         })?;
-        // Remember whether this is a fresh install or a reinstall over an
-        // existing skill, so a failed reinstall does not delete the previously
-        // installed (possibly trusted / locally modified) skill.
-        let pre_existed = target_dir.join(&skill.slug).exists();
-        pre_quarantine(target_dir, &skill.slug)?;
-        match adapter.install(skill, target_dir) {
-            Ok(result) => Ok(result),
-            Err(e) => {
-                // Only remove on a failed FRESH install; a failed reinstall
-                // must leave the previous skill intact rather than destroy it.
-                if !pre_existed {
-                    let _ = std::fs::remove_dir_all(target_dir.join(&skill.slug));
-                }
-                Err(e)
-            }
-        }
+        Self::install_transactional(adapter, skill, target_dir, None)
     }
 
     /// Install a skill, respecting a cooperative cancel flag checked between
@@ -285,15 +270,65 @@ impl RegistryManager {
         let adapter = self.find_adapter(&skill.registry).ok_or_else(|| {
             aish_core::AishError::Skill(format!("No adapter for registry '{}'", skill.registry))
         })?;
-        let pre_existed = target_dir.join(&skill.slug).exists();
-        pre_quarantine(target_dir, &skill.slug)?;
-        match adapter.install_with_cancel(skill, target_dir, cancel) {
-            Ok(result) => Ok(result),
+        Self::install_transactional(adapter, skill, target_dir, Some(cancel))
+    }
+
+    /// Transactional install core shared by [`install`](Self::install) and
+    /// [`install_with_cancel`](Self::install_with_cancel).
+    ///
+    /// For a reinstall the existing skill dir is moved aside first (same
+    /// filesystem, so the rename is atomic), then the replacement is downloaded
+    /// into a fresh dir and validated. On failure the failed replacement is
+    /// removed and the original restored in place — a bad replacement can never
+    /// overwrite/quarantine a previously trusted or locally modified skill.
+    fn install_transactional(
+        adapter: &dyn RegistryAdapter,
+        skill: &RegistrySkill,
+        target_dir: &Path,
+        cancel: Option<&AtomicBool>,
+    ) -> Result<InstallResult> {
+        // Hold the per-slug lock for the whole transaction: two concurrent
+        // installs of the same slug would race the live→stash rename / swap.
+        let install_lock = install_lock_for(&skill.slug);
+        let _install_guard = install_lock.lock().unwrap();
+        // Reject path-escaping slugs BEFORE constructing the stash path —
+        // reinstall_stash_path joins the slug into target_dir, so an unsafe
+        // slug must not reach it. (pre_quarantine re-validates downstream.)
+        installer::validate_install_slug(&skill.slug)?;
+        let live = target_dir.join(&skill.slug);
+        let stash = if live.exists() {
+            let stash = reinstall_stash_path(target_dir, &skill.slug);
+            if stash.exists() {
+                let _ = std::fs::remove_dir_all(&stash);
+            }
+            std::fs::rename(&live, &stash).map_err(|e| {
+                aish_core::AishError::Skill(format!(
+                    "failed to stash existing skill for reinstall: {e}"
+                ))
+            })?;
+            Some(stash)
+        } else {
+            None
+        };
+        let result = pre_quarantine(target_dir, &skill.slug)
+            .and_then(|_| match cancel {
+                None => adapter.install(skill, target_dir),
+                Some(flag) => adapter.install_with_cancel(skill, target_dir, flag),
+            })
+            .and_then(|r| validate_installed_skill(&r.dir).map(|_| r));
+        match result {
+            Ok(result) => {
+                // Success: the validated replacement supersedes the original.
+                if let Some(s) = stash {
+                    let _ = std::fs::remove_dir_all(s);
+                }
+                Ok(result)
+            }
             Err(e) => {
-                // Only remove on a failed FRESH install; a failed reinstall
-                // must leave the previous skill intact rather than destroy it.
-                if !pre_existed {
-                    let _ = std::fs::remove_dir_all(target_dir.join(&skill.slug));
+                // Failure: drop the failed replacement and restore the original.
+                let _ = std::fs::remove_dir_all(&live);
+                if let Some(s) = stash {
+                    let _ = std::fs::rename(s, &live);
                 }
                 Err(e)
             }
@@ -365,6 +400,44 @@ pub fn parse_skill_id_rest(rest: &str) -> Option<(String, String)> {
     } else {
         None
     }
+}
+
+/// Build a unique sibling path (same `target_dir` filesystem) for stashing an
+/// existing skill dir during a transactional reinstall. A same-filesystem
+/// rename is atomic; stashing under `/tmp` could cross mounts and fail with
+/// EXDEV. The nanos+pid suffix avoids collisions between concurrent installs.
+fn reinstall_stash_path(target_dir: &Path, slug: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    target_dir.join(format!(".{slug}.reinstall-{nanos}-{}", std::process::id()))
+}
+
+/// Per-slug install lock. Concurrent installs of the SAME slug would race the
+/// stash/restore swap (each renames the live dir aside and writes a fresh
+/// replacement), so serialize per-slug — different slugs still install in
+/// parallel. Entries live for the process, bounded by the finite slug set.
+static INSTALL_LOCKS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<String, std::sync::Arc<std::sync::Mutex<()>>>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+fn install_lock_for(slug: &str) -> std::sync::Arc<std::sync::Mutex<()>> {
+    let mut map = INSTALL_LOCKS.lock().unwrap();
+    map.entry(slug.to_string())
+        .or_insert_with(|| std::sync::Arc::new(std::sync::Mutex::new(())))
+        .clone()
+}
+
+/// Confirm an installed skill's SKILL.md is loadable by running the exact
+/// parse the loader uses. A skill the loader rejects is unusable — it lands on
+/// disk only to be rejected on every hot-reload — so this turns a silent
+/// post-install failure (warning spam) into an actionable install-time error.
+fn validate_installed_skill(dir: &Path) -> Result<()> {
+    let content = std::fs::read_to_string(dir.join("SKILL.md")).map_err(|e| {
+        aish_core::AishError::Skill(format!("Installed skill has no readable SKILL.md: {}", e))
+    })?;
+    crate::manager::parse_skill_metadata(&content).map(|_| ())
 }
 
 /// Pre-create the skill directory with its `.untrusted` quarantine marker
@@ -445,6 +518,124 @@ mod tests {
         assert!(
             parent.join("sibling").exists(),
             "parent contents must be intact"
+        );
+    }
+    /// Test adapter that writes a fixed SKILL.md into the install dir, so we
+    /// can drive `RegistryManager::install` end-to-end without any HTTP.
+    struct FakeAdapter {
+        name: &'static str,
+        skill_md: &'static str,
+    }
+
+    impl RegistryAdapter for FakeAdapter {
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn search(&self, _query: &str, _limit: usize) -> Result<Vec<RegistrySkill>> {
+            Ok(vec![])
+        }
+        fn install(&self, skill: &RegistrySkill, target_dir: &Path) -> Result<InstallResult> {
+            let dir = target_dir.join(&skill.slug);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("SKILL.md"), self.skill_md).unwrap();
+            Ok(InstallResult {
+                dir,
+                skill_name: skill.slug.clone(),
+            })
+        }
+    }
+
+    fn fake_registry_skill(slug: &str, registry: &str) -> RegistrySkill {
+        RegistrySkill {
+            id: format!("{registry}/{slug}"),
+            name: slug.to_string(),
+            description: "test".into(),
+            registry: registry.to_string(),
+            source: "owner/repo".into(),
+            slug: slug.to_string(),
+            installs: 0,
+            homepage: None,
+        }
+    }
+
+    #[test]
+    fn install_rejects_unloadable_skill_and_rolls_back_fresh_install() {
+        // Regression for "installed skill spams hot-reload warnings forever":
+        // a skill the loader rejects (context=fork, no agent) must be refused
+        // at install time and the fresh install dir removed.
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let mut manager = RegistryManager { adapters: vec![] };
+        manager.register(Box::new(FakeAdapter {
+            name: "fake",
+            skill_md: "---\nname: bad\ndescription: d\ncontext: fork\n---\nbody\n",
+        }));
+        let skill = fake_registry_skill("bad-skill", "fake");
+
+        let err = manager
+            .install(&skill, tmp.path())
+            .expect_err("unloadable skill must be rejected at install time");
+        assert!(err.to_string().contains("agent"), "got: {err}");
+        assert!(
+            !tmp.path().join("bad-skill").exists(),
+            "fresh install must be rolled back"
+        );
+    }
+
+    #[test]
+    fn install_accepts_loadable_skill() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let mut manager = RegistryManager { adapters: vec![] };
+        manager.register(Box::new(FakeAdapter {
+            name: "fake",
+            skill_md: "---\nname: good\ndescription: d\n---\nbody\n",
+        }));
+        let skill = fake_registry_skill("good-skill", "fake");
+
+        let result = manager
+            .install(&skill, tmp.path())
+            .expect("loadable skill installs");
+        assert!(result.dir.join("SKILL.md").exists());
+    }
+
+    #[test]
+    fn install_failed_reinstall_keeps_previous_skill_dir() {
+        // A failed RE-install must not delete the previously installed skill
+        // dir, even when the newly written SKILL.md fails validation.
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let dir = tmp.path().join("exists");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("SKILL.md"),
+            "---\nname: old\ndescription: d\n---\nold body\n",
+        )
+        .unwrap();
+
+        let mut manager = RegistryManager { adapters: vec![] };
+        manager.register(Box::new(FakeAdapter {
+            name: "fake",
+            skill_md: "---\nname: bad\ndescription: d\ncontext: fork\n---\nbody\n",
+        }));
+        let skill = fake_registry_skill("exists", "fake");
+
+        let err = manager
+            .install(&skill, tmp.path())
+            .expect_err("unloadable reinstall must still fail");
+        assert!(err.to_string().contains("agent"));
+        assert!(
+            dir.exists(),
+            "previous skill dir must survive a failed reinstall"
+        );
+        // The original content must be byte-for-byte intact (not overwritten by
+        // the failed replacement) and the original trusted state preserved.
+        let preserved = std::fs::read_to_string(dir.join("SKILL.md"))
+            .expect("original SKILL.md must survive a failed reinstall");
+        assert_eq!(
+            preserved, "---\nname: old\ndescription: d\n---\nold body\n",
+            "failed reinstall must not overwrite the previous skill content"
+        );
+        assert!(
+            !dir.join(crate::models::UNTRUSTED_MARKER).exists(),
+            "original trust state must be restored (no quarantine marker)"
         );
     }
 }

--- a/crates/aish-skills/src/registry/verifier.rs
+++ b/crates/aish-skills/src/registry/verifier.rs
@@ -57,37 +57,25 @@ pub fn verify_skill_dir(dir: &Path) -> VerifyReport {
         }
     };
 
-    // 2. Frontmatter parses.
-    let frontmatter_ok = match parse_frontmatter(&content) {
-        Ok(fm) => {
-            if let Some(name) = fm.get("name").and_then(|v| v.as_str()) {
-                skill_name = name.to_string();
-            }
-            let has_name = fm.get("name").and_then(|v| v.as_str()).is_some();
-            let has_desc = fm.get("description").and_then(|v| v.as_str()).is_some();
+    // 2. Frontmatter parses and satisfies the loader's invariants. Reuses the
+    //    exact parse the loader + installer use, so `verify` cannot report a
+    //    skill as valid that the loader would reject (e.g. context=fork with
+    //    no agent).
+    let frontmatter_ok = match crate::manager::parse_skill_metadata(&content) {
+        Ok((metadata, _)) => {
+            skill_name = metadata.name.clone();
             checks.push(VerifyCheck {
                 label: "Frontmatter valid".into(),
-                passed: has_name && has_desc,
-                detail: if has_name && has_desc {
-                    format!("name=\"{}\", has description", skill_name)
-                } else {
-                    let mut missing = Vec::new();
-                    if !has_name {
-                        missing.push("name");
-                    }
-                    if !has_desc {
-                        missing.push("description");
-                    }
-                    format!("Missing fields: {}", missing.join(", "))
-                },
+                passed: true,
+                detail: format!("name=\"{}\"", skill_name),
             });
-            has_name && has_desc
+            true
         }
         Err(e) => {
             checks.push(VerifyCheck {
                 label: "Frontmatter valid".into(),
                 passed: false,
-                detail: e,
+                detail: e.to_string(),
             });
             false
         }
@@ -107,23 +95,6 @@ pub fn verify_skill_dir(dir: &Path) -> VerifyReport {
         skill_name,
         checks,
     }
-}
-
-/// Parse YAML frontmatter from SKILL.md content.
-/// Returns a map of key → JSON value.
-fn parse_frontmatter(content: &str) -> Result<serde_json::Value, String> {
-    let re = regex::Regex::new(r"(?s)^---\s*\n(.*?)\n---\s*\n")
-        .map_err(|e| format!("Regex error: {}", e))?;
-
-    let caps = re
-        .captures(content)
-        .ok_or_else(|| "Missing YAML frontmatter (--- delimiters)".to_string())?;
-
-    let yaml_str = caps.get(1).unwrap().as_str();
-    let yaml: serde_yaml::Value =
-        serde_yaml::from_str(yaml_str).map_err(|e| format!("YAML parse error: {}", e))?;
-
-    serde_json::to_value(&yaml).map_err(|e| format!("Conversion error: {}", e))
 }
 
 /// Check that scripts in a directory exist and have executable permissions.

--- a/crates/aish-tools/src/skill_registry/skill_registry.rs
+++ b/crates/aish-tools/src/skill_registry/skill_registry.rs
@@ -202,6 +202,17 @@ impl SkillInstallTool {
         }
     }
 
+    /// Shared handle to the session-scoped "auto-vet" flag.
+    ///
+    /// Set when the user picks "remember this session" on the post-install
+    /// review dialog, so later installs skip the dialog and auto-run the
+    /// vetter. `/forget-approvals` swaps it back to `false` so the review
+    /// dialog reappears — the same `[a]` choice reaches this flag and the
+    /// command approval memory, so both must be clearable together.
+    pub fn auto_vet_handle(&self) -> std::sync::Arc<std::sync::atomic::AtomicBool> {
+        self.auto_vet.clone()
+    }
+
     fn user_skills_dir() -> PathBuf {
         // Shared with the loader (SkillManager::scan_skill_roots) so installs
         // always land where skills are read from.
@@ -659,5 +670,30 @@ determining its risk is Low or Medium. Never trust a High/Extreme skill."
             },
             Err(e) => ToolResult::error(format!("Failed to trust '{}': {}", name, e)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The handle returned by `auto_vet_handle` must alias the tool's internal
+    /// flag. `/forget-approvals` relies on this to reset a "remember this
+    /// session" decision the skill-install tool recorded privately.
+    #[test]
+    fn auto_vet_handle_resets_the_remembered_decision() {
+        let tool = SkillInstallTool::new(vec![]);
+        let handle = tool.auto_vet_handle();
+        assert!(!handle.load(std::sync::atomic::Ordering::SeqCst));
+
+        // Simulate the user picking "remember this session" on the review
+        // dialog (execute_async_in_session stores into this same flag).
+        handle.store(true, std::sync::atomic::Ordering::SeqCst);
+        assert!(tool.auto_vet.load(std::sync::atomic::Ordering::SeqCst));
+
+        // `/forget-approvals` swaps the handle back to false; the tool must
+        // observe the reset so later installs re-prompt for review.
+        assert!(handle.swap(false, std::sync::atomic::Ordering::SeqCst));
+        assert!(!tool.auto_vet.load(std::sync::atomic::Ordering::SeqCst));
     }
 }

--- a/crates/aish-ui/src/select.rs
+++ b/crates/aish-ui/src/select.rs
@@ -91,17 +91,34 @@ pub enum SearchSelectOutcome {
     Rename(String),
     /// Exit the panel (triggered by Ctrl+Q). Callers decide exit semantics.
     Quit,
+    /// A configured single-key action was pressed (e.g. 'a' add, 'd' delete).
+    /// Action keys are intercepted before the search buffer.
+    Action(char, String),
 }
 
-/// Match when every whitespace-separated token in `query` is a substring of `search_text`.
-fn matches_tokenized_query(search_text: &str, query: &str) -> bool {
+/// Relevance score for `query` against `search_text`: every whitespace-separated
+/// token must be a substring (AND), but exact matches beat prefix matches beat
+/// substring matches, so the most relevant entry floats to the top. Returns
+/// `None` when any token is absent.
+fn match_score(search_text: &str, query: &str) -> Option<usize> {
     let query = query.trim().to_lowercase();
     if query.is_empty() {
-        return true;
+        return Some(0);
     }
-    query
-        .split_whitespace()
-        .all(|token| search_text.contains(token))
+    let st = search_text.to_lowercase();
+    let mut total = 0;
+    for token in query.split_whitespace() {
+        if st == token {
+            total += 100;
+        } else if st.starts_with(token) {
+            total += 50;
+        } else if st.contains(token) {
+            total += 10;
+        } else {
+            return None;
+        }
+    }
+    Some(total)
 }
 
 #[derive(Debug, Clone)]
@@ -121,6 +138,9 @@ pub struct SearchSelectPanel {
     shimmer_value: Option<String>,
     /// Animation clock in milliseconds, advanced one tick per redraw.
     anim_ms: u64,
+    /// Configured single-key actions (key, label). These keys are intercepted
+    /// before the search buffer so they trigger `Action(char)`, not typing.
+    actions: Vec<(char, String)>,
 }
 
 impl SearchSelectPanel {
@@ -141,8 +161,16 @@ impl SearchSelectPanel {
             selected: 0,
             max_visible_items: DEFAULT_VISIBLE_ITEMS,
             shimmer_value: None,
+            actions: Vec::new(),
             anim_ms: 0,
         }
+    }
+
+    /// Register a single-key action. The key is intercepted before the search
+    /// buffer and emitted as `SearchSelectOutcome::Action(char)`.
+    pub fn with_action(mut self, key: char, label: impl Into<String>) -> Self {
+        self.actions.push((key, label.into()));
+        self
     }
 
     pub fn with_footer(mut self, footer: impl Into<String>) -> Self {
@@ -196,13 +224,19 @@ impl SearchSelectPanel {
         if query.is_empty() {
             (0..self.items.len()).map(SelectEntry::Item).collect()
         } else {
-            self.items
+            let mut scored: Vec<(usize, usize)> = self
+                .items
                 .iter()
                 .enumerate()
                 .filter_map(|(index, item)| {
-                    matches_tokenized_query(&item.search_text, query)
-                        .then_some(SelectEntry::Item(index))
+                    match_score(&item.search_text, query).map(|s| (index, s))
                 })
+                .collect();
+            // Highest score first; ties keep original order for stability.
+            scored.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+            scored
+                .into_iter()
+                .map(|(i, _)| SelectEntry::Item(i))
                 .collect()
         }
     }
@@ -431,6 +465,25 @@ impl PanelComponent for SearchSelectPanel {
                 if !key.modifiers.contains(KeyModifiers::CONTROL)
                     && !key.modifiers.contains(KeyModifiers::ALT) =>
             {
+                let lower = ch.to_ascii_lowercase();
+                // Action keys only fire on an empty query; once the user is
+                // typing a search, letters must filter instead of triggering a
+                // panel action (otherwise typing "model" would hit the `m`
+                // manage action).
+                if self.query.is_empty() {
+                    if let Some((action_key, _)) = self.actions.iter().find(|(k, _)| *k == lower) {
+                        let value = self
+                            .filtered_entries()
+                            .get(self.selected)
+                            .and_then(|e| match e {
+                                SelectEntry::Item(i) => {
+                                    self.items.get(*i).map(|it| it.value.clone())
+                                }
+                            })
+                            .unwrap_or_default();
+                        return PanelEvent::Submit(SearchSelectOutcome::Action(*action_key, value));
+                    }
+                }
                 self.query.push(ch);
                 self.selected = 0;
                 self.clamp_selection();


### PR DESCRIPTION
## Summary

Independent hardening/fixes that apply to already-shipped code (no new commands, no new features): unified skill-metadata validation + transactional reinstall, and relevance-ranked search.

Refs #414 (the skill-hardening + search-ranking slice of the bug-fix issue).

## Skill registry (`aish-skills` / `aish-tools`)

- **Unified validation**: `parse_skill_metadata` is now the single source of truth the loader, installer, and verifier all use, so install/verify-time validation can't drift from load-time. Rejects `context=fork/subagent` skills that don't declare an `agent`.
- **Transactional reinstall**: the existing skill is stashed (same-filesystem atomic rename) before the replacement is downloaded + validated, and restored on failure — a bad replacement can no longer overwrite/quarantine a previously trusted skill. Path-escaping slugs are rejected before the stash path is built.

## Search panel (`aish-ui`)

- `SearchSelect` ranks results by relevance (exact > prefix > substring) and adds an opt-in single-key `Action` outcome, intercepted only on an empty query so typing never triggers an action.

## Scope / deferred

Truly independent of the new commands. The remaining #414 items are intentionally **not** here:
- approval-memory tool-scoping + `approval_key` — coupled to the rotation/credential work, will follow together.
- `delete_session` reparent, `/sessions` persist, `/export` escaping — ship with their command PRs (#417/#418/#419).

## Verification

- `cargo clippy -p aish-skills -p aish-tools -p aish-ui -p aish-shell --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- `aish-skills` 45 tests pass (incl. reinstall preservation); `aish-ui` 73 pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now rank exact, prefix, and partial matches by relevance.
  * Selection panels support configurable single-key actions.
  * Skill installation validates metadata before completion and safely restores previous versions if validation fails.
  * Session approval preferences can be reset so future installations request review again.

* **Bug Fixes**
  * Skill loading and verification now apply consistent frontmatter validation.
  * Failed skill reinstalls preserve the existing skill and its trust state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->