### PR TITLE
feat(update): show Keep-a-Changelog summary after upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- After upgrading, the next interactive `aish` launch shows a Keep-a-Changelog summary for every version between the previously seen release and the newly installed one (oldest → newest), sourced from the `CHANGELOG.md` embedded in the binary. A `~/.config/aish/last-changelog-version` marker tracks what has already been shown.
+
 ## [0.3.9] - 2026-07-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ version = "0.3.9"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
+ "semver",
  "serde_yaml",
  "tracing",
 ]

--- a/crates/aish-cli/src/update.rs
+++ b/crates/aish-cli/src/update.rs
@@ -411,22 +411,27 @@ fn download_release(tag_name: &str) -> Result<PathBuf, AishError> {
 // Archive extraction & install
 // ---------------------------------------------------------------------------
 
-fn find_install_sh(dir: &Path) -> Result<PathBuf, AishError> {
-    fn search(dir: &Path) -> Option<PathBuf> {
+fn find_file_named(dir: &Path, name: &str) -> Option<PathBuf> {
+    fn search(dir: &Path, name: &str) -> Option<PathBuf> {
         for entry in std::fs::read_dir(dir).ok()? {
             let entry = entry.ok()?;
             let path = entry.path();
             if path.is_dir() {
-                if let Some(found) = search(&path) {
+                if let Some(found) = search(&path, name) {
                     return Some(found);
                 }
-            } else if path.file_name().is_some_and(|n| n == "install.sh") {
+            } else if path.file_name().is_some_and(|n| n == name) {
                 return Some(path);
             }
         }
         None
     }
-    search(dir).ok_or_else(|| AishError::Config(t("cli.update.install_sh_not_found")))
+    search(dir, name)
+}
+
+fn find_install_sh(dir: &Path) -> Result<PathBuf, AishError> {
+    find_file_named(dir, "install.sh")
+        .ok_or_else(|| AishError::Config(t("cli.update.install_sh_not_found")))
 }
 
 fn install_release(archive_path: &Path) -> Result<(), AishError> {
@@ -730,15 +735,16 @@ pub fn run_update(check_only: bool, pre_release: bool) {
             }
 
             match download_release(&info.tag_name) {
-                Ok(archive_path) => {
-                    if let Err(e) = install_release(&archive_path) {
+                Ok(archive_path) => match install_release(&archive_path) {
+                    Ok(()) => {}
+                    Err(e) => {
                         eprintln!("\x1b[31m{}\x1b[0m", {
                             let mut args = std::collections::HashMap::new();
                             args.insert("error".to_string(), e.to_string());
                             t_with_args("cli.update.installation_error", &args)
                         });
                     }
-                }
+                },
                 Err(e) => {
                     eprintln!("\x1b[31m{}\x1b[0m", {
                         let mut args = std::collections::HashMap::new();

--- a/crates/aish-i18n/Cargo.toml
+++ b/crates/aish-i18n/Cargo.toml
@@ -8,3 +8,4 @@ aish-core.workspace = true
 serde_yaml.workspace = true
 tracing.workspace = true
 dirs.workspace = true
+semver.workspace = true

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -340,6 +340,10 @@ shell:
     changelog_title: "What's New in {version}"
     changelog_hint_prefix: "{count} updates -"
     changelog_hint_suffix: "to view all"
+    changelog_summary_title: "What's new ({current} → {latest}):"
+    changelog_summary_version: "v{version}"
+    changelog_summary_more: "... and {count} more"
+    changelog_summary_truncated: "... truncated. Full notes ship in CHANGELOG.md."
 
   # General error messages
   general_error: "error: {error}"

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -340,6 +340,10 @@ shell:
     changelog_title: "{version} 更新内容"
     changelog_hint_prefix: "共 {count} 条更新 -"
     changelog_hint_suffix: "查看全部"
+    changelog_summary_title: "更新内容（{current} → {latest}）："
+    changelog_summary_version: "v{version}"
+    changelog_summary_more: "……还有 {count} 条"
+    changelog_summary_truncated: "……已截断。完整说明见 CHANGELOG.md。"
 
   # 通用错误消息
   general_error: "错误: {error}"

--- a/crates/aish-i18n/src/changelog.rs
+++ b/crates/aish-i18n/src/changelog.rs
@@ -1,5 +1,5 @@
 /// A single changelog entry extracted from CHANGELOG.md.
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ChangelogEntry {
     // Keep-a-Changelog categories: "Added", "Changed", "Fixed", "Removed",
     // "Deprecated", "Security". Stored as a free-form String because the
@@ -8,8 +8,25 @@ pub struct ChangelogEntry {
     pub text: String, // description text (without leading "- ")
 }
 
+/// One Keep-a-Changelog version section (`## [x.y.z]`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChangelogVersionSection {
+    pub version: String,
+    pub entries: Vec<ChangelogEntry>,
+}
+
 /// Embed the workspace root CHANGELOG.md at compile time.
 const CHANGELOG_CONTENT: &str = include_str!("../../../CHANGELOG.md");
+
+/// Workspace root CHANGELOG.md embedded at compile time.
+pub fn embedded_changelog() -> &'static str {
+    CHANGELOG_CONTENT
+}
+
+/// Parse every Keep-a-Changelog section from the embedded file.
+pub fn parse_embedded_changelog_sections() -> Vec<ChangelogVersionSection> {
+    parse_changelog_sections(CHANGELOG_CONTENT)
+}
 
 /// Parse the current version's changelog section from the embedded CHANGELOG.md.
 ///
@@ -18,28 +35,117 @@ const CHANGELOG_CONTENT: &str = include_str!("../../../CHANGELOG.md");
 /// Security — the standard Keep-a-Changelog set). Categories the parser does
 /// not recognise are still emitted; the caller decides how to render them.
 pub fn parse_current_changelog(version: &str) -> Vec<ChangelogEntry> {
-    let section = match extract_version_section(CHANGELOG_CONTENT, version) {
+    parse_changelog_version(CHANGELOG_CONTENT, version)
+}
+
+/// Parse list items for a single version section from arbitrary changelog text.
+pub fn parse_changelog_version(content: &str, version: &str) -> Vec<ChangelogEntry> {
+    let section = match extract_version_section(content, version) {
         Some(s) => s,
         None => return Vec::new(),
     };
     parse_section_entries(&section)
 }
 
-/// Extract the text between `## [{version}]` and the next `## [` heading.
-fn extract_version_section(content: &str, version: &str) -> Option<String> {
-    let heading = format!("## [{}]", version);
-    let start = content.find(&heading)?;
-    let after_heading = &content[start + heading.len()..];
+/// Parse every `## [version]` section in document order (typically newest-first).
+///
+/// Skips `[Unreleased]` and any heading that is not wrapped in `[...]`.
+/// Empty version bodies are kept so callers can still enumerate the release range.
+pub fn parse_changelog_sections(content: &str) -> Vec<ChangelogVersionSection> {
+    let mut sections = Vec::new();
+    let mut current_version: Option<String> = None;
+    let mut current_body = String::new();
 
-    let end = after_heading
-        .find("\n## [")
-        .map(|i| start + heading.len() + i);
-    let section_text = match end {
-        Some(e) => &content[start..e],
-        None => &content[start..],
+    let flush = |version: &Option<String>, body: &str, out: &mut Vec<ChangelogVersionSection>| {
+        let Some(version) = version else {
+            return;
+        };
+        if version.eq_ignore_ascii_case("Unreleased") {
+            return;
+        }
+        // Keep empty version sections so update summaries can still name every
+        // release in the current→latest range, even when a section has no bullets.
+        let entries = parse_section_entries(body);
+        out.push(ChangelogVersionSection {
+            version: version.clone(),
+            entries,
+        });
     };
 
-    Some(section_text.to_string())
+    for line in content.lines() {
+        if let Some(version) = parse_version_heading(line) {
+            flush(&current_version, &current_body, &mut sections);
+            current_version = Some(version);
+            current_body.clear();
+            continue;
+        }
+        if current_version.is_some() {
+            current_body.push_str(line);
+            current_body.push('\n');
+        }
+    }
+    flush(&current_version, &current_body, &mut sections);
+    sections
+}
+
+/// Keep sections where `after < version <= through`, preserving document order.
+pub fn select_changelog_range(
+    sections: &[ChangelogVersionSection],
+    after: &str,
+    through: &str,
+    mut cmp: impl FnMut(&str, &str) -> std::cmp::Ordering,
+) -> Vec<ChangelogVersionSection> {
+    let after = after.strip_prefix('v').unwrap_or(after);
+    let through = through.strip_prefix('v').unwrap_or(through);
+
+    sections
+        .iter()
+        .filter(|section| {
+            let version = section.version.as_str();
+            cmp(version, after) == std::cmp::Ordering::Greater
+                && cmp(version, through) != std::cmp::Ordering::Greater
+        })
+        .cloned()
+        .collect()
+}
+
+/// Extract the text between `## [{version}]` and the next `## [` heading.
+///
+/// Uses [`parse_version_heading`] so version matching is exact (avoids treating
+/// `0.3.1` as a prefix of `0.3.10`).
+fn extract_version_section(content: &str, version: &str) -> Option<String> {
+    let mut collecting = false;
+    let mut out = String::new();
+
+    for line in content.lines() {
+        if let Some(heading_version) = parse_version_heading(line) {
+            if collecting {
+                break;
+            }
+            if heading_version == version {
+                collecting = true;
+                out.push_str(line);
+                out.push('\n');
+            }
+            continue;
+        }
+        if collecting {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+
+    collecting.then_some(out)
+}
+
+fn parse_version_heading(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    let rest = trimmed.strip_prefix("## [")?;
+    let version = rest.split(']').next()?.trim();
+    if version.is_empty() {
+        return None;
+    }
+    Some(version.to_string())
 }
 
 /// Parse `### Category` subsections into entries.
@@ -66,6 +172,237 @@ fn parse_section_entries(section: &str) -> Vec<ChangelogEntry> {
     }
 
     entries
+}
+
+/// Compare version strings with SemVer prerelease ordering.
+pub fn compare_changelog_versions(a: &str, b: &str) -> std::cmp::Ordering {
+    let parse_semver = |v: &str| semver::Version::parse(v.strip_prefix('v').unwrap_or(v));
+    if let (Ok(a_version), Ok(b_version)) = (parse_semver(a), parse_semver(b)) {
+        return a_version.cmp(&b_version);
+    }
+
+    let parse_parts = |v: &str| -> Vec<u64> {
+        v.strip_prefix('v')
+            .unwrap_or(v)
+            .split('.')
+            .filter_map(|s| s.parse().ok())
+            .collect()
+    };
+    let a_parts = parse_parts(a);
+    let b_parts = parse_parts(b);
+    for i in 0..a_parts.len().max(b_parts.len()) {
+        let a_val = a_parts.get(i).unwrap_or(&0);
+        let b_val = b_parts.get(i).unwrap_or(&0);
+        match a_val.cmp(b_val) {
+            std::cmp::Ordering::Equal => continue,
+            other => return other,
+        }
+    }
+    std::cmp::Ordering::Equal
+}
+
+const STARTUP_CHANGELOG_MAX_CHARS: usize = 8_000;
+const STARTUP_CHANGELOG_MAX_ENTRIES_PER_VERSION: usize = 8;
+
+fn category_badge(category: &str) -> &'static str {
+    match category {
+        "Added" => "\x1b[32m[+]\x1b[0m",
+        "Changed" => "\x1b[33m[*]\x1b[0m",
+        "Fixed" => "\x1b[31m[!]\x1b[0m",
+        _ => "\x1b[2m[-]\x1b[0m",
+    }
+}
+
+fn render_changelog_version_section(section: &ChangelogVersionSection) -> String {
+    use crate::t_with_args;
+    use std::collections::HashMap;
+
+    let mut chunk = String::new();
+    let version_label = {
+        let mut args = HashMap::new();
+        args.insert("version".to_string(), section.version.clone());
+        t_with_args("shell.welcome2.changelog_summary_version", &args)
+    };
+    chunk.push('\n');
+    chunk.push_str("\x1b[1m");
+    chunk.push_str(&version_label);
+    chunk.push_str("\x1b[0m\n");
+
+    let show = section
+        .entries
+        .len()
+        .min(STARTUP_CHANGELOG_MAX_ENTRIES_PER_VERSION);
+    for entry in &section.entries[..show] {
+        chunk.push_str("  ");
+        chunk.push_str(category_badge(&entry.category));
+        chunk.push(' ');
+        chunk.push_str(&entry.text);
+        chunk.push('\n');
+    }
+    if section.entries.len() > show {
+        let mut args = HashMap::new();
+        args.insert(
+            "count".to_string(),
+            (section.entries.len() - show).to_string(),
+        );
+        chunk.push_str("  \x1b[2m");
+        chunk.push_str(&t_with_args("shell.welcome2.changelog_summary_more", &args));
+        chunk.push_str("\x1b[0m\n");
+    }
+    chunk
+}
+
+/// Keep as many complete version chunks as fit in `budget`, preferring newer
+/// versions. Returns the kept chunks in display order (oldest → newest) and
+/// whether anything was omitted.
+fn select_sections_preferring_latest(
+    rendered_oldest_first: &[String],
+    budget: usize,
+) -> (Vec<&str>, bool) {
+    if rendered_oldest_first.is_empty() {
+        return (Vec::new(), false);
+    }
+
+    // Always try to keep the newest section, even if it alone exceeds the budget.
+    let mut keep_from = rendered_oldest_first.len() - 1;
+    let mut used = rendered_oldest_first[keep_from].len();
+    while keep_from > 0 {
+        let prev = keep_from - 1;
+        let next_used = used + rendered_oldest_first[prev].len();
+        if next_used > budget {
+            break;
+        }
+        used = next_used;
+        keep_from = prev;
+    }
+
+    let truncated = keep_from > 0;
+    let kept = rendered_oldest_first[keep_from..]
+        .iter()
+        .map(String::as_str)
+        .collect();
+    (kept, truncated)
+}
+
+/// Format Keep-a-Changelog notes for `after → through` (exclusive of `after`,
+/// inclusive of `through`) from the embedded CHANGELOG.md.
+///
+/// Display order is oldest → newest. When the char budget is exceeded, older
+/// versions are dropped first so the newest (`through`) section is kept.
+pub fn format_changelog_range_summary(after: &str, through: &str) -> Option<String> {
+    use crate::{t, t_with_args};
+    use std::collections::HashMap;
+
+    let sections = parse_embedded_changelog_sections();
+    let selected = select_changelog_range(&sections, after, through, compare_changelog_versions);
+    if selected.is_empty() {
+        return None;
+    }
+
+    let ordered: Vec<_> = selected.into_iter().rev().collect();
+    let rendered_sections: Vec<String> = ordered
+        .iter()
+        .map(render_changelog_version_section)
+        .collect();
+
+    let mut out = String::new();
+    out.push_str("\x1b[1;36m");
+    out.push_str(&{
+        let mut args = HashMap::new();
+        args.insert(
+            "current".to_string(),
+            after.strip_prefix('v').unwrap_or(after).to_string(),
+        );
+        args.insert(
+            "latest".to_string(),
+            through.strip_prefix('v').unwrap_or(through).to_string(),
+        );
+        t_with_args("shell.welcome2.changelog_summary_title", &args)
+    });
+    out.push_str("\x1b[0m\n");
+
+    let title_len = out.len();
+    let budget = STARTUP_CHANGELOG_MAX_CHARS.saturating_sub(title_len);
+    let (kept, truncated) = select_sections_preferring_latest(&rendered_sections, budget);
+
+    for chunk in kept {
+        out.push_str(chunk);
+    }
+
+    let overflowed = out.len() > STARTUP_CHANGELOG_MAX_CHARS;
+    if overflowed {
+        // Cut on a line boundary so a partial ANSI escape is never emitted.
+        let end = out[..STARTUP_CHANGELOG_MAX_CHARS.min(out.len())]
+            .rfind('\n')
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        out.truncate(end);
+    }
+    if truncated || overflowed {
+        out.push_str("\n\x1b[2m");
+        out.push_str(&t("shell.welcome2.changelog_summary_truncated"));
+        out.push_str("\x1b[0m\n");
+    }
+
+    Some(out)
+}
+
+/// Plain-text Ctrl+O body for a startup range summary (no ANSI).
+pub fn format_changelog_range_plain(after: &str, through: &str) -> Option<String> {
+    use crate::t_with_args;
+    use std::collections::HashMap;
+
+    let sections = parse_embedded_changelog_sections();
+    let selected = select_changelog_range(&sections, after, through, compare_changelog_versions);
+    if selected.is_empty() {
+        return None;
+    }
+    let ordered: Vec<_> = selected.into_iter().rev().collect();
+    let mut out = String::new();
+    out.push_str(&{
+        let mut args = HashMap::new();
+        args.insert(
+            "current".to_string(),
+            after.strip_prefix('v').unwrap_or(after).to_string(),
+        );
+        args.insert(
+            "latest".to_string(),
+            through.strip_prefix('v').unwrap_or(through).to_string(),
+        );
+        t_with_args("shell.welcome2.changelog_summary_title", &args)
+    });
+    out.push('\n');
+    for section in ordered {
+        let mut args = HashMap::new();
+        args.insert("version".to_string(), section.version.clone());
+        out.push('\n');
+        out.push_str(&t_with_args(
+            "shell.welcome2.changelog_summary_version",
+            &args,
+        ));
+        out.push('\n');
+        let show = section
+            .entries
+            .len()
+            .min(STARTUP_CHANGELOG_MAX_ENTRIES_PER_VERSION);
+        for entry in &section.entries[..show] {
+            out.push_str("- [");
+            out.push_str(&entry.category);
+            out.push_str("] ");
+            out.push_str(&entry.text);
+            out.push('\n');
+        }
+        if section.entries.len() > show {
+            let mut more = HashMap::new();
+            more.insert(
+                "count".to_string(),
+                (section.entries.len() - show).to_string(),
+            );
+            out.push_str(&t_with_args("shell.welcome2.changelog_summary_more", &more));
+            out.push('\n');
+        }
+    }
+    Some(out)
 }
 
 #[cfg(test)]
@@ -96,7 +433,17 @@ mod tests {
 ### Fixed
 
 - Fixed PTY cleanup on shell shutdown.
+
+## [0.3.2] - 2026-05-01
+
+### Fixed
+
+- Fixed an older bug.
 "#;
+
+    fn cmp_versions(a: &str, b: &str) -> std::cmp::Ordering {
+        compare_changelog_versions(a, b)
+    }
 
     #[test]
     fn test_parse_returns_current_version_entries() {
@@ -202,13 +549,139 @@ mod tests {
         assert_eq!(entries[0].text, "Sneak preview feature.");
     }
 
+    #[test]
+    fn test_extract_version_section_does_not_prefix_match() {
+        let changelog = r#"## [0.3.10] - 2026-07-01
+
+### Added
+
+- Ten.
+
+## [0.3.1] - 2026-06-01
+
+### Added
+
+- One.
+"#;
+        let entries = parse_changelog_version(changelog, "0.3.1");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].text, "One.");
+        let ten = parse_changelog_version(changelog, "0.3.10");
+        assert_eq!(ten.len(), 1);
+        assert_eq!(ten[0].text, "Ten.");
+    }
+
+    #[test]
+    fn test_parse_changelog_sections_keeps_empty_version() {
+        let changelog = r#"## [0.2.0] - 2026-01-02
+
+## [0.1.0] - 2026-01-01
+
+### Fixed
+
+- Older fix.
+"#;
+        let sections = parse_changelog_sections(changelog);
+        assert_eq!(
+            sections
+                .iter()
+                .map(|s| (s.version.as_str(), s.entries.len()))
+                .collect::<Vec<_>>(),
+            vec![("0.2.0", 0), ("0.1.0", 1)]
+        );
+    }
+
+    #[test]
+    fn test_parse_changelog_sections_skips_unreleased() {
+        let changelog = r#"## [Unreleased]
+
+### Added
+
+- Not shipped yet.
+
+## [0.2.0] - 2026-01-02
+
+### Added
+
+- Newer feature.
+
+## [0.1.0] - 2026-01-01
+
+### Fixed
+
+- Older fix.
+"#;
+        let sections = parse_changelog_sections(changelog);
+        assert_eq!(
+            sections
+                .iter()
+                .map(|s| s.version.as_str())
+                .collect::<Vec<_>>(),
+            vec!["0.2.0", "0.1.0"]
+        );
+    }
+
+    #[test]
+    fn test_select_changelog_range_exclusive_after_inclusive_through() {
+        let sections = parse_changelog_sections(SAMPLE_CHANGELOG);
+        let selected = select_changelog_range(&sections, "0.3.2", "0.3.4", cmp_versions);
+        assert_eq!(
+            selected
+                .iter()
+                .map(|s| s.version.as_str())
+                .collect::<Vec<_>>(),
+            vec!["0.3.4", "0.3.3"]
+        );
+        assert!(selected.iter().all(|s| !s.entries.is_empty()));
+    }
+
+    #[test]
+    fn test_format_changelog_range_summary_real_range() {
+        let sections = parse_embedded_changelog_sections();
+        assert!(
+            sections.len() >= 3,
+            "embedded CHANGELOG.md needs at least three released sections"
+        );
+        let latest = sections[0].version.as_str();
+        let intermediate = sections[1].version.as_str();
+        let current = sections[2].version.as_str();
+        let summary = format_changelog_range_summary(current, latest)
+            .expect("real changelog range should render");
+        let heading = |v: &str| {
+            let mut args = std::collections::HashMap::new();
+            args.insert("version".to_string(), v.to_string());
+            crate::t_with_args("shell.welcome2.changelog_summary_version", &args)
+        };
+        assert!(summary.contains(&heading(intermediate)));
+        assert!(summary.contains(&heading(latest)));
+        assert!(!summary.contains(&heading(current)));
+    }
+
+    #[test]
+    fn test_select_sections_preferring_latest_drops_older_first() {
+        let newest = "NEWEST_CHUNK".to_string();
+        let older = "O".repeat(100);
+        let rendered = vec![older, newest];
+        let (kept, truncated) = select_sections_preferring_latest(&rendered, 20);
+        assert!(truncated);
+        assert_eq!(kept, vec!["NEWEST_CHUNK"]);
+
+        let (kept_all, truncated_all) = select_sections_preferring_latest(&rendered, usize::MAX);
+        assert!(!truncated_all);
+        assert_eq!(kept_all.len(), 2);
+        assert_eq!(kept_all[1], "NEWEST_CHUNK");
+    }
+
+    #[test]
+    fn test_select_changelog_range_supports_v_prefix() {
+        let sections = parse_changelog_sections(SAMPLE_CHANGELOG);
+        let selected = select_changelog_range(&sections, "v0.3.3", "v0.3.4", cmp_versions);
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].version, "0.3.4");
+    }
+
     // Helper for testing: parse from a given string instead of the embedded file.
     fn parse_changelog_from(content: &str, version: &str) -> Vec<ChangelogEntry> {
-        let section = extract_version_section(content, version);
-        if section.is_none() {
-            return Vec::new();
-        }
-        let section = section.unwrap();
-        parse_section_entries(&section)
+        parse_changelog_version(content, version)
     }
 }

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -2041,8 +2041,21 @@ impl AishShell {
 
         let version = env!("CARGO_PKG_VERSION").to_string();
 
-        // Print welcome banner with changelog
-        let changelog = aish_i18n::changelog::parse_current_changelog(&version);
+        // After an upgrade, show the Keep-a-Changelog range once (omp-style),
+        // sourced from the CHANGELOG.md embedded in this binary. Steady-state
+        // launches keep the existing current-version welcome panel.
+        let upgrade_summary = prompt::take_startup_changelog_summary(&version);
+        if let Some((ref ansi, _, _)) = upgrade_summary {
+            print!("\n{ansi}");
+            let _ = io::stdout().flush();
+        }
+
+        let changelog = if upgrade_summary.is_some() {
+            // Range summary already covered the newly installed versions.
+            Vec::new()
+        } else {
+            aish_i18n::changelog::parse_current_changelog(&version)
+        };
         print!(
             "{}",
             prompt::render_welcome(&version, &config.model, skill_count, changelog.clone())
@@ -2057,7 +2070,16 @@ impl AishShell {
 
         // Store full changelog in expand_history so Ctrl+O can show all entries
         // when the welcome panel truncates them with "and N more".
-        if changelog.len() > 2 {
+        if let Some((_, plain, prev)) = upgrade_summary {
+            let mut args = std::collections::HashMap::new();
+            args.insert("current".to_string(), prev);
+            args.insert("latest".to_string(), version.clone());
+            let cl_title = aish_i18n::t_with_args("shell.welcome2.changelog_summary_title", &args);
+            expand_history
+                .lock()
+                .unwrap()
+                .add(format!("[changelog] {cl_title}"), plain);
+        } else if changelog.len() > 2 {
             let full_text = prompt::format_changelog_full(&version, &changelog);
             let cl_title = prompt::changelog_title(&version);
             expand_history

--- a/crates/aish-shell/src/prompt.rs
+++ b/crates/aish-shell/src/prompt.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -176,6 +176,71 @@ fn strip_ansi_len_with(s: &str, char_width: impl Fn(char) -> usize) -> usize {
         }
     }
     len
+}
+
+/// Path to the last-seen changelog version marker (`~/.config/aish/last-changelog-version`).
+fn last_changelog_version_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("aish")
+        .join("last-changelog-version")
+}
+
+fn read_last_changelog_version() -> Option<String> {
+    let raw = std::fs::read_to_string(last_changelog_version_path()).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn write_last_changelog_version(version: &str) {
+    let path = last_changelog_version_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(path, version.trim());
+}
+
+/// Consume the startup upgrade changelog for `current_version`.
+///
+/// Mimics omp: the first interactive launch after an upgrade shows notes from
+/// the embedded CHANGELOG for every version in `last_seen → current`. The
+/// marker then advances so steady-state launches keep the existing
+/// current-version welcome panel.
+///
+/// Returns `(ansi_summary, plain_expand_text, previous_version)` when a range
+/// should be shown.
+pub fn take_startup_changelog_summary(current_version: &str) -> Option<(String, String, String)> {
+    let current = current_version.strip_prefix('v').unwrap_or(current_version);
+    let last = match read_last_changelog_version() {
+        Some(v) => v,
+        None => {
+            write_last_changelog_version(current);
+            return None;
+        }
+    };
+    let last_norm = last.strip_prefix('v').unwrap_or(&last);
+    if last_norm == current {
+        return None;
+    }
+    if aish_i18n::changelog::compare_changelog_versions(last_norm, current)
+        != std::cmp::Ordering::Less
+    {
+        // Marker is ahead or incomparable — reseat to current and skip.
+        write_last_changelog_version(current);
+        return None;
+    }
+
+    let summary = aish_i18n::changelog::format_changelog_range_summary(last_norm, current);
+    let plain = aish_i18n::changelog::format_changelog_range_plain(last_norm, current);
+    write_last_changelog_version(current);
+    match (summary, plain) {
+        (Some(ansi), Some(text)) => Some((ansi, text, last_norm.to_string())),
+        _ => None,
+    }
 }
 
 /// Localized changelog title for the current version (e.g. "v0.3.4 更新内容").

--- a/packaging/build_bundle.sh
+++ b/packaging/build_bundle.sh
@@ -42,6 +42,7 @@ mkdir -p "${STAGE_DIR}/systemd"
 install -m 0644 packaging/systemd/aish-sandbox.service.in "${STAGE_DIR}/systemd/aish-sandbox.service.in"
 install -m 0644 packaging/systemd/aish-sandbox.socket "${STAGE_DIR}/systemd/aish-sandbox.socket"
 
+
 cat > "${STAGE_DIR}/README.txt" <<EOF
 AI Shell bundle ${VERSION} (${ARCH})
 

--- a/packaging/scripts/publish_release.sh
+++ b/packaging/scripts/publish_release.sh
@@ -59,6 +59,7 @@ for artifact_path in "${ARTIFACT_FILES[@]}"; do
         upload_object "$artifact_path" "$release_key" "$cache_control" "${content_type_args[@]}"
 done
 
+
 latest_file="$(mktemp)"
 trap 'rm -f "$latest_file"' EXIT
 printf '%s' "$VERSION" > "$latest_file"
@@ -74,6 +75,7 @@ for artifact_path in "${ARTIFACT_FILES[@]}"; do
         artifact_name="$(basename "$artifact_path")"
         validated_urls+=("${CDN_BASE_URL%/}/${DOWNLOAD_PREFIX}/releases/${VERSION}/${artifact_name}")
 done
+
 
 for url in "${validated_urls[@]}"; do
         echo "Validating ${url}"


### PR DESCRIPTION
## Summary

- Problem: after `aish update`, users only saw version numbers and had no easy way to learn what changed across skipped releases.
- Changes: On the first interactive launch after an upgrade, print a Keep-a-Changelog summary for every version in `last_seen → current` (exclusive of last_seen, inclusive of current). Notes come from the `CHANGELOG.md` embedded in the binary. Track progress with `~/.config/aish/last-changelog-version` (omp-style). Truncation keeps newer versions first.
- Related Issue: N/A (feature request from session; inspired by omp post-update/startup changelog UX)

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Other

## Scope

- [ ] Core shell / PTY
- [ ] AI agent / LLM
- [ ] Skills / Tools
- [ ] Security
- [ ] Configuration
- [x] CLI / Interface
- [ ] Packaging / Installation
- [ ] CI/CD
- [ ] Documentation

## User-visible Changes

- After upgrading and starting interactive `aish`, a one-shot changelog summary may appear for versions since the last seen release.
- Steady-state launches keep the existing current-version welcome changelog panel.
- `aish update` itself no longer prints changelog notes after install success.

## Compatibility

- Backward compatible? Yes
- Config changes? No (adds optional marker file `~/.config/aish/last-changelog-version`; missing marker seeds current version and shows no upgrade summary)

## Testing

- `cargo test -p aish-i18n changelog`
- `cargo test -p aish-cli update::`
- `cargo clippy -p aish-i18n -p aish-cli -p aish-shell --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

## Checklist

- [x] Code follows project style
- [x] Tests added if needed
- [x] Documentation updated if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Interactive launches now show a localized “What’s new” changelog summary after an upgrade, covering only the changes since the last seen version.
  - Updates are formatted for both display and later browsing (including localized “[changelog]” labeling), with English and Simplified Chinese wording.

- **Bug Fixes**
  - Improved archive install script discovery for more reliable upgrades.
  - More accurate changelog parsing and “range” selection, preventing incorrect version matching.

- **Documentation**
  - Added an **[Unreleased]** changelog entry describing the upgrade summary behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->