### PR TITLE
feat(shell): 启动时 omp 式异步更新提示

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
  "richrs",
  "rusqlite",
  "rustyline",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/aish-config/src/model.rs
+++ b/crates/aish-config/src/model.rs
@@ -507,6 +507,10 @@ pub struct ConfigModel {
     /// a fallback. Default: true.
     #[serde(default = "default_true")]
     pub fallback_revert_on_cooldown: bool,
+    /// Check for a newer aish release on startup (omp-style async notice).
+    /// Default: true.
+    #[serde(default = "default_true")]
+    pub check_update_on_startup: bool,
 }
 
 impl Default for ConfigModel {
@@ -558,6 +562,7 @@ impl Default for ConfigModel {
             fallback_models: vec![],
             recent_models: vec![],
             fallback_revert_on_cooldown: default_true(),
+            check_update_on_startup: default_true(),
         }
     }
 }

--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -164,6 +164,11 @@ shell:
     risk: "Von der KI erzeugte Inhalte können riskant sein; bitte sorgfältig prüfen."
     skills_loaded_suffix: " geladen"
 
+  update_available:
+    title: "Update verfügbar"
+    version_line: "Neue Version {latest} verfügbar"
+    run_prefix: "Befehl:"
+
   slash:
     help: "Hilfeinformationen anzeigen"
     model: "KI-Modell anzeigen oder wechseln"

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -333,6 +333,11 @@ shell:
     changelog_summary_more: "... and {count} more"
     changelog_summary_truncated: "... truncated. Full notes ship in CHANGELOG.md."
 
+  update_available:
+    title: "Update Available"
+    version_line: "New version {latest} is available"
+    run_prefix: "Run:"
+
   # General error messages
   general_error: "error: {error}"
   readline_init_failed: "Failed to initialize readline: {error}"

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -164,6 +164,11 @@ shell:
     risk: "El contenido generado por IA puede ser arriesgado; verificalo con cuidado."
     skills_loaded_suffix: " cargadas"
 
+  update_available:
+    title: "Actualización disponible"
+    version_line: "Nueva versión {latest} disponible"
+    run_prefix: "Comando:"
+
   slash:
     help: "Mostrar información de ayuda"
     model: "Mostrar o cambiar modelo de IA"

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -164,6 +164,11 @@ shell:
     risk: "Le contenu genere par l'IA peut etre risque ; verifiez-le attentivement."
     skills_loaded_suffix: " charges"
 
+  update_available:
+    title: "Mise à jour disponible"
+    version_line: "Nouvelle version {latest} disponible"
+    run_prefix: "Commande :"
+
   slash:
     help: "Afficher les informations d'aide"
     model: "Afficher ou changer le modèle IA"

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -164,6 +164,11 @@ shell:
     risk: "AI が生成した内容にはリスクがあるため、必ず注意して確認してください。"
     skills_loaded_suffix: " 件読み込み済み"
 
+  update_available:
+    title: "更新があります"
+    version_line: "新バージョン {latest} が利用可能です"
+    run_prefix: "コマンド:"
+
   slash:
     help: "ヘルプ情報を表示"
     model: "AI モデルの表示・切替"

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -333,6 +333,11 @@ shell:
     changelog_summary_more: "……还有 {count} 条"
     changelog_summary_truncated: "……已截断。完整说明见 CHANGELOG.md。"
 
+  update_available:
+    title: "发现新版本"
+    version_line: "新版本 {latest} 可用"
+    run_prefix: "升级命令："
+
   # 通用错误消息
   general_error: "错误: {error}"
   readline_init_failed: "初始化 readline 失败: {error}"

--- a/crates/aish-shell/Cargo.toml
+++ b/crates/aish-shell/Cargo.toml
@@ -34,6 +34,7 @@ chrono.workspace = true
 uuid.workspace = true
 dirs.workspace = true
 reqwest.workspace = true
+semver.workspace = true
 richrs.workspace = true
 pulldown-cmark.workspace = true
 regex.workspace = true

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -2166,6 +2166,26 @@ impl AishShell {
             sigterm_stream.recv().await;
             sigterm_flag.store(true, Ordering::SeqCst);
         });
