### PR TITLE
fix(web_fetch): confirm and remember by Host key

### DIFF
--- a/crates/aish-llm/src/agents/tools.rs
+++ b/crates/aish-llm/src/agents/tools.rs
@@ -1,6 +1,7 @@
 //! Tool filtering for sub-agent spawn paths.
 
 use super::registry::{AgentDefinition, ToolStrategy};
+use crate::tool_names_match;
 use crate::types::ToolSpec;
 
 const SKILL_TOOL_NAME: &str = "skill";
@@ -21,13 +22,18 @@ pub fn resolve_tool_names_for_agent(
     match &def.tool_strategy {
         ToolStrategy::Allowlist(allowed) => allowed
             .iter()
-            .filter(|name| parent_tool_names.contains(&name.as_str()))
-            .cloned()
+            .filter_map(|name| {
+                parent_tool_names
+                    .iter()
+                    .copied()
+                    .find(|parent| tool_names_match(name, parent))
+                    .map(str::to_string)
+            })
             .collect(),
         ToolStrategy::Denylist(denied) => parent_tool_names
             .iter()
             .filter(|name| {
-                if denied.contains(&name.to_string()) {
+                if denied.iter().any(|denied| tool_names_match(name, denied)) {
                     return false;
                 }
                 if **name == SKILL_TOOL_NAME && !parent_has_skill {
@@ -273,5 +279,20 @@ mod tests {
 
     fn command_diagnose_def() -> AgentDefinition {
         AgentDefinition::command_diagnose("sys".into())
+    }
+
+    #[test]
+    fn test_allowlist_maps_web_fetch_alias_to_parent_webfetch() {
+        let def = AgentDefinition {
+            subagent_type: "alias-check".into(),
+            when_to_use: String::new(),
+            system_prompt: String::new(),
+            max_turns: 1,
+            tool_strategy: ToolStrategy::Allowlist(vec!["web_fetch".into()]),
+            tool_execution_policy: crate::tool_context::ToolExecutionPolicy::default(),
+        };
+        let parent = vec!["WebFetch", "bash"];
+        let names = resolve_tool_names_for_agent(&def, &parent, false);
+        assert_eq!(names, vec!["WebFetch".to_string()]);
     }
 }

--- a/crates/aish-llm/src/agents/tools.rs
+++ b/crates/aish-llm/src/agents/tools.rs
@@ -280,19 +280,4 @@ mod tests {
     fn command_diagnose_def() -> AgentDefinition {
         AgentDefinition::command_diagnose("sys".into())
     }
-
-    #[test]
-    fn test_allowlist_maps_web_fetch_alias_to_parent_webfetch() {
-        let def = AgentDefinition {
-            subagent_type: "alias-check".into(),
-            when_to_use: String::new(),
-            system_prompt: String::new(),
-            max_turns: 1,
-            tool_strategy: ToolStrategy::Allowlist(vec!["web_fetch".into()]),
-            tool_execution_policy: crate::tool_context::ToolExecutionPolicy::default(),
-        };
-        let parent = vec!["WebFetch", "bash"];
-        let names = resolve_tool_names_for_agent(&def, &parent, false);
-        assert_eq!(names, vec!["WebFetch".to_string()]);
-    }
 }

--- a/crates/aish-llm/src/approval_memory.rs
+++ b/crates/aish-llm/src/approval_memory.rs
@@ -38,6 +38,7 @@ pub enum ApprovalChoice {
 #[derive(Debug, Default)]
 pub struct ApprovalMemory {
     allowed: HashSet<(String, String)>,
+    allowed_targets: HashSet<(String, String)>,
 }
 
 impl ApprovalMemory {
@@ -74,19 +75,37 @@ impl ApprovalMemory {
         }
     }
 
+    /// Whether this tool + target was remembered for the session.
+    pub fn is_target_allowed(&self, tool_name: &str, target: &str) -> bool {
+        !target.is_empty()
+            && self
+                .allowed_targets
+                .contains(&(tool_name.to_string(), target.to_string()))
+    }
+
+    /// Remember a tool + target (for example WebFetch Host key) for the session.
+    pub fn remember_target(&mut self, tool_name: &str, target: &str) {
+        if target.is_empty() {
+            return;
+        }
+        self.allowed_targets
+            .insert((tool_name.to_string(), target.to_string()));
+    }
+
     /// Forget all remembered approvals for this session.
     pub fn clear(&mut self) {
         self.allowed.clear();
+        self.allowed_targets.clear();
     }
 
     /// Number of remembered approvals (mainly for diagnostics/tests).
     pub fn len(&self) -> usize {
-        self.allowed.len()
+        self.allowed.len() + self.allowed_targets.len()
     }
 
     /// Whether no approvals are currently remembered.
     pub fn is_empty(&self) -> bool {
-        self.allowed.is_empty()
+        self.allowed.is_empty() && self.allowed_targets.is_empty()
     }
 }
 
@@ -287,6 +306,18 @@ mod tests {
         mem.remember("");
         assert!(mem.is_empty());
         assert!(!mem.is_allowed(""));
+    }
+
+    #[test]
+    fn remembers_tool_target_for_session() {
+        let mut mem = ApprovalMemory::new();
+        mem.remember_target("WebFetch", "example.com");
+        assert!(mem.is_target_allowed("WebFetch", "example.com"));
+        assert!(!mem.is_target_allowed("WebFetch", "other.com"));
+        assert!(!mem.is_target_allowed("bash", "example.com"));
+        mem.clear();
+        assert!(!mem.is_target_allowed("WebFetch", "example.com"));
+        assert!(mem.is_empty());
     }
 
     #[test]

--- a/crates/aish-llm/src/approval_memory.rs
+++ b/crates/aish-llm/src/approval_memory.rs
@@ -309,18 +309,6 @@ mod tests {
     }
 
     #[test]
-    fn remembers_tool_target_for_session() {
-        let mut mem = ApprovalMemory::new();
-        mem.remember_target("WebFetch", "example.com");
-        assert!(mem.is_target_allowed("WebFetch", "example.com"));
-        assert!(!mem.is_target_allowed("WebFetch", "other.com"));
-        assert!(!mem.is_target_allowed("bash", "example.com"));
-        mem.clear();
-        assert!(!mem.is_target_allowed("WebFetch", "example.com"));
-        assert!(mem.is_empty());
-    }
-
-    #[test]
     fn strips_leading_wrappers() {
         // nohup is stripped (no privilege change).
         assert_eq!(

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -1627,13 +1627,19 @@ impl LlmSession {
             )));
         }
 
-        // Approval memory: if this command was previously approved for the
-        // session, skip the whole preflight (including the sandbox pre-run).
+        // Approval memory: if this command or tool target was previously
+        // approved for the session, skip the whole preflight (including the
+        // sandbox pre-run).
         let memory_command = args.get("command").and_then(|value| value.as_str());
+        let memory_target = tool.approval_memory_key(args);
         if memory_command.is_some_and(|command| {
             self.approval_memory
                 .as_ref()
                 .is_some_and(|memory| memory.lock().is_allowed(command))
+        }) || memory_target.as_deref().is_some_and(|target| {
+            self.approval_memory
+                .as_ref()
+                .is_some_and(|memory| memory.lock().is_target_allowed(tool_name, target))
         }) {
             self.emit_audit(AuditEvent::security_decision(
                 chrono::Utc::now(),
@@ -1683,6 +1689,9 @@ impl LlmSession {
                     if let Some(memory) = &self.approval_memory {
                         if let Some(command) = memory_command {
                             memory.lock().remember(command);
+                        }
+                        if let Some(target) = memory_target.as_deref() {
+                            memory.lock().remember_target(tool_name, target);
                         }
                     }
                 }
@@ -3315,6 +3324,168 @@ mod tests {
             1,
             "remembered command must skip preflight entirely"
         );
+    }
+
+    struct ConfirmCountingNamedTool {
+        name: &'static str,
+        preflight_calls: std::sync::Arc<std::sync::atomic::AtomicU32>,
+        memory_key: Option<String>,
+    }
+
+    impl Tool for ConfirmCountingNamedTool {
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn description(&self) -> &str {
+            "confirm-counting test tool"
+        }
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {}})
+        }
+        fn approval_memory_key(&self, args: &serde_json::Value) -> Option<String> {
+            if let Some(key) = &self.memory_key {
+                return Some(key.clone());
+            }
+            let url = args.get("url")?.as_str()?;
+            reqwest::Url::parse(url)
+                .ok()?
+                .host_str()
+                .map(str::to_string)
+        }
+        fn preflight(&self, _args: &serde_json::Value) -> PreflightResult {
+            self.preflight_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            PreflightResult::Confirm {
+                message: "test confirmation".to_string(),
+                security: None,
+            }
+        }
+        fn execute(&self, _args: serde_json::Value) -> ToolResult {
+            ToolResult::success("executed")
+        }
+    }
+
+    #[tokio::test]
+    async fn approval_memory_skips_preflight_on_remembered_webfetch_host() {
+        let mut session = LlmSession::new("http://localhost", "key", "model", None, None);
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        session.register_tool(Box::new(ConfirmCountingNamedTool {
+            name: "WebFetch",
+            preflight_calls: counter.clone(),
+            memory_key: Some("example.com".into()),
+        }));
+        session.set_confirmation_callback(std::sync::Arc::new(
+            |_ctx: &PreflightSecurityContext| ApprovalChoice::RememberSession,
+        ));
+        session.set_approval_memory(std::sync::Arc::new(parking_lot::Mutex::new(
+            ApprovalMemory::new(),
+        )));
+
+        let first = ToolCall {
+            id: "call_1".into(),
+            name: "WebFetch".into(),
+            arguments: serde_json::json!({ "url": "https://example.com/a" }).to_string(),
+        };
+        assert!(session.execute_tool_external(&first).await.ok);
+        assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+        let second = ToolCall {
+            id: "call_2".into(),
+            name: "WebFetch".into(),
+            arguments: serde_json::json!({ "url": "https://example.com/b" }).to_string(),
+        };
+        assert!(session.execute_tool_external(&second).await.ok);
+        assert_eq!(
+            counter.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "remembered WebFetch Host key must skip preflight"
+        );
+    }
+
+    #[tokio::test]
+    async fn approval_once_does_not_remember_webfetch_host() {
+        let mut session = LlmSession::new("http://localhost", "key", "model", None, None);
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        session.register_tool(Box::new(ConfirmCountingNamedTool {
+            name: "WebFetch",
+            preflight_calls: counter.clone(),
+            memory_key: Some("example.com".into()),
+        }));
+        session.set_confirmation_callback(std::sync::Arc::new(
+            |_ctx: &PreflightSecurityContext| ApprovalChoice::Once,
+        ));
+        session.set_approval_memory(std::sync::Arc::new(parking_lot::Mutex::new(
+            ApprovalMemory::new(),
+        )));
+
+        let call = ToolCall {
+            id: "call_1".into(),
+            name: "WebFetch".into(),
+            arguments: serde_json::json!({ "url": "https://example.com/a" }).to_string(),
+        };
+        assert!(session.execute_tool_external(&call).await.ok);
+        assert!(session.execute_tool_external(&call).await.ok);
+        assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn approval_memory_still_confirms_other_webfetch_host() {
+        let mut session = LlmSession::new("http://localhost", "key", "model", None, None);
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        session.register_tool(Box::new(ConfirmCountingNamedTool {
+            name: "WebFetch",
+            preflight_calls: counter.clone(),
+            memory_key: None,
+        }));
+        session.set_confirmation_callback(std::sync::Arc::new(
+            |_ctx: &PreflightSecurityContext| ApprovalChoice::RememberSession,
+        ));
+        session.set_approval_memory(std::sync::Arc::new(parking_lot::Mutex::new(
+            ApprovalMemory::new(),
+        )));
+
+        let first = ToolCall {
+            id: "call_1".into(),
+            name: "WebFetch".into(),
+            arguments: serde_json::json!({ "url": "https://example.com/a" }).to_string(),
+        };
+        assert!(session.execute_tool_external(&first).await.ok);
+
+        let other = ToolCall {
+            id: "call_2".into(),
+            name: "WebFetch".into(),
+            arguments: serde_json::json!({ "url": "https://other.com/a" }).to_string(),
+        };
+        assert!(session.execute_tool_external(&other).await.ok);
+        assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn approval_memory_clear_reconfirms_webfetch_host() {
+        let mut session = LlmSession::new("http://localhost", "key", "model", None, None);
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        session.register_tool(Box::new(ConfirmCountingNamedTool {
+            name: "WebFetch",
+            preflight_calls: counter.clone(),
+            memory_key: Some("example.com".into()),
+        }));
+        session.set_confirmation_callback(std::sync::Arc::new(
+            |_ctx: &PreflightSecurityContext| ApprovalChoice::RememberSession,
+        ));
+        let memory = std::sync::Arc::new(parking_lot::Mutex::new(ApprovalMemory::new()));
+        session.set_approval_memory(memory.clone());
+
+        let call = ToolCall {
+            id: "call_1".into(),
+            name: "WebFetch".into(),
+            arguments: serde_json::json!({ "url": "https://example.com/a" }).to_string(),
+        };
+        assert!(session.execute_tool_external(&call).await.ok);
+        assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+        memory.lock().clear();
+        assert!(session.execute_tool_external(&call).await.ok);
+        assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 2);
     }
 
     #[tokio::test]

--- a/crates/aish-llm/src/types.rs
+++ b/crates/aish-llm/src/types.rs
@@ -799,16 +799,6 @@ mod tests {
     }
 
     #[test]
-    fn web_fetch_aliases_match_runtime_name() {
-        assert!(tool_names_match("WebFetch", "web_fetch"));
-        assert!(tool_names_match("web_fetch", "WebFetch"));
-        assert!(tool_names_match("webfetch", "WebFetch"));
-        assert_eq!(canonicalize_tool_name("web_fetch"), "WebFetch");
-        assert!(!tool_names_match("WebFetch", "web_search"));
-        assert!(!tool_names_match("Bash", "bash"));
-    }
-
-    #[test]
     fn test_cancel_atomic_sets_is_cancelled() {
         let token = CancellationToken::new();
         assert!(!token.is_cancelled());

--- a/crates/aish-llm/src/types.rs
+++ b/crates/aish-llm/src/types.rs
@@ -499,6 +499,25 @@ pub enum PreflightResult {
     },
 }
 
+/// Whether two tool names refer to the same built-in.
+/// `WebFetch` and `web_fetch` are aliases; other names match exactly.
+pub fn tool_names_match(left: &str, right: &str) -> bool {
+    left == right || (is_webfetch_alias(left) && is_webfetch_alias(right))
+}
+
+fn is_webfetch_alias(name: &str) -> bool {
+    name.eq_ignore_ascii_case("WebFetch") || name.eq_ignore_ascii_case("web_fetch")
+}
+
+/// Canonical runtime name for a tool listed in skill metadata or allowlists.
+pub fn canonicalize_tool_name(name: &str) -> String {
+    if is_webfetch_alias(name) {
+        "WebFetch".to_string()
+    } else {
+        name.to_string()
+    }
+}
+
 /// Whether a tool's [`Tool::prompt`] is included in the system appendix.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PromptVisibility {
@@ -549,6 +568,12 @@ pub trait Tool: Send + Sync {
     ) -> PreflightResult {
         let _ = ctx;
         self.preflight(args)
+    }
+
+    /// Session-remembered identity for this call, if the tool supports remembering
+    /// something other than a bash `command` (for example a WebFetch Host key).
+    fn approval_memory_key(&self, _args: &serde_json::Value) -> Option<String> {
+        None
     }
 
     fn execute(&self, args: serde_json::Value) -> ToolResult;
@@ -771,6 +796,16 @@ mod tests {
                 security: None,
             }
         );
+    }
+
+    #[test]
+    fn web_fetch_aliases_match_runtime_name() {
+        assert!(tool_names_match("WebFetch", "web_fetch"));
+        assert!(tool_names_match("web_fetch", "WebFetch"));
+        assert!(tool_names_match("webfetch", "WebFetch"));
+        assert_eq!(canonicalize_tool_name("web_fetch"), "WebFetch");
+        assert!(!tool_names_match("WebFetch", "web_search"));
+        assert!(!tool_names_match("Bash", "bash"));
     }
 
     #[test]

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -10633,8 +10633,6 @@ mod webfetch_display_tests {
         });
         let shown = format_tool_args_for_display("WebFetch", &args);
         assert!(shown.contains("https://example.com/page"), "{shown}");
-        let alias = format_tool_args_for_display("web_fetch", &args);
-        assert!(alias.contains("https://example.com/page"), "{alias}");
     }
 }
 

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -3590,8 +3590,8 @@ impl AishShell {
         true
     }
 
