### PR TITLE
fix(pty): strip device-query requests and drain leaked stdin responses

### DIFF
--- a/crates/aish-pty/src/persistent.rs
+++ b/crates/aish-pty/src/persistent.rs
@@ -55,9 +55,93 @@ where
     true
 }
 
+/// Count of active TUI/remote programs running inside the PTY. While > 0,
+/// `write_stdout_all` forwards bytes verbatim (no query stripping) so they
+/// can get their device-query answers from the real terminal. A counter
+/// (not a bool) keeps nested/concurrent commands correct: the outer guard
+/// stays armed until every inner guard has dropped.
+static RAW_OUTPUT_PASSTHROUGH: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// RAII guard that arms [`RAW_OUTPUT_PASSTHROUGH`] for its lifetime so TUI
+/// programs receive their terminal-query responses through the real terminal.
+/// Nestable: each `enter_if(true)` increments the counter, each drop
+/// decrements it.
+struct RawOutputPassthroughGuard(bool);
+
+impl RawOutputPassthroughGuard {
+    fn enter_if(tui: bool) -> Self {
+        if tui {
+            RAW_OUTPUT_PASSTHROUGH.fetch_add(1, std::sync::atomic::Ordering::Release);
+        }
+        Self(tui)
+    }
+}
+
+impl Drop for RawOutputPassthroughGuard {
+    fn drop(&mut self) {
+        if self.0 {
+            RAW_OUTPUT_PASSTHROUGH.fetch_sub(1, std::sync::atomic::Ordering::Release);
+        }
+    }
+}
+
+/// Remove terminal device-query *request* sequences from `buf` so the real
+/// terminal is never asked to respond. Its response would otherwise be echoed
+/// as garbled text (`ESC[…R`, `ESC[…c`) while the shell sits in cooked mode
+/// between prompts.
+///
+/// Stripped: CPR/DSR requests `ESC[…n`, and device-attribute requests
+/// `ESC[…c` reached via the `>`/`=` private markers or no marker (DA1/DA2/DA3
+/// requests). DA1 *responses* keep the `?` marker, which this scan does not
+/// treat as a private marker, so they pass through unchanged (harmless to
+/// forward). Stateless per call; query sequences are short and rarely span
+/// the 8 KB read boundary.
+fn strip_device_queries(buf: &[u8]) -> std::borrow::Cow<'_, [u8]> {
+    if !buf.contains(&0x1b) {
+        return std::borrow::Cow::Borrowed(buf);
+    }
+    let mut out: Vec<u8> = Vec::with_capacity(buf.len());
+    let mut i = 0;
+    while i < buf.len() {
+        // Match CSI query requests: ESC [ (private '>' | '=')? digits (n | c).
+        if buf[i] == 0x1b && i + 1 < buf.len() && buf[i + 1] == b'[' {
+            let mut j = i + 2;
+            if j < buf.len() && matches!(buf[j], b'>' | b'=') {
+                j += 1;
+            }
+            while j < buf.len() && buf[j].is_ascii_digit() {
+                j += 1;
+            }
+            if j < buf.len() && matches!(buf[j], b'n' | b'c') {
+                // Complete query request: drop the whole sequence.
+                i = j + 1;
+                continue;
+            }
+            // Not a query — copy ESC and rescan from the next byte.
+        }
+        out.push(buf[i]);
+        i += 1;
+    }
+    if out.len() == buf.len() {
+        std::borrow::Cow::Borrowed(buf)
+    } else {
+        std::borrow::Cow::Owned(out)
+    }
+}
+
 fn write_stdout_all(buf: &[u8]) {
+    // Strip terminal device-query requests unless a real TUI/remote program is
+    // running and needs the real terminal to answer them. Forwarded prompt-tool
+    // queries (CPR/DA) would otherwise make the real terminal respond, and that
+    // response echoes as garbled text while the shell is in cooked mode.
+    let filtered = if RAW_OUTPUT_PASSTHROUGH.load(std::sync::atomic::Ordering::Acquire) > 0 {
+        std::borrow::Cow::Borrowed(buf)
+    } else {
+        strip_device_queries(buf)
+    };
     // Return value intentionally ignored: callers fire-and-forget stdout writes.
-    let _ = write_all_with_retry(buf, |remaining| {
+    let _ = write_all_with_retry(&filtered, |remaining| {
         let rc = unsafe {
             libc::write(
                 libc::STDOUT_FILENO,
@@ -1136,6 +1220,11 @@ impl PersistentPty {
         remote_show_kube: bool,
     ) -> aish_core::Result<(i32, String, String)> {
         let is_session = is_session_command(command);
+        // Real TUI/remote programs (vim/less/ssh/...) need the real terminal
+        // to answer their device queries; let their output through verbatim.
+        // Everything else has prompt-tool queries stripped (see write_stdout_all).
+        let _raw_output_guard =
+            RawOutputPassthroughGuard::enter_if(is_interactive_command(command) || is_session);
         debug!(
             "send_command_interactive ENTER: cmd={:?}, is_session={}, master_fd={}, control_fd={}",
             command, is_session, self.master_fd, self.control_fd
@@ -7088,6 +7177,62 @@ mod tests {
         assert!(is_interactive_command("htop"));
         assert!(!is_interactive_command("ls -la"));
         assert!(!is_interactive_command("echo hello"));
+    }
+
+    #[test]
+    fn strip_device_queries_removes_cpr_and_da_requests() {
+        // CPR request ESC[6n and DA2 request ESC[>c removed; visible text kept.
+        let out = strip_device_queries(b"hi\x1b[6n\x1b[>cbye");
+        assert_eq!(&out[..], b"hibye");
+    }
+
+    #[test]
+    fn strip_device_queries_removes_da1_variants() {
+        assert_eq!(&strip_device_queries(b"\x1b[c")[..], b"");
+        assert_eq!(&strip_device_queries(b"\x1b[0c")[..], b"");
+        assert_eq!(&strip_device_queries(b"x\x1b[0cy")[..], b"xy");
+    }
+
+    #[test]
+    fn strip_device_queries_removes_da3_and_dsr() {
+        assert_eq!(&strip_device_queries(b"\x1b[=c")[..], b"");
+        assert_eq!(&strip_device_queries(b"\x1b[5n")[..], b"");
+    }
+
+    #[test]
+    fn strip_device_queries_preserves_da_responses() {
+        // DA1 response keeps '?' -> not a request -> forwarded unchanged.
+        assert_eq!(&strip_device_queries(b"\x1b[?64;1c")[..], b"\x1b[?64;1c");
+        // DA2 response has ';' (params beyond digits) -> preserved.
+        assert_eq!(
+            &strip_device_queries(b"\x1b[>0;115;0c")[..],
+            b"\x1b[>0;115;0c"
+        );
+    }
+
+    #[test]
+    fn strip_device_queries_preserves_other_csi() {
+        // SGR colors, cursor moves, clear-line must survive.
+        assert_eq!(
+            &strip_device_queries(b"\x1b[31mtext\x1b[0m\x1b[2K\x1b[1;1H")[..],
+            b"\x1b[31mtext\x1b[0m\x1b[2K\x1b[1;1H"
+        );
+    }
+
+    #[test]
+    fn strip_device_queries_fast_path_no_esc() {
+        // No ESC byte -> borrowed, zero alloc.
+        match strip_device_queries(b"plain text no escapes") {
+            std::borrow::Cow::Borrowed(_) => {}
+            other => panic!("expected borrowed, got owned: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn strip_device_queries_realistic_prompt_burst() {
+        // A prompt-tool burst (two CPR + DA2) embedded in prompt output.
+        let input = b"before\x1b[6n\x1b[6n\x1b[>cafter";
+        assert_eq!(&strip_device_queries(input)[..], b"beforeafter");
     }
 
     #[test]

--- a/crates/aish-shell/src/keyboard/mod.rs
+++ b/crates/aish-shell/src/keyboard/mod.rs
@@ -39,7 +39,13 @@ pub mod raw_mode;
 pub use bindings::default_bindings;
 pub use events::{read_event, ShellEvent};
 #[cfg(unix)]
+pub use raw_mode::drain_terminal_responses;
+#[cfg(unix)]
 pub use raw_mode::InputRawGuard;
+
+// No-op stub so non-Unix builds keep a usable symbol.
+#[cfg(not(unix))]
+pub fn drain_terminal_responses() {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/aish-shell/src/keyboard/raw_mode.rs
+++ b/crates/aish-shell/src/keyboard/raw_mode.rs
@@ -2,6 +2,7 @@
 
 use std::os::fd::BorrowedFd;
 use std::sync::atomic::{AtomicBool, Ordering};
+use tracing::warn;
 
 /// Guard that enters input-raw mode on the terminal.
 ///
@@ -68,6 +69,155 @@ impl Drop for InputRawGuard {
     }
 }
 
+/// Discard terminal query responses that leaked into the stdin input queue
+/// while the shell sat in cooked (canonical + ECHO) mode between readlines.
+///
+/// The real terminal emits these responses when it sees a device-query
+/// escape sequence — either aish's own `cursor::position()` (`ESC[6n`) or a
+/// query forwarded verbatim from the PTY subprocess (`ESC[>c`, `ESC[?c`,
+/// ...). Left in the queue, rustyline reads them as key events, which shows
+/// up as garbled text and corrupts the next prompt's input (e.g.
+/// `0;115;0cRRR` spliced into the typed line).
+///
+/// Only complete CSI report sequences (`ESC[...R`, `ESC[?...c`,
+/// `ESC[>...c`, `ESC[=...c`, DSR `ESC[...n`, text-area `ESC[...t`) are
+/// dropped. Any remaining bytes — genuine user type-ahead — are re-injected
+/// with `TIOCSTI` so the editor still receives them. When nothing is
+/// pending this performs a single non-blocking poll and returns
+/// immediately (no prompt latency).
+pub fn drain_terminal_responses() {
+    let fd = libc::STDIN_FILENO;
+
+    // Enter raw mode BEFORE the readiness probe. In canonical (cooked) mode
+    // the line discipline releases input only as complete lines, and a
+    // terminal report (e.g. `ESC[2;2R`) carries no line delimiter — so
+    // poll() would never see it and the report would stay queued until
+    // rustyline enters raw mode and reads it as key events. Raw mode makes
+    // pending reports visible to a zero-timeout poll.
+    let guard = match InputRawGuard::enter() {
+        Ok(g) => g,
+        Err(_) => return, // stdin is not a tty
+    };
+    let saved_flags = set_stdin_nonblocking(fd);
+
+    // Cheap probe: if nothing is pending, do no further work.
+    if !stdin_readable_now(fd) {
+        restore_stdin_flags(fd, saved_flags);
+        return; // `guard` restores termios on drop.
+    }
+
+    let data = read_pending(fd);
+
+    // Drop the leading run of complete report sequences; keep the rest.
+    let keep_from = report_prefix_len(&data);
+    let tail = &data[keep_from..];
+    let mut reinjected = 0;
+    for &byte in tail {
+        if !reinject_byte(fd, byte) {
+            break;
+        }
+        reinjected += 1;
+    }
+    if reinjected < tail.len() {
+        // TIOCSTI rejected by the kernel (dev.tty.legacy_tiocsti=0). The
+        // remaining non-report bytes — genuine user type-ahead — cannot be
+        // put back and are lost. Log so this rare loss is diagnosable.
+        warn!(
+            tail_len = tail.len(),
+            reinjected, "TIOCSTI unavailable; non-report type-ahead left in stdin was lost"
+        );
+    }
+
+    restore_stdin_flags(fd, saved_flags);
+    drop(guard);
+}
+
+/// True if at least one byte is readable from `fd` right now.
+fn stdin_readable_now(fd: libc::c_int) -> bool {
+    let mut pfd = libc::pollfd {
+        fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    // SAFETY: poll() on a single valid fd with a zero timeout never blocks.
+    unsafe { libc::poll(&mut pfd, 1, 0) > 0 && (pfd.revents & libc::POLLIN) != 0 }
+}
+
+/// Make `fd` non-blocking. Returns the prior flags (for restoration).
+fn set_stdin_nonblocking(fd: libc::c_int) -> libc::c_int {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags >= 0 && (flags & libc::O_NONBLOCK) == 0 {
+        unsafe {
+            libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+        }
+    }
+    flags
+}
+
+/// Restore `fd` to blocking if it was blocking before the drain.
+fn restore_stdin_flags(fd: libc::c_int, saved: libc::c_int) {
+    if saved >= 0 && (saved & libc::O_NONBLOCK) == 0 {
+        unsafe {
+            libc::fcntl(fd, libc::F_SETFL, saved);
+        }
+    }
+}
+
+/// Read every byte available right now. Never blocks and never waits for
+/// stragglers — the drain must finish in microseconds so it cannot capture
+/// keystrokes the user types as the prompt appears.
+fn read_pending(fd: libc::c_int) -> Vec<u8> {
+    let mut out: Vec<u8> = Vec::new();
+    let mut buf = [0u8; 512];
+    loop {
+        // SAFETY: reading into a valid buffer from a valid (non-blocking) fd.
+        let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+        if n <= 0 {
+            break;
+        }
+        out.extend_from_slice(&buf[..n as usize]);
+    }
+    out
+}
+
+/// Length of the leading run of complete terminal-report CSI sequences.
+///
+/// Recognized reports: `ESC[` + optional `?`/`>`/`=` + digits/`;` + final
+/// byte in `{R, c, n, t}`. Parsing stops at the first byte that is not part
+/// of such a sequence (e.g. user input or an unrecognized escape), so the
+/// returned offset is safe to discard.
+fn report_prefix_len(data: &[u8]) -> usize {
+    let mut i = 0;
+    while i < data.len() {
+        if data[i] != 0x1b || i + 1 >= data.len() || data[i + 1] != b'[' {
+            break;
+        }
+        let mut j = i + 2;
+        if j < data.len() && matches!(data[j], b'?' | b'>' | b'=') {
+            j += 1;
+        }
+        while j < data.len() && (data[j].is_ascii_digit() || data[j] == b';') {
+            j += 1;
+        }
+        if j >= data.len() || !matches!(data[j], b'R' | b'c' | b'n' | b't') {
+            break;
+        }
+        i = j + 1;
+    }
+    i
+}
+
+/// Push `byte` back into the tty input queue as if the user typed it, so
+/// genuine type-ahead is preserved across the drain. Returns false when the
+/// kernel rejects `TIOCSTI` (restricted via `dev.tty.legacy_tiocsti=0`).
+fn reinject_byte(fd: libc::c_int, byte: u8) -> bool {
+    let c = byte as libc::c_char;
+    let ptr: *const libc::c_char = &c;
+    // SAFETY: TIOCSTI reads one char from the supplied pointer. `ptr` is a
+    // valid pointer to `c` for the duration of the call.
+    unsafe { libc::ioctl(fd, libc::TIOCSTI, ptr) == 0 }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -88,5 +238,58 @@ mod tests {
             active: AtomicBool::new(false),
         };
         assert!(!guard.is_active());
+    }
+
+    #[test]
+    fn report_prefix_drops_cpr() {
+        // ESC[2;2R cursor-position report -> fully consumed.
+        assert_eq!(report_prefix_len(b"\x1b[2;2R"), 6);
+    }
+
+    #[test]
+    fn report_prefix_drops_secondary_da() {
+        // ESC[>0;115;0c secondary device attributes -> fully consumed.
+        assert_eq!(report_prefix_len(b"\x1b[>0;115;0c"), 11);
+    }
+
+    #[test]
+    fn report_prefix_drops_primary_da() {
+        // ESC[?64;1c primary device attributes -> fully consumed.
+        assert_eq!(report_prefix_len(b"\x1b[?64;1c"), 8);
+    }
+
+    #[test]
+    fn report_prefix_drops_burst_then_keeps_user_input() {
+        // A burst of reports followed by a user-typed command: only the
+        // leading report run is consumed, the command is preserved.
+        let data = b"\x1b[2;2R\x1b[3;4R\x1b[>0;115;0cls -la\r";
+        let n = report_prefix_len(data);
+        assert_eq!(&data[..n], b"\x1b[2;2R\x1b[3;4R\x1b[>0;115;0c");
+        assert_eq!(&data[n..], b"ls -la\r");
+    }
+
+    #[test]
+    fn report_prefix_keeps_unrecognized_escape() {
+        // A bare ESC (user pressed Escape) is not a complete report: keep it.
+        assert_eq!(report_prefix_len(b"\x1b"), 0);
+        // ESC followed by something other than '[' is also kept.
+        assert_eq!(report_prefix_len(b"\x1blls"), 0);
+    }
+
+    #[test]
+    fn report_prefix_keeps_incomplete_sequence() {
+        // Truncated report (no final byte): keep everything.
+        assert_eq!(report_prefix_len(b"\x1b[2;2"), 0);
+    }
+
+    #[test]
+    fn report_prefix_keeps_non_report_final() {
+        // ESC[2;2H is a cursor move (not a report): keep it.
+        assert_eq!(report_prefix_len(b"\x1b[2;2H"), 0);
+    }
+
+    #[test]
+    fn report_prefix_empty() {
+        assert_eq!(report_prefix_len(b""), 0);
     }
 }

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -720,6 +720,10 @@ impl ShellReadline {
         if let Some(ai) = &self.inline_ai {
             ai.cancel();
         }
+        // Discard terminal query responses (CPR/DA) that leaked into stdin
+        // while the prompt was away — otherwise rustyline reads them as
+        // key events and corrupts the input line.
+        crate::keyboard::drain_terminal_responses();
         match self.editor.readline_with_initial(prompt, initial) {
             Ok(line) => Ok(Some(line)),
             Err(rustyline::error::ReadlineError::Eof) => Ok(None),
@@ -740,6 +744,10 @@ impl ShellReadline {
         if let Some(ai) = &self.inline_ai {
             ai.cancel();
         }
+        // Discard terminal query responses (CPR/DA) that leaked into stdin
+        // while the prompt was away — otherwise rustyline reads them as
+        // key events and corrupts the input line.
+        crate::keyboard::drain_terminal_responses();
         let line = match self.editor.readline(prompt) {
             Ok(line) => line,
             Err(rustyline::error::ReadlineError::Eof) => return Ok(None),
@@ -755,6 +763,7 @@ impl ShellReadline {
         result.truncate(result.len() - 1); // remove trailing backslash
 
         loop {
+            crate::keyboard::drain_terminal_responses();
             match self.editor.readline("> ") {
                 Ok(next) => {
                     if next.is_empty() {


### PR DESCRIPTION
## Summary

- **Problem:** 终端设备查询响应（CPR/DA/DSR）泄漏进 stdin，被 rustyline 当作按键读入，输入行被注入乱码（如 `0;115;0cRRR`）。详见 #434。
- **Changes:** 双层防御——输出端剥离转发的 query 请求（源头阻止响应），输入端 readline 前进 raw 模式 drain 残留响应（兜底清理）。
- **Related Issue:** #434

## Change Type

- [x] Bug fix

## Scope

- [x] Core shell / PTY

## User-visible Changes

修复远程 ssh/telnet 会话、tmux/screen、man/less 等场景下输入行被终端响应乱码污染的问题。用户不再需要在 prompt 里手动清除 `0;115;0c` 之类的残留片段。

## Compatibility

- Backward compatible? **Yes**
- Config changes? **No**

## Testing

- `cargo test -p aish-pty strip_device_queries` → 7/7
- `cargo test -p aish-shell report_prefix` → 8/8
- `cargo clippy -p aish-pty --all-targets -- -D warnings` → 零警告
- `cargo clippy -p aish-shell --all-targets -- -D warnings` → 零警告
- PTY + termios 实验：验证 canonical（ICANON）模式下 `poll()` 对无换行的 report 返回不可读，raw 模式下可读——确认输入端必须在 poll 前进 raw 模式

## Checklist

- [x] Code follows project style
- [x] Tests added if needed
- [x] Documentation updated if needed

---

### 实现细节

**1. 输出端**（`aish-pty` `write_stdout_all`）：剥离转发到真实终端的设备查询 *请求*（CPR/DA1/DA2/DA3/DSR），从源头阻止真实终端被诱导响应。真正的 TUI/远程程序（vim/less/ssh…）走 passthrough 透传，标志由 `bool` 改为引用计数 `AtomicUsize`，修正嵌套/并发命令下内层 guard 提前关闭的隐患。

**2. 输入端**（`aish-shell` `drain_terminal_responses`）：每次 readline 前（含 multiline 续行 `> `）进 raw 模式 + `O_NONBLOCK` 再 `poll` stdin。raw 模式必须在 poll 前——canonical 模式只按行释放输入，而 report 无行分隔符，poll 否则永远看不到。残留响应则丢弃前导完整 report 序列，剩余用户 type-ahead 用 `TIOCSTI` 重新注入；`TIOCSTI` 被内核禁用且非 report 字节丢失时记 `warn`（`tail_len`/`reinjected`）。

`strip_device_queries` 区分 *请求* 与 *响应*：请求 private marker 只认 `>`/`=`（不认 `?`），避开误删 DA1 响应 `ESC[?64;1c`；响应参数带 `;` 自然落出 digit 扫描而被保留。

Fixes #434
