### PR TITLE
feat(tools): file-change snapshot store with /undo, /rollback, and tool prompt hardening

### DIFF
--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -186,6 +186,8 @@ shell:
     export: "Aktuelle Sitzung als Markdown exportieren"
     fork: "Aktuelle Sitzung abzweigen"
     sessions: "Sitzungsbaum anzeigen"
+    rollback: "KI-Dateibearbeitungen dieser Sitzung prüfen und zurückrollen (edit_file/write_file)"
+    undo: "Letzte Dateiänderung dieser Sitzung rückgängig machen (edit_file/write_file)"
 
   feedback:
     select_type: "Feedback-Typ auswählen"
@@ -718,6 +720,16 @@ shell:
     is_current: "{id} ist die aktuelle Sitzung — verwenden Sie 'exit' zum Beenden."
     summary: "{killed} beendet, {failed} fehlgeschlagen."
     all_terminated: "{count} Sitzung(en) beendet."
+  rollback:
+    title: "Zurücksetzen"
+    prompt: "Auf eine Änderung zurücksetzen (verwirft sie und alle späteren):"
+    empty: "In dieser Sitzung wurden keine Dateiänderungen aufgezeichnet."
+  undo:
+    nothing_to_undo: "Keine Dateiänderungen zum Rückgängigmachen."
+    restored: "{path} wiederhergestellt"
+    removed: "{path} entfernt"
+    restore_failed: "Wiederherstellung fehlgeschlagen: {error}"
+    remove_failed: "Entfernen fehlgeschlagen: {error}"
 
   time:
     seconds_ago: "vor {seconds}s"
@@ -890,6 +902,16 @@ security:
   command_blocked_with_reason: "Fehler: Befehl wurde vom Sicherheitssystem blockiert: {reason}"
 
 tools:
+  fs:
+    edit_file:
+      stale_tag: "Datei {path} wurde seit dem letzten Lesen geändert — neu lesen vor dem Bearbeiten"
+      invalid_tag: "Ungültiger Snapshot-Tag '{tag}' für {path}"
+    undo_edit:
+      nothing_to_undo: "Keine Dateiänderungen zum Rückgängigmachen."
+      restored: "{path} auf vorherigen Inhalt zurückgesetzt."
+      removed: "{path} entfernt (durch die rückgängig gemachte Änderung erstellt)."
+      restore_failed: "Wiederherstellen von {path} fehlgeschlagen: {error}"
+      remove_failed: "Entfernen von {path} fehlgeschlagen: {error}"
   ask_user:
     description: "Stellt dem Benutzer eine gezielte Rückfrage. Nur mit prompt wird Texteingabe verwendet; mit options werden Auswahlmöglichkeiten angeboten."
     unknown_kind: "Unbekannter Typ: {kind}"

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -375,6 +375,8 @@ shell:
     export: "Export the current session to Markdown"
     fork: "Branch the current session"
     sessions: "Show the session tree"
+    rollback: "Review and roll back AI file edits (edit_file/write_file) this session"
+    undo: "Undo the last file change (edit_file/write_file) this session"
 
   record:
     started: "⏺ Recording started: {path}"
@@ -621,6 +623,16 @@ shell:
     is_current: "{id} is the current session — use 'exit' to quit."
     summary: "{killed} killed, {failed} failed."
     all_terminated: "{count} live session(s) terminated."
+  rollback:
+    title: "Rollback"
+    prompt: "Roll back to a change (discards it and all later changes):"
+    empty: "No file changes recorded this session."
+  undo:
+    nothing_to_undo: "No file changes to undo."
+    restored: "Restored {path}"
+    removed: "Removed {path}"
+    restore_failed: "Restore failed: {error}"
+    remove_failed: "Remove failed: {error}"
 
   time:
     seconds_ago: "{seconds}s ago"
@@ -1240,6 +1252,14 @@ tools:
       old_string_ambiguous: "'old_string' appears {count} times in {path} - use replace_all=true or provide more context"
       edit_success: "Edited {path}"
       edit_write_failed: "Failed to write {path}: {error}"
+      stale_tag: "File {path} changed since you last read it — re-read before editing"
+      invalid_tag: "Invalid snapshot tag '{tag}' for {path}"
+    undo_edit:
+      nothing_to_undo: "No file changes to undo."
+      restored: "Restored {path} to its prior content."
+      removed: "Removed {path} (it was created by the undone change)."
+      restore_failed: "Failed to restore {path}: {error}"
+      remove_failed: "Failed to remove {path}: {error}"
 
   ask_user:
     description: "Ask the user a focused clarifying question. Use prompt for text input, and add options when you can offer choices."

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -186,6 +186,8 @@ shell:
     export: "Exportar la sesión actual a Markdown"
     fork: "Bifurcar la sesión actual"
     sessions: "Mostrar el árbol de sesiones"
+    rollback: "Revisar y revertir ediciones de archivo de la IA (edit_file/write_file) de esta sesión"
+    undo: "Deshacer el último cambio de archivo (edit_file/write_file) de esta sesión"
 
   feedback:
     select_type: "Seleccionar tipo de comentario"
@@ -718,6 +720,16 @@ shell:
     is_current: "{id} es la sesion actual — use 'exit' para salir."
     summary: "{killed} terminadas, {failed} fallaron."
     all_terminated: "{count} sesion(es) terminada(s)."
+  rollback:
+    title: "Revertir"
+    prompt: "Revertir a un cambio (descarta ese y todos los posteriores):"
+    empty: "No se registraron cambios de archivos en esta sesión."
+  undo:
+    nothing_to_undo: "No hay cambios de archivos para deshacer."
+    restored: "{path} restaurado"
+    removed: "{path} eliminado"
+    restore_failed: "Restauración fallida: {error}"
+    remove_failed: "Eliminación fallida: {error}"
 
   time:
     seconds_ago: "hace {seconds}s"
@@ -889,6 +901,16 @@ security:
   command_blocked_with_reason: "Error: el comando fue bloqueado por el sistema de seguridad: {reason}"
 
 tools:
+  fs:
+    edit_file:
+      stale_tag: "El archivo {path} cambió desde la última lectura — reléelo antes de editar"
+      invalid_tag: "Etiqueta de instantánea '{tag}' no válida para {path}"
+    undo_edit:
+      nothing_to_undo: "No hay cambios de archivos para deshacer."
+      restored: "{path} restaurado a su contenido previo."
+      removed: "{path} eliminado (fue creado por el cambio deshecho)."
+      restore_failed: "Error al restaurar {path}: {error}"
+      remove_failed: "Error al eliminar {path}: {error}"
   ask_user:
     description: "Haz al usuario una pregunta de aclaración enfocada. Con solo prompt se usa texto libre; con options se ofrecen elecciones."
     unknown_kind: "Tipo desconocido: {kind}"

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -186,6 +186,8 @@ shell:
     export: "Exporter la session actuelle en Markdown"
     fork: "Créer une branche de la session actuelle"
     sessions: "Afficher l'arborescence des sessions"
+    rollback: "Examiner et annuler les modifications de fichier de l'IA (edit_file/write_file) cette session"
+    undo: "Annuler la dernière modification de fichier (edit_file/write_file) cette session"
 
   feedback:
     select_type: "Sélectionner le type de commentaire"
@@ -718,6 +720,16 @@ shell:
     is_current: "{id} est la session actuelle — utilisez 'exit' pour quitter."
     summary: "{killed} terminees, {failed} echouees."
     all_terminated: "{count} session(s) terminee(s)."
+  rollback:
+    title: "Retour arrière"
+    prompt: "Revenir à une modification (abandonne celle-ci et les ultérieures):"
+    empty: "Aucune modification de fichier enregistrée cette session."
+  undo:
+    nothing_to_undo: "Aucune modification de fichier à annuler."
+    restored: "{path} restauré"
+    removed: "{path} supprimé"
+    restore_failed: "Restauration échouée: {error}"
+    remove_failed: "Suppression échouée: {error}"
 
   time:
     seconds_ago: "il y a {seconds}s"
@@ -890,6 +902,16 @@ security:
   command_blocked_with_reason: "Erreur : commande bloquee par le systeme de securite : {reason}"
 
 tools:
+  fs:
+    edit_file:
+      stale_tag: "Le fichier {path} a changé depuis la dernière lecture — relisez-le avant de modifier"
+      invalid_tag: "Étiquette d'instantané '{tag}' invalide pour {path}"
+    undo_edit:
+      nothing_to_undo: "Aucune modification de fichier à annuler."
+      restored: "{path} restauré à son contenu précédent."
+      removed: "{path} supprimé (créé par la modification annulée)."
+      restore_failed: "Échec de la restauration de {path} : {error}"
+      remove_failed: "Échec de la suppression de {path} : {error}"
   ask_user:
     description: "Poser a l'utilisateur une question de clarification ciblee. Avec seulement prompt, ask_user utilise la saisie texte ; avec options, il propose des choix."
     unknown_kind: "Type inconnu : {kind}"

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -186,6 +186,8 @@ shell:
     export: "現在のセッションを Markdown にエクスポート"
     fork: "現在のセッションを分岐"
     sessions: "セッションツリーを表示"
+    rollback: "このセッションの AI によるファイル編集を確認・ロールバック (edit_file/write_file)"
+    undo: "このセッションの最後のファイル変更を取り消す (edit_file/write_file)"
 
   feedback:
     select_type: "フィードバックの種類を選択"
@@ -718,6 +720,16 @@ shell:
     is_current: "{id} は現在のセッションです — 'exit' で終了してください。"
     summary: "{killed} 件終了、{failed} 件失敗。"
     all_terminated: "{count} 件のセッションを終了しました。"
+  rollback:
+    title: "ロールバック"
+    prompt: "変更を選んでロールバック（その変更以降のすべてを破棄）:"
+    empty: "このセッションではファイル変更が記録されていません。"
+  undo:
+    nothing_to_undo: "元に戻すファイル変更がありません。"
+    restored: "{path} を復元しました"
+    removed: "{path} を削除しました"
+    restore_failed: "復元失敗: {error}"
+    remove_failed: "削除失敗: {error}"
 
   time:
     seconds_ago: "{seconds}秒前"
@@ -890,6 +902,16 @@ security:
   command_blocked_with_reason: "エラー: コマンドはセキュリティシステムによりブロックされました: {reason}"
 
 tools:
+  fs:
+    edit_file:
+      stale_tag: "ファイル {path} は最後の読み取り以降に変更されました — 編集前に再読み込みしてください"
+      invalid_tag: "{path} のスナップショットタグ '{tag}' が無効です"
+    undo_edit:
+      nothing_to_undo: "元に戻すファイル変更がありません。"
+      restored: "{path} を以前の内容に復元しました。"
+      removed: "{path} を削除しました（取り消した変更で作成されたファイルです）。"
+      restore_failed: "{path} の復元に失敗: {error}"
+      remove_failed: "{path} の削除に失敗: {error}"
   ask_user:
     description: "ユーザーに焦点を絞った確認質問をします。prompt のみならテキスト入力、options があれば選択肢を提示します。"
     unknown_kind: "不明な種類です: {kind}"

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -375,6 +375,8 @@ shell:
     export: "导出当前会话为 Markdown"
     fork: "分支当前会话"
     sessions: "显示会话树"
+    rollback: "查看并回滚本次会话中 AI 的文件修改 (edit_file/write_file)"
+    undo: "撤销本次会话最后一次文件修改 (edit_file/write_file)"
 
   record:
     started: "⏺ 录制已开始: {path}"