-    /// Handle `/forget-approvals` — clear all session-scoped command approvals
-    /// so previously "remembered" commands prompt for confirmation again.
+    /// Handle `/forget-approvals` — clear session-scoped command and Host key
+    /// approvals so previously remembered confirmations prompt again.
     fn handle_forget_approvals(&mut self) {
         let count = {
             let mut memory = self.approval_memory.lock();
@@ -10585,7 +10585,7 @@ fn format_tool_args_for_display(tool_name: &str, args: &serde_json::Value) -> St
             "bash" | "secure_bash" => "command",
             "read_file" | "edit_file" => "path",
             "grep" | "glob" => "pattern",
-            "web_fetch" => "url",
+            "WebFetch" | "web_fetch" => "url",
             "ask_user" | "agent" => "prompt",
             _ => "",
         };
@@ -10619,6 +10619,23 @@ fn format_tool_args_for_display(tool_name: &str, args: &serde_json::Value) -> St
     }
 
     truncate_str(&args.to_string(), 120)
+}
+
+#[cfg(test)]
+mod webfetch_display_tests {
+    use super::format_tool_args_for_display;
+
+    #[test]
+    fn webfetch_display_shows_url() {
+        let args = serde_json::json!({
+            "url": "https://example.com/page",
+            "prompt": "summarize"
+        });
+        let shown = format_tool_args_for_display("WebFetch", &args);
+        assert!(shown.contains("https://example.com/page"), "{shown}");
+        let alias = format_tool_args_for_display("web_fetch", &args);
+        assert!(alias.contains("https://example.com/page"), "{alias}");
+    }
 }
 
 /// Truncate a string to max_len *display columns*, accounting for CJK double-width chars.