+        // omp-style async update check: fire-and-forget, never blocks startup.
+        let update_notice = Arc::new(parking_lot::Mutex::new(
+            crate::update_check::UpdateNotice::Pending,
+        ));
+        if self.config.check_update_on_startup
+            && std::io::IsTerminal::is_terminal(&std::io::stdout())
+        {
+            let notice = update_notice.clone();
+            let current = self.version.clone();
+            runtime.handle().spawn(async move {
+                let res = tokio::task::spawn_blocking(move || {
+                    crate::update_check::probe_update(&current)
+                })
+                .await;
+                *notice.lock() = match res {
+                    Ok(Some(info)) => crate::update_check::UpdateNotice::Available(info),
+                    _ => crate::update_check::UpdateNotice::Done,
+                };
+            });
+        }
 
         // Build the shared AutoSuggest engine up here, before ShellReadline::new.
         let autosuggest = Arc::new(Mutex::new(crate::autosuggest::AutoSuggest::new(5000)));
@@ -2246,6 +2266,18 @@ impl AishShell {
             }
             if sigterm_exit.load(Ordering::SeqCst) {
                 break;
+            }
+
+            // Drain the one-shot update notice once the background probe lands.
+            {
+                let drained = {
+                    let mut guard = update_notice.lock();
+                    std::mem::replace(&mut *guard, crate::update_check::UpdateNotice::Done)
+                };
+                if let crate::update_check::UpdateNotice::Available(info) = drained {
+                    prompt::print_update_available(&info.latest);
+                    let _ = io::stdout().flush();
+                }
             }
 
             // Check for skill hot-reload changes

--- a/crates/aish-shell/src/lib.rs
+++ b/crates/aish-shell/src/lib.rs
@@ -45,6 +45,7 @@ pub mod theme;
 pub mod token_store;
 pub mod tui;
 pub mod types;
+pub mod update_check;
 pub mod wizard;
 
 pub use app::AishShell;

--- a/crates/aish-shell/src/prompt.rs
+++ b/crates/aish-shell/src/prompt.rs
@@ -670,6 +670,29 @@ fn wrap_text(text: &str, max: usize) -> Vec<String> {
     lines
 }
 