@@ -621,6 +623,16 @@ shell:
     is_current: "{id} 是当前会话 — 请使用 'exit' 退出。"
     summary: "已终止 {killed} 个，失败 {failed} 个。"
     all_terminated: "已终止 {count} 个活跃会话。"
+  rollback:
+    title: "回滚"
+    prompt: "选择一个修改回滚（将丢弃它及之后的所有修改）:"
+    empty: "本次会话没有记录文件修改。"
+  undo:
+    nothing_to_undo: "没有可撤销的文件修改。"
+    restored: "已恢复 {path}"
+    removed: "已删除 {path}"
+    restore_failed: "恢复失败: {error}"
+    remove_failed: "删除失败: {error}"
 
   time:
     seconds_ago: "{seconds}秒前"
@@ -1239,6 +1251,14 @@ tools:
       old_string_ambiguous: "'old_string' 在 {path} 中出现了 {count} 次 - 使用 replace_all=true 或提供更多上下文"
       edit_success: "已编辑 {path}"
       edit_write_failed: "写入 {path} 失败: {error}"
+      stale_tag: "文件 {path} 自上次读取后已变更 — 请重新读取后再编辑"
+      invalid_tag: "{path} 的快照标签 '{tag}' 无效"
+    undo_edit:
+      nothing_to_undo: "没有可撤销的文件修改。"
+      restored: "已将 {path} 恢复到修改前的内容。"
+      removed: "已删除 {path}（它由被撤销的修改创建）。"
+      restore_failed: "恢复 {path} 失败: {error}"
+      remove_failed: "删除 {path} 失败: {error}"
 
   ask_user:
     description: “向用户提出一个聚焦的澄清问题。只填 prompt 时为文本输入，提供 options 时为选项交互。”

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -639,6 +639,7 @@ pub struct AishShell {
     secret_check_closure:
         std::sync::Arc<dyn Fn(&str) -> Option<aish_pty::SshSecretCheckResult> + Send + Sync>,
     secret_vault: std::sync::Arc<std::sync::Mutex<aish_security::secret::SecretVault>>,
+    snapshot_store: aish_tools::fs::SharedSnapshotStore,
     pub session_store: Option<SessionStore>,
     audit_store: Option<std::sync::Arc<aish_session::AuditStore>>,
     audit_user: Option<String>,
@@ -990,9 +991,20 @@ impl AishShell {
             std::sync::Arc::new(std::sync::Mutex::new(None));
         bash_tool.set_secret_vault(vault_slot.clone());
         tool_registry.register(Box::new(bash_tool));
-        tool_registry.register(Box::new(aish_tools::fs::ReadFileTool::new()));
-        tool_registry.register(Box::new(aish_tools::fs::WriteFileTool::new()));
-        tool_registry.register(Box::new(aish_tools::fs::EditFileTool::new()));
+        let snapshot_store: aish_tools::fs::SharedSnapshotStore =
+            std::sync::Arc::new(std::sync::Mutex::new(aish_tools::fs::SnapshotStore::new()));
+        tool_registry.register(Box::new(aish_tools::fs::ReadFileTool::with_store(
+            snapshot_store.clone(),
+        )));
+        tool_registry.register(Box::new(aish_tools::fs::WriteFileTool::with_store(
+            snapshot_store.clone(),
+        )));
+        tool_registry.register(Box::new(aish_tools::fs::EditFileTool::with_store(
+            snapshot_store.clone(),
+        )));
+        tool_registry.register(Box::new(aish_tools::fs::UndoEditTool::new(
+            snapshot_store.clone(),
+        )));
         tool_registry.register(Box::new(aish_tools::AskUserTool::with_runtime(Arc::new(
             crate::tui::run_ask_user_request,
         ))));
@@ -2087,6 +2099,7 @@ impl AishShell {
             shared_recorder,
             inline_ai: None,
             approval_memory,
+            snapshot_store,
         })
     }
 
@@ -3415,6 +3428,119 @@ impl AishShell {
             Some("/status") => self.handle_status_command(),
             Some("/live_sessions") => self.handle_live_sessions_command(),
             Some("/kill_live_sessions") => self.handle_kill_live_sessions_command(&parts),
+            Some("/undo") => {
+                let path = parts.get(1).copied();
+                // Peek without consuming — commit only after the disk restore
+                // succeeds, so a failed IO does not lose the snapshot.
+                let peeked = {
+                    let store = self
+                        .snapshot_store
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner());
+                    match path {
+                        Some(p) => store.peek_undo_last_for(std::path::Path::new(p)),
+                        None => store.peek_undo_last(),
+                    }
+                };
+                let msg = match peeked {
+                    None => aish_i18n::t("shell.undo.nothing_to_undo"),
+                    Some(result) => {
+                        let (ok, m) = apply_restore_action(&result, false);
+                        if ok {
+                            let mut store = self
+                                .snapshot_store
+                                .lock()
+                                .unwrap_or_else(|e| e.into_inner());
+                            match path {
+                                Some(p) => store.commit_undo_last_for(
+                                    std::path::Path::new(p),
+                                    result.snapshot_id,
+                                ),
+                                None => store.commit_undo_last(result.snapshot_id),
+                            };
+                        }
+                        m
+                    }
+                };
+                println!("{}", msg);
+            }
+            Some("/rollback") => {
+                // AI file-edit history (newest first). Selecting one rolls
+                // back to before that change, discarding it and all later
+                // changes.
+                let items: Vec<aish_ui::SearchSelectItem> = {
+                    let store = self
+                        .snapshot_store
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner());
+                    store
+                        .history()
+                        .iter()
+                        .rev()
+                        .map(|s| {
+                            let prior = s.prior_content.as_deref().map(|c| c.len()).unwrap_or(0);
+                            aish_ui::SearchSelectItem::new(
+                                s.id.to_string(),
+                                format!(
+                                    "#{} {:>5} {} ({}B prior)",
+                                    s.id,
+                                    s.op,
+                                    s.path.display(),
+                                    prior
+                                ),
+                            )
+                        })
+                        .collect()
+                };
+                if items.is_empty() {
+                    println!("{}", aish_i18n::t("shell.rollback.empty"));
+                } else {
+                    let panel = aish_ui::ChoicePanel::new(
+                        aish_i18n::t("shell.rollback.title"),
+                        aish_i18n::t("shell.rollback.prompt"),
+                        items,
+                    );
+                    let _guard = aish_tools::bash::acquire_interactive_input_guard();
+                    let outcome = aish_ui::PanelRuntime::new().run(panel);
+                    if let Ok(aish_ui::PanelOutcome::Submitted(aish_ui::ChoiceOutcome::Selected(
+                        value,
+                    ))) = outcome
+                    {
+                        if let Ok(id) = value.parse::<u64>() {
+                            // Peek -> disk restore -> commit only on success.
+                            let peeked = {
+                                let store = self
+                                    .snapshot_store
+                                    .lock()
+                                    .unwrap_or_else(|e| e.into_inner());
+                                store.peek_restore(id)
+                            };
+                            if let Some(actions) = peeked {
+                                // Apply every rollback action (reverse order:
+                                // newest first); commit only if all succeed.
+                                let mut all_ok = true;
+                                let mut msgs: Vec<String> = Vec::new();
+                                for action in &actions {
+                                    let (ok, msg) = apply_restore_action(action, true);
+                                    msgs.push(msg);
+                                    if !ok {
+                                        all_ok = false;
+                                        break;
+                                    }
+                                }
+                                if all_ok {
+                                    let mut store = self
+                                        .snapshot_store
+                                        .lock()
+                                        .unwrap_or_else(|e| e.into_inner());
+                                    store.commit_restore(id);
+                                }
+                                println!("{}", msgs.join("\n"));
+                            }
+                        }
+                    }
+                }
+            }
             Some("/audit") => self.handle_audit_command(&parts),
             Some("/forget-approvals") => self.handle_forget_approvals(),
             Some("/skill") => self.handle_skill_command(&parts),
@@ -10857,6 +10983,33 @@ fn emit_osc(op: &str) {
     // OSC 5151 ; <op> BEL
     let _ = write!(std::io::stdout(), "\x1b]5151;{}\x07", op);
     let _ = std::io::stdout().flush();
+}
+
+/// Apply one rollback action to disk and format a user-facing message.
+/// Returns `(ok, message)`. `tolerate_missing` lets a delete of an
+/// already-absent file succeed (idempotent retry after a partial batch).
+fn apply_restore_action(
+    result: &aish_tools::fs::UndoResult,
+    tolerate_missing: bool,
+) -> (bool, String) {
+    use aish_tools::fs::ApplyOutcome;
+    use std::collections::HashMap;
+
+    let mut args = HashMap::new();
+    args.insert("path".to_string(), result.path.display().to_string());
+    match result.apply_to_disk(tolerate_missing) {
+        Ok(ApplyOutcome::Restored) => (true, aish_i18n::t_with_args("shell.undo.restored", &args)),
+        Ok(ApplyOutcome::Removed) => (true, aish_i18n::t_with_args("shell.undo.removed", &args)),
+        Err(e) => {
+            args.insert("error".to_string(), e.to_string());
+            let key = if result.content.is_some() {
+                "shell.undo.restore_failed"
+            } else {
+                "shell.undo.remove_failed"
+            };
+            (false, aish_i18n::t_with_args(key, &args))
+        }
+    }
 }
 
 /// Format a duration in seconds as a localized "N s/min/h ago" string.

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -55,6 +55,14 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
         "Branch the current session into a new one (copied context)",
     ),
     ("/sessions", "Show the session tree (roots + forks)"),
+    (
+        "/undo",
+        "Undo the last file change (edit_file/write_file) this session",
+    ),
+    (
+        "/rollback",
+        "Review and roll back AI file edits (edit_file/write_file) this session",
+    ),
 ];
 
 // ---------------------------------------------------------------------------
@@ -833,6 +841,23 @@ mod tests {
                 cmd
             );
         }
-        assert_eq!(SLASH_COMMANDS.len(), 21);
+        assert_eq!(SLASH_COMMANDS.len(), 23);
+    }
+
+    #[test]
+    fn slash_commands_have_i18n_descriptions() {
+        // Every SLASH_COMMANDS entry must resolve shell.slash.<cmd> to a real
+        // translation, not the raw key. Regression: a slash command once
+        // rendered its raw i18n key in the popup (shell.slash.<cmd> missing).
+        aish_i18n::set_locale("en-US");
+        for (name, _desc) in SLASH_COMMANDS {
+            let cmd = name.trim_start_matches('/');
+            let key = format!("shell.slash.{cmd}");
+            let translated = aish_i18n::t(&key);
+            assert_ne!(
+                translated, key,
+                "missing i18n key {key} for slash command {name}"
+            );
+        }
     }
 }

--- a/crates/aish-shell/src/theme.rs
+++ b/crates/aish-shell/src/theme.rs
@@ -504,12 +504,17 @@ fn line_diff(old_lines: &[&str], new_lines: &[&str]) -> Vec<DiffLine> {
     out
 }
 
+/// Default unchanged-context lines shown around each changed region.
+const DIFF_CONTEXT: usize = 3;
+
 /// Render a colored unified diff between `old` and `new` text.
 ///