--- a/crates/aish-tools/src/skill_tool/skill_tool.rs
+++ b/crates/aish-tools/src/skill_tool/skill_tool.rs
@@ -134,15 +134,23 @@ fn intersect_tool_strategy(definition: &AgentDefinition, skill_tools: &[String])
         ToolStrategy::Allowlist(agent_tools) => ToolStrategy::Allowlist(
             agent_tools
                 .iter()
-                .filter(|tool| skill_tools.contains(tool))
+                .filter(|tool| {
+                    skill_tools
+                        .iter()
+                        .any(|skill_tool| aish_llm::tool_names_match(tool, skill_tool))
+                })
                 .cloned()
                 .collect(),
         ),
         ToolStrategy::Denylist(denied) => ToolStrategy::Allowlist(
             skill_tools
                 .iter()
-                .filter(|tool| !denied.contains(tool))
-                .cloned()
+                .map(|tool| aish_llm::canonicalize_tool_name(tool))
+                .filter(|tool| {
+                    !denied
+                        .iter()
+                        .any(|denied| aish_llm::tool_names_match(tool, denied))
+                })
                 .collect(),
         ),
     }
@@ -394,5 +402,17 @@ mod tests {
         assert!(!tool.prompt().contains("host-diagnose"));
         assert!(child_tool.prompt().contains("host-diagnose"));
         assert!(child_tool.prompt().contains("Diagnose host performance"));
+    }
+
+    #[test]
+    fn skill_web_fetch_alias_intersects_webfetch() {
+        let def = AgentDefinition::general_purpose();
+        match intersect_tool_strategy(&def, &["web_fetch".into(), "bash".into()]) {
+            ToolStrategy::Allowlist(names) => {
+                assert!(names.iter().any(|name| name == "WebFetch"));
+                assert!(names.iter().any(|name| name == "bash"));
+            }
+            other => panic!("expected allowlist, got {other:?}"),
+        }
     }
 }

