### PR TITLE
feat(setup): show local model catalog immediately

### DIFF
--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -67,6 +67,8 @@ cli:
     model_custom_option: "Benutzerdefiniertes Modell..."
     model_custom_required: "Modellname ist erforderlich"
     model_custom_saved_as: "Wird gespeichert als: {model}"
+    model_discover_in_progress: "Verfügbare Modelle werden ermittelt..."
+    model_discover_failed: "Modelle konnten nicht ermittelt werden: {reason}"
     verify_title: "Verifizierung"
     verify_connectivity_in_progress: "Konnektivität wird geprüft..."
     verify_tool_in_progress: "Prüfen, ob die API tools-Parameter akzeptiert..."

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -226,6 +226,8 @@ cli:
     model_custom_option: "Custom model..."
     model_custom_required: "Model name is required"
     model_custom_saved_as: "Will be saved as: {model}"
+    model_discover_in_progress: "Discovering available models..."
+    model_discover_failed: "Could not discover models: {reason}"
     verify_title: "Verification"
     verify_connectivity_in_progress: "Checking connectivity..."
     verify_tool_in_progress: "Checking whether the API accepts tools parameters..."

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -67,6 +67,8 @@ cli:
     model_custom_option: "Modelo personalizado..."
     model_custom_required: "El nombre del modelo es obligatorio"
     model_custom_saved_as: "Se guardará como: {model}"
+    model_discover_in_progress: "Buscando modelos disponibles..."
+    model_discover_failed: "No se pudieron descubrir modelos: {reason}"
     verify_title: "Verificación"
     verify_connectivity_in_progress: "Comprobando la conectividad..."
     verify_tool_in_progress: "Comprobando si la API acepta parámetros tools..."

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -67,6 +67,8 @@ cli:
     model_custom_option: "Modele personnalise..."
     model_custom_required: "Le nom du modele est obligatoire"
     model_custom_saved_as: "Sera enregistre sous : {model}"
+    model_discover_in_progress: "Recherche des modeles disponibles..."
+    model_discover_failed: "Impossible de decouvrir les modeles : {reason}"
     verify_title: "Verification"
     verify_connectivity_in_progress: "Verification de la connectivite..."
     verify_tool_in_progress: "Verification de l'acceptation des parametres tools..."

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -67,6 +67,8 @@ cli:
     model_custom_option: "カスタムモデル..."
     model_custom_required: "モデル名は必須です"
     model_custom_saved_as: "保存名: {model}"
+    model_discover_in_progress: "利用可能なモデルを検出しています..."
+    model_discover_failed: "モデルを検出できませんでした: {reason}"
     verify_title: "検証"
     verify_connectivity_in_progress: "接続性を確認しています..."
     verify_tool_in_progress: "API が tools パラメータを受け付けるか確認しています..."

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -226,6 +226,8 @@ cli:
     model_custom_option: "自定义模型..."
     model_custom_required: "模型名称不能为空"
     model_custom_saved_as: "将保存为：{model}"
+    model_discover_in_progress: "正在发现可用模型..."
+    model_discover_failed: "无法发现模型：{reason}"
     verify_title: "验证"
     verify_connectivity_in_progress: "正在检查连通性..."
     verify_tool_in_progress: "正在检查 API 是否接受 tools 参数..."

--- a/crates/aish-shell/src/wizard/mod.rs
+++ b/crates/aish-shell/src/wizard/mod.rs
@@ -870,36 +870,41 @@ impl SetupWizard {
         }
     }
 
