### PR TITLE
fix(security): surface rule reason in sandbox block message (#408)

### DIFF
--- a/crates/aish-security/src/sandbox/assess.rs
+++ b/crates/aish-security/src/sandbox/assess.rs
@@ -355,7 +355,10 @@ mod tests {
         );
         // The rule's `reason` should be the first (human-readable) reason,
         // preceding internal diagnostics like "sandbox matched ...".
-        assert_eq!(analysis.reasons.first(), Some(&"system config is protected".to_string()));
+        assert_eq!(
+            analysis.reasons.first(),
+            Some(&"system config is protected".to_string())
+        );
         assert_eq!(analysis.impact_description, "system config directory");
         assert_eq!(
             analysis.suggested_alternatives,

--- a/crates/aish-security/src/sandbox/assess.rs
+++ b/crates/aish-security/src/sandbox/assess.rs
@@ -78,8 +78,23 @@ pub(crate) fn assess_sandbox_result(
         (policy.default_risk_level, Vec::new())
     };
 
+    let primary_rule = selected_hits.first().map(|(_, _, rule)| (*rule).clone());
     let mut reasons = Vec::new();
     if !selected_hits.is_empty() {
+        // Prepend the primary rule's human-readable `reason` so downstream
+        // message formatting (format_security_message) has a non-internal
+        // reason to display — matching the pattern in risk.rs / degraded.rs.
+        // Internal diagnostics ("sandbox matched ...", "matched paths: ...")
+        // are filtered out by is_internal_security_reason, so without this
+        // the message degrades to a generic "needs HIGH security" fallback.
+        if let Some(reason) = primary_rule
+            .as_ref()
+            .and_then(|rule| rule.reason.as_deref())
+            .map(str::trim)
+            .filter(|reason| !reason.is_empty())
+        {
+            reasons.push(reason.to_string());
+        }
         reasons.push(format!(
             "sandbox matched {} {}-risk filesystem change(s)",
             selected_hits.len(),
@@ -112,7 +127,6 @@ pub(crate) fn assess_sandbox_result(
         }
     }
 
-    let primary_rule = selected_hits.first().map(|(_, _, rule)| (*rule).clone());
     let mut analysis = SecurityAnalysis {
         risk_level,
         reasons,
@@ -339,6 +353,9 @@ mod tests {
                 .and_then(|rule| rule.id.as_deref()),
             Some("H-001")
         );
+        // The rule's `reason` should be the first (human-readable) reason,
+        // preceding internal diagnostics like "sandbox matched ...".
+        assert_eq!(analysis.reasons.first(), Some(&"system config is protected".to_string()));
         assert_eq!(analysis.impact_description, "system config directory");
         assert_eq!(
             analysis.suggested_alternatives,

--- a/crates/aish-tools/src/bash/bash.rs
+++ b/crates/aish-tools/src/bash/bash.rs
@@ -236,10 +236,36 @@ fn format_security_message(decision: &SecurityDecision) -> String {
     {
         return reason.clone();
     }
-
-    let mut args = std::collections::HashMap::new();
-    args.insert("level".to_string(), decision.level.to_string());
-    aish_i18n::t_with_args("tools.bash.security_handling_required", &args)
+    // Last-resort fallback: instead of a bare generic level message,
+    // include the matched rule id/name and preview paths so the user can
+    // see what triggered the block (issue #408).
+    let mut parts = vec![aish_i18n::t_with_args(
+        "tools.bash.security_handling_required",
+        &{
+            let mut args = std::collections::HashMap::new();
+            args.insert("level".to_string(), decision.level.to_string());
+            args
+        },
+    )];
+    if let Some(rule) = &decision.analysis.matched_rule {
+        if let Some(id) = &rule.id {
+            parts.push(format!("rule: {}", id));
+        } else if let Some(name) = &rule.name {
+            parts.push(format!("rule: {}", name));
+        }
+    }
+    if !decision.analysis.matched_paths.is_empty() {
+        let preview = decision
+            .analysis
+            .matched_paths
+            .iter()
+            .take(3)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        parts.push(format!("paths: {}", preview));
+    }
+    parts.join(" | ")
 }
 
 fn build_security_context(
@@ -1203,5 +1229,70 @@ mod tests {
             }
             other => panic!("unexpected preflight result: {other:?}"),
         }
+    }
+    #[test]
+    fn test_format_security_message_shows_rule_reason_from_sandbox() {
+        // Issue #408: when a sandbox hit matches a rule that has `reason`
+        // but no `description`/`confirm_message`, the block message should
+        // surface the rule's reason — not a generic "needs HIGH security".
+        let decision = SecurityDecision {
+            level: aish_security::RiskLevel::High,
+            allow: false,
+            require_confirmation: false,
+            analysis: aish_security::SecurityAnalysis {
+                risk_level: aish_security::RiskLevel::High,
+                reasons: vec![
+                    "system config is protected".to_string(),
+                    "sandbox matched 1 high-risk filesystem change(s)".to_string(),
+                    "matched paths: /etc/aish/123".to_string(),
+                ],
+                matched_rule: Some(aish_security::MatchedRuleSummary {
+                    id: Some("H-001".to_string()),
+                    name: Some("Protect /etc".to_string()),
+                    pattern: "/etc/**".to_string(),
+                }),
+                matched_paths: vec!["/etc/aish/123".to_string()],
+                ..aish_security::SecurityAnalysis::default()
+            },
+        };
+
+        let message = format_security_message(&decision);
+        assert_eq!(message, "system config is protected");
+    }
+
+    #[test]
+    fn test_format_security_message_fallback_includes_rule_id_and_paths() {
+        // Issue #408: when no human-readable reason is available at all,
+        // the fallback should include the rule id and matched paths
+        // rather than just a bare generic level message.
+        let decision = SecurityDecision {
+            level: aish_security::RiskLevel::High,
+            allow: false,
+            require_confirmation: false,
+            analysis: aish_security::SecurityAnalysis {
+                risk_level: aish_security::RiskLevel::High,
+                reasons: vec![
+                    "sandbox matched 1 high-risk filesystem change(s)".to_string(),
+                    "matched paths: /etc/aish/123".to_string(),
+                ],
+                matched_rule: Some(aish_security::MatchedRuleSummary {
+                    id: Some("H-001".to_string()),
+                    name: Some("Protect /etc".to_string()),
+                    pattern: "/etc/**".to_string(),
+                }),
+                matched_paths: vec!["/etc/aish/123".to_string()],
+                ..aish_security::SecurityAnalysis::default()
+            },
+        };
+
+        let message = format_security_message(&decision);
+        assert!(
+            message.contains("H-001"),
+            "fallback should mention rule id, got: {message}"
+        );
+        assert!(
+            message.contains("/etc/aish/123"),
+            "fallback should mention matched paths, got: {message}"
+        );
     }
 }


### PR DESCRIPTION
## 概述

- 问题: 沙箱命中 HIGH 规则后 Block 文案退化为通用「bash 命令需要 HIGH 级安全处理」，而非规则的可读 reason
- 改动: 在 assess_sandbox_result 中将 rule.reason 作为第一条可读原因；改进 format_security_message 兜底附带 rule id/paths
- 关联 Issue: #408

## 改动类型

- [x] Bug 修复

## 涉及范围

- [x] 安全模块
- [x] 技能 / 工具

## 用户可见变更

- 沙箱命中安全规则 Block 时，消息现在展示规则的可读 reason（如 "System config changes can break the host"）而非空泛的通用 level 句
- 即使规则缺少 reason/description/confirm_message，兜底消息也会附带 rule id 和 matched paths

## 兼容性

- 向后兼容? 是
- 配置变更? 否

## 测试验证

- `cargo test -p aish-security -p aish-tools -p aish-llm` — 757 个测试全部通过
- 新增 `test_format_security_message_shows_rule_reason_from_sandbox`：验证沙箱命中路径的 rule reason 正确展示
- 新增 `test_format_security_message_fallback_includes_rule_id_and_paths`：验证兜底附带 rule id 和 paths
- 更新 `assess_sandbox_result_blocks_high_risk_delete`：断言 reason 出现在 reasons 首位

## 根因分析

沙箱命中路径 `assess_sandbox_result` 构造 `reasons` 时只放入内部诊断串（`"sandbox matched ..."`、`"matched paths: ..."`），从未使用 `PolicyRule.reason` 字段。`format_security_message` 通过 `is_internal_security_reason` 过滤掉这些内部串后无可读原因可用，退化为通用 level 句。

`risk.rs` 和 `degraded.rs` 早已正确使用 `primary_rule.reason`，但沙箱命中路径遗漏了同一模式。

## 检查清单

- [x] 代码风格符合项目规范
- [x] 已添加必要的测试
- [x] 文档已更新（如需要）

🤖 AI-assisted (Claude)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Security assessments now show the matched policy’s explanation before other diagnostic details.
  * Security fallback messages now include the applicable rule and up to three affected paths.
  * Explicit policy explanations take precedence over generated fallback messages.
  * Improved security diagnostics make it easier to understand why an action was flagged.
  * Policy details are now presented consistently across assessment and fallback messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->