--- a/crates/aish-tools/src/web_fetch/preapproved.rs
+++ b/crates/aish-tools/src/web_fetch/preapproved.rs
@@ -132,26 +132,4 @@ mod tests {
         ));
         assert!(is_preapproved_host("doc.rust-lang.org", "/book/"));
     }
-
-    #[test]
-    fn host_key_lowercases_strips_dot_and_www() {
-        assert_eq!(host_key("WWW.Example.COM."), "example.com");
-        assert_eq!(host_key("docs.python.org"), "docs.python.org");
-        assert_eq!(host_key("www.docs.python.org"), "docs.python.org");
-    }
-
-    #[test]
-    fn preapproved_host_uses_host_key() {
-        assert!(is_preapproved_host("WWW.docs.python.org.", "/3/"));
-        assert!(is_preapproved_host(
-            "www.github.com",
-            "/anthropics/claude-code"
-        ));
-        assert!(!is_preapproved_host("www.github.com", "/other/repo"));
-        assert!(is_preapproved_host("php.net", "/"));
-        assert!(!is_preapproved_host(
-            "gist.github.com",
-            "/anthropics/claude-code"
-        ));
-    }
 }

--- a/crates/aish-tools/src/web_fetch/preapproved.rs
+++ b/crates/aish-tools/src/web_fetch/preapproved.rs
@@ -93,17 +93,26 @@ const PREAPPROVED_HOSTS: &[&str] = &[
     "httpd.apache.org",
 ];
 