-    /// Step 3: Model selection (with dynamic fetch from provider API).
+    /// Step 3: Model selection. Known providers use the local catalog immediately;
+    /// Ollama / vLLM / unknown endpoints discover models live.
     fn select_model(&mut self) -> Result<(), AishError> {
         let provider = self
             .selected_provider
             .as_ref()
             .ok_or(AishError::Cancelled)?;
+        let provider_key = provider.key.clone();
+        let provider_label = provider.label.clone();
 
         let mut args = std::collections::HashMap::new();
-        args.insert("provider".to_string(), provider.label.clone());
+        args.insert("provider".to_string(), provider_label);
         let title = t_with_args("cli.setup.model_header", &args);
 
-        let api_base = self.api_base.as_deref().unwrap_or("");
+        let api_base = self.api_base.clone().unwrap_or_default();
+        let api_key = self.api_key.clone();
 
-        // Try dynamic model fetch first; fall back to static list.
-        let dynamic_models = if let Some(api_key) = &self.api_key {
-            model_fetch::get_models_for_provider(&provider.key, api_base, Some(api_key.as_str()))
-        } else if provider.key == "ollama" || provider.key == "vllm" {
-            model_fetch::get_models_for_provider(&provider.key, api_base, None)
+        let fetch =
+            || model_fetch::get_models_for_provider(&provider_key, &api_base, api_key.as_deref());
+        let catalog = if model_fetch::uses_live_discovery(&provider_key) {
+            clack_log::step(&t("cli.setup.model_discover_in_progress"));
+            clack_log::with_spinner("...", fetch)
         } else {
-            vec![]
+            fetch()
         };
 
-        let models = if dynamic_models.is_empty() {
-            get_provider_models(&provider.key)
-        } else {
-            dynamic_models
-        };
+        if let Some(err) = catalog.error.as_deref() {
+            let mut err_args = std::collections::HashMap::new();
+            err_args.insert("reason".to_string(), err.to_string());
+            clack_log::error(&t_with_args("cli.setup.model_discover_failed", &err_args));
+        }
 
-        if !models.is_empty() {
-            let options: Vec<DialogOption> = models
+        if !catalog.models.is_empty() {
+            let options: Vec<DialogOption> = catalog
+                .models
                 .iter()
                 .map(|m| DialogOption::new(m, m.clone()))
                 .collect();

--- a/crates/aish-shell/src/wizard/mod.rs
+++ b/crates/aish-shell/src/wizard/mod.rs
@@ -197,30 +197,44 @@ pub fn get_all_providers() -> Vec<ProviderInfo> {
 // Model lists (static for common providers)
 // ---------------------------------------------------------------------------
 
-/// Get predefined models for a provider (matches Python's constants).
+/// Get predefined models for a provider.
+///
+/// IDs follow OpenClaw's shipped provider catalogs (non-deprecated rows).
+/// Ollama / vLLM still have leftover names here but setup discovers them live.
 pub fn get_provider_models(provider_key: &str) -> Vec<String> {
     match provider_key {
         "openai" => vec![
-            "gpt-4o".into(),
-            "gpt-4o-mini".into(),
-            "gpt-4-turbo".into(),
-            "gpt-3.5-turbo".into(),
+            "gpt-5.6-sol".into(),
+            "gpt-5.6-terra".into(),
+            "gpt-5.6-luna".into(),
+            "gpt-5.4".into(),
+            "gpt-5.4-pro".into(),
+            "gpt-5.4-mini".into(),
+            "gpt-5.4-nano".into(),
         ],
         "anthropic" => vec![
-            "claude-sonnet-4-20250514".into(),
-            "claude-3-5-sonnet-20241022".into(),
-            "claude-3-5-haiku-20241022".into(),
-            "claude-3-opus-20240229".into(),
+            "claude-opus-5".into(),
+            "claude-sonnet-5".into(),
+            "claude-fable-5".into(),
+            "claude-mythos-5".into(),
+            "claude-haiku-4-5".into(),
         ],
         "gemini" | "google" => vec![
-            "gemini-2.5-flash-preview".into(),
+            "gemini-3.1-pro-preview".into(),
+            "gemini-3.5-flash".into(),
+            "gemini-3-flash-preview".into(),
+            "gemini-3.1-flash-lite".into(),
             "gemini-2.5-flash".into(),
-            "gemini-2.0-flash-exp".into(),
-            "gemini-1.5-pro".into(),
+            "gemini-2.5-flash-lite".into(),
         ],
-        "deepseek" => vec!["deepseek-chat".into(), "deepseek-coder".into()],
-        "xai" => vec!["grok-4".into()],
-        "openai-codex" => vec!["openai-codex/gpt-5.4".into()],
+        "deepseek" => vec!["deepseek-v4-pro".into(), "deepseek-v4-flash".into()],
+        "xai" => vec!["grok-4.6".into(), "grok-4.5".into(), "grok-4.3".into()],
+        "openai-codex" => vec![
+            "openai-codex/gpt-5.6-sol".into(),
+            "openai-codex/gpt-5.6-terra".into(),
+            "openai-codex/gpt-5.6-luna".into(),
+            "openai-codex/gpt-5.4".into(),
+        ],
         "ollama" => vec![
             "llama3.2".into(),
             "llama3.1".into(),
@@ -230,36 +244,32 @@ pub fn get_provider_models(provider_key: &str) -> Vec<String> {
             "codellama".into(),
         ],
         "minimax" => vec![
-            "MiniMax-M2.5".into(),
-            "MiniMax-M2.5-highspeed".into(),
-            "MiniMax-M2.5-Lightning".into(),
+            "MiniMax-M3".into(),
+            "MiniMax-M2.7".into(),
+            "MiniMax-M2.7-highspeed".into(),
         ],
         "moonshot" => vec![
-            "kimi-k2.5".into(),
-            "kimi-k2-turbo-preview".into(),
-            "k2p5".into(),
+            "kimi-k3".into(),
+            "kimi-k2.7-code".into(),
+            "kimi-k2.7-code-highspeed".into(),
+            "kimi-k2.6".into(),
         ],
         "zai" => vec![
-            "glm-5".into(),
-            "glm-4.7".into(),
-            "glm-4.7-flash".into(),
-            "glm-4.7-flashx".into(),
+            "glm-5.2".into(),
+            "glm-5-turbo".into(),
+            "glm-5v-turbo".into(),
         ],
         "qianfan" => vec![
-            "deepseek-v3.2".into(),
-            "ernie-5.0-thinking-preview".into(),
-            "ernie-4.0-8k".into(),
-            "ernie-4.0-turbo-8k".into(),
-            "ernie-3.5-8k".into(),
+            "deepseek-v4-pro".into(),
+            "ernie-5.1".into(),
+            "ernie-5.0".into(),
         ],
         "mistral" => vec![
             "mistral-large-latest".into(),
-            "mistral-large-2411".into(),
-            "pixtral-12b-2409".into(),
-            "mistral-nemo".into(),
-            "open-mistral-7b".into(),
-            "open-mixtral-8x7b".into(),
-            "open-mixtral-8x22b".into(),
+            "mistral-medium-3-5".into(),
+            "mistral-small-latest".into(),
+            "codestral-latest".into(),
+            "mistral-small-2603".into(),
         ],
         "together" => vec![
             "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo".into(),
@@ -277,12 +287,13 @@ pub fn get_provider_models(provider_key: &str) -> Vec<String> {
             "bigcode/starcoder2-15b".into(),
         ],
         "qwen" => vec![
-            "qwen-max".into(),
-            "qwen-plus".into(),
-            "qwen-turbo".into(),
-            "qwen-long".into(),
-            "qwen-vl-max".into(),
-            "qwen-vl-plus".into(),
+            "qwen3.5-plus".into(),
+            "qwen3.7-plus".into(),
+            "qwen3.7-max".into(),
+            "qwen3.6-plus".into(),
+            "qwen3.6-flash".into(),
+            "qwen3-coder-plus".into(),
+            "qwen3-coder-next".into(),
         ],
         "kilocode" => vec![
             "openai/gpt-4o".into(),
@@ -1292,15 +1303,14 @@ mod tests {
     fn test_get_provider_models() {
         let openai_models = get_provider_models("openai");
         assert!(!openai_models.is_empty());
-        assert!(openai_models.contains(&"gpt-4o".to_string()));
+        assert!(openai_models.contains(&"gpt-5.6-sol".to_string()));
 
         let anthropic_models = get_provider_models("anthropic");
         assert!(!anthropic_models.is_empty());
         assert!(anthropic_models.iter().any(|m| m.starts_with("claude-")));
 
-        // Verify updated xai model
         let xai_models = get_provider_models("xai");
-        assert!(xai_models.contains(&"grok-4".to_string()));
+        assert!(xai_models.contains(&"grok-4.6".to_string()));
 
         // Verify new providers have models
         let qianfan_models = get_provider_models("qianfan");

--- a/crates/aish-shell/src/wizard/model_fetch.rs
+++ b/crates/aish-shell/src/wizard/model_fetch.rs
@@ -1,13 +1,62 @@
 //! Dynamic model fetching from provider APIs.
 //!
-//! Provides functions to fetch available models from OpenAI-compatible and
-//! Ollama APIs, with graceful fallback to static model lists.
+//! Known providers with a local catalog skip the network during setup.
+//! Ollama, vLLM, and providers without a local catalog discover models live.
 
 use tracing::debug;
 
 use aish_llm::trim_model_name;
 
 use super::get_provider_models;
+
+/// How the setup model list was obtained.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelCatalogKind {
+    /// Built-in catalog; no network request was made.
+    Local,
+    /// Result of a live discovery request (success or failure).
+    Discovered,
+}
+
+/// Models shown in setup, plus whether they came from the local catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelCatalog {
+    pub models: Vec<String>,
+    pub kind: ModelCatalogKind,
+    pub error: Option<String>,
+}
+
+impl ModelCatalog {
+    fn local(models: Vec<String>) -> Self {
+        Self {
+            models,
+            kind: ModelCatalogKind::Local,
+            error: None,
+        }
+    }
+
+    fn discovered(models: Vec<String>) -> Self {
+        Self {
+            models,
+            kind: ModelCatalogKind::Discovered,
+            error: None,
+        }
+    }
+
+    fn discover_failed(error: String) -> Self {
+        Self {
+            models: Vec::new(),
+            kind: ModelCatalogKind::Discovered,
+            error: Some(error),
+        }
+    }
+}
+
+/// Providers with no reliable local catalog (Ollama, vLLM, custom/unknown, or
+/// hosted providers that ship an empty built-in list) must be discovered online.
+pub fn uses_live_discovery(provider_key: &str) -> bool {
+    matches!(provider_key, "ollama" | "vllm") || get_provider_models(provider_key).is_empty()
+}
 
 // ---------------------------------------------------------------------------
 // Default timeout
@@ -160,91 +209,37 @@ pub fn fetch_ollama_models(timeout_s: u64) -> Result<Vec<String>, String> {
     Ok(models)
 }
 
-/// Get models for a provider, combining dynamic fetch with static fallback.
+/// Resolve the setup model list for a provider.
 ///
-/// - For "ollama": calls [`fetch_ollama_models`], falls back to static list on
-///   error.
-/// - For known providers with an `api_key`: calls [`fetch_models_from_api`],
-///   merges with the static list.
-/// - For unknown providers with an `api_key`: tries [`fetch_models_from_api`],
-///   returns empty on failure.
-/// - Results are deduplicated while preserving order (dynamic models first).
+/// Known providers return the local catalog immediately. Ollama, vLLM, and
+/// providers without a local catalog discover models from the endpoint and
+/// never substitute the built-in list on failure.
 pub fn get_models_for_provider(
     provider_key: &str,
     api_base: &str,
     api_key: Option<&str>,
-) -> Vec<String> {
-    let static_models = get_provider_models(provider_key);
-    let is_known_provider = !static_models.is_empty() || provider_key == "ollama";
+) -> ModelCatalog {
+    if !uses_live_discovery(provider_key) {
+        return ModelCatalog::local(get_provider_models(provider_key));
+    }
 
-    // --- Ollama special path ---
     if provider_key == "ollama" {
-        match fetch_ollama_models(DEFAULT_FETCH_TIMEOUT_S) {
-            Ok(dynamic) => {
-                if dynamic.is_empty() {
-                    return static_models;
-                }
-                return merge_dedup(dynamic, static_models);
-            }
+        return match fetch_ollama_models(DEFAULT_FETCH_TIMEOUT_S) {
+            Ok(models) => ModelCatalog::discovered(models),
             Err(e) => {
-                debug!("Ollama fetch failed, using static list: {}", e);
-                return static_models;
+                debug!("Ollama discovery failed: {}", e);
+                ModelCatalog::discover_failed(e)
             }
+        };
+    }
+
+    match fetch_models_from_api(api_base, api_key.unwrap_or(""), DEFAULT_FETCH_TIMEOUT_S) {
+        Ok(models) => ModelCatalog::discovered(models),
+        Err(e) => {
+            debug!("Live discovery failed for '{}': {}", provider_key, e);
+            ModelCatalog::discover_failed(e)
         }
     }
-
-    // --- Providers with API key ---
-    if let Some(key) = api_key {
-        if !key.is_empty() {
-            match fetch_models_from_api(api_base, key, DEFAULT_FETCH_TIMEOUT_S) {
-                Ok(dynamic) => {
-                    if is_known_provider {
-                        return merge_dedup(dynamic, static_models);
-                    } else {
-                        // Unknown provider: return whatever we got (may be empty).
-                        return dynamic;
-                    }
-                }
-                Err(e) => {
-                    debug!(
-                        "Dynamic fetch failed for '{}', using fallback: {}",
-                        provider_key, e
-                    );
-                    if is_known_provider {
-                        return static_models;
-                    }
-                    // Unknown provider with failed fetch: return empty.
-                    return Vec::new();
-                }
-            }
-        }
-    }
-
-    // No API key available — static fallback for known providers.
-    if is_known_provider {
-        return static_models;
-    }
-
-    Vec::new()
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Merge two Vecs, deduplicating while preserving order (items from `first`
-/// appear before items from `second` that are not duplicates).
-fn merge_dedup(first: Vec<String>, second: Vec<String>) -> Vec<String> {
-    let mut seen = std::collections::HashSet::new();
-    let mut result = Vec::new();
-
-    for item in first.into_iter().chain(second) {
-        if seen.insert(item.clone()) {
-            result.push(item);
-        }
-    }
-
-    result
 }
 
 // ---------------------------------------------------------------------------
@@ -272,53 +267,53 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_dedup_preserves_order() {
-        let a = vec!["a".to_string(), "b".to_string()];
-        let b = vec!["b".to_string(), "c".to_string()];
-        let result = merge_dedup(a, b);
-        assert_eq!(result, vec!["a", "b", "c"]);
+    fn known_providers_skip_live_discovery() {
+        assert!(!uses_live_discovery("openai"));
+        assert!(!uses_live_discovery("anthropic"));
+        assert!(!uses_live_discovery("openai-codex"));
     }
 
     #[test]
-    fn test_merge_dedup_empty_first() {
-        let a: Vec<String> = vec![];
-        let b = vec!["x".to_string()];
-        let result = merge_dedup(a, b);
-        assert_eq!(result, vec!["x"]);
+    fn discovery_only_providers_use_live_discovery() {
+        assert!(uses_live_discovery("ollama"));
+        assert!(uses_live_discovery("vllm"));
+        assert!(uses_live_discovery("custom"));
+        assert!(uses_live_discovery("unknown-provider"));
+        assert!(uses_live_discovery("openrouter"));
     }
 
     #[test]
-    fn test_merge_dedup_all_duplicates() {
-        let a = vec!["a".to_string(), "b".to_string()];
-        let b = vec!["a".to_string(), "b".to_string()];
-        let result = merge_dedup(a, b);
-        assert_eq!(result, vec!["a", "b"]);
+    fn known_provider_returns_local_catalog_without_using_endpoint() {
+        let catalog = get_models_for_provider("openai", "http://127.0.0.1:1", Some("fake-key"));
+        assert_eq!(catalog.kind, ModelCatalogKind::Local);
+        assert!(catalog.error.is_none());
+        assert!(catalog.models.iter().any(|m| m == "gpt-4o"));
     }
 
     #[test]
-    fn test_get_models_for_provider_ollama_fallback() {
-        // Ollama is almost certainly not running in CI, so this tests the
-        // fallback to the static list.
-        let models = get_models_for_provider("ollama", "http://localhost:11434", None);
-        assert!(!models.is_empty());
-        // Should contain at least one entry from the static list.
-        assert!(models.iter().any(|m| m.contains("llama")));
+    fn ollama_discovery_failure_does_not_return_builtin_list() {
+        let catalog = get_models_for_provider("ollama", "http://localhost:11434", None);
+        assert_eq!(catalog.kind, ModelCatalogKind::Discovered);
+        if catalog.error.is_some() {
+            assert!(catalog.models.is_empty());
+        }
     }
 
     #[test]
-    fn test_get_models_for_provider_unknown_no_key() {
-        let models =
-            get_models_for_provider("unknown-provider", "https://api.example.com/v1", None);
-        assert!(models.is_empty());
+    fn vllm_discovery_failure_does_not_return_builtin_list() {
+        let catalog = get_models_for_provider("vllm", "http://127.0.0.1:1", None);
+        assert_eq!(catalog.kind, ModelCatalogKind::Discovered);
+        assert!(catalog.error.is_some());
+        assert!(catalog.models.is_empty());
     }
 
     #[test]
-    fn test_get_models_for_provider_known_static_fallback() {
-        // Use an unreachable endpoint to force a fetch failure, which should
-        // fall back to the static list for known providers.
-        let models = get_models_for_provider("openai", "http://127.0.0.1:1", Some("fake-key"));
-        assert!(!models.is_empty());
-        assert!(models.iter().any(|m| m == "gpt-4o"));
+    fn unknown_provider_discovery_failure_is_empty_not_local() {
+        let catalog =
+            get_models_for_provider("unknown-provider", "http://127.0.0.1:1", Some("fake-key"));
+        assert_eq!(catalog.kind, ModelCatalogKind::Discovered);
+        assert!(catalog.error.is_some());
+        assert!(catalog.models.is_empty());
     }
 
     #[test]

--- a/crates/aish-shell/src/wizard/model_fetch.rs
+++ b/crates/aish-shell/src/wizard/model_fetch.rs
@@ -47,7 +47,7 @@ impl ModelCatalog {
         Self {
             models: Vec::new(),
             kind: ModelCatalogKind::Discovered,
-            error: Some(error),
+            error: Some(aish_ui::strip_ansi_escapes(&error)),
         }
     }
 }
@@ -115,7 +115,8 @@ pub fn fetch_models_from_api(
 
         let status = response.status();
         if !status.is_success() {
-            let body = response.text().unwrap_or_default();
+            // Strip ANSI/C0 before truncating so the 200-byte cap is visible text.
+            let body = aish_ui::strip_ansi_escapes(&response.text().unwrap_or_default());
             let detail = if body.len() > 200 {
                 let mut end = 200;
                 while end > 0 && !body.is_char_boundary(end) {
@@ -305,6 +306,16 @@ mod tests {
         assert_eq!(catalog.kind, ModelCatalogKind::Discovered);
         assert!(catalog.error.is_some());
         assert!(catalog.models.is_empty());
+    }
+
+    #[test]
+    fn discovery_error_strips_ansi_and_control_sequences() {
+        let catalog = ModelCatalog::discover_failed(
+            "HTTP 500: \x1b[31mred\x1b[0m \x1b]0;evil\x07ok\x08".into(),
+        );
+        assert_eq!(catalog.error.as_deref(), Some("HTTP 500: red ok"));
+        assert!(catalog.models.is_empty());
+        assert_eq!(catalog.kind, ModelCatalogKind::Discovered);
     }
 
     #[test]

--- a/crates/aish-shell/src/wizard/model_fetch.rs
+++ b/crates/aish-shell/src/wizard/model_fetch.rs
@@ -287,7 +287,7 @@ mod tests {
         let catalog = get_models_for_provider("openai", "http://127.0.0.1:1", Some("fake-key"));
         assert_eq!(catalog.kind, ModelCatalogKind::Local);
         assert!(catalog.error.is_none());
-        assert!(catalog.models.iter().any(|m| m == "gpt-4o"));
+        assert!(catalog.models.iter().any(|m| m == "gpt-5.6-sol"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `aish setup` no longer waits on `GET /models` for providers that already have a built-in catalog; the picker appears immediately.
- Live discovery is limited to Ollama, vLLM, and endpoints without a local catalog, with a loading state. Failed discovery shows an error and custom entry instead of silently substituting a built-in list.
- Refresh the built-in catalog to current model IDs (GPT-5.6, Claude 5, Gemini 3.x, Grok 4.x, and matching DeepSeek / MiniMax / Kimi / GLM / Qwen / Mistral / Qianfan names). Custom entry remains available.

Closes #444
Related #404

## Test plan
- [ ] `aish setup` with OpenAI/Anthropic: model picker appears without a network wait; custom model still works
- [ ] Connectivity verification still runs after model selection
- [ ] Ollama/vLLM down: loading + unreachable message, then custom entry; no fake `llama3.2` list
- [ ] Unknown/custom endpoint: live discovery with loading; failure goes to custom entry
- [ ] `cargo test -p aish-shell --lib wizard::`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup now discovers available models for supported providers, with progress updates while discovery is in progress.
  * Providers without built-in catalogs can retrieve models dynamically.
  * If discovery fails, setup displays the error and allows selecting an available or custom model.
  * Updated model selections across multiple providers.

* **Localization**
  * Added setup discovery and failure messages in English, German, Spanish, French, Japanese, and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->