### PR TITLE
Release v0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.10] - 2026-08-10
 
 ### Added
 
+- Multi-source skill registry with search, install, verify, trust/quarantine, and an AI-callable `skill_install` tool (`/skill`, `aish skill`), including built-in adapters for `skills.sh` and `skillhub.cn`.
+- Interactive `/skill` manager panel (Installed / Browse / Registries tabs) for search, install, trust, verify, remove, and registry enable/disable; complete-arg subcommands still run directly.
+- `/model` multi-account rotation and interactive model picker: recoverable failures (429 / usage limits) rotate across configured API accounts.
+- Session workflow commands: `/export [md]` (session → Markdown), `/fork` (branch a session while preserving the original), and `/sessions` (browse the session tree and switch).
+- File-change snapshot store with `/undo [path]` and interactive `/rollback` to restore prior checkpoints in the current session; `write_file` / `edit_file` results report when a write is not undoable.
+- Parallel execution for batches of independent `Agent` (sub-agent) tool calls.
 - After upgrading, the next interactive `aish` launch shows a Keep-a-Changelog summary for every version between the previously seen release and the newly installed one (oldest → newest), sourced from the `CHANGELOG.md` embedded in the binary. A `~/.config/aish/last-changelog-version` marker tracks what has already been shown.
+- Built-in local ops diagnostic skills: rewritten symptom-first `diagnose_system_lag`, plus `network-path-diagnose`, `dns-diagnose`, `nfs-cifs-mount-diagnose`, and `ssl-cert-toolkit`.
+
+### Changed
+
+- `security_policy.yaml` is the sole source of truth for security settings: `/setting` reads/writes the live `SecurityManager`, security fields are stripped from `config.yaml` on load (with a warning), and installs no longer write `/etc/aish` security config.
+- Hardened the read-only bash classifier so harmless inspection redirects/globs are allowed while real write redirects are not misclassified as read-only.
+- File-edit diffs render as centered hunks with bounded context so edits near the end of large files stay visible.
+
+### Fixed
+
+- Restored rich sandbox policy reasons (rule id / paths / human-facing `reason`) instead of generic HIGH-level block text; wired the security panel UI with a closed confirm layout and independent Paths / degraded-sandbox Note rows.
+- Fixed PTY handling so terminal device-query responses (CPR/DA/DSR) no longer leak into stdin as garbage keystrokes (e.g. `0;115;0c`) under ssh/tmux/pager scenarios.
+- CI always reports the Lint and test required check for docs-only PRs, and treats `Makefile` / `rust-toolchain.toml` as code changes.
 
 ## [0.3.9] - 2026-07-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "aish-cli"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "aish-config"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "aish-context"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "aish-core",
  "serde",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "aish-core"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "aish-hosts"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "aish-i18n"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aish-llm"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "aish-context",
  "aish-core",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "aish-md-table"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "richrs",
  "unicode-width",
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "aish-memory"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "aish-core",
  "chrono",
@@ -160,14 +160,14 @@ dependencies = [
 
 [[package]]
 name = "aish-prompts"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "dirs 5.0.1",
 ]
 
 [[package]]
 name = "aish-pty"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "aish-scripts"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "dirs 5.0.1",
  "regex",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "aish-security"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "libc",
  "regex",
@@ -213,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "aish-session"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "aish-core",
  "chrono",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "aish-shell"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "aish-config",
  "aish-context",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "aish-skills"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "aish-tools"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "aish-ui"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "crossterm 0.28.1",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.9"
+version = "0.3.10"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.89"


### PR DESCRIPTION
## Summary
- Bump version to `0.3.10` (`Cargo.toml` / `Cargo.lock`)
- Add `CHANGELOG.md` section for 0.3.10 covering changes since 0.3.9

### Highlights
- **Added**: multi-source skill registry + interactive `/skill` panel; `/model` multi-account rotation; `/export` / `/fork` / `/sessions`; `/undo` + `/rollback` file snapshots; parallel sub-agents; post-upgrade changelog summary; local ops diagnostic skills
- **Changed**: `security_policy.yaml` as sole SSOT; hardened read-only bash classifier; centered file-edit diffs
- **Fixed**: rich sandbox policy reasons + security panel UI; PTY device-query stdin leak; docs-only CI required check

## Local checks
- [x] `python3 packaging/tests/test_resolve_release_pr.py -q`
- [x] `python3 packaging/scripts/release_metadata.py --expected-version 0.3.10`
- [x] `make ci-check`

## Release prep
Please run **Release Preparation** with this PR number before merge:
```bash
gh workflow run release-preparation.yml \
  --repo AI-Shell-Team/aish \
  --ref main \
  -f pr_number=<PR_NUMBER>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added skill discovery and management tools, diagnostic skills, and parallel agent execution.
  * Added model account rotation, session workflow commands, and file rollback support.
  * Changelog information is now displayed after upgrades.
* **Bug Fixes**
  * Improved command safety, file-edit diff rendering, sandbox policy details, and terminal input handling.
  * Centralized security configuration and improved handling of documentation-only checks.
* **Chores**
  * Released version 0.3.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->