+/// Host key: lowercase, no trailing dot, a leading `www.` treated as the apex.
+pub(crate) fn host_key(hostname: &str) -> String {
+    let normalized = hostname.trim_end_matches('.').to_ascii_lowercase();
+    match normalized.strip_prefix("www.") {
+        Some(rest) if !rest.is_empty() => rest.to_string(),
+        _ => normalized,
+    }
+}
+
 pub(crate) fn is_preapproved_host(hostname: &str, pathname: &str) -> bool {
+    let hostname = host_key(hostname);
     for entry in PREAPPROVED_HOSTS {
         if let Some((host, prefix)) = entry.split_once('/') {
-            if hostname == host {
-                let prefix = format!("/{}", prefix);
-                if pathname == prefix || pathname.starts_with(&(prefix + "/")) {
+            if hostname == host_key(host) {
+                let prefix = format!("/{prefix}");
+                if pathname == prefix || pathname.starts_with(&format!("{prefix}/")) {
                     return true;
                 }
             }
-        }
-        if hostname == *entry {
+        } else if hostname == host_key(entry) {
             return true;
         }
     }
@@ -122,5 +131,27 @@ mod tests {
             "/anthropics-evil/project"
         ));
         assert!(is_preapproved_host("doc.rust-lang.org", "/book/"));
+    }
+
+    #[test]
+    fn host_key_lowercases_strips_dot_and_www() {
+        assert_eq!(host_key("WWW.Example.COM."), "example.com");
+        assert_eq!(host_key("docs.python.org"), "docs.python.org");
+        assert_eq!(host_key("www.docs.python.org"), "docs.python.org");
+    }
+
+    #[test]
+    fn preapproved_host_uses_host_key() {
+        assert!(is_preapproved_host("WWW.docs.python.org.", "/3/"));
+        assert!(is_preapproved_host(
+            "www.github.com",
+            "/anthropics/claude-code"
+        ));
+        assert!(!is_preapproved_host("www.github.com", "/other/repo"));
+        assert!(is_preapproved_host("php.net", "/"));
+        assert!(!is_preapproved_host(
+            "gist.github.com",
+            "/anthropics/claude-code"
+        ));
     }
 }