-/// Produces a line-level diff (LCS-based). Added lines are green (`+`),
-/// removed lines are red (`-`), unchanged context lines are dimmed. Output is
-/// capped at `max_lines` diff lines; a `... N more lines` hint is appended
-/// when truncated. Returns an empty string when inputs are identical.
+/// Output is split into hunks centered on changed lines (added/removed), each
+/// surrounded by up to [`DIFF_CONTEXT`] unchanged context lines. Edits at the
+/// end of a large file stay fully visible — leading context no longer crowds
+/// them out. `max_lines` caps total output; context is shed first, and only
+/// when the bare changed lines themselves overflow the cap are lines dropped
+/// (with a trailing `... N more lines` hint). Returns empty when identical.
 pub fn render_diff(old: &str, new: &str, max_lines: usize) -> String {
     // Skip expensive LCS when inputs are byte-identical.
     if old == new {
@@ -524,27 +529,147 @@ pub fn render_diff(old: &str, new: &str, max_lines: usize) -> String {
         &old_lines[..old_lines.len().min(MAX_LCS_LINES)],
         &new_lines[..new_lines.len().min(MAX_LCS_LINES)],
     );
-
-    let mut out = String::new();
-    let total = diff.len();
-    if total == 0 {
-        return out;
+    if max_lines == 0 {
+        return String::new();
     }
-    let shown = total.min(max_lines);
-    for line in diff.iter().take(shown) {
-        match line {
-            DiffLine::Context(s) => out.push_str(&format!("{}\n", muted(&format!("  {s}")))),
-            DiffLine::Added(s) => out.push_str(&format!("{}\n", success(&format!("+ {s}")))),
-            DiffLine::Removed(s) => out.push_str(&format!("{}\n", error(&format!("- {s}")))),
+    let has_change = diff.iter().any(|l| !matches!(l, DiffLine::Context(_)));
+    if !has_change {
+        // Bounded region shows no change but inputs differ: the change lies
+        // beyond the LCS bound. Fall back to diffing the tails so a
+        // large-file tail edit is rendered instead of an empty diff.
+        if old_lines.len() > MAX_LCS_LINES || new_lines.len() > MAX_LCS_LINES {
+            let start_o = old_lines.len().saturating_sub(MAX_LCS_LINES);
+            let start_n = new_lines.len().saturating_sub(MAX_LCS_LINES);
+            let tail_diff = line_diff(&old_lines[start_o..], &new_lines[start_n..]);
+            if tail_diff.iter().any(|l| !matches!(l, DiffLine::Context(_))) {
+                return render_diff_hunks(&tail_diff, max_lines);
+            }
+        }
+        return String::new();
+    }
+    render_diff_hunks(&diff, max_lines)
+}
+
+/// Merge changed-line indices into contiguous `[start, end)` regions, each
+/// padded by `ctx` unchanged lines on both sides and clamped to `0..n`.
+/// Adjacent or overlapping regions collapse into one.
+fn merged_regions(changes: &[usize], ctx: usize, n: usize) -> Vec<(usize, usize)> {
+    let pad = ctx as isize;
+    let clamp = |v: isize| v.clamp(0, n as isize) as usize;
+    let mut regions: Vec<(usize, usize)> = Vec::new();
+    for &c in changes {
+        let s = clamp(c as isize - pad);
+        let e = clamp((c + 1) as isize + pad);
+        if let Some(last) = regions.last_mut() {
+            if s <= last.1 {
+                last.1 = last.1.max(e);
+                continue;
+            }
+        }
+        regions.push((s, e));
+    }
+    regions
+}
+
+/// Total rendered line count for a set of regions: content lines plus one
+/// separator line per gap (before the first region when it does not start at
+/// the file head, between regions, and after the last when it does not reach
+/// the tail).
+fn rendered_size(regions: &[(usize, usize)], n: usize) -> usize {
+    let content: usize = regions.iter().map(|(s, e)| e - s).sum();
+    let lead = usize::from(regions.first().is_some_and(|(s, _)| *s > 0));
+    let between = regions.len().saturating_sub(1);
+    let tail = usize::from(regions.last().is_some_and(|(_, e)| *e < n));
+    content + lead + between + tail
+}
+
+/// Choose the largest context whose rendered output fits `max_lines`; shed
+/// context before dropping any changed line. Falls back to zero context when
+/// even the bare changes overflow the cap.
+fn choose_regions(changes: &[usize], n: usize, max_lines: usize) -> Vec<(usize, usize)> {
+    let mut best = merged_regions(changes, 0, n);
+    for try_ctx in (1..=DIFF_CONTEXT).rev() {
+        let r = merged_regions(changes, try_ctx, n);
+        if rendered_size(&r, n) <= max_lines {
+            best = r;
+            break;
         }
     }
-    if total > shown {
-        out.push_str(&format!(
-            "{}\n",
-            dim(&format!("  ... {} more lines", total - shown))
-        ));
+    best
+}
+
+/// Render the diff as hunks: changed regions padded with context, separated
+/// by `... N lines` hints for the elided stretches.
+fn render_diff_hunks(diff: &[DiffLine], max_lines: usize) -> String {
+    let n = diff.len();
+    let changes: Vec<usize> = diff
+        .iter()
+        .enumerate()
+        .filter_map(|(i, l)| match l {
+            DiffLine::Context(_) => None,
+            _ => Some(i),
+        })
+        .collect();
+    if changes.is_empty() || max_lines == 0 {
+        return String::new();
+    }
+    let regions = choose_regions(&changes, n, max_lines);
+
+    let mut lines: Vec<String> = Vec::with_capacity(max_lines);
+    let mut prev_end = 0usize;
+    // Reserve one line for a trailing elision marker when content is
+    // dropped, so output never exceeds max_lines. Emit whole regions and
+    // stop at a region boundary on overflow — earlier changed lines stay
+    // visible instead of truncating mid-region and hiding a later hunk.
+    let soft_cap = max_lines.saturating_sub(1);
+    let mut dropped = false;
+
+    for &(s, e) in &regions {
+        let gap_marker = match (prev_end, s) {
+            (0, sp) if sp > 0 => Some(format!("  ... {} lines above", sp)),
+            (pe, sp) if pe > 0 && sp > pe => Some(format!("  ... {} lines hidden", sp - pe)),
+            _ => None,
+        };
+        let need = gap_marker.as_ref().map(|_| 1).unwrap_or(0) + (e - s);
+        if !lines.is_empty() && lines.len() + need > soft_cap {
+            dropped = true;
+            break;
+        }
+        if let Some(m) = gap_marker {
+            lines.push(dim(&m));
+        }
+        // A single oversized region (nothing emitted yet) still shows its
+        // leading lines up to the soft cap so changed lines surface.
+        let room = soft_cap.saturating_sub(lines.len());
+        for line in diff[s..e].iter().take(room) {
+            lines.push(render_diff_line(line));
+        }
+        if e - s > room {
+            dropped = true;
+            prev_end = s + room;
+            break;
+        }
+        prev_end = e;
+    }
+
+    if (dropped || prev_end < n) && lines.len() < max_lines {
+        lines.push(dim(&format!("  ... {} more lines", n - prev_end)));
+    }
+
+    let mut out = String::new();
+    for l in &lines {
+        out.push_str(l);
+        out.push('\n');
     }
     out
+}
+
+fn render_diff_line(line: &DiffLine) -> String {
+    match line {
+        DiffLine::Context(s) => muted(&format!("  {s}")),
+        DiffLine::Added(s) => success(&format!("+ {s}")),
+        DiffLine::Removed(s) => error(&format!("- {s}")),
+    }
 }
 
 #[cfg(test)]
@@ -603,7 +728,7 @@ mod diff_tests {
         let old = String::new();
         let new: String = (0..50).map(|i| format!("line {i}\n")).collect();
         let d = strip_ansi(&render_diff(&old, &new, 5));
-        assert!(d.contains("... 46 more lines"));
+        assert!(d.contains("... 47 more lines"));
     }
 
     #[test]
@@ -612,6 +737,107 @@ mod diff_tests {
         // The removed empty line proves trailing-newline changes are surfaced.
         let d = strip_ansi(&render_diff("a\n", "a", 20));
         assert!(!d.is_empty(), "trailing newline diff must not be empty");
+    }
+
+    #[test]
+    fn edit_at_tail_is_not_truncated() {
+        // Regression: an edit appending lines at the end of a long file must
+        // show the change in full. Leading context is collapsed into a hint,
+        // not printed verbatim, so it cannot crowd the edit out of the window.
+        let old: String = (0..40).map(|i| format!("line {i}\n")).collect();
+        let mut new = old.clone();
+        new.push_str("added1\n");
+        new.push_str("added2\n");
+        let d = strip_ansi(&render_diff(&old, &new, 20));
+        assert!(d.contains("+ added1"));
+        assert!(d.contains("+ added2"));
+        // Lines far from the edit are elided, not printed as context.
+        assert!(!d.contains("line 0"));
+        assert!(d.contains("lines above"));
+    }
+
+    #[test]
+    fn edit_at_head_is_not_truncated() {
+        let old: String = (0..40).map(|i| format!("line {i}\n")).collect();
+        let mut new = old.clone();
+        // Prepend two changed lines at the very top.
+        new.insert_str(0, "added1\nadded2\n");
+        let d = strip_ansi(&render_diff(&old, &new, 20));
+        assert!(d.contains("+ added1"));
+        assert!(d.contains("+ added2"));
+        assert!(!d.contains("line 39"));
+    }
+
+    #[test]
+    fn separate_edits_produce_multiple_hunks() {
+        // Two edits far apart yield two hunks separated by a "... lines hidden"
+        // marker; both edits remain visible within the cap.
+        let mut old: String = (0..30).map(|i| format!("line {i}\n")).collect();
+        let mut new = old.clone();
+        // Edit near the top and near the bottom.
+        old = old.replace("line 2\n", "old top\n");
+        old = old.replace("line 27\n", "old bottom\n");
+        new = new.replace("line 2\n", "new top\n");
+        new = new.replace("line 27\n", "new bottom\n");
+        let d = strip_ansi(&render_diff(&old, &new, 20));
+        assert!(d.contains("- old top"));
+        assert!(d.contains("+ new top"));
+        assert!(d.contains("- old bottom"));
+        assert!(d.contains("+ new bottom"));
+        assert!(d.contains("lines hidden"));
+    }
+
+    #[test]
+    fn tail_edit_beyond_lcs_bound_is_shown() {
+        // Regression (CodeRabbit B): an edit beyond the 1000-line LCS bound
+        // (leading prefix unchanged) must still render, via the tail fallback.
+        let prefix: String = (0..1005).map(|i| format!("line {i}\n")).collect();
+        let old = format!("{prefix}tail old\n");
+        let new = format!("{prefix}tail new\n");
+        let d = strip_ansi(&render_diff(&old, &new, 20));
+        assert!(
+            !d.is_empty(),
+            "tail edit beyond LCS bound must not be empty"
+        );
+        assert!(d.contains("- tail old"));
+        assert!(d.contains("+ tail new"));
+    }
+
+    #[test]
+    fn output_never_exceeds_max_lines() {
+        // Regression (CodeRabbit C): output must never exceed max_lines, even
+        // with many scattered changes. The trailing elision marker is budgeted.
+        let mut old = String::new();
+        let mut new = String::new();
+        for i in 0..60 {
+            old.push_str(&format!("old {i}\n"));
+            new.push_str(&format!("new {i}\n"));
+        }
+        let d = strip_ansi(&render_diff(&old, &new, 10));
+        let line_count = d.lines().count();
+        assert!(
+            line_count <= 10,
+            "output must not exceed max_lines: got {line_count}"
+        );
+        assert!(!d.is_empty());
+    }
+
+    #[test]
+    fn distant_hunks_kept_when_changed_fit() {
+        // Regression (CodeRabbit C): when changed lines fit within max_lines,
+        // distant hunks stay visible (not truncated away) and output <= cap.
+        let mut old: String = (0..50).map(|i| format!("line {i}\n")).collect();
+        let mut new = old.clone();
+        old = old.replace("line 5\n", "old a\n");
+        old = old.replace("line 45\n", "old b\n");
+        new = new.replace("line 5\n", "new a\n");
+        new = new.replace("line 45\n", "new b\n");
+        let d = strip_ansi(&render_diff(&old, &new, 12));
+        assert!(d.contains("- old a"));
+        assert!(d.contains("+ new a"));
+        assert!(d.contains("- old b"));
+        assert!(d.contains("+ new b"));
+        assert!(d.lines().count() <= 12, "output must not exceed max_lines");
     }
 
     #[test]

--- a/crates/aish-shell/tests/slash_popup_commands.rs
+++ b/crates/aish-shell/tests/slash_popup_commands.rs
@@ -30,7 +30,7 @@ fn each_builtin_command_enter_executes() {
 
 #[test]
 fn slash_commands_table_has_expected_count() {
-    assert_eq!(SLASH_COMMANDS.len(), 21);
+    assert_eq!(SLASH_COMMANDS.len(), 23);
 }
 
 #[test]

--- a/crates/aish-tools/src/bash/prompt.rs
+++ b/crates/aish-tools/src/bash/prompt.rs
@@ -1,9 +1,11 @@
 pub(crate) const DESCRIPTION: &str = "\
-Execute a bash command and return the output. Prefer for direct shell commands and scripts; \
-use read_file, grep, or glob for file content; use Python for structured scripts; use Agent \
-(subagent_type=explore) for open-ended multi-round path/code search; use Agent \
-(subagent_type=troubleshoot) for open-ended system/service diagnosis; use Agent to delegate \
-other isolated sub-tasks.";
+Execute a bash command and return its output. Use ONLY for running commands, \
+builds, tests, and read-only discovery (find, ls, stat, ps). NEVER use bash \
+to read, write, or edit files — use read_file to read, edit_file to modify, \
+write_file to create; use grep/glob for search; use Python for structured \
+scripts; use Agent (subagent_type=explore) for open-ended multi-round \
+path/code search; use Agent (subagent_type=troubleshoot) for open-ended \
+system/service diagnosis; use Agent to delegate other isolated sub-tasks.";
 
 pub(crate) const PROMPT: &str = r#"Use this tool to run shell commands.
 
@@ -11,8 +13,13 @@ Usage:
 - Explain non-trivial commands before running them.
 - Use timeout only when a bounded runtime is expected.
 - Do not retry commands the user rejected or cancelled.
-- Prefer read_file, grep, or glob for file content; use bash for one-shot commands or read-only \
-discovery (find, ls, stat) when those tools are a better fit."#;
+- NEVER read or modify files through bash. Do not use redirections (>, >>),
+  write-heredocs, `cat >>`, `echo >`, `printf >`, `sed -i`, `tee`, `dd`, or
+  `patch` to alter files. Use read_file to read, edit_file to modify, and
+  write_file to create — those tools snapshot changes for undo and anchor
+  edits against stale content; bash file writes bypass all of that.
+- Prefer read_file, grep, or glob for file content; use bash for one-shot
+  commands or read-only discovery (find, ls, stat) when those tools fit better."#;
 
 pub(crate) fn parameters() -> serde_json::Value {
     serde_json::json!({

--- a/crates/aish-tools/src/edit_file/edit_file.rs
+++ b/crates/aish-tools/src/edit_file/edit_file.rs
@@ -2,11 +2,15 @@ use aish_i18n;
 use aish_llm::{Tool, ToolResult};
 
 use super::prompt;
+use crate::fs::{SharedSnapshotStore, SnapshotOp, SnapshotTag};
+use std::path::Path;
 
 const SIZE_LIMIT: u64 = 32 * 1024;
 
 /// Edit file tool (string replacement).
-pub struct EditFileTool;
+pub struct EditFileTool {
+    store: Option<SharedSnapshotStore>,
+}
 
 impl Default for EditFileTool {
     fn default() -> Self {
@@ -16,7 +20,11 @@ impl Default for EditFileTool {
 
 impl EditFileTool {
     pub fn new() -> Self {
-        Self
+        Self { store: None }
+    }
+
+    pub fn with_store(store: SharedSnapshotStore) -> Self {
+        Self { store: Some(store) }
     }
 }
 
@@ -120,13 +128,63 @@ impl Tool for EditFileTool {
             content.replacen(old, new, 1)
         };
 
-        match std::fs::write(path, new_content) {
-            Ok(()) => {
+        // Server-side drift enforcement: if this file was observed before
+        // (read_file/edit_file/write_file), the on-disk content must still
+        // match the remembered tag — a mismatch means it drifted since the
+        // model last saw it, so reject and force a re-read. Files never
+        // observed have no baseline and pass through.
+        if let Some(store) = &self.store {
+            let fresh = store
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .is_fresh(Path::new(path), &content);
+            if !fresh {
                 let mut args_map = std::collections::HashMap::new();
                 args_map.insert("path".to_string(), path.to_string());
-                ToolResult::success(aish_i18n::t_with_args(
-                    "tools.fs.edit_file.edit_success",
+                return ToolResult::error(aish_i18n::t_with_args(
+                    "tools.fs.edit_file.stale_tag",
                     &args_map,
+                ));
+            }
+        }
+        // Validate an explicit tag's format when supplied. The drift check
+        // above already covers staleness regardless of the tag value.
+        if let Some(tag_str) = args.get("tag").and_then(|t| t.as_str()) {
+            if tag_str.parse::<SnapshotTag>().is_err() {
+                let mut args_map = std::collections::HashMap::new();
+                args_map.insert("path".to_string(), path.to_string());
+                args_map.insert("tag".to_string(), tag_str.to_string());
+                return ToolResult::error(aish_i18n::t_with_args(
+                    "tools.fs.edit_file.invalid_tag",
+                    &args_map,
+                ));
+            }
+        }
+
+        match std::fs::write(path, &new_content) {
+            Ok(()) => {
+                // Record the mutation for rollback and mint a fresh tag.
+                let tag_suffix = if let Some(store) = &self.store {
+                    store
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .record_mutation(
+                            Path::new(path),
+                            Some(content.into_bytes()),
+                            &new_content,
+                            SnapshotOp::Edit,
+                        );
+                    let new_tag = SnapshotTag::from_content(&new_content);
+                    format!("\n[{}#{}]", path, new_tag)
+                } else {
+                    String::new()
+                };
+                let mut args_map = std::collections::HashMap::new();
+                args_map.insert("path".to_string(), path.to_string());
+                ToolResult::success(format!(
+                    "{}{}",
+                    aish_i18n::t_with_args("tools.fs.edit_file.edit_success", &args_map),
+                    tag_suffix
                 ))
             }
             Err(e) => {
@@ -216,6 +274,92 @@ mod tests {
             result.output.contains("limit") || result.output.contains("bytes"),
             "Expected size limit error, got: {}",
             result.output
+        );
+    }
+
+    #[test]
+    fn edit_file_rejects_stale_drift_without_tag() {
+        // #3: server-side enforcement — even with no `tag` arg, an edit on a
+        // file that changed since read_file must be rejected.
+        use std::sync::{Arc, Mutex};
+
+        use crate::fs::{SharedSnapshotStore, SnapshotStore};
+
+        aish_i18n::set_locale("en-US");
+        let dir = temp_dir();
+        let f = dir.path().join("a.txt");
+        fs::write(&f, "v1").unwrap();
+
+        let store: SharedSnapshotStore = Arc::new(Mutex::new(SnapshotStore::new()));
+        // Simulate read_file observing "v1", then the file drifts.
+        store.lock().unwrap().record_read(&f, "v1");
+        fs::write(&f, "v2").unwrap();
+
+        let tool = EditFileTool::with_store(store);
+        let res = tool.execute(serde_json::json!({
+            "path": f.to_str().unwrap(),
+            "old_string": "v2",
+            "new_string": "v3",
+        }));
+        assert!(!res.ok, "stale edit must be rejected even without a tag");
+        assert!(
+            res.output.contains("changed") || res.output.contains("re-read"),
+            "expected stale message, got: {}",
+            res.output
+        );
+        assert_eq!(fs::read_to_string(&f).unwrap(), "v2");
+    }
+
+    #[test]
+    fn edit_file_allows_when_fresh_and_records_mutation() {
+        use std::sync::{Arc, Mutex};
+
+        use crate::fs::{SharedSnapshotStore, SnapshotStore};
+
+        let dir = temp_dir();
+        let f = dir.path().join("a.txt");
+        fs::write(&f, "hello").unwrap();
+
+        let store: SharedSnapshotStore = Arc::new(Mutex::new(SnapshotStore::new()));
+        store.lock().unwrap().record_read(&f, "hello");
+
+        let tool = EditFileTool::with_store(store.clone());
+        let res = tool.execute(serde_json::json!({
+            "path": f.to_str().unwrap(),
+            "old_string": "hello",
+            "new_string": "world",
+        }));
+        assert!(res.ok, "fresh edit must succeed");
+        assert_eq!(fs::read_to_string(&f).unwrap(), "world");
+        assert_eq!(store.lock().unwrap().history_len(), 1);
+    }
+
+    #[test]
+    fn edit_file_rejects_malformed_tag() {
+        use std::sync::{Arc, Mutex};
+
+        use crate::fs::{SharedSnapshotStore, SnapshotStore};
+
+        aish_i18n::set_locale("en-US");
+        let dir = temp_dir();
+        let f = dir.path().join("a.txt");
+        fs::write(&f, "hello").unwrap();
+
+        let store: SharedSnapshotStore = Arc::new(Mutex::new(SnapshotStore::new()));
+        store.lock().unwrap().record_read(&f, "hello");
+
+        let tool = EditFileTool::with_store(store);
+        let res = tool.execute(serde_json::json!({
+            "path": f.to_str().unwrap(),
+            "old_string": "hello",
+            "new_string": "world",
+            "tag": "ZZZZ",
+        }));
+        assert!(!res.ok, "malformed tag must be rejected");
+        assert!(
+            res.output.contains("Invalid") || res.output.contains("invalid"),
+            "expected invalid-tag message, got: {}",
+            res.output
         );
     }
 }

--- a/crates/aish-tools/src/edit_file/prompt.rs
+++ b/crates/aish-tools/src/edit_file/prompt.rs
@@ -1,12 +1,16 @@
 pub(crate) const DESCRIPTION: &str = "\
-Edit a file by replacing exact text. Use after read_file when modifying existing files.";
+Modify an existing file by replacing exact text — the correct way to edit \
+files. Never use bash (sed -i, echo >, cat >>, tee) to modify files; always \
+use this tool instead.";
 
 pub(crate) const PROMPT: &str = r#"Use this tool to make exact string replacements in text files.
 
 Usage:
 - old_string must match exactly.
 - Provide enough surrounding context when replacing a repeated string.
-- Use replace_all only when every occurrence should change."#;
+- Use replace_all only when every occurrence should change.
+- Pass the tag from read_file's [path#TAG] header to anchor the edit; if the
+  file changed since you read it the edit is rejected and you must re-read."#;
 
 pub(crate) fn parameters() -> serde_json::Value {
     serde_json::json!({
@@ -27,6 +31,10 @@ pub(crate) fn parameters() -> serde_json::Value {
             "replace_all": {
                 "type": "boolean",
                 "description": "Replace all occurrences. Defaults to false."
+            },
+            "tag": {
+                "type": "string",
+                "description": "Snapshot tag from read_file's [path#TAG] header. Anchors the edit: if the file changed since you read it, the edit is rejected."
             }
         },
         "required": ["path", "old_string", "new_string"]

--- a/crates/aish-tools/src/fs/snapshot_store.rs
+++ b/crates/aish-tools/src/fs/snapshot_store.rs
@@ -1,0 +1,610 @@
+//! Session-scoped snapshot store for file edit anchoring and rollback.
+//!
+//! Two responsibilities, combining content-anchoring with an aish-native
+//! rollback layer:
+//!
+//! 1. **TAG anchoring (optimistic concurrency)**: `read_file` stamps a file
+//!    with a 4-hex content-derived tag; `edit_file` verifies the tag still
+//!    matches the on-disk content before applying. A mismatch means the file
+//!    drifted since the model last read it — the edit is rejected and the
+//!    model must re-read.
+//!
+//! 2. **Rollback chain**: every `edit_file`/`write_file` mutation pushes the
+//!    prior content into an append-only history, enabling `/undo` and
+//!    `restore` to revert AI-made file changes.
+//!
+//! The tag is a non-cryptographic content hash truncated to 16 bits. By the
+//! birthday paradox, ~300 distinct file versions in a session give a ~50%
+//! collision chance, so a tag match is necessary but not sufficient — stale
+//! detection is a safety net, never a guarantee.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
+
+/// A 4-uppercase-hex snapshot tag derived from file content (FNV-1a 64-bit,
+/// avalanche-finalized, truncated to 16 bits).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SnapshotTag(u16);
+
+impl SnapshotTag {
+    /// Compute a tag from text content (UTF-8). Delegates to [`from_bytes`].
+    ///
+    /// Non-cryptographic: a collision only causes a missed stale detection
+    /// (never data loss). The murmur3-style finalizer in [`from_bytes`] keeps
+    /// the 16-bit output well-distributed so small edits almost always flip it.
+    pub fn from_content(content: &str) -> Self {
+        Self::from_bytes(content.as_bytes())
+    }
+
+    /// Compute a tag from raw bytes. Works for binary files (non-UTF-8) so
+    /// rollback tags stay stable regardless of content type.
+    pub fn from_bytes(content: &[u8]) -> Self {
+        let mut hash: u64 = 0xcbf29ce484222325;
+        for &byte in content {
+            hash ^= byte as u64;
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        // Avalanche finalizer (murmur3-style) so every bit reacts to small
+        // input changes. Plain FNV-1a leaves high bits insensitive to single-
+        // byte deltas, causing collisions on near-identical content.
+        hash ^= hash >> 33;
+        hash = hash.wrapping_mul(0xff51afd7ed558ccd);
+        hash ^= hash >> 33;
+        Self(hash as u16)
+    }
+
+    /// Render as 4 uppercase hex chars, e.g. `0A3B`.
+    pub fn as_hex(self) -> String {
+        format!("{:04X}", self.0)
+    }
+}
+
+impl fmt::Display for SnapshotTag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.as_hex())
+    }
+}
+
+impl FromStr for SnapshotTag {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() != 4 || !s.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(format!("expected 4 hex chars, got {:?}", s));
+        }
+        Ok(Self(u16::from_str_radix(s, 16).map_err(|e| e.to_string())?))
+    }
+}
+
+/// Kind of mutation that produced a snapshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotOp {
+    Edit,
+    Write,
+}
+
+impl fmt::Display for SnapshotOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SnapshotOp::Edit => f.write_str("edit"),
+            SnapshotOp::Write => f.write_str("write"),
+        }
+    }
+}
+
+/// One recorded file state, pushed before a mutation is applied.
+#[derive(Debug, Clone)]
+pub struct FileSnapshot {
+    pub id: u64,
+    pub path: PathBuf,
+    /// Content before the mutation (raw bytes, so binary files roll back too).
+    /// `None` means the file did not exist yet (it was created by the
+    /// mutation); restoring deletes it.
+    pub prior_content: Option<Vec<u8>>,
+    /// Tag of the content AFTER the mutation (for quick re-read skipping).
+    pub tag: SnapshotTag,
+    pub op: SnapshotOp,
+    pub ts: SystemTime,
+}
+
+/// What an undo/restore must write back to disk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UndoResult {
+    pub path: PathBuf,
+    /// Bytes to write. `None` means delete the file (it was newly created).
+    pub content: Option<Vec<u8>>,
+    pub snapshot_id: u64,
+}
+
+/// What [`UndoResult::apply_to_disk`] did to the filesystem.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplyOutcome {
+    /// Wrote prior bytes back to the file.
+    Restored,
+    /// Deleted the file (the undone mutation had created it).
+    Removed,
+}
+
+impl UndoResult {
+    /// Apply this restore action to disk: write the prior bytes back, or
+    /// delete the file when `content` is `None` (the mutation created it).
+    ///
+    /// `tolerate_missing` makes a delete of an already-absent file succeed —
+    /// used by batch `/rollback` so a partial-restore retry converges instead
+    /// of wedging on `NotFound`. Single-step undo passes `false` so an
+    /// unexpected absence surfaces as an error.
+    pub fn apply_to_disk(&self, tolerate_missing: bool) -> std::io::Result<ApplyOutcome> {
+        match &self.content {
+            Some(bytes) => {
+                std::fs::write(&self.path, bytes)?;
+                Ok(ApplyOutcome::Restored)
+            }
+            None => match std::fs::remove_file(&self.path) {
+                Ok(()) => Ok(ApplyOutcome::Removed),
+                Err(e) if tolerate_missing && e.kind() == std::io::ErrorKind::NotFound => {
+                    Ok(ApplyOutcome::Removed)
+                }
+                Err(e) => Err(e),
+            },
+        }
+    }
+}
+
+/// Maximum rollback entries kept in memory. Older entries are dropped (FIFO)
+/// to bound memory on long sessions with many large-file edits.
+const MAX_HISTORY: usize = 200;
+
+/// Canonicalize a path for use as a stable store key. Falls back to the
+/// lexical form when canonicalization fails (e.g. the file does not exist
+/// yet, so symlinks cannot be resolved).
+fn normalize_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Session-scoped store: latest tag per file plus a bounded rollback chain.
+#[derive(Debug, Default)]
+pub struct SnapshotStore {
+    /// Latest known tag per canonical path, updated on read/edit/write.
+    tags: HashMap<PathBuf, SnapshotTag>,
+    /// Bounded rollback chain (newest last; oldest dropped past MAX_HISTORY).
+    history: Vec<FileSnapshot>,
+    next_id: u64,
+}
+
+impl SnapshotStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a read: compute the tag, remember it, and return it so the
+    /// caller can emit a `[path#TAG]` header.
+    pub fn record_read(&mut self, path: &Path, content: &str) -> SnapshotTag {
+        let key = normalize_path(path);
+        let tag = SnapshotTag::from_content(content);
+        self.tags.insert(key, tag);
+        tag
+    }
+
+    /// Latest tag remembered for a path (from a prior read/edit/write).
+    /// Returns `None` when the path was never observed through the store.
+    pub fn current_tag(&self, path: &Path) -> Option<SnapshotTag> {
+        self.tags.get(&normalize_path(path)).copied()
+    }
+
+    /// Whether `disk_content` still matches the tag last recorded for `path`
+    /// (from a read/edit/write). Returns `true` when fresh, or when the path
+    /// was never observed (no baseline — allow the edit through).
+    ///
+    /// Server-side drift check: even without a model-supplied tag, a file that
+    /// changed since the last `read_file` is detected and must be re-read.
+    pub fn is_fresh(&self, path: &Path, disk_content: &str) -> bool {
+        match self.tags.get(&normalize_path(path)) {
+            Some(remembered) => SnapshotTag::from_content(disk_content) == *remembered,
+            None => true,
+        }
+    }
+
+    /// Record a mutation (edit or write). Pushes the prior content into the
+    /// rollback chain and refreshes the remembered tag to the new content.
+    /// Returns the snapshot id assigned to this entry.
+    ///
+    /// `prior_content` is the file's bytes before the mutation (`None` if the
+    /// file did not exist).
+    pub fn record_mutation(
+        &mut self,
+        path: &Path,
+        prior_content: Option<Vec<u8>>,
+        new_content: &str,
+        op: SnapshotOp,
+    ) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        let key = normalize_path(path);
+        let tag = SnapshotTag::from_content(new_content);
+        let snapshot = FileSnapshot {
+            id,
+            path: key.clone(),
+            prior_content,
+            tag,
+            op,
+            ts: SystemTime::now(),
+        };
+        self.history.push(snapshot);
+        // Bound memory: drop the oldest entry when over capacity.
+        if self.history.len() > MAX_HISTORY {
+            self.history.remove(0);
+        }
+        self.tags.insert(key, tag);
+        id
+    }
+
+    /// Peek the restore action for the most recent mutation WITHOUT removing
+    /// it. Use this to attempt the disk restore first; call
+    /// [`commit_undo_last`] only after the restore succeeds, so a failed IO
+    /// does not lose the snapshot.
+    pub fn peek_undo_last(&self) -> Option<UndoResult> {
+        let snap = self.history.last()?;
+        Some(Self::build_undo_result(snap))
+    }
+
+    /// Peek the restore action for the most recent mutation on a specific
+    /// path, without removing it.
+    pub fn peek_undo_last_for(&self, path: &Path) -> Option<UndoResult> {
+        let key = normalize_path(path);
+        let snap = self.history.iter().rev().find(|s| s.path == key)?;
+        Some(Self::build_undo_result(snap))
+    }
+
+    /// Build a restore action from a snapshot without mutating store state.
+    fn build_undo_result(snap: &FileSnapshot) -> UndoResult {
+        UndoResult {
+            path: snap.path.clone(),
+            content: snap.prior_content.clone(),
+            snapshot_id: snap.id,
+        }
+    }
+
+    /// Commit the undo by removing the most recent mutation and rewinding the
+    /// remembered tag. Call ONLY after the disk restore for the peeked action
+    /// succeeded. `snapshot_id` must match the peeked entry's id; returns
+    /// `None` (without mutating) when a newer mutation has landed in between,
+    /// so a stale peek is rejected rather than consuming the wrong snapshot.
+    pub fn commit_undo_last(&mut self, snapshot_id: u64) -> Option<FileSnapshot> {
+        let snap = self.history.last()?;
+        if snap.id != snapshot_id {
+            return None;
+        }
+        let snap = self.history.pop()?;
+        self.rewind_tag(&snap);
+        Some(snap)
+    }
+
+    /// Commit undo for a specific path. Call only after a successful restore.
+    /// `snapshot_id` must match the peeked entry's id; returns `None` (without
+    /// mutating) when a newer mutation on this path has landed in between.
+    pub fn commit_undo_last_for(&mut self, path: &Path, snapshot_id: u64) -> Option<FileSnapshot> {
+        let key = normalize_path(path);
+        let idx = self.history.iter().rposition(|s| s.path == key)?;
+        if self.history[idx].id != snapshot_id {
+            return None;
+        }
+        let snap = self.history.remove(idx);
+        self.rewind_tag(&snap);
+        Some(snap)
+    }
+
+    /// Rewind the remembered tag to a snapshot's prior content. If the file
+    /// was created by the mutation (no prior), forget the tag entirely.
+    fn rewind_tag(&mut self, snap: &FileSnapshot) {
+        match &snap.prior_content {
+            Some(prior) => {
+                self.tags
+                    .insert(snap.path.clone(), SnapshotTag::from_bytes(prior));
+            }
+            None => {
+                self.tags.remove(&snap.path);
+            }
+        }
+    }
+
+    /// Convenience: peek + commit with no disk IO between (atomic undo).
+    /// Prefer [`peek_undo_last`] + [`commit_undo_last`] when a disk restore
+    /// must succeed before consuming the history entry.
+    pub fn undo_last(&mut self) -> Option<UndoResult> {
+        let result = self.peek_undo_last()?;
+        self.commit_undo_last(result.snapshot_id);
+        Some(result)
+    }
+
+    /// Convenience: peek + commit for a specific path (atomic undo).
+    pub fn undo_last_for(&mut self, path: &Path) -> Option<UndoResult> {
+        let result = self.peek_undo_last_for(path)?;
+        self.commit_undo_last_for(path, result.snapshot_id);
+        Some(result)
+    }
+
+    /// Peek ALL restore actions needed to roll back to before snapshot `id`,
+    /// in reverse chronological order (newest first). Each action must be
+    /// applied to disk; call [`commit_restore`] only after all succeed.
+    ///
+    /// Rolling back to `id` reverts `id` and every newer mutation — every
+    /// file touched in that range is restored to its prior content. A single
+    /// file edited multiple times in the range yields multiple actions; apply
+    /// them in the returned order so the earliest mutation's prior wins.
+    pub fn peek_restore(&self, id: u64) -> Option<Vec<UndoResult>> {
+        let pos = self.history.iter().position(|s| s.id == id)?;
+        Some(
+            self.history[pos..]
+                .iter()
+                .rev()
+                .map(Self::build_undo_result)
+                .collect(),
+        )
+    }
+
+    /// Commit: drop the target and everything newer, rewinding the remembered
+    /// tag for every affected file. Rewinding in reverse (newest first) lets
+    /// the earliest mutation's prior win per file. Call ONLY after all disk
+    /// restores for the peeked actions succeeded.
+    pub fn commit_restore(&mut self, id: u64) -> Option<()> {
+        let pos = self.history.iter().position(|s| s.id == id)?;
+        let drained: Vec<FileSnapshot> = self.history.split_off(pos);
+        for snap in drained.iter().rev() {
+            self.rewind_tag(snap);
+        }
+        Some(())
+    }
+
+    /// Convenience: peek + commit with no disk IO between (atomic restore).
+    pub fn restore(&mut self, id: u64) -> Option<Vec<UndoResult>> {
+        let result = self.peek_restore(id)?;
+        self.commit_restore(id);
+        Some(result)
+    }
+
+    /// Immutable view of the full rollback chain (newest last).
+    pub fn history(&self) -> &[FileSnapshot] {
+        &self.history
+    }
+
+    /// Number of recorded mutations.
+    pub fn history_len(&self) -> usize {
+        self.history.len()
+    }
+
+    /// Clear all history and remembered tags (e.g. on session reset).
+    pub fn clear(&mut self) {
+        self.tags.clear();
+        self.history.clear();
+    }
+}
+
+/// Shared, thread-safe handle to a [`SnapshotStore`] for injection into
+/// multiple tools (read_file / edit_file / write_file) that must observe the
+/// same session state. Constructed once per session, cloned into each tool.
+///
+/// **Concurrency model:** the shell drives tools sequentially (only `Agent`
+/// sub-agent batches run concurrently, and those use isolated sub-sessions),
+/// so the peek → disk-IO → commit sequences in `/undo` and `/rollback` never
+/// interleave with a concurrent mutation. The `Mutex` guards data integrity
+/// for the rare shared-access path (e.g. inherited tools), not because callers
+/// race in practice.
+pub type SharedSnapshotStore = Arc<Mutex<SnapshotStore>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tag_is_4_hex_and_stable() {
+        let t = SnapshotTag::from_content("hello world");
+        let hex = t.as_hex();
+        assert_eq!(hex.len(), 4);
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(t, SnapshotTag::from_content("hello world"));
+    }
+
+    #[test]
+    fn tag_differs_for_different_content() {
+        assert_ne!(
+            SnapshotTag::from_content("foo"),
+            SnapshotTag::from_content("bar")
+        );
+    }
+
+    #[test]
+    fn tag_roundtrips_through_str() {
+        let t = SnapshotTag::from_content("payload");
+        let parsed: SnapshotTag = t.as_hex().parse().unwrap();
+        assert_eq!(t, parsed);
+    }
+
+    #[test]
+    fn tag_rejects_bad_input() {
+        assert!("XYZ".parse::<SnapshotTag>().is_err());
+        assert!("ZZZZ".parse::<SnapshotTag>().is_err());
+        assert!("12345".parse::<SnapshotTag>().is_err());
+    }
+
+    #[test]
+    fn tag_works_for_binary_bytes() {
+        // H2: binary content must also produce a stable, distinct tag.
+        let a = SnapshotTag::from_bytes(&[0x00, 0xFF, 0x80]);
+        let b = SnapshotTag::from_bytes(&[0x00, 0xFF, 0x81]);
+        assert_ne!(a, b);
+        assert_eq!(a, SnapshotTag::from_bytes(&[0x00, 0xFF, 0x80]));
+    }
+
+    #[test]
+    fn record_read_remembers_tag() {
+        let mut store = SnapshotStore::new();
+        let p = Path::new("/tmp/a.txt");
+        let t = store.record_read(p, "body");
+        assert_eq!(store.current_tag(p), Some(t));
+    }
+
+    #[test]
+    fn is_fresh_detects_drift() {
+        let mut store = SnapshotStore::new();
+        let p = Path::new("/tmp/a.txt");
+        store.record_read(p, "v1");
+        assert!(store.is_fresh(p, "v1"));
+        assert!(!store.is_fresh(p, "v2"));
+    }
+
+    #[test]
+    fn is_fresh_allows_unobserved_path() {
+        // No baseline (file never read) → treated as fresh; edits are allowed.
+        let store = SnapshotStore::new();
+        assert!(store.is_fresh(Path::new("/tmp/never_read.txt"), "anything"));
+    }
+
+    #[test]
+    fn record_mutation_pushes_history_and_refreshes_tag() {
+        let mut store = SnapshotStore::new();
+        let p = Path::new("/tmp/a.txt");
+        store.record_read(p, "v1");
+        let id = store.record_mutation(p, Some(b"v1".to_vec()), "v2", SnapshotOp::Edit);
+        assert_eq!(store.history_len(), 1);
+        assert_eq!(store.current_tag(p), Some(SnapshotTag::from_content("v2")));
+        assert_eq!(store.history()[0].id, id);
+    }
+
+    #[test]
+    fn undo_last_restores_prior_content() {
+        let mut store = SnapshotStore::new();
+        let p = Path::new("/tmp/a.txt");
+        store.record_mutation(p, Some(b"old".to_vec()), "new", SnapshotOp::Edit);
+        let r = store.undo_last().unwrap();
+        assert_eq!(r.path, p);
+        assert_eq!(r.content.as_deref(), Some(b"old".as_slice()));
+        assert_eq!(store.current_tag(p), Some(SnapshotTag::from_content("old")));
+        assert!(store.history().is_empty());
+    }
+
+    #[test]
+    fn undo_last_for_created_file_returns_none_content() {
+        let mut store = SnapshotStore::new();
+        let p = Path::new("/tmp/new.txt");
+        store.record_mutation(p, None, "created", SnapshotOp::Write);
+        let r = store.undo_last().unwrap();
+        assert_eq!(r.content, None);
+        assert!(store.current_tag(p).is_none());
+    }
+
+    #[test]
+    fn undo_last_for_targets_specific_path() {
+        let mut store = SnapshotStore::new();
+        let a = Path::new("/tmp/a.txt");
+        let b = Path::new("/tmp/b.txt");
+        store.record_mutation(a, Some(b"a0".to_vec()), "a1", SnapshotOp::Edit);
+        store.record_mutation(b, Some(b"b0".to_vec()), "b1", SnapshotOp::Edit);
+        let r = store.undo_last_for(b).unwrap();
+        assert_eq!(r.path, b);
+        assert_eq!(store.history_len(), 1);
+        assert_eq!(store.history()[0].path, a);
+    }
+
+    #[test]
+    fn restore_drops_newer_mutations() {
+        let mut store = SnapshotStore::new();
+        let p = Path::new("/tmp/a.txt");
+        let id0 = store.record_mutation(p, Some(b"v0".to_vec()), "v1", SnapshotOp::Edit);
+        store.record_mutation(p, Some(b"v1".to_vec()), "v2", SnapshotOp::Edit);
+        store.record_mutation(p, Some(b"v2".to_vec()), "v3", SnapshotOp::Edit);
+        let actions = store.restore(id0).unwrap();
+        // Reverse order: [v2_prior, v1_prior, v0_prior]. Target's prior last.
+        assert_eq!(actions.len(), 3);
+        assert_eq!(
+            actions.last().unwrap().content.as_deref(),
+            Some(b"v0".as_slice())
+        );
+        assert!(store.history().is_empty());
+    }
+
+    #[test]
+    fn restore_unknown_id_returns_none() {
+        let mut store = SnapshotStore::new();
+        let p = Path::new("/tmp/a.txt");
+        store.record_mutation(p, Some(b"v0".to_vec()), "v1", SnapshotOp::Edit);
+        assert!(store.restore(999).is_none());
+    }
+    #[test]
+    fn restore_rolls_back_all_files_in_range() {
+        // Regression: restore to a point must revert EVERY file changed at
+        // or after that point — not just the target file.
+        let mut store = SnapshotStore::new();
+        let tf = Path::new("/tmp/testfile");
+        let af = Path::new("/tmp/a");
+        let id1 = store.record_mutation(tf, Some(b"t0".to_vec()), "t1", SnapshotOp::Edit);
+        store.record_mutation(tf, Some(b"t1".to_vec()), "t2", SnapshotOp::Edit);
+        store.record_mutation(af, Some(b"a0".to_vec()), "a1", SnapshotOp::Edit);
+        let actions = store.restore(id1).unwrap();
+        // 3 actions in reverse: a->a0, testfile->t1, testfile->t0.
+        assert_eq!(actions.len(), 3);
+        let has_a = actions
+            .iter()
+            .any(|a| a.path == af && a.content.as_deref() == Some(b"a0".as_slice()));
+        let has_tf_t0 = actions
+            .iter()
+            .any(|a| a.path == tf && a.content.as_deref() == Some(b"t0".as_slice()));
+        assert!(has_a, "a file rollback missing");
+        assert!(has_tf_t0, "testfile earliest prior missing");
+        assert!(store.history().is_empty());
+    }
+
+    #[test]
+    fn undo_on_empty_history_returns_none() {
+        let mut store = SnapshotStore::new();
+        assert!(store.undo_last().is_none());
+    }
+
+    #[test]
+    fn clear_resets_everything() {
+        let mut store = SnapshotStore::new();
+        let p = Path::new("/tmp/a.txt");
+        store.record_read(p, "x");
+        store.record_mutation(p, Some(b"x".to_vec()), "y", SnapshotOp::Edit);
+        store.clear();
+        assert!(store.current_tag(p).is_none());
+        assert!(store.history().is_empty());
+    }
+
+    #[test]
+    fn peek_then_failed_io_keeps_history() {
+        // H1: peek must not consume history; only commit does. A failed disk
+        // restore between peek and commit leaves the snapshot recoverable.
+        let mut store = SnapshotStore::new();
+        let p = Path::new("/tmp/a.txt");
+        store.record_mutation(p, Some(b"old".to_vec()), "new", SnapshotOp::Edit);
+        let peeked = store.peek_undo_last().unwrap();
+        assert_eq!(peeked.content.as_deref(), Some(b"old".as_slice()));
+        // History still intact after peek (simulating a failed IO before commit).
+        assert_eq!(store.history_len(), 1);
+        // Now commit succeeds — history consumed only here.
+        store.commit_undo_last(peeked.snapshot_id);
+        assert!(store.history().is_empty());
+    }
+
+    #[test]
+    fn history_is_bounded() {
+        // M2: history must not exceed MAX_HISTORY.
+        let mut store = SnapshotStore::new();
+        let p = Path::new("/tmp/a.txt");
+        for i in 0..(MAX_HISTORY + 50) {
+            store.record_mutation(
+                p,
+                Some(b"prior".to_vec()),
+                &format!("v{i}"),
+                SnapshotOp::Edit,
+            );
+        }
+        assert_eq!(store.history_len(), MAX_HISTORY);
+        // Oldest entries dropped; the first kept entry is not id 0.
+        assert!(store.history()[0].id > 0);
+    }
+}

--- a/crates/aish-tools/src/lib.rs
+++ b/crates/aish-tools/src/lib.rs
@@ -60,9 +60,22 @@ pub mod edit_file {
     pub use self::edit_file::*;
 }
 
+pub mod undo_edit {
+    mod prompt;
+    mod undo_edit;
+
+    pub use self::undo_edit::UndoEditTool;
+}
+
 pub mod fs {
+    mod snapshot_store;
+    pub use self::snapshot_store::{
+        ApplyOutcome, FileSnapshot, SharedSnapshotStore, SnapshotOp, SnapshotStore, SnapshotTag,
+        UndoResult,
+    };
     pub use crate::edit_file::EditFileTool;
     pub use crate::read_file::{ReadFileTool, SshReadFileTool};
+    pub use crate::undo_edit::UndoEditTool;
     pub use crate::write_file::WriteFileTool;
 }
 

--- a/crates/aish-tools/src/python/prompt.rs
+++ b/crates/aish-tools/src/python/prompt.rs
@@ -1,13 +1,20 @@
 pub(crate) const DESCRIPTION: &str = "\
-Execute Python code and return the result. Prefer for scripted data processing, formatting, \
-calculations, and multi-step logic instead of bash pipelines.";
+Execute Python code and return the result. Use ONLY for in-memory data \
+processing, formatting, and calculations — NEVER to read or write files \
+(use read_file/write_file/edit_file, which snapshot changes for undo).";
 
 pub(crate) const PROMPT: &str = r#"Use this tool for small Python snippets that are better expressed as code than shell pipelines.
 
 Usage:
 - Print values that should be returned to the conversation.
 - Keep snippets focused and self-contained.
-- Do not use this tool for long-running or interactive programs."#;
+- Do not use this tool for long-running or interactive programs.
+- NEVER read or write files through Python. Do not use open(), pathlib
+  Path.write_text/write_bytes, shutil, or os file calls (rename, remove,
+  makedirs) to create or modify files. Use read_file to read, edit_file to
+  modify, and write_file to create — those tools snapshot changes for undo
+  and anchor edits against stale content; Python file I/O bypasses all of
+  that. Use Python only for in-memory data processing and print the result."#;
 
 pub(crate) fn parameters() -> serde_json::Value {
     serde_json::json!({

--- a/crates/aish-tools/src/read_file/prompt.rs
+++ b/crates/aish-tools/src/read_file/prompt.rs
@@ -6,7 +6,9 @@ pub(crate) const PROMPT: &str = r#"Use this tool to read text files.
 Usage:
 - Provide path to the file to read.
 - Use offset and limit when you only need part of a larger file.
-- Offset is a 0-based index; results display 1-based line numbers."#;
+- Offset is a 0-based index; results display 1-based line numbers.
+- Output begins with a [path#TAG] header; pass that TAG to edit_file's tag
+  param so edits are rejected if the file changed since you read it."#;
 
 pub(crate) fn parameters() -> serde_json::Value {
     serde_json::json!({

--- a/crates/aish-tools/src/read_file/read_file.rs
+++ b/crates/aish-tools/src/read_file/read_file.rs
@@ -2,11 +2,15 @@ use aish_i18n;
 use aish_llm::{Tool, ToolResult};
 
 use super::prompt;
+use crate::fs::SharedSnapshotStore;
+use std::path::Path;
 
 const SIZE_LIMIT: usize = 32 * 1024;
 
 /// Read file content tool.
-pub struct ReadFileTool;
+pub struct ReadFileTool {
+    store: Option<SharedSnapshotStore>,
+}
 
 impl Default for ReadFileTool {
     fn default() -> Self {
@@ -16,7 +20,11 @@ impl Default for ReadFileTool {
 
 impl ReadFileTool {
     pub fn new() -> Self {
-        Self
+        Self { store: None }
+    }
+
+    pub fn with_store(store: SharedSnapshotStore) -> Self {
+        Self { store: Some(store) }
     }
 }
 
@@ -122,7 +130,18 @@ impl Tool for ReadFileTool {
             .map(|(i, line)| format!("{:>6}\t{}", offset + i + 1, line))
             .collect();
 
-        ToolResult::success(selected.join("\n"))
+        let body = selected.join("\n");
+
+        // Stamp a snapshot tag so a later edit_file can detect stale content.
+        if let Some(store) = &self.store {
+            let tag = store
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .record_read(Path::new(path), &content);
+            ToolResult::success(format!("[{}#{}]\n{}", path, tag, body))
+        } else {
+            ToolResult::success(body)
+        }
     }
 }
 

--- a/crates/aish-tools/src/undo_edit/prompt.rs
+++ b/crates/aish-tools/src/undo_edit/prompt.rs
@@ -1,0 +1,22 @@
+pub(crate) const DESCRIPTION: &str = "\
+Undo the most recent edit_file or write_file change, restoring the file to its prior content.";
+
+pub(crate) const PROMPT: &str = r#"Reverts the last file mutation made by edit_file or write_file.
+
+Usage:
+- With no args, undoes the most recent change across all files.
+- Pass path to undo only the last change to that specific file.
+- If the undone change created the file, undo deletes it."#;
+
+pub(crate) fn parameters() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Optional: undo only the last change to this path. Omit to undo the most recent change overall."
+            }
+        },
+        "required": []
+    })
+}

--- a/crates/aish-tools/src/undo_edit/undo_edit.rs
+++ b/crates/aish-tools/src/undo_edit/undo_edit.rs
@@ -1,0 +1,156 @@
+use std::path::Path;
+
+use aish_llm::{Tool, ToolResult};
+
+use crate::fs::{ApplyOutcome, SharedSnapshotStore, UndoResult};
+
+use super::prompt;
+
+/// Undo the most recent file mutation (edit_file / write_file) recorded by the
+/// shared snapshot store. Restores prior content, or deletes the file if it was
+/// created by the undone mutation.
+pub struct UndoEditTool {
+    store: SharedSnapshotStore,
+}
+
+impl UndoEditTool {
+    pub fn new(store: SharedSnapshotStore) -> Self {
+        Self { store }
+    }
+}
+
+impl Tool for UndoEditTool {
+    fn name(&self) -> &str {
+        "undo_edit"
+    }
+
+    fn description(&self) -> &str {
+        prompt::DESCRIPTION
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        prompt::parameters()
+    }
+
+    fn prompt(&self) -> &str {
+        prompt::PROMPT
+    }
+
+    fn execute(&self, args: serde_json::Value) -> ToolResult {
+        let path = args.get("path").and_then(|p| p.as_str());
+        // Peek WITHOUT consuming — a failed disk restore must not lose the
+        // snapshot, so we commit only after the IO succeeds.
+        let peeked = {
+            let store = self.store.lock().unwrap_or_else(|e| e.into_inner());
+            match path {
+                Some(p) => store.peek_undo_last_for(Path::new(p)),
+                None => store.peek_undo_last(),
+            }
+        };
+        let result = match peeked {
+            Some(r) => r,
+            None => return ToolResult::error(aish_i18n::t("tools.fs.undo_edit.nothing_to_undo")),
+        };
+        let applied = apply_undo(&result);
+        if applied.ok {
+            // Disk restore succeeded — now safe to consume the history entry.
+            let mut store = self.store.lock().unwrap_or_else(|e| e.into_inner());
+            match path {
+                Some(p) => store.commit_undo_last_for(Path::new(p), result.snapshot_id),
+                None => store.commit_undo_last(result.snapshot_id),
+            };
+        }
+        // On failure the history is retained so the caller can retry.
+        applied
+    }
+}
+
+/// Apply an [`UndoResult`] to disk. Writes prior content back, or removes the
+/// file when the undone mutation had created it.
+fn apply_undo(result: &UndoResult) -> ToolResult {
+    let mut args = std::collections::HashMap::new();
+    args.insert("path".to_string(), result.path.display().to_string());
+    match result.apply_to_disk(false) {
+        Ok(ApplyOutcome::Restored) => {
+            ToolResult::success(aish_i18n::t_with_args("tools.fs.undo_edit.restored", &args))
+        }
+        Ok(ApplyOutcome::Removed) => {
+            ToolResult::success(aish_i18n::t_with_args("tools.fs.undo_edit.removed", &args))
+        }
+        Err(e) => {
+            args.insert("error".to_string(), e.to_string());
+            let key = if result.content.is_some() {
+                "tools.fs.undo_edit.restore_failed"
+            } else {
+                "tools.fs.undo_edit.remove_failed"
+            };
+            ToolResult::error(aish_i18n::t_with_args(key, &args))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::SnapshotStore;
+    use std::fs;
+
+    fn temp_dir() -> tempfile::TempDir {
+        tempfile::tempdir().expect("failed to create temp dir")
+    }
+
+    #[test]
+    fn undo_restores_overwritten_content() {
+        let dir = temp_dir();
+        let f = dir.path().join("a.txt");
+        fs::write(&f, "original").unwrap();
+
+        let store: SharedSnapshotStore =
+            std::sync::Arc::new(std::sync::Mutex::new(SnapshotStore::new()));
+        // Simulate a write_file mutation that overwrites.
+        {
+            let mut g = store.lock().unwrap();
+            g.record_mutation(
+                &f,
+                Some("original".into()),
+                "changed",
+                crate::fs::SnapshotOp::Write,
+            );
+        }
+        fs::write(&f, "changed").unwrap();
+
+        let tool = UndoEditTool::new(store.clone());
+        let res = tool.execute(serde_json::json!({}));
+        assert!(res.ok, "undo should succeed");
+        assert_eq!(fs::read_to_string(&f).unwrap(), "original");
+    }
+
+    #[test]
+    fn undo_deletes_created_file() {
+        let dir = temp_dir();
+        let f = dir.path().join("new.txt");
+        fs::write(&f, "created").unwrap();
+
+        let store: SharedSnapshotStore =
+            std::sync::Arc::new(std::sync::Mutex::new(SnapshotStore::new()));
+        {
+            let mut g = store.lock().unwrap();
+            // prior = None => file was created
+            g.record_mutation(&f, None, "created", crate::fs::SnapshotOp::Write);
+        }
+
+        let tool = UndoEditTool::new(store.clone());
+        let res = tool.execute(serde_json::json!({}));
+        assert!(res.ok);
+        assert!(!f.exists(), "created file should be deleted on undo");
+    }
+
+    #[test]
+    fn undo_nothing_returns_error() {
+        let store: SharedSnapshotStore =
+            std::sync::Arc::new(std::sync::Mutex::new(SnapshotStore::new()));
+        let tool = UndoEditTool::new(store);
+        let res = tool.execute(serde_json::json!({}));
+        assert!(!res.ok);
+    }
+}

--- a/crates/aish-tools/src/write_file/prompt.rs
+++ b/crates/aish-tools/src/write_file/prompt.rs
@@ -1,5 +1,6 @@
 pub(crate) const DESCRIPTION: &str = "\
-Write text content to a file. Use when the user explicitly wants a file created or overwritten.";
+Create or overwrite a text file — the correct way to create files. Never use \
+bash (echo >, cat >, printf >, tee) to create files; use this tool instead.";
 
 pub(crate) const PROMPT: &str = r#"Use this tool to create or overwrite a text file.
 

--- a/crates/aish-tools/src/write_file/write_file.rs
+++ b/crates/aish-tools/src/write_file/write_file.rs
@@ -4,11 +4,14 @@ use aish_i18n;
 use aish_llm::{Tool, ToolResult};
 
 use super::prompt;
+use crate::fs::{SharedSnapshotStore, SnapshotOp, SnapshotTag};
 
 const MAX_WRITE_BYTES: usize = 32 * 1024;
 
 /// Write file tool (creates or overwrites).
-pub struct WriteFileTool;
+pub struct WriteFileTool {
+    store: Option<SharedSnapshotStore>,
+}
 
 impl Default for WriteFileTool {
     fn default() -> Self {
@@ -18,7 +21,11 @@ impl Default for WriteFileTool {
 
 impl WriteFileTool {
     pub fn new() -> Self {
-        Self
+        Self { store: None }
+    }
+
+    pub fn with_store(store: SharedSnapshotStore) -> Self {
+        Self { store: Some(store) }
     }
 }
 
@@ -72,14 +79,70 @@ impl Tool for WriteFileTool {
                 }
             }
         }
+        // Capture prior content for rollback before overwriting. Use raw
+        // bytes (not read_to_string) so binary files are snapshotted too.
+        // `None` means the file does not exist yet (undo deletes). A read
+        // failure on an existing-but-unreadable file MUST NOT record a bogus
+        // empty prior — that would make /undo truncate the file to zero
+        // bytes. Instead `skip_rollback` refreshes only the anchor tag (no
+        // history entry), so the write stays undoable-safe.
+        let (prior, skip_rollback): (Option<Vec<u8>>, bool) = match self.store.as_ref() {
+            Some(_) => {
+                if !Path::new(path).exists() {
+                    (None, false)
+                } else {
+                    match std::fs::read(path) {
+                        Ok(bytes) => {
+                            // Cap rollback memory: a prior larger than the
+                            // write budget isn't tracked (mirrors the
+                            // SIZE_LIMIT gate in read_file/edit_file). The
+                            // overwrite still happens; it just isn't
+                            // undoable — same boundary those tools enforce.
+                            if bytes.len() > MAX_WRITE_BYTES {
+                                (None, true)
+                            } else {
+                                (Some(bytes), false)
+                            }
+                        }
+                        Err(_) => (None, true),
+                    }
+                }
+            }
+            None => (None, false),
+        };
         match std::fs::write(path, content) {
             Ok(()) => {
+                let tag_suffix = if let Some(store) = &self.store {
+                    let mut g = store.lock().unwrap_or_else(|e| e.into_inner());
+                    if skip_rollback {
+                        // No safe prior to restore: refresh the anchor tag
+                        // only, without pushing a rollback entry.
+                        g.record_read(Path::new(path), content);
+                    } else {
+                        g.record_mutation(Path::new(path), prior, content, SnapshotOp::Write);
+                    }
+                    let new_tag = SnapshotTag::from_content(content);
+                    // Surface that this write is not undoable (prior was
+                    // unreadable or oversized) so the caller knows /undo
+                    // and /rollback cannot bring the old content back.
+                    if skip_rollback {
+                        format!(
+                            "\n[{}#{}] (not undoable: prior content unavailable)",
+                            path, new_tag
+                        )
+                    } else {
+                        format!("\n[{}#{}]", path, new_tag)
+                    }
+                } else {
+                    String::new()
+                };
                 let mut args_map = std::collections::HashMap::new();
                 args_map.insert("bytes".to_string(), content.len().to_string());
                 args_map.insert("path".to_string(), path.to_string());
-                ToolResult::success(aish_i18n::t_with_args(
-                    "tools.fs.write_file.write_success",
-                    &args_map,
+                ToolResult::success(format!(
+                    "{}{}",
+                    aish_i18n::t_with_args("tools.fs.write_file.write_success", &args_map),
+                    tag_suffix
                 ))
             }
             Err(e) => {
@@ -137,5 +200,77 @@ mod tests {
             result.output
         );
         assert!(!file_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_file_unreadable_prior_skips_rollback() {
+        // Regression (#1): an existing-but-unreadable file must NOT record
+        // an empty prior — otherwise /undo would restore zero bytes and
+        // truncate the file. The write still succeeds; the store just skips
+        // the rollback entry while refreshing the anchor tag.
+        use std::os::unix::fs::PermissionsExt;
+        use std::sync::{Arc, Mutex};
+
+        use crate::fs::{SharedSnapshotStore, SnapshotStore};
+
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let f = dir.path().join("write_only.txt");
+        fs::write(&f, "secret-prior").unwrap();
+        // write-only (0o222): writable, NOT readable
+        fs::set_permissions(&f, fs::Permissions::from_mode(0o222)).unwrap();
+
+        let store: SharedSnapshotStore = Arc::new(Mutex::new(SnapshotStore::new()));
+        let tool = WriteFileTool::with_store(store.clone());
+        let res = tool.execute(serde_json::json!({
+            "path": f.to_str().unwrap(),
+            "content": "new-content",
+        }));
+        assert!(res.ok, "write must succeed on a write-only file");
+
+        let g = store.lock().unwrap();
+        assert_eq!(
+            g.history_len(),
+            0,
+            "unreadable prior must not enter the rollback chain"
+        );
+        assert!(
+            g.current_tag(std::path::Path::new(&f)).is_some(),
+            "anchor tag should still be refreshed"
+        );
+    }
+    #[test]
+    fn write_file_oversized_prior_skips_rollback() {
+        // A prior larger than MAX_WRITE_BYTES must not enter history (memory
+        // cap + consistency with read_file/edit_file SIZE_LIMIT). The
+        // overwrite still succeeds; it just isn't undoable.
+        use std::sync::{Arc, Mutex};
+
+        use crate::fs::{SharedSnapshotStore, SnapshotStore};
+
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let f = dir.path().join("big.log");
+        fs::write(&f, "x".repeat(MAX_WRITE_BYTES + 1)).unwrap();
+
+        let store: SharedSnapshotStore = Arc::new(Mutex::new(SnapshotStore::new()));
+        let tool = WriteFileTool::with_store(store.clone());
+        let res = tool.execute(serde_json::json!({
+            "path": f.to_str().unwrap(),
+            "content": "small",
+        }));
+        assert!(res.ok, "overwrite of an oversized prior must still succeed");
+
+        let g = store.lock().unwrap();
+        assert_eq!(
+            g.history_len(),
+            0,
+            "oversized prior must not enter the rollback chain"
+        );
+        assert!(
+            g.current_tag(std::path::Path::new(&f)).is_some(),
+            "anchor tag should still be refreshed"
+        );
+        drop(g);
+        assert_eq!(fs::read_to_string(&f).unwrap(), "small");
     }
 }


### PR DESCRIPTION
## User-visible Changes

- New `/undo [path]` command: undo the most recent AI file change (optional path filter to undo a specific file).
- New `/rollback` command: interactive panel to review and restore any prior checkpoint.
- `write_file`/`edit_file` results carry a content tag; a non-undoable write (unreadable/oversized prior) now reports `(not undoable: prior content unavailable)`.
- File-edit diffs render as centered hunks with bounded context — edits near the end of a large file stay visible instead of being crowded out.

## Compatibility

- No config or storage format changes. The snapshot store is session-scoped and in-memory; it does not persist across shell restarts (both `/undo` and `/rollback` descriptions mark "this session").
- Internal API change: `commit_undo_last`/`commit_undo_last_for` now require a `snapshot_id` argument (self-verifying peek→commit). All callers updated.
- No breaking changes to existing commands; two new slash commands added.

## Testing

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` ✅ — incl. new regression tests:
  - snapshot: stale-drift-rejected, fresh-allows-and-records, malformed-tag-rejected, peek-then-failed-io-keeps-history, oversized-prior-skips-rollback, unreadable-prior-skips-rollback
  - diff: tail_edit_beyond_lcs_bound_is_shown, output_never_exceeds_max_lines, distant_hunks_kept_when_changed_fit
  - i18n: slash-command descriptions resolve across all 6 locales
- `cargo build --release --target x86_64-unknown-linux-musl` + `aish --help` smoke ✅
- Packaging smoke tests ✅

## Change Type

- [x] Feature: `/undo`, `/rollback`, `undo_edit` tool, server-side drift detection
- [x] Improvement: tool prompt hardening, diff rendering as bounded hunks
- [x] Bug fix: render_diff lost tail edits beyond the LCS bound; truncation emitted `max_lines+1` and could drop later changed hunks

## Scope

Implements #205 (检查点/快照/回退). Refs #432 (tool prompt hardening).

**Snapshot & undo (#205)**
- `/undo [path]`, `/rollback` panel, `undo_edit` tool — all use peek → apply → commit-on-success with `snapshot_id` verification (a stale peek is rejected rather than consuming the wrong snapshot).
- `read_file` stamps a content tag; `edit_file` enforces `is_fresh` server-side to reject edits against stale/drifted content even without a model-supplied tag.
- Memory bounded: `MAX_HISTORY=200` FIFO; `write_file` skips rollback for priors larger than `MAX_WRITE_BYTES` (mirrors the `SIZE_LIMIT` gate in `read_file`/`edit_file`).

**Tool prompt hardening (#432)**
- bash / secure_bash: forbid redirections and file writes.
- python_exec: forbid `open()`/pathlib/shutil/os file I/O; guide the AI to `print` and use `write_file`/`edit_file`.
- channel_bash (SSH remote): unchanged — the only remote write path; remote files are outside the local snapshot scope.

**Design notes**
- Defense in depth: prompt soft-constraint (guidance) + `is_fresh` hard safety net (edit drift detection). The `write`-creates-new-file path has no `is_fresh` net (no prior tag), so it relies on prompt guidance.
- Session-scoped: store is in-memory; descriptions set that expectation.

Closes #205
Refs #432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/undo` to reverse the latest file change.
  * Added `/rollback` to review and restore earlier file changes.
  * Added snapshot tags and safeguards against editing files that changed after reading.
  * Added undo support for restoring overwritten files and removing newly created files.
  * Improved diff displays with clearer change hunks and context limits.
  * Added localized messages in English, German, Spanish, French, Japanese, and Chinese.

* **Documentation**
  * Clarified that dedicated file tools should be used instead of Bash or Python for file modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->