### PR TITLE
ci(release): single deployment approval for CDN + PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,23 +35,10 @@ jobs:
           version: ${{ github.ref_name }}
           artifact_prefix: release
 
-  release-gate:
-    name: Release boundary checkpoint
-    needs: release-meta
-    runs-on: ubuntu-latest
-    environment: release
-    steps:
-      - name: Confirm release payload
-        run: |
-          echo "Release ${RELEASE_TAG} is ready for bundle publishing."
-        env:
-          RELEASE_TAG: ${{ needs.release-meta.outputs.tag }}
-
   create-release:
     name: Create GitHub release
     needs:
       - release-meta
-      - release-gate
     runs-on: ubuntu-latest
     steps:
       - name: Create release entry with changelog notes
@@ -66,7 +53,6 @@ jobs:
     name: Build release bundle (${{ matrix.arch }})
     needs:
       - release-meta
-      - release-gate
       - create-release
     strategy:
       fail-fast: false
@@ -132,7 +118,6 @@ jobs:
     name: Build PyPI package (${{ matrix.arch }})
     needs:
       - release-meta
-      - release-gate
       - create-release
     strategy:
       fail-fast: false
@@ -204,14 +189,16 @@ jobs:
           path: artifacts/pypi/${{ matrix.arch }}/*
           if-no-files-found: error
 
-  publish-release-bundles:
-    name: Publish release bundles
+  publish-release:
+    name: Publish release
     needs:
       - release-meta
-      - release-gate
       - build-release-packages
+      - build-pypi-packages
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      id-token: write
     env:
       VERSION: ${{ needs.release-meta.outputs.version }}
       ARTIFACT_ROOT: artifacts/release
@@ -243,17 +230,6 @@ jobs:
       - name: Publish release bundles
         run: bash ./packaging/scripts/publish_release.sh
 
-  publish-pypi:
-    name: Publish PyPI package
-    needs:
-      - release-meta
-      - release-gate
-      - build-pypi-packages
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      id-token: write
-    steps:
       - name: Skip PyPI publish for prerelease versions
         if: ${{ contains(needs.release-meta.outputs.version, '-') }}
         run: |
@@ -290,8 +266,7 @@ jobs:
       - create-release
       - build-release-packages
       - build-pypi-packages
-      - publish-release-bundles
-      - publish-pypi
+      - publish-release
     runs-on: ubuntu-latest
     steps:
       - name: Write job summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,6 +198,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     permissions:
+      contents: read
       id-token: write
     env:
       VERSION: ${{ needs.release-meta.outputs.version }}
@@ -270,12 +271,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Write job summary
+        env:
+          RELEASE_VERSION: ${{ needs.release-meta.outputs.version }}
+          RELEASE_TAG: ${{ needs.release-meta.outputs.tag }}
         run: |
-          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
-          # Release Assets Published
-
-          - Version: ${{ needs.release-meta.outputs.version }}
-          - Tag: ${{ needs.release-meta.outputs.tag }}
-
-          GitHub Release metadata was generated from the tag push, bundle assets were uploaded successfully, stable releases were published to PyPI via Trusted Publishing, and the CDN channel was updated for this release.
-          EOF
+          {
+            echo "# Release Assets Published"
+            echo
+            echo "- Version: ${RELEASE_VERSION}"
+            echo "- Tag: ${RELEASE_TAG}"
+            echo
+            if [[ "${RELEASE_VERSION}" == *-* ]]; then
+              echo "GitHub Release metadata was generated from the tag push, bundle assets were uploaded successfully, PyPI publishing was skipped for this prerelease, and the CDN beta channel was updated for this release."
+            else
+              echo "GitHub Release metadata was generated from the tag push, bundle assets were uploaded successfully, the package was published to PyPI via Trusted Publishing, and the CDN channel was updated for this release."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Welcome to make Shell smarter!
 - `make prepare-release-files VERSION=X.Y.Z[-PRERELEASE] [DATE=YYYY-MM-DD]` updates the workspace version files and inserts a dated release section at the top of `CHANGELOG.md`.
 - Prepare release files locally in a normal PR, merge that PR into `main`, then run `Release Preparation` as the single preflight validation for the target version. It includes release metadata checks and bundle dry-run validation before publication.
 - `Release Preparation` validates the target version, generates a release summary from the versioned changelog section, builds dry-run bundles, and runs install smoke checks before publication.
-- `Release` is triggered by pushing a tag `vX.Y.Z` or `vX.Y.Z-PRERELEASE`. It validates the tag against repository metadata, verifies that the tagged commit is on `main` or the temporary `rust` release branch, creates the GitHub Release entry with the versioned changelog notes, marks prerelease tags as GitHub prereleases, builds bundle/PyPI artifacts, then waits on a single protected `release` environment approval before publishing to the CDN and PyPI.
+- `Release` is triggered by pushing a tag `vX.Y.Z` or `vX.Y.Z-PRERELEASE`. It validates the tag against repository metadata, verifies that the tagged commit is on `main`, creates the GitHub Release entry with the versioned changelog notes, marks prerelease tags as GitHub prereleases, builds release artifacts, then waits on a single protected `release` environment approval before publishing to the CDN. Stable tags also build and publish PyPI packages; prerelease tags skip PyPI.
 - Configure the GitHub Environment named `release` with required reviewers if you want manual approval before production publishing.
 
 ## Code Style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Welcome to make Shell smarter!
 - `make prepare-release-files VERSION=X.Y.Z[-PRERELEASE] [DATE=YYYY-MM-DD]` updates the workspace version files and inserts a dated release section at the top of `CHANGELOG.md`.
 - Prepare release files locally in a normal PR, merge that PR into `main`, then run `Release Preparation` as the single preflight validation for the target version. It includes release metadata checks and bundle dry-run validation before publication.
 - `Release Preparation` validates the target version, generates a release summary from the versioned changelog section, builds dry-run bundles, and runs install smoke checks before publication.
-- `Release` is triggered by pushing a tag `vX.Y.Z` or `vX.Y.Z-PRERELEASE`. It validates the tag against repository metadata, verifies that the tagged commit is on `main` or the temporary `rust` release branch, waits on the protected `release` environment approval gate, creates the GitHub Release entry with the versioned changelog notes, marks prerelease tags as GitHub prereleases, and uploads bundle assets.
+- `Release` is triggered by pushing a tag `vX.Y.Z` or `vX.Y.Z-PRERELEASE`. It validates the tag against repository metadata, verifies that the tagged commit is on `main` or the temporary `rust` release branch, creates the GitHub Release entry with the versioned changelog notes, marks prerelease tags as GitHub prereleases, builds bundle/PyPI artifacts, then waits on a single protected `release` environment approval before publishing to the CDN and PyPI.
 - Configure the GitHub Environment named `release` with required reviewers if you want manual approval before production publishing.
 
 ## Code Style


### PR DESCRIPTION
## Summary

- Problem: Tag releases required multiple `release` environment deployment approvals (early gate + separate CDN/PyPI publish jobs).
- Changes: Remove `release-gate`, merge CDN and PyPI publishing into a single `publish-release` job with one environment approval, and document the flow. Also grant `contents: read` for checkout, and make prerelease summary/docs accurate about skipping PyPI.
- Related Issue: N/A

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Other

## Scope

- [ ] Core shell / PTY
- [ ] AI agent / LLM
- [ ] Skills / Tools
- [ ] Security
- [ ] Configuration
- [ ] CLI / Interface
- [ ] Packaging / Installation
- [x] CI/CD
- [x] Documentation

## User-visible Changes

None

## Compatibility

- Backward compatible? Yes
- Config changes? No

## Testing

- [ ] Review the workflow graph: no `release-gate`; only `publish-release` references `environment: release`
- [ ] Confirm `publish-release` has `contents: read` and `id-token: write`
- [ ] On next tag push, confirm a single deployment review notification for `Release / Publish release`
- [ ] After approval, confirm CDN publish runs; PyPI runs for stable tags and is skipped for prerelease tags
- [ ] Confirm `release-summary` text matches stable vs prerelease behavior

## Checklist

- [x] Code follows project style
- [x] Tests added if needed
- [x] Documentation updated if needed