--- a/crates/aish-tools/src/web_fetch/utils.rs
+++ b/crates/aish-tools/src/web_fetch/utils.rs
@@ -358,11 +358,7 @@ fn is_permitted_redirect(original: &Url, redirect_url: &Url) -> bool {
     let Some(redirect_host) = redirect_url.host_str() else {
         return false;
     };
-    strip_www(original_host) == strip_www(redirect_host)
-}
-
-fn strip_www(host: &str) -> &str {
-    host.strip_prefix("www.").unwrap_or(host)
+    super::preapproved::host_key(original_host) == super::preapproved::host_key(redirect_host)
 }
 
 async fn read_limited_body(response: reqwest::Response) -> Result<Vec<u8>, String> {
@@ -554,6 +550,11 @@ mod tests {
         assert!(is_permitted_redirect(&original, &same));
         assert!(!is_permitted_redirect(&original, &other));
         assert!(!is_permitted_redirect(&original, &http));
+        let mixed_case = Url::parse("https://WWW.EXAMPLE.COM/docs").unwrap();
+        assert!(is_permitted_redirect(&original, &mixed_case));
+        let gist = Url::parse("https://gist.github.com/docs").unwrap();
+        let github = Url::parse("https://github.com/docs").unwrap();
+        assert!(!is_permitted_redirect(&github, &gist));
     }
 
     #[test]

--- a/crates/aish-tools/src/web_fetch/utils.rs
+++ b/crates/aish-tools/src/web_fetch/utils.rs
@@ -552,9 +552,6 @@ mod tests {
         assert!(!is_permitted_redirect(&original, &http));
         let mixed_case = Url::parse("https://WWW.EXAMPLE.COM/docs").unwrap();
         assert!(is_permitted_redirect(&original, &mixed_case));
-        let gist = Url::parse("https://gist.github.com/docs").unwrap();
-        let github = Url::parse("https://github.com/docs").unwrap();
-        assert!(!is_permitted_redirect(&github, &gist));
     }
 
     #[test]

--- a/crates/aish-tools/src/web_fetch/web_fetch.rs
+++ b/crates/aish-tools/src/web_fetch/web_fetch.rs
@@ -346,11 +346,5 @@ mod tests {
             tool().approval_memory_key(&args).as_deref(),
             Some("example.com")
         );
-        let apex = serde_json::json!({ "url": "https://example.com/b" });
-        let www = serde_json::json!({ "url": "https://www.example.com/c" });
-        assert_eq!(
-            tool().approval_memory_key(&apex),
-            tool().approval_memory_key(&www)
-        );
     }
 }

