### PR TITLE
fix(shell): stop sub-agent animation thread on Ctrl+C cancellation

### DIFF
--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -1763,6 +1763,11 @@ impl AishShell {
                         }
                         // Stop progress spinner started at ToolExecutionStart.
                         animation_ref.stop();
+                        // Also stop the sub-agent thinking animation so its
+                        // background thread does not keep overwriting the
+                        // terminal line with \r\x1b[K while we print the
+                        // tool result and status indicator below.
+                        sub_agent_animation_ref.stop();
                         let tool_ok = event
                             .data
                             .get("ok")

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -666,6 +666,11 @@ pub struct AishShell {
     last_ctrl_c: Option<std::time::Instant>,
     /// Shared animation spinner, stored so it can be stopped on cancellation.
     animation: Arc<SharedAnimation>,
+    /// Sub-agent thinking animation (`  └─ explore · 思考中`), stored so it
+    /// can be stopped on cancellation — without this, a Ctrl+C during a
+    /// sub-agent tool loop leaks the animation thread, which keeps
+    /// overwriting the terminal line.
+    sub_agent_animation: Arc<SubAgentThinkingAnimation>,
     /// Session history of collapsed outputs for Ctrl+O browsing.
     expand_history: Arc<Mutex<crate::expand_history::ExpandHistory>>,
     /// Shared terminal session recorder for asciinema v2 recording.
@@ -1341,6 +1346,12 @@ impl AishShell {
         }
 
         let shared_recorder_cb = shared_recorder.clone();
+        // Capture the cancellation token so the event callback can check
+        // is_cancelled() before starting animations — late LLM events
+        // arriving after Ctrl+C would otherwise restart the animation
+        // thread, leaking it.
+        let cancel_token_for_cb = llm_session.cancellation_token_arc();
+
         let event_callback: Arc<dyn Fn(LlmEvent) -> Option<LlmCallbackResult> + Send + Sync> =
             Arc::new(move |event: LlmEvent| {
                 // Helper: clear multi-line reasoning overlay and reset state.
@@ -1368,7 +1379,9 @@ impl AishShell {
                         reasoning_active_ref.store(false, Ordering::SeqCst);
                         compaction_active_ref.store(false, Ordering::SeqCst);
                         compaction_notice_shown_ref.store(false, Ordering::SeqCst);
-                        animation_ref.start(&t("shell.status.thinking"));
+                        if !cancel_token_for_cb.is_cancelled() {
+                            animation_ref.start(&t("shell.status.thinking"));
+                        }
                     }
                     LlmEventType::OpEnd if crate::llm_event_ui::sub_agent_llm_event(&event) => {
                         // A sub-agent OpEnd marks one sub-session finishing, not the
@@ -1397,7 +1410,9 @@ impl AishShell {
                         *thinking_start_ref.lock().unwrap() = None;
                     }
                     LlmEventType::ContextCompactionStart => {
-                        if !compaction_active_ref.swap(true, Ordering::SeqCst) {
+                        if !compaction_active_ref.swap(true, Ordering::SeqCst)
+                            && !cancel_token_for_cb.is_cancelled()
+                        {
                             animation_ref.start(&t("shell.status.compacting_context"));
                         }
                     }
@@ -1410,12 +1425,17 @@ impl AishShell {
                             }
                         }
                     }
-                    LlmEventType::GenerationStart if react_agent_llm_event(&event) => {}
                     LlmEventType::GenerationStart
                         if crate::llm_event_ui::sub_agent_llm_event(&event) =>
                     {
                         animation_ref.stop();
                         clear_reasoning();
+                        // Late sub-agent events arriving after Ctrl+C would
+                        // restart the animation thread — bail out instead.
+                        if cancel_token_for_cb.is_cancelled() {
+                            sub_agent_animation_ref.stop();
+                            return None;
+                        }
                         if let Some(prefix) =
                             crate::llm_event_ui::sub_agent_thinking_animation_prefix(&event)
                         {
@@ -1436,7 +1456,9 @@ impl AishShell {
                         reasoning_buf_ref.lock().unwrap().clear();
                         reasoning_frame_ref.store(0, Ordering::SeqCst);
                         renderer_ref.lock().unwrap().reset();
-                        if sub_agent_active_count_ref.load(Ordering::SeqCst) == 0 {
+                        if sub_agent_active_count_ref.load(Ordering::SeqCst) == 0
+                            && !cancel_token_for_cb.is_cancelled()
+                        {
                             animation_ref.start(&t("shell.status.thinking"));
                         }
                     }
@@ -1681,6 +1703,7 @@ impl AishShell {
                                 && !react_agent_llm_event(&event)
                                 && !is_interactive_tool
                                 && !bash_needs_tty
+                                && !cancel_token_for_cb.is_cancelled()
                             {
                                 animation_ref.start(&theme::tool_status_label(name));
                             }
@@ -2095,6 +2118,7 @@ impl AishShell {
             interruption: InterruptionState::default(),
             last_ctrl_c: None,
             animation,
+            sub_agent_animation: sub_agent_animation.clone(),
             expand_history,
             shared_recorder,
             inline_ai: None,
@@ -2552,6 +2576,7 @@ impl AishShell {
                                 }
                                 Err(aish_core::AishError::Cancelled) => {
                                     self.animation.stop();
+                                    self.sub_agent_animation.stop();
                                     crate::recorder::shared_record_output(
                                         &self.shared_recorder,
                                         &format!("{}\r\n", theme::warning("Interrupted")),
@@ -2622,6 +2647,7 @@ impl AishShell {
                     match result {
                         Ok(response) => {
                             if self.ai_handler.cancellation_token().is_cancelled() {
+                                self.sub_agent_animation.stop();
                                 // Agent short-circuit cancel returns Ok("") — show the same
                                 // user-facing line as Err(Cancelled). Do not treat as success
                                 // (no plan approval / history-as-ok).
@@ -2793,6 +2819,7 @@ impl AishShell {
                         }
                         Err(aish_core::AishError::Cancelled) => {
                             self.animation.stop();
+                            self.sub_agent_animation.stop();
                             println!("{}", theme::warning(&t("shell.interrupted")));
                         }
                         Err(e) => {
@@ -2961,6 +2988,7 @@ impl AishShell {
                                 match result {
                                     Ok(response) => {
                                         if self.ai_handler.cancellation_token().is_cancelled() {
+                                            self.sub_agent_animation.stop();
                                             // Same as Err(Cancelled): do not persist/history as success.
                                             println!("{}", theme::warning(&t("shell.interrupted")));
                                         } else {
@@ -2982,6 +3010,7 @@ impl AishShell {
                                     }
                                     Err(aish_core::AishError::Cancelled) => {
                                         self.animation.stop();
+                                        self.sub_agent_animation.stop();
                                         println!("{}", theme::warning(&t("shell.interrupted")));
                                     }
                                     Err(e) => {
@@ -3320,6 +3349,7 @@ impl AishShell {
                 match result {
                     Ok(response) => {
                         if self.ai_handler.cancellation_token().is_cancelled() {
+                            self.sub_agent_animation.stop();
                             println!("{}", theme::warning(&t("shell.interrupted")));
                         } else if !did_stream && !response.trim().is_empty() {
                             let mut sep = ShellRenderer::new();
@@ -3330,6 +3360,7 @@ impl AishShell {
                         }
                     }
                     Err(aish_core::AishError::Cancelled) => {
+                        self.sub_agent_animation.stop();
                         println!("{}", theme::warning(&t("shell.interrupted")));
                     }
                     Err(e) => {
@@ -4725,6 +4756,7 @@ impl AishShell {
         esc_watcher.stop();
         Self::restore_ai_sigint_handler(old_sigint);
         self.animation.stop();
+        self.sub_agent_animation.stop();
 
         match result {
             Ok(_) => {
@@ -4732,6 +4764,7 @@ impl AishShell {
                 // and outcome (trusted on Low/Medium, quarantined on High).
             }
             Err(aish_core::AishError::Cancelled) => {
+                self.sub_agent_animation.stop();
                 println!(
                     "\n{}",
                     t_with_args("shell.skill.vetter.cancelled", &name_args)
@@ -5661,6 +5694,7 @@ impl AishShell {
         let report = match diagnose_result {
             Ok(parsed) => parsed,
             Err(aish_core::AishError::Cancelled) => {
+                self.sub_agent_animation.stop();
                 println!("{}", theme::warning(&t("shell.command_cancelled")));
                 return;
             }
@@ -7644,6 +7678,7 @@ impl AishShell {
                 );
             }
             Err(aish_core::AishError::Cancelled) => {
+                self.sub_agent_animation.stop();
                 eprintln!("{}", theme::warning(&t("shell.setup.cancelled")));
             }
             Err(e) => {

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -671,6 +671,11 @@ pub struct AishShell {
     /// sub-agent tool loop leaks the animation thread, which keeps
     /// overwriting the terminal line.
     sub_agent_animation: Arc<SubAgentThinkingAnimation>,
+    /// Monotonic operation generation counter, bumped before each AI turn.
+    /// The event callback captures the generation at callback-build time and
+    /// rejects events from stale (older) operations to avoid restarting
+    /// animations after cancellation + new-operation reset.
+    ai_op_generation: Arc<std::sync::atomic::AtomicU64>,
     /// Session history of collapsed outputs for Ctrl+O browsing.
     expand_history: Arc<Mutex<crate::expand_history::ExpandHistory>>,
     /// Shared terminal session recorder for asciinema v2 recording.
@@ -1279,6 +1284,8 @@ impl AishShell {
         let sub_agent_active_count_ref = sub_agent_active_count.clone();
         let sub_agent_animation = Arc::new(SubAgentThinkingAnimation::new());
         let sub_agent_animation_ref = sub_agent_animation.clone();
+        let ai_op_generation = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let ai_op_generation_cb = ai_op_generation.clone();
 
         // Shared history of collapsed bash outputs for Ctrl+O browsing.
         let expand_history = Arc::new(Mutex::new(crate::expand_history::ExpandHistory::new()));
@@ -1352,6 +1359,12 @@ impl AishShell {
         // thread, leaking it.
         let cancel_token_for_cb = llm_session.cancellation_token_arc();
 
+        // Per-operation generation: the callback captures the generation
+        // at OpStart and rejects events whose generation is stale (from a
+        // prior cancelled operation whose token was reset).
+        let op_gen = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let ai_op_generation_cb_ref = ai_op_generation_cb.clone();
+
         let event_callback: Arc<dyn Fn(LlmEvent) -> Option<LlmCallbackResult> + Send + Sync> =
             Arc::new(move |event: LlmEvent| {
                 // Helper: clear multi-line reasoning overlay and reset state.
@@ -1368,6 +1381,34 @@ impl AishShell {
                     reasoning_active_ref.store(false, Ordering::SeqCst);
                 };
 
+                // Reject events from a stale (older) operation whose token
+                // was reset by a newer operation.
+                let is_stale = || {
+                    op_gen.load(Ordering::SeqCst) != ai_op_generation_cb_ref.load(Ordering::SeqCst)
+                };
+
+                // Start `anim` with label only if the operation has not been
+                // cancelled and is not stale.  Re-check after start() to
+                // close the TOCTOU window between is_cancelled() and start().
+                let guarded_start = |anim: &SharedAnimation, label: &str| {
+                    if !cancel_token_for_cb.is_cancelled() && !is_stale() {
+                        anim.start(label);
+                        if cancel_token_for_cb.is_cancelled() {
+                            anim.stop();
+                        }
+                    }
+                };
+                // Same guard for sub-agent animation (two-arg start).
+                let guarded_start_sub =
+                    |anim: &SubAgentThinkingAnimation, prefix: &str, label: &str| {
+                        if !cancel_token_for_cb.is_cancelled() && !is_stale() {
+                            anim.start(prefix, label);
+                            if cancel_token_for_cb.is_cancelled() {
+                                anim.stop();
+                            }
+                        }
+                    };
+
                 match event.event_type {
                     LlmEventType::OpStart => {
                         // Operation begins — start thinking animation
@@ -1379,9 +1420,11 @@ impl AishShell {
                         reasoning_active_ref.store(false, Ordering::SeqCst);
                         compaction_active_ref.store(false, Ordering::SeqCst);
                         compaction_notice_shown_ref.store(false, Ordering::SeqCst);
-                        if !cancel_token_for_cb.is_cancelled() {
-                            animation_ref.start(&t("shell.status.thinking"));
-                        }
+                        op_gen.store(
+                            ai_op_generation_cb_ref.load(Ordering::SeqCst),
+                            Ordering::SeqCst,
+                        );
+                        guarded_start(&animation_ref, &t("shell.status.thinking"));
                     }
                     LlmEventType::OpEnd if crate::llm_event_ui::sub_agent_llm_event(&event) => {
                         // A sub-agent OpEnd marks one sub-session finishing, not the
@@ -1409,12 +1452,10 @@ impl AishShell {
                         }
                         *thinking_start_ref.lock().unwrap() = None;
                     }
-                    LlmEventType::ContextCompactionStart => {
-                        if !compaction_active_ref.swap(true, Ordering::SeqCst)
-                            && !cancel_token_for_cb.is_cancelled()
-                        {
-                            animation_ref.start(&t("shell.status.compacting_context"));
-                        }
+                    LlmEventType::ContextCompactionStart
+                        if !compaction_active_ref.swap(true, Ordering::SeqCst) =>
+                    {
+                        guarded_start(&animation_ref, &t("shell.status.compacting_context"));
                     }
                     LlmEventType::ContextCompactionEnd => {
                         compaction_active_ref.store(false, Ordering::SeqCst);
@@ -1432,14 +1473,18 @@ impl AishShell {
                         clear_reasoning();
                         // Late sub-agent events arriving after Ctrl+C would
                         // restart the animation thread — bail out instead.
-                        if cancel_token_for_cb.is_cancelled() {
+                        if cancel_token_for_cb.is_cancelled() || is_stale() {
                             sub_agent_animation_ref.stop();
                             return None;
                         }
                         if let Some(prefix) =
                             crate::llm_event_ui::sub_agent_thinking_animation_prefix(&event)
                         {
-                            sub_agent_animation_ref.start(&prefix, &t("shell.sub_agent.thinking"));
+                            guarded_start_sub(
+                                &sub_agent_animation_ref,
+                                &prefix,
+                                &t("shell.sub_agent.thinking"),
+                            );
                         }
                     }
                     LlmEventType::GenerationStart => {
@@ -1456,10 +1501,8 @@ impl AishShell {
                         reasoning_buf_ref.lock().unwrap().clear();
                         reasoning_frame_ref.store(0, Ordering::SeqCst);
                         renderer_ref.lock().unwrap().reset();
-                        if sub_agent_active_count_ref.load(Ordering::SeqCst) == 0
-                            && !cancel_token_for_cb.is_cancelled()
-                        {
-                            animation_ref.start(&t("shell.status.thinking"));
+                        if sub_agent_active_count_ref.load(Ordering::SeqCst) == 0 {
+                            guarded_start(&animation_ref, &t("shell.status.thinking"));
                         }
                     }
                     LlmEventType::GenerationEnd if react_agent_llm_event(&event) => {}
@@ -1703,9 +1746,8 @@ impl AishShell {
                                 && !react_agent_llm_event(&event)
                                 && !is_interactive_tool
                                 && !bash_needs_tty
-                                && !cancel_token_for_cb.is_cancelled()
                             {
-                                animation_ref.start(&theme::tool_status_label(name));
+                                guarded_start(&animation_ref, &theme::tool_status_label(name));
                             }
                         }
                     }
@@ -1906,6 +1948,7 @@ impl AishShell {
                             println!("{}", theme::accent(prompt_text));
                         }
                     }
+                    _ => {}
                 }
                 None // Always continue
             });
@@ -2119,6 +2162,7 @@ impl AishShell {
             last_ctrl_c: None,
             animation,
             sub_agent_animation: sub_agent_animation.clone(),
+            ai_op_generation,
             expand_history,
             shared_recorder,
             inline_ai: None,
@@ -2153,6 +2197,10 @@ impl AishShell {
 
         // Clear any leftover cancellation state from a previous operation.
         self.ai_handler.cancellation_token().reset();
+        // Bump the operation generation so the event callback can reject
+        // stale events from a prior (cancelled) operation.
+        self.ai_op_generation
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
         let token_ptr = self.ai_handler.cancellation_token() as *const CancellationToken;
         CANCEL_TOKEN_PTR.store(token_ptr as *mut (), Ordering::SeqCst);
@@ -7931,6 +7979,8 @@ impl AishShell {
     pub fn shutdown(&mut self) {
         self.set_phase(ShellPhase::Exiting);
         self.lock_pty().stop();
+        self.animation.stop();
+        self.sub_agent_animation.stop();
     }
 
     fn restart_pty_with_notice(&mut self, show_notice: bool) -> aish_core::Result<()> {

--- a/tests/repro_subagent_anim_leak.py
+++ b/tests/repro_subagent_anim_leak.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Reproduce/verify the sub_agent_animation leak bug.
+
+Spawns aish in a PTY (stdout+stderr merged), triggers a sub-agent via an
+AI prompt, sends Ctrl+C while the sub-agent is thinking, drains all
+buffered output, then checks whether NEW animation frames keep arriving.
+
+- Bug:   the animation thread keeps running; new "思考中" frames flow.
+- Fixed: the animation thread is stopped; no new frames after drain.
+
+Usage:
+    AISH_BIN=target/debug/aish python3 tests/repro_subagent_anim_leak.py
+"""
+
+import fcntl
+import os
+import re
+import select
+import struct
+import subprocess
+import sys
+import termios
+import time
+
+import pty
+
+
+def read_available(fd: int, timeout: float = 0.5) -> bytes:
+    data = b""
+    end = time.time() + timeout
+    while time.time() < end:
+        r, _, _ = select.select([fd], [], [], 0.1)
+        if r:
+            try:
+                chunk = os.read(fd, 65536)
+                if chunk:
+                    data += chunk
+            except OSError:
+                break
+    return data
+
+
+def main() -> int:
+    aish_bin = os.environ.get("AISH_BIN", "target/debug/aish")
+    if not os.path.isfile(aish_bin):
+        print(f"aish binary not found: {aish_bin}")
+        return 2
+
+    real_config_home = os.path.expanduser("~/.config")
+    tmp_config = os.environ.get("XDG_CONFIG_HOME", "/tmp/aish-repro-config")
+    os.makedirs(tmp_config, exist_ok=True)
+    dst = os.path.join(tmp_config, "aish")
+    if not os.path.exists(dst):
+        os.symlink(os.path.join(real_config_home, "aish"), dst)
+
+    env = os.environ.copy()
+    env["XDG_CONFIG_HOME"] = tmp_config
+    env["TERM"] = "xterm-256color"
+    env["RUST_LOG"] = "warn"
+
+    master, slave = pty.openpty()
+    winsize = struct.pack("HHHH", 40, 120, 0, 0)
+    fcntl.ioctl(master, termios.TIOCSWINSZ, winsize)
+
+    proc = subprocess.Popen(
+        [aish_bin],
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        env=env,
+        close_fds=True,
+    )
+    os.close(slave)
+    flags = fcntl.fcntl(master, fcntl.F_GETFL)
+    fcntl.fcntl(master, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+    try:
+        # Wait for prompt.
+        end = time.time() + 20
+        while time.time() < end:
+            data = read_available(master, 1.0)
+            text = data.decode("utf-8", errors="replace")
+            if "●" in text and "->" in text:
+                print("--- aish prompt reached ---")
+                break
+        else:
+            print("--- timeout waiting for prompt ---")
+            return 4
+
+        # Send AI prompt that triggers explore sub-agent (long-running task
+        # so the animation thread has time to build up frames).
+        prompt = ("; Please use the explore sub-agent to do a deep dive into "
+                  "the entire workspace structure, read all Cargo.toml files, "
+                  "and provide a comprehensive summary of every crate and its "
+                  "dependencies. This requires thorough exploration.\r")
+        os.write(master, prompt.encode())
+        print("--- AI prompt sent ---")
+
+        # Wait for sub-agent thinking line.
+        end = time.time() + 30
+        saw_sub_agent = False
+        while time.time() < end:
+            data = read_available(master, 2.0)
+            if b"explore" in data and b"\xe6\x80\x9d\xe8\x80\x83" in data:
+                saw_sub_agent = True
+                print("--- sub-agent thinking line detected ---")
+                break
+        else:
+            print("--- sub-agent not triggered; skipping ---")
+            os.write(master, b"\x03\x03")
+            return 77
+
+        # Let animation build up (3 s ensures the sub-agent's tool loop is
+        # actively running and emitting "思考中" frames).
+        time.sleep(3.0)
+        read_available(master, 0.5)
+
+        # Send Ctrl+C.
+        os.write(master, b"\x03")
+        print("--- Ctrl+C sent ---")
+        # Phase 1: drain ALL buffered output (3 s quiet period).
+        end = time.time() + 20
+        last_data = time.time()
+        drained = b""
+        while time.time() < end:
+            data = read_available(master, 0.5)
+            drained += data
+            if data:
+                last_data = time.time()
+            elif time.time() - last_data > 3.0:
+                break
+        print(f"--- drained {len(drained)} bytes ---")
+
+        # Phase 2: check for NEW output (animation still running?).
+        new_data = b""
+        end = time.time() + 5.0
+        while time.time() < end:
+            data = read_available(master, 0.5)
+            new_data += data
+
+        new_text = new_data.decode("utf-8", errors="replace")
+        new_timers = re.findall(r"(\d+\.\d+)s", new_text)
+        print(f"--- new output after drain: {len(new_data)} bytes, {len(new_timers)} timer frames ---")
+
+        if len(new_data) > 100 or len(new_timers) > 0:
+            print("\n--- BUG REPRODUCED: animation still running after Ctrl+C ---")
+            return 1
+        else:
+            print("\n--- FIX VERIFIED: animation stopped after Ctrl+C ---")
+            return 0
+
+    finally:
+        try:
+            os.write(master, b"\x03\x03")
+            proc.terminate()
+            proc.wait(timeout=5)
+        except Exception:
+            pass
+        os.close(master)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repro_subagent_anim_leak.py
+++ b/tests/repro_subagent_anim_leak.py
@@ -19,10 +19,14 @@ import select
 import struct
 import subprocess
 import sys
+import tempfile
 import termios
 import time
 
 import pty
+
+# UTF-8 bytes for "思考中" (think indicator).
+THINKING_BYTES = "\u601d\u8003\u4e2d".encode("utf-8")
 
 
 def read_available(fd: int, timeout: float = 0.5) -> bytes:
@@ -47,8 +51,7 @@ def main() -> int:
         return 2
 
     real_config_home = os.path.expanduser("~/.config")
-    tmp_config = os.environ.get("XDG_CONFIG_HOME", "/tmp/aish-repro-config")
-    os.makedirs(tmp_config, exist_ok=True)
+    tmp_config = tempfile.mkdtemp(prefix="aish-repro-")
     dst = os.path.join(tmp_config, "aish")
     if not os.path.exists(dst):
         os.symlink(os.path.join(real_config_home, "aish"), dst)
@@ -80,7 +83,7 @@ def main() -> int:
         while time.time() < end:
             data = read_available(master, 1.0)
             text = data.decode("utf-8", errors="replace")
-            if "●" in text and "->" in text:
+            if "\u25cf" in text and "->" in text:
                 print("--- aish prompt reached ---")
                 break
         else:
@@ -89,10 +92,12 @@ def main() -> int:
 
         # Send AI prompt that triggers explore sub-agent (long-running task
         # so the animation thread has time to build up frames).
-        prompt = ("; Please use the explore sub-agent to do a deep dive into "
-                  "the entire workspace structure, read all Cargo.toml files, "
-                  "and provide a comprehensive summary of every crate and its "
-                  "dependencies. This requires thorough exploration.\r")
+        prompt = (
+            "; Please use the explore sub-agent to do a deep dive into "
+            "the entire workspace structure, read all Cargo.toml files, "
+            "and provide a comprehensive summary of every crate and its "
+            "dependencies. This requires thorough exploration.\r"
+        )
         os.write(master, prompt.encode())
         print("--- AI prompt sent ---")
 
@@ -101,7 +106,7 @@ def main() -> int:
         saw_sub_agent = False
         while time.time() < end:
             data = read_available(master, 2.0)
-            if b"explore" in data and b"\xe6\x80\x9d\xe8\x80\x83" in data:
+            if b"explore" in data and THINKING_BYTES in data:
                 saw_sub_agent = True
                 print("--- sub-agent thinking line detected ---")
                 break
@@ -113,7 +118,15 @@ def main() -> int:
         # Let animation build up (3 s ensures the sub-agent's tool loop is
         # actively running and emitting "思考中" frames).
         time.sleep(3.0)
-        read_available(master, 0.5)
+        pre_ctrl_c = read_available(master, 0.5)
+        # Confirm the sub-agent animation is actually emitting frames.
+        if THINKING_BYTES not in pre_ctrl_c:
+            print(
+                "--- sub-agent animation not emitting frames before "
+                "Ctrl+C; inconclusive ---"
+            )
+            return 77
+        print("--- thinking frames confirmed before Ctrl+C ---")
 
         # Send Ctrl+C.
         os.write(master, b"\x03")
@@ -138,25 +151,57 @@ def main() -> int:
             data = read_available(master, 0.5)
             new_data += data
 
-        new_text = new_data.decode("utf-8", errors="replace")
-        new_timers = re.findall(r"(\d+\.\d+)s", new_text)
-        print(f"--- new output after drain: {len(new_data)} bytes, {len(new_timers)} timer frames ---")
+        # Verify the aish process is still alive (the leak is a
+        # background thread, not a crash).
+        if proc.poll() is not None:
+            print("--- aish process exited unexpectedly ---")
+            return 3
 
-        if len(new_data) > 100 or len(new_timers) > 0:
-            print("\n--- BUG REPRODUCED: animation still running after Ctrl+C ---")
+        # The key signal: new "思考中" frames after drain.
+        new_text = new_data.decode("utf-8", errors="replace")
+        new_thinking_frames = new_text.count(THINKING_BYTES.decode("utf-8"))
+        new_timers = re.findall(r"(\d+\.\d+)s", new_text)
+        print(
+            f"--- new output after drain: {len(new_data)} bytes, "
+            f"{new_thinking_frames} thinking frames, "
+            f"{len(new_timers)} timer frames ---"
+        )
+
+        if new_thinking_frames > 0:
+            print(
+                "\n--- BUG REPRODUCED: animation still running after "
+                "Ctrl+C ---"
+            )
             return 1
         else:
-            print("\n--- FIX VERIFIED: animation stopped after Ctrl+C ---")
+            print(
+                "\n--- FIX VERIFIED: animation stopped after Ctrl+C ---"
+            )
             return 0
 
     finally:
+        cleanup_proc(proc, master)
+
+
+def cleanup_proc(proc: subprocess.Popen, master: int) -> None:
+    """Ensure the child process and PTY are cleaned up."""
+    try:
+        os.write(master, b"\x03\x03")
+    except OSError:
+        pass
+    try:
+        proc.terminate()
+        proc.wait(timeout=5)
+    except Exception:
         try:
-            os.write(master, b"\x03\x03")
-            proc.terminate()
+            proc.kill()
             proc.wait(timeout=5)
         except Exception:
             pass
+    try:
         os.close(master)
+    except OSError:
+        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

When a sub-agent (e.g. `explore`) is running and the user presses Ctrl+C, the `SubAgentThinkingAnimation` thread keeps running and emitting "思考中" frames that overwrite the terminal line indefinitely.

## Root cause

`poll_cancelled` wins the `tokio::select!` and drops `handle_question`. The `Err(Cancelled)` path called `self.animation.stop()` but never stopped the `SubAgentThinkingAnimation` thread. Additionally, late LLM events arriving after Ctrl+C could restart the animation via `sub_agent_animation_ref.start()` in the event callback.

## Fix

1. Store `sub_agent_animation` as a struct field (mirroring the existing `animation: Arc<SharedAnimation>` pattern)
2. Call `self.sub_agent_animation.stop()` in every `Err(Cancelled)` and `Ok(is_cancelled)` path (7 paths total)
3. Add `cancel_token_for_cb.is_cancelled()` guards before `animation_ref.start()` and `sub_agent_animation_ref.start()` calls in the event callback, so late LLM events arriving after Ctrl+C cannot restart the leaked thread

## Test

Includes `tests/repro_subagent_anim_leak.py` — a PTY-based reproduction script that triggers a sub-agent, sends Ctrl+C, drains all buffered output, then checks whether new animation frames keep arriving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sub-agent animations continuing or restarting after cancellation, interruption, errors, or delayed events.
  * Improved animation cleanup when AI operations and follow-up actions shut down.
  * Prevented stale AI events from triggering animations after an operation is canceled or reset.

* **Tests**
  * Added regression coverage to verify interrupted sub-agents stop animating reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->