### PR TITLE
fix(ci): drop obsolete /etc/aish security_policy smoke assert

### DIFF
--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -158,7 +158,8 @@ jobs:
           AISH_INSTALL_ROOT="$INSTALL_ROOT" AISH_SKIP_SYSTEMD=1 "$EXTRACT_DIR/${BUNDLE}/install.sh"
 
           test -x "$INSTALL_ROOT/usr/local/bin/aish"
-          test -f "$INSTALL_ROOT/etc/aish/security_policy.yaml"
+          # Security policy is seeded under ~/.config/aish on first run (#416), not under /etc.
+          test ! -e "$INSTALL_ROOT/etc/aish/security_policy.yaml"
           test -f "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.service"
           test -f "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.socket"
 

--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -158,8 +158,6 @@ jobs:
           AISH_INSTALL_ROOT="$INSTALL_ROOT" AISH_SKIP_SYSTEMD=1 "$EXTRACT_DIR/${BUNDLE}/install.sh"
 
           test -x "$INSTALL_ROOT/usr/local/bin/aish"
-          # Security policy is seeded under ~/.config/aish on first run (#416), not under /etc.
-          test ! -e "$INSTALL_ROOT/etc/aish/security_policy.yaml"
           test -f "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.service"
           test -f "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.socket"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,8 @@ jobs:
           AISH_INSTALL_ROOT="$INSTALL_ROOT" AISH_SKIP_SYSTEMD=1 "$EXTRACT_DIR/${BUNDLE}/install.sh"
 
           test -x "$INSTALL_ROOT/usr/local/bin/aish"
-          test -f "$INSTALL_ROOT/etc/aish/security_policy.yaml"
+          # Security policy is seeded under ~/.config/aish on first run (#416), not under /etc.
+          test ! -e "$INSTALL_ROOT/etc/aish/security_policy.yaml"
           test -f "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.service"
           test -f "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.socket"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,8 +111,6 @@ jobs:
           AISH_INSTALL_ROOT="$INSTALL_ROOT" AISH_SKIP_SYSTEMD=1 "$EXTRACT_DIR/${BUNDLE}/install.sh"
 
           test -x "$INSTALL_ROOT/usr/local/bin/aish"
-          # Security policy is seeded under ~/.config/aish on first run (#416), not under /etc.
-          test ! -e "$INSTALL_ROOT/etc/aish/security_policy.yaml"
           test -f "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.service"
           test -f "$INSTALL_ROOT/etc/systemd/system/aish-sandbox.socket"
 


### PR DESCRIPTION
## Summary
- Release Preparation for #436 failed because smoke still required `$INSTALL_ROOT/etc/aish/security_policy.yaml`
- After #416 the installer seeds policy under `~/.config/aish` on first run and no longer installs under `/etc/aish`
- Remove the obsolete assert from `release-preparation.yml` and `release.yml`

## Test plan
- [ ] CI green on this PR
- [ ] Re-run Release Preparation on #436 after merge
- [ ] Confirm package smoke steps pass on amd64/arm64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated installation and release verification to stop requiring the security policy file in the system configuration directory.
  - Installation and release checks now align with the current security policy handling, reducing false failures during package validation.
  - No changes were made to exported functionality or the end-user installation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->