--- a/crates/aish-tools/src/web_fetch/web_fetch.rs
+++ b/crates/aish-tools/src/web_fetch/web_fetch.rs
@@ -128,24 +128,31 @@ impl Tool for WebFetchTool {
             }
         };
 
-        let hostname = normalized.host_str().unwrap_or("").to_string();
-        if is_preapproved_host(&hostname, normalized.path()) {
+        let hostname = normalized.host_str().unwrap_or("");
+        if is_preapproved_host(hostname, normalized.path()) {
             return PreflightResult::Allow;
         }
 
+        let host = super::preapproved::host_key(hostname);
         let message = aish_i18n::t_with_args(
             "tools.web_fetch.confirm_fetch",
-            &HashMap::from([("host".to_string(), hostname.clone())]),
+            &HashMap::from([("host".to_string(), host)]),
         );
         PreflightResult::Confirm {
             message: message.clone(),
             security: Some(PreflightSecurityContext::fallback(
                 TOOL_NAME,
-                Some(hostname),
+                Some(url.to_string()),
                 message,
                 SecurityPanelMode::Confirm,
             )),
         }
+    }
+
+    fn approval_memory_key(&self, args: &serde_json::Value) -> Option<String> {
+        let url = args.get("url")?.as_str()?;
+        let parsed = validate_and_normalize_url(url).ok()?;
+        parsed.host_str().map(super::preapproved::host_key)
     }
 
     fn execute(&self, _args: serde_json::Value) -> ToolResult {
@@ -287,5 +294,63 @@ mod tests {
                 "expected fetched content to contain {expected:?}"
             );
         }