+/// Print a one-shot omp-style "update available" notice.
+pub fn print_update_available(latest: &str) {
+    let rule = theme::warning(&"─".repeat(46));
+    let mut args = HashMap::new();
+    args.insert("latest".to_string(), latest.to_string());
+    println!();
+    println!("{rule}");
+    println!(
+        "  {}",
+        theme::bold(&theme::warning(&t("shell.update_available.title")))
+    );
+    println!(
+        "  {}",
+        theme::muted(&t_with_args("shell.update_available.version_line", &args))
+    );
+    println!(
+        "  {} {}",
+        theme::muted(&t("shell.update_available.run_prefix")),
+        theme::accent("aish update")
+    );
+    println!("{rule}");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aish-shell/src/update_check.rs
+++ b/crates/aish-shell/src/update_check.rs
@@ -1,0 +1,279 @@
+//! Startup update check (omp-style async notice).
+//!
+//! Probes `cdn.aishell.ai/download/latest` for a newer version on a background
+//! thread. When one exists, the REPL prints a one-shot notice. Cache-backed
+//! (24h TTL) so a typical day triggers at most one network request, and silent
+//! on every failure — the probe never blocks or interrupts startup.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use aish_core::AishError;
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+const LATEST_VERSION_URL: &str = "https://cdn.aishell.ai/download/latest";
+/// How long a cached probe result stays valid.
+const CACHE_TTL_SECS: i64 = 24 * 3600;
+/// Hard cap on the network fetch so a slow CDN cannot stall the check.
+const FETCH_TIMEOUT_SECS: u64 = 5;
+
+/// Resolved update info ready to display.
+#[derive(Debug, Clone)]
+pub struct UpdateInfo {
+    pub latest: String,
+}
+
+/// REPL-side state machine. Drained exactly once per session: `Pending` while
+/// the background probe is in flight, `Available` once a newer version lands,
+/// then `Done` forever after (shown, up-to-date, or failed).
+#[derive(Debug)]
+pub enum UpdateNotice {
+    Pending,
+    Available(UpdateInfo),
+    Done,
+}
+
+/// On-disk cache of the last probe outcome.
+#[derive(Serialize, Deserialize)]
+struct CacheEntry {
+    last_check_ts: i64,
+    /// Local version at probe time. A version change invalidates the cache so
+    /// a just-upgraded binary re-probes instead of trusting a stale verdict.
+    last_current: String,
+    /// `None` when the probe found no newer version (or failed).
+    latest: Option<String>,
+}
+
+/// Probe for a newer release. Cache-first (within TTL + same local version);
+/// falls back to a short network fetch otherwise. Returns `None` on any
+/// failure or when the running version is already current.
+///
+/// This runs on a `spawn_blocking` thread, so blocking `reqwest` is fine.
+pub fn probe_update(current: &str) -> Option<UpdateInfo> {
+    let cache_path = cache_file_path();
+
+    // Cache hit: reuse the last verdict without touching the network.
+    if let Some(entry) = read_cache(&cache_path) {
+        if cache_fresh(&entry, current) {
+            return entry
+                .latest
+                .filter(|l| is_newer(l, current))
+                .map(|l| UpdateInfo { latest: l });
+        }
+    }
+
+    // Cache miss/stale/expired — fetch fresh.
+    let latest = match fetch_latest_tag() {
+        Ok(tag) => tag,
+        // Network/parse failure: do not touch the cache so the next launch
+        // retries instead of trusting a 24h negative verdict.
+        Err(_) => return None,
+    };
+    let newer = is_newer(&latest, current);
+    write_cache(
+        &cache_path,
+        &CacheEntry {
+            last_check_ts: now_ts(),
+            last_current: current.to_string(),
+            latest: newer.then_some(latest.clone()),
+        },
+    );
+    newer.then_some(UpdateInfo { latest })
+}
+
+fn latest_version_url() -> String {
+    // Mirrors aish-cli's AISH_LATEST_URL override so tests/enterprise mirrors
+    // can point both the manual `aish update` and this startup probe at one host.
+    std::env::var("AISH_LATEST_URL").unwrap_or_else(|_| LATEST_VERSION_URL.to_string())
+}
+
+fn fetch_latest_tag() -> Result<String, AishError> {
+    let client = reqwest::blocking::Client::builder()
+        .user_agent("aish-update-checker")
+        .timeout(Duration::from_secs(FETCH_TIMEOUT_SECS))
+        .build()
+        .map_err(|e| AishError::Config(e.to_string()))?;
+    let resp = client
+        .get(latest_version_url())
+        .send()
+        .map_err(|e| AishError::Config(e.to_string()))?;
+    if !resp.status().is_success() {
+        return Err(AishError::Config(format!(
+            "latest endpoint returned status {}",
+            resp.status()
+        )));
+    }
+    let body = resp.text().map_err(|e| AishError::Config(e.to_string()))?;
+    normalize_tag(&body)
+}
+
+/// Trim whitespace, strip an optional leading `v`, and validate as SemVer.
+fn normalize_tag(raw: &str) -> Result<String, AishError> {
+    let cleaned = raw.trim();
+    let stripped = cleaned.strip_prefix('v').unwrap_or(cleaned);
+    if stripped.is_empty() {
+        return Err(AishError::Config(
+            "invalid latest version metadata: empty".into(),
+        ));
+    }
+    Version::parse(stripped)
+        .map_err(|_| AishError::Config(format!("invalid latest version: {cleaned}")))?;
+    Ok(stripped.to_string())
+}
+
+/// `true` only when `remote` is strictly newer than `local`. Any parse failure
+/// is conservative (`false`) — never offer an update on an unparseable tag.
+fn is_newer(remote: &str, local: &str) -> bool {
+    let parse = |v: &str| Version::parse(v.strip_prefix('v').unwrap_or(v));
+    match (parse(remote), parse(local)) {
+        (Ok(r), Ok(l)) => r > l,
+        _ => false,
+    }
+}
+
+fn cache_file_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("aish")
+        .join("update-check.json")
+}
+
+fn now_ts() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+fn cache_fresh(entry: &CacheEntry, current: &str) -> bool {
+    entry.last_current == current && now_ts().saturating_sub(entry.last_check_ts) < CACHE_TTL_SECS
+}
+
+fn read_cache(path: &PathBuf) -> Option<CacheEntry> {
+    let data = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+fn write_cache(path: &PathBuf, entry: &CacheEntry) {
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    if std::fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    let Ok(json) = serde_json::to_string(entry) else {
+        return;
+    };
+    // Atomic write: stage to a sibling temp, then rename, so a crash mid-write
+    // cannot leave a half-written JSON for the next launch to choke on.
+    let tmp = path.with_extension("json.tmp");
+    if std::fs::write(&tmp, json).is_err() {
+        return;
+    }
+    let _ = std::fs::rename(&tmp, path);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_newer_strictly_greater() {
+        assert!(is_newer("0.3.5", "0.3.4"));
+        assert!(!is_newer("0.3.4", "0.3.4"));
+        assert!(!is_newer("0.3.3", "0.3.4"));
+    }
+
+    #[test]
+    fn is_newer_strips_v_prefix() {
+        assert!(is_newer("v0.4.0", "0.3.4"));
+        assert!(is_newer("0.4.0", "v0.3.4"));
+        assert!(is_newer("v1.0.0", "v0.9.9"));
+    }
+
+    #[test]
+    fn is_newer_garbage_is_false() {
+        assert!(!is_newer("garbage", "0.3.4"));
+        assert!(!is_newer("0.3.5", "garbage"));
+    }
+
+    #[test]
+    fn normalize_strips_and_validates() {
+        assert_eq!(normalize_tag("v0.3.4\n").unwrap(), "0.3.4");
+        assert_eq!(normalize_tag(" 0.3.4 ").unwrap(), "0.3.4");
+        assert_eq!(normalize_tag("0.3.4").unwrap(), "0.3.4");
+        assert!(normalize_tag("").is_err());
+        assert!(normalize_tag("abc").is_err());
+    }
+
+    #[test]
+    fn cache_fresh_within_ttl() {
+        let entry = CacheEntry {
+            last_check_ts: now_ts(),
+            last_current: "0.3.4".into(),
+            latest: Some("0.3.5".into()),
+        };
+        assert!(cache_fresh(&entry, "0.3.4"));
+    }
+
+    #[test]
+    fn cache_stale_after_ttl() {
+        let entry = CacheEntry {
+            last_check_ts: now_ts() - CACHE_TTL_SECS - 10,
+            last_current: "0.3.4".into(),
+            latest: Some("0.3.5".into()),
+        };
+        assert!(!cache_fresh(&entry, "0.3.4"));
+    }
+
+    #[test]
+    fn cache_invalidated_when_local_version_changed() {
+        let entry = CacheEntry {
+            last_check_ts: now_ts(),
+            last_current: "0.3.3".into(),
+            latest: Some("0.3.5".into()),
+        };
+        // User just upgraded; the cached verdict was for the old binary.
+        assert!(!cache_fresh(&entry, "0.3.4"));
+    }
+
+    #[test]
+    fn cache_roundtrip_preserves_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("update-check.json");
+        let entry = CacheEntry {
+            last_check_ts: 12345,
+            last_current: "0.3.4".into(),
+            latest: Some("0.3.5".into()),
+        };
+        write_cache(&path, &entry);
+        let read = read_cache(&path).unwrap();
+        assert_eq!(read.last_check_ts, 12345);
+        assert_eq!(read.last_current, "0.3.4");
+        assert_eq!(read.latest.as_deref(), Some("0.3.5"));
+    }
+
+    #[test]
+    fn cache_none_latest_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("update-check.json");
+        let entry = CacheEntry {
+            last_check_ts: 1,
+            last_current: "0.3.4".into(),
+            latest: None,
+        };
+        write_cache(&path, &entry);
+        assert!(read_cache(&path).unwrap().latest.is_none());
+    }
+
+    #[test]
+    fn read_cache_missing_file_is_none() {
+        assert!(read_cache(&PathBuf::from("/nonexistent/update-check.json")).is_none());
+    }
+
+    #[test]
+    fn read_cache_corrupt_json_is_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("update-check.json");
+        std::fs::write(&path, "not json {").unwrap();
+        assert!(read_cache(&path).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

- Problem: aish 启动后不会提示有新版本，用户需手动 `aish update` 检查，常长期运行旧版本。
- Changes: 新增启动时异步版本检查——后台 `spawn_blocking` 探测 `cdn.aishell.ai/download/latest`，semver 比较后若新版可用在 REPL 显示 omp 风格一次性提示。24h 缓存、失败静默、不阻塞启动。
- Related Issue: #442

## Change Type

- [x] Feature

## Scope

- [x] CLI / Interface
- [x] Configuration

## User-visible Changes

启动进入交互 REPL 后，若远程有新版本，下次回车时显示一条提示（omp 风格，warning 色上下分隔线）：

    发现新版本
    新版本 0.3.11 可用
    升级命令： aish update

受 `check_update_on_startup` 配置控制（默认 true），非 TTY 不触发。

## Compatibility

- Backward compatible? Yes
- Config changes? Yes — 新增 `check_update_on_startup: bool`（默认 true，serde default，老配置无需迁移）

## Testing

- `cargo clippy --all-targets -- -D warnings`：零 warning
- `cargo test --lib update_check`：11/11 通过（版本比较、v 前缀、缓存 TTL/过期/版本变更失效、normalize、读写往返、损坏 JSON）
- 6 个 locale YAML 语法验证通过

## Checklist

- [x] Code follows project style
- [x] Tests added if needed
- [x] Documentation updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional startup update checks, enabled by default and shown only when a newer version is available.
  - Added a one-time notification with the latest version and the `aish update` command.
  - Update checks avoid repeated notices and continue gracefully when unavailable.

- **Localization**
  - Added update notification translations in English, German, Spanish, French, Japanese, and Chinese.

- **Configuration**
  - Added a setting to disable update checks at startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->