### PR TITLE
Release v0.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.11] - 2026-08-18
+
+### Added
+
+- Startup update check in the interactive shell: after entering the REPL, if `cdn.aishell.ai` has a newer release, show a one-time omp-style tip (`check_update_on_startup`, default `true`; failures stay silent).
+- Setup model picker shows the built-in local catalog immediately instead of blocking on `GET /models`; only Ollama, vLLM, and endpoints without a local catalog discover models online, and failed discovery no longer silently substitutes a built-in list.
+- Refreshed the built-in local model catalog so known providers show current model IDs in setup.
+
+### Changed
+
+- `aish update` output is denser and less debug-like, progress placeholders are fixed, and the `y/N` confirm is dropped so at most one sudo prompt remains.
+
+### Fixed
+
+- WebFetch "remember this session" now keys on Host (not bash command memory), shows the full URL in the confirm panel, and treats `web_fetch` as an alias of `WebFetch` for skills and display.
+- Chat Completions requests send `max_completion_tokens` so newer OpenAI-compatible gateways that reject `max_tokens` or treat a missing budget as `0` no longer break tool probes and live tool calls.
+- Setup live model discovery strips ANSI/control sequences from untrusted HTTP error bodies before they reach the terminal.
+
 ## [0.3.10] - 2026-08-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "aish-cli"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "aish-config"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "aish-context"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "aish-core",
  "serde",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "aish-core"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aish-hosts"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "aish-i18n"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "aish-llm"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "aish-context",
  "aish-core",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "aish-md-table"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "richrs",
  "unicode-width",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "aish-memory"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "aish-core",
  "chrono",
@@ -159,14 +159,14 @@ dependencies = [
 
 [[package]]
 name = "aish-prompts"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "dirs 5.0.1",
 ]
 
 [[package]]
 name = "aish-pty"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "aish-scripts"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "dirs 5.0.1",
  "regex",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "aish-security"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "libc",
  "regex",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "aish-session"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "aish-core",
  "chrono",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "aish-shell"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "aish-config",
  "aish-context",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "aish-skills"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "aish-tools"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "aish-ui"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "crossterm 0.28.1",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.10"
+version = "0.3.11"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.89"


### PR DESCRIPTION
## Summary
- Bump version to `0.3.11` (`Cargo.toml` / `Cargo.lock`)
- Add `CHANGELOG.md` section for 0.3.11 covering changes since 0.3.10

### Highlights
- **Added**: startup update check tip in REPL; setup shows local model catalog immediately; refreshed built-in model IDs
- **Changed**: denser `aish update` output, fixed progress placeholders, drop `y/N` confirm (at most one sudo prompt)
- **Fixed**: WebFetch session remember by Host key; chat completions `max_completion_tokens`; strip ANSI from setup discovery errors

## Local checks
- [x] `python3 packaging/scripts/release_metadata.py --expected-version 0.3.11`
- [x] `make ci-check`
- Note: `packaging/tests/test_resolve_release_pr.py` is not present in this tree (manual step skipped)

## Release prep
Please run **Release Preparation** with this PR number before merge:
```bash
gh workflow run release-preparation.yml \
  --repo AI-Shell-Team/aish \
  --ref main \
  -f pr_number=<PR_NUMBER>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup update checks.
  * Setup model selection is now non-blocking, with refreshed local catalogs.
  * Improved WebFetch session handling.
  * Updated Chat Completions token handling.

* **Bug Fixes**
  * Made update output more concise.
  * Sanitized terminal control sequences in model-discovery errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->