+    }
+
+    fn tool() -> WebFetchTool {
+        WebFetchTool::new("", "", "", Some(0.1), Some(256))
+    }
+
+    #[test]
+    fn preflight_allows_preapproved_host_key() {
+        let args = serde_json::json!({
+            "url": "https://WWW.docs.python.org./3/",
+            "prompt": "summarize"
+        });
+        assert_eq!(tool().preflight(&args), PreflightResult::Allow);
+    }
+
+    #[test]
+    fn preflight_confirms_host_key_and_shows_full_url() {
+        let url = "https://WWW.Example.COM/path?token=secret";
+        let args = serde_json::json!({ "url": url, "prompt": "summarize" });
+        match tool().preflight(&args) {
+            PreflightResult::Confirm { message, security } => {
+                assert!(message.contains("example.com"), "{message}");
+                assert!(
+                    !message.to_ascii_lowercase().contains("www.example.com"),
+                    "{message}"
+                );
+                let security = security.expect("confirm should include security context");
+                assert_eq!(security.target.as_deref(), Some(url));
+            }
+            other => panic!("expected Confirm, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn preflight_still_confirms_github_outside_anthropics() {
+        let args = serde_json::json!({
+            "url": "https://github.com/AI-Shell-Team/aish",
+            "prompt": "summarize"
+        });
+        assert!(matches!(
+            tool().preflight(&args),
+            PreflightResult::Confirm { .. }
+        ));
+    }
+
+    #[test]
+    fn approval_memory_key_is_host_key() {
+        let args = serde_json::json!({ "url": "https://WWW.Example.COM./a" });
+        assert_eq!(
+            tool().approval_memory_key(&args).as_deref(),
+            Some("example.com")
+        );
+        let apex = serde_json::json!({ "url": "https://example.com/b" });
+        let www = serde_json::json!({ "url": "https://www.example.com/c" });
+        assert_eq!(
+            tool().approval_memory_key(&apex),
+            tool().approval_memory_key(&www)
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Problem: WebFetch 对非预批准站点每次确认，「记住本次」无效（approval memory 只认 bash 的 `command`）。
- Changes: 按 Host key 做预批准匹配、确认问句和会话记住；面板详情展示完整 URL；`web_fetch` 作为 skill / 展示别名。
- Related Issue: #458

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Other

## Scope

- [ ] Core shell / PTY
- [x] AI agent / LLM
- [x] Skills / Tools
- [ ] Security
- [ ] Configuration
- [x] CLI / Interface
- [ ] Packaging / Installation
- [ ] CI/CD
- [ ] Documentation

## User-visible Changes

非预批准站点的确认问句显示 Host key（`www.` 与 apex 视为同一站），面板详情为完整 URL。「记住本次」在当前会话内对该 Host key 不再询问；`/forget-approvals` 会清掉这些记住的站点。

## Compatibility

- Backward compatible? Yes
- Config changes? No

## Testing

Host key 匹配、会话记住、以及 `web_fetch` 别名已有对应单测。

## Checklist

- [x] Code follows project style
- [x] Tests added if needed
- [ ] Documentation updated if needed

Closes #458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remembered approvals for WebFetch hosts during a session.
  * Recognized equivalent tool-name aliases, including `WebFetch` and `web_fetch`.
  * Added normalized host matching for case differences, trailing dots, and `www.` prefixes.

* **Bug Fixes**
  * Improved redirect and preapproved-host matching.
  * Preserved full URLs in approval confirmations while using normalized hosts for validation.
  * Updated `/forget-approvals` to clear command and host approvals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->