### PR TITLE
feat(memory): user confirmation, provenance, expiry, /memory command

### DIFF
--- a/crates/aish-core/src/types.rs
+++ b/crates/aish-core/src/types.rs
@@ -51,6 +51,14 @@ pub enum MemoryCategory {
     Other,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MemoryScope {
+    #[default]
+    User,
+    Host,
+    Project,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MemoryType {
     Llm,

--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -195,6 +195,7 @@ shell:
     sessions: "Sitzungsbaum anzeigen"
     rollback: "KI-Dateibearbeitungen dieser Sitzung prüfen und zurückrollen (edit_file/write_file)"
     undo: "Letzte Dateiänderung dieser Sitzung rückgängig machen (edit_file/write_file)"
+    memory: "Langfristige Erinnerungen anzeigen, verifizieren oder löschen"
 
   feedback:
     select_type: "Feedback-Typ auswählen"
@@ -964,6 +965,45 @@ tools:
 
   bash:
     security_handling_required: "der Bash-Befehl erfordert eine Sicherheitsbehandlung der Stufe {level}"
+
+  memory:
+    missing_action: "Parameter 'action' fehlt"
+    unknown_action: "Unbekannte Aktion: {action}. Verwenden Sie search/store/forget/list."
+    search_missing_query: "'query' fehlt für search"
+    store_missing_content: "'content' fehlt für store"
+    forget_missing_id: "'memory_id' fehlt für forget"
+    no_results: "Keine übereinstimmenden Erinnerungen gefunden."
+    stored: "Als Erinnerung #{id} gespeichert."
+    forgot: "Erinnerung #{id} vergessen."
+    not_found: "Erinnerung #{id} nicht gefunden."
+    empty: "Noch keine Erinnerungen."
+    not_available: "Erinnerungsfunktion nicht verfügbar"
+    confirm_store: "Speichern der Erinnerung bestätigen?"
+    confirm_forget: "Löschen der Erinnerung bestätigen"
+    field_category: "Kategorie"
+    field_scope: "Bereich"
+    field_ttl: "Gültigkeit"
+    field_reason: "Grund"
+    field_expires: "läuft ab"
+    expired_tag: "ABGELAUFEN"
+    list_header: "Langfristige Erinnerungen:"
+    verify_usage: "Verwendung: /memory verify <id>"
+    forget_usage: "Verwendung: /memory forget <id>"
+    invalid_id: "Ungültige Erinnerungs-ID: {id}"
+    verified: "Erinnerung #{id} verifiziert (Ablauf gelöscht)."
+    no_expired: "Keine abgelaufenen Erinnerungen."
+    cleared_expired: "{count} abgelaufene Erinnerung(en) gelöscht."
+    unknown_subcommand: "Unbekannter Unterbefehl: {subcommand}. Verwenden Sie list/verify/forget/clear-expired."
+
+  host_note:
+    missing_action: "Parameter 'action' fehlt"
+    unknown_action: "Unbekannte Aktion: {action}. Verwenden Sie store/list/forget."
+    store_missing_content: "'content' fehlt für store"
+    forget_missing_keyword: "'keyword' fehlt für forget"
+    empty: "Für diesen Host sind noch keine Notizen gespeichert."
+    stored: "Notiz gespeichert."
+    forgot: "{count} Notiz(en) entfernt."
+    forgot_none: "Keine übereinstimmenden Notizen gefunden."
 
 help:
   labels:

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -372,6 +372,7 @@ shell:
     sessions: "Show the session tree"
     rollback: "Review and roll back AI file edits (edit_file/write_file) this session"
     undo: "Undo the last file change (edit_file/write_file) this session"
+    memory: "View, verify, or forget long-term memories"
 
   record:
     started: "⏺ Recording started: {path}"
@@ -1316,6 +1317,22 @@ tools:
     not_found: "Memory #{id} not found."
     empty: "No memories yet."
     not_available: "memory not available"
+    confirm_store: "Confirm store memory?"
+    confirm_forget: "Confirm forget memory"
+    field_category: "Category"
+    field_scope: "Scope"
+    field_ttl: "TTL"
+    field_reason: "Reason"
+    field_expires: "expires"
+    expired_tag: "EXPIRED"
+    list_header: "Long-term memories:"
+    verify_usage: "Usage: /memory verify <id>"
+    forget_usage: "Usage: /memory forget <id>"
+    invalid_id: "Invalid memory ID: {id}"
+    verified: "Memory #{id} verified (expiry cleared)."
+    no_expired: "No expired memories."
+    cleared_expired: "Cleared {count} expired memorie(s)."
+    unknown_subcommand: "Unknown subcommand: {subcommand}. Use list/verify/forget/clear-expired."
 
   host_note:
     missing_action: "Missing 'action' parameter"

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -195,6 +195,7 @@ shell:
     sessions: "Mostrar el árbol de sesiones"
     rollback: "Revisar y revertir ediciones de archivo de la IA (edit_file/write_file) de esta sesión"
     undo: "Deshacer el último cambio de archivo (edit_file/write_file) de esta sesión"
+    memory: "Ver, verificar u olvidar memorias a largo plazo"
 
   feedback:
     select_type: "Seleccionar tipo de comentario"
@@ -963,6 +964,35 @@ tools:
 
   bash:
     security_handling_required: "el comando bash requiere manejo de seguridad de nivel {level}"
+
+  memory:
+    missing_action: "Falta el parámetro 'action'"
+    unknown_action: "Acción desconocida: {action}. Use search/store/forget/list."
+    search_missing_query: "Falta 'query' para search"
+    store_missing_content: "Falta 'content' para store"
+    forget_missing_id: "Falta 'memory_id' para forget"
+    no_results: "No se encontraron memorias coincidentes."
+    stored: "Almacenado como memoria #{id}."
+    forgot: "Se olvidó la memoria #{id}."
+    not_found: "No se encontró la memoria #{id}."
+    empty: "Aún no hay memorias."
+    not_available: "memoria no disponible"
+    confirm_store: "¿Confirmar guardar memoria?"
+    confirm_forget: "Confirmar olvido de memoria"
+    field_category: "Categoría"
+    field_scope: "Ámbito"
+    field_ttl: "TTL"
+    field_reason: "Razón"
+    field_expires: "expira"
+    expired_tag: "EXPIRADO"
+    list_header: "Memorias a largo plazo:"
+    verify_usage: "Uso: /memory verify <id>"
+    forget_usage: "Uso: /memory forget <id>"
+    invalid_id: "ID de memoria inválido: {id}"
+    verified: "Memoria #{id} verificada (expiración borrada)."
+    no_expired: "No hay memorias expiradas."
+    cleared_expired: "Se borraron {count} memoria(s) expirada(s)."
+    unknown_subcommand: "Subcomando desconocido: {subcommand}. Use list/verify/forget/clear-expired."
 
 help:
   labels:

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -195,6 +195,7 @@ shell:
     sessions: "Afficher l'arborescence des sessions"
     rollback: "Examiner et annuler les modifications de fichier de l'IA (edit_file/write_file) cette session"
     undo: "Annuler la dernière modification de fichier (edit_file/write_file) cette session"
+    memory: "Visualiser, vérifier ou oublier les mémoires"
 
   feedback:
     select_type: "Sélectionner le type de commentaire"
@@ -964,6 +965,35 @@ tools:
 
   bash:
     security_handling_required: "la commande bash nécessite un traitement de sécurité de niveau {level}"
+
+  memory:
+    missing_action: "Paramètre 'action' manquant"
+    unknown_action: "Action inconnue : {action}. Utilisez search/store/forget/list."
+    search_missing_query: "Paramètre 'query' manquant pour search"
+    store_missing_content: "Paramètre 'content' manquant pour store"
+    forget_missing_id: "Paramètre 'memory_id' manquant pour forget"
+    no_results: "Aucune mémoire correspondante trouvée."
+    stored: "Enregistré comme mémoire #{id}."
+    forgot: "Mémoire #{id} oubliée."
+    not_found: "Mémoire #{id} introuvable."
+    empty: "Aucune mémoire pour le moment."
+    not_available: "mémoire indisponible"
+    confirm_store: "Confirmer la sauvegarde de la mémoire ?"
+    confirm_forget: "Confirmer l'oubli de la mémoire"
+    field_category: "Catégorie"
+    field_scope: "Portée"
+    field_ttl: "Durée de vie"
+    field_reason: "Raison"
+    field_expires: "expire"
+    expired_tag: "EXPIRÉ"
+    list_header: "Mémoires à long terme :"
+    verify_usage: "Usage : /memory verify <id>"
+    forget_usage: "Usage : /memory forget <id>"
+    invalid_id: "ID de mémoire invalide : {id}"
+    verified: "Mémoire #{id} vérifiée (expiration effacée)."
+    no_expired: "Aucune mémoire expirée."
+    cleared_expired: "{count} mémoire(s) expirée(s) effacée(s)."
+    unknown_subcommand: "Sous-commande inconnue : {subcommand}. Utilisez list/verify/forget/clear-expired."
 
 help:
   labels:

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -195,6 +195,7 @@ shell:
     sessions: "セッションツリーを表示"
     rollback: "このセッションの AI によるファイル編集を確認・ロールバック (edit_file/write_file)"
     undo: "このセッションの最後のファイル変更を取り消す (edit_file/write_file)"
+    memory: "長期メモリの表示、検証、削除"
 
   feedback:
     select_type: "フィードバックの種類を選択"
@@ -953,6 +954,35 @@ tools:
       text: "ユーザー入力: {value}"
       empty_answer: "ユーザーは空の回答を返しました。"
       cancelled: "ユーザーが質問をキャンセルしました。"
+
+  memory:
+    missing_action: "'action' パラメータが不足しています"
+    unknown_action: "不明なアクションです: {action}。search/store/forget/list を使用してください。"
+    search_missing_query: "検索に 'query' が必要です"
+    store_missing_content: "保存に 'content' が必要です"
+    forget_missing_id: "削除に 'memory_id' が必要です"
+    no_results: "一致するメモリが見つかりませんでした。"
+    stored: "メモリ #{id} として保存しました。"
+    forgot: "メモリ #{id} を削除しました。"
+    not_found: "メモリ #{id} が見つかりません。"
+    empty: "まだメモリはありません。"
+    not_available: "メモリ機能は利用できません"
+    confirm_store: "メモリの保存を確認しますか？"
+    confirm_forget: "メモリの削除を確認"
+    field_category: "カテゴリ"
+    field_scope: "スコープ"
+    field_ttl: "有効期限"
+    field_reason: "理由"
+    field_expires: "期限切れ"
+    expired_tag: "期限切れ"
+    list_header: "長期メモリ："
+    verify_usage: "使用法：/memory verify <id>"
+    forget_usage: "使用法：/memory forget <id>"
+    invalid_id: "無効なメモリ ID：{id}"
+    verified: "メモリ #{id} を検証しました（期限をクリア）。"
+    no_expired: "期限切れのメモリはありません。"
+    cleared_expired: "{count} 件の期限切れメモリを削除しました。"
+    unknown_subcommand: "不明なサブコマンド：{subcommand}。list/verify/forget/clear-expired を使用してください。"
 
   smart_log:
     summary:

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -372,6 +372,7 @@ shell:
     sessions: "显示会话树"
     rollback: "查看并回滚本次会话中 AI 的文件修改 (edit_file/write_file)"
     undo: "撤销本次会话最后一次文件修改 (edit_file/write_file)"
+    memory: "查看、验证或删除长期记忆"
 
   record:
     started: "⏺ 录制已开始: {path}"
@@ -1315,6 +1316,22 @@ tools:
     not_found: "未找到记忆 #{id}。"
     empty: "还没有记忆。"
     not_available: "记忆功能不可用"
+    confirm_store: "确认存储记忆？"
+    confirm_forget: "确认删除记忆"
+    field_category: "分类"
+    field_scope: "范围"
+    field_ttl: "有效期"
+    field_reason: "原因"
+    field_expires: "过期"
+    expired_tag: "已过期"
+    list_header: "长期记忆："
+    verify_usage: "用法：/memory verify <id>"
+    forget_usage: "用法：/memory forget <id>"
+    invalid_id: "无效的记忆 ID：{id}"
+    verified: "记忆 #{id} 已验证（过期时间已清除）。"
+    no_expired: "没有过期的记忆。"
+    cleared_expired: "已清除 {count} 条过期记忆。"
+    unknown_subcommand: "未知子命令：{subcommand}。可用 list/verify/forget/clear-expired。"
 
   host_note:
     missing_action: "缺少 'action' 参数"

--- a/crates/aish-memory/src/lib.rs
+++ b/crates/aish-memory/src/lib.rs
@@ -17,4 +17,4 @@ pub mod manager;
 pub mod models;
 
 pub use manager::MemoryManager;
-pub use models::MemoryEntry;
+pub use models::{MemoryEntry, MemorySource};

--- a/crates/aish-memory/src/manager.rs
+++ b/crates/aish-memory/src/manager.rs
@@ -224,7 +224,8 @@ impl MemoryManager {
     }
 
     /// Re-verify a memory entry by ID: updates `last_verified_at` to today.
-    /// If `new_ttl_seconds` is provided, also resets `expires_at`.
+    /// If `new_ttl_seconds` is provided, resets `expires_at` to now + ttl.
+    /// If `new_ttl_seconds` is None, clears `expires_at` (makes the entry non-expiring).
     /// Returns true if the entry was found and updated.
     pub fn verify(
         &mut self,
@@ -237,12 +238,18 @@ impl MemoryManager {
         for entry in &mut self.entries {
             if entry.id == id {
                 entry.last_verified_at = Some(now_rfc.clone());
-                if let Some(secs) = new_ttl_seconds {
-                    entry.expires_at = Some(
-                        (now + chrono::Duration::seconds(secs as i64))
-                            .format("%Y-%m-%dT%H:%M:%SZ")
-                            .to_string(),
-                    );
+                match new_ttl_seconds {
+                    Some(secs) => {
+                        entry.expires_at = Some(
+                            (now + chrono::Duration::seconds(secs as i64))
+                                .format("%Y-%m-%dT%H:%M:%SZ")
+                                .to_string(),
+                        );
+                    }
+                    None => {
+                        // Clear expiry — the entry becomes non-expiring.
+                        entry.expires_at = None;
+                    }
                 }
                 found = true;
                 break;
@@ -417,6 +424,9 @@ fn parse_file(path: &Path) -> aish_core::Result<Vec<MemoryEntry>> {
     let mut entries = Vec::new();
     let mut current_body: Vec<String> = Vec::new();
     let mut current_meta: Option<ParsedMeta> = None;
+    // Once content lines start after the metadata block, subsequent `> ` lines
+    // belong to the content body (e.g. markdown blockquotes), not metadata.
+    let mut in_content = false;
 
     for line in content.lines() {
         if let Some(rest) = line.strip_prefix("## [") {
@@ -427,7 +437,8 @@ fn parse_file(path: &Path) -> aish_core::Result<Vec<MemoryEntry>> {
                 current_body.clear();
             }
             current_meta = parse_header(rest);
-        } else if line.starts_with("> ") {
+            in_content = false;
+        } else if !in_content && line.starts_with("> ") {
             // v2 metadata line — attach to current meta if present
             if let Some(meta) = current_meta.as_mut() {
                 let kv = &line[2..];
@@ -449,6 +460,7 @@ fn parse_file(path: &Path) -> aish_core::Result<Vec<MemoryEntry>> {
                 }
             }
         } else if current_meta.is_some() {
+            in_content = true;
             current_body.push(line.to_string());
         }
     }
@@ -974,6 +986,69 @@ mod tests {
         let ctx = mgr.get_session_context();
         assert!(!ctx.is_empty());
         assert!(ctx.contains("test entry"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_verify_none_clears_expiry() {
+        let dir = std::env::temp_dir().join("aish_memory_test_verify_clears");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("MEMORY.md");
+
+        let mut mgr = MemoryManager::new(path).unwrap();
+        let id = mgr
+            .store_with_provenance(
+                "temp fact",
+                MemoryCategory::Other,
+                MemoryScope::User,
+                MemorySource { label: "test".to_string(), session_uuid: None, host: None },
+                0.8,
+                Some(3600), // 1 hour TTL
+            )
+            .unwrap();
+        // Entry has expires_at set
+        assert!(mgr.list()[0].expires_at.is_some());
+
+        // verify(id, None) should clear expires_at
+        let ok = mgr.verify(id, None).unwrap();
+        assert!(ok);
+        let entry = mgr.list().iter().find(|e| e.id == id).unwrap();
+        assert!(entry.expires_at.is_none(), "expires_at should be cleared");
+        assert!(entry.last_verified_at.is_some(), "last_verified_at should be set");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_parse_content_with_blockquote() {
+        // Content containing `> ` lines (e.g. markdown blockquotes) must not
+        // be misinterpreted as v2 metadata lines.
+        let dir = std::env::temp_dir().join("aish_memory_test_blockquote");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("MEMORY.md");
+
+        let mut mgr = MemoryManager::new(path.clone()).unwrap();
+        let content = "User said:\n> This is a quote\n> source: not metadata";
+        let id = mgr
+            .store_with_provenance(
+                content,
+                MemoryCategory::Other,
+                MemoryScope::User,
+                MemorySource { label: "test".to_string(), session_uuid: None, host: None },
+                0.8,
+                None,
+            )
+            .unwrap();
+
+        // Reload from disk and verify content is preserved
+        let mgr2 = MemoryManager::new(path).unwrap();
+        let entry = mgr2.list().iter().find(|e| e.id == id).unwrap();
+        assert!(entry.content.contains("> This is a quote"), "blockquote lost");
+        assert!(entry.content.contains("> source: not metadata"), "metadata-like line lost");
+        assert_eq!(entry.source, "test", "source corrupted by content line");
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/aish-memory/src/manager.rs
+++ b/crates/aish-memory/src/manager.rs
@@ -157,7 +157,7 @@ impl MemoryManager {
                 .into_iter()
                 .take(limit)
                 .map(|i| &self.entries[i])
- .collect();
+                .collect();
         }
 
         let now = Utc::now().format("%Y-%m-%d").to_string();
@@ -227,11 +227,7 @@ impl MemoryManager {
     /// If `new_ttl_seconds` is provided, resets `expires_at` to now + ttl.
     /// If `new_ttl_seconds` is None, clears `expires_at` (makes the entry non-expiring).
     /// Returns true if the entry was found and updated.
-    pub fn verify(
-        &mut self,
-        id: i64,
-        new_ttl_seconds: Option<u64>,
-    ) -> aish_core::Result<bool> {
+    pub fn verify(&mut self, id: i64, new_ttl_seconds: Option<u64>) -> aish_core::Result<bool> {
         let now = Utc::now();
         let now_rfc = now.format("%Y-%m-%dT%H:%M:%SZ").to_string();
         let mut found = false;
@@ -452,9 +448,7 @@ fn parse_file(path: &Path) -> aish_core::Result<Vec<MemoryEntry>> {
                         "created" => meta.created_at = Some(value),
                         "verified" => meta.last_verified_at = Some(value),
                         "expires" => meta.expires_at = Some(value),
-                        "importance" => {
-                            meta.importance = value.parse().unwrap_or(1.0)
-                        }
+                        "importance" => meta.importance = value.parse().unwrap_or(1.0),
                         _ => {}
                     }
                 }
@@ -522,7 +516,10 @@ fn parse_header(rest: &str) -> Option<ParsedMeta> {
     }
 
     // v1 legacy format: `Source: source | date`
-    let rest = rest.strip_prefix("Source:").map(|r| r.trim_start()).unwrap_or("");
+    let rest = rest
+        .strip_prefix("Source:")
+        .map(|r| r.trim_start())
+        .unwrap_or("");
     let mut parts = rest.splitn(2, '|');
     let source = parts.next().unwrap_or("").trim().to_string();
     let date = parts.next().map(|d| d.trim().to_string());
@@ -542,9 +539,10 @@ fn parse_header(rest: &str) -> Option<ParsedMeta> {
 }
 
 fn build_entry(meta: ParsedMeta, content: String) -> MemoryEntry {
-    let created = meta.created_at.clone().unwrap_or_else(|| {
-        Utc::now().format("%Y-%m-%d").to_string()
-    });
+    let created = meta
+        .created_at
+        .clone()
+        .unwrap_or_else(|| Utc::now().format("%Y-%m-%d").to_string());
     MemoryEntry {
         id: meta.id,
         source: meta.source,
@@ -1003,7 +1001,11 @@ mod tests {
                 "temp fact",
                 MemoryCategory::Other,
                 MemoryScope::User,
-                MemorySource { label: "test".to_string(), session_uuid: None, host: None },
+                MemorySource {
+                    label: "test".to_string(),
+                    session_uuid: None,
+                    host: None,
+                },
                 0.8,
                 Some(3600), // 1 hour TTL
             )
@@ -1016,7 +1018,10 @@ mod tests {
         assert!(ok);
         let entry = mgr.list().iter().find(|e| e.id == id).unwrap();
         assert!(entry.expires_at.is_none(), "expires_at should be cleared");
-        assert!(entry.last_verified_at.is_some(), "last_verified_at should be set");
+        assert!(
+            entry.last_verified_at.is_some(),
+            "last_verified_at should be set"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -1037,7 +1042,11 @@ mod tests {
                 content,
                 MemoryCategory::Other,
                 MemoryScope::User,
-                MemorySource { label: "test".to_string(), session_uuid: None, host: None },
+                MemorySource {
+                    label: "test".to_string(),
+                    session_uuid: None,
+                    host: None,
+                },
                 0.8,
                 None,
             )
@@ -1046,8 +1055,14 @@ mod tests {
         // Reload from disk and verify content is preserved
         let mgr2 = MemoryManager::new(path).unwrap();
         let entry = mgr2.list().iter().find(|e| e.id == id).unwrap();
-        assert!(entry.content.contains("> This is a quote"), "blockquote lost");
-        assert!(entry.content.contains("> source: not metadata"), "metadata-like line lost");
+        assert!(
+            entry.content.contains("> This is a quote"),
+            "blockquote lost"
+        );
+        assert!(
+            entry.content.contains("> source: not metadata"),
+            "metadata-like line lost"
+        );
         assert_eq!(entry.source, "test", "source corrupted by content line");
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/aish-memory/src/manager.rs
+++ b/crates/aish-memory/src/manager.rs
@@ -1,6 +1,6 @@
-use crate::models::MemoryEntry;
-use aish_core::{AishError, MemoryCategory};
-use chrono::Utc;
+use crate::models::{MemoryEntry, MemorySource};
+use aish_core::{AishError, MemoryCategory, MemoryScope};
+use chrono::{DateTime, Utc};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -62,6 +62,35 @@ impl MemoryManager {
         source: &str,
         importance: f64,
     ) -> aish_core::Result<i64> {
+        self.store_with_provenance(
+            content,
+            category,
+            MemoryScope::User,
+            MemorySource {
+                label: source.to_string(),
+                session_uuid: None,
+                host: None,
+            },
+            importance,
+            None,
+        )
+    }
+
+    /// Store a new memory entry with full provenance metadata. Returns the
+    /// assigned ID. If an entry with the same content and category already
+    /// exists, returns the existing ID without creating a duplicate.
+    ///
+    /// `ttl_seconds` controls the optional expiry: `None` means no expiry,
+    /// `Some(secs)` sets `expires_at` to now + secs.
+    pub fn store_with_provenance(
+        &mut self,
+        content: &str,
+        category: MemoryCategory,
+        scope: MemoryScope,
+        source: MemorySource,
+        importance: f64,
+        ttl_seconds: Option<u64>,
+    ) -> aish_core::Result<i64> {
         let content_trimmed = content.trim();
 
         // Duplicate detection: same content (case-insensitive) + same category
@@ -72,19 +101,32 @@ impl MemoryManager {
             }
         }
 
-        let now = Utc::now().format("%Y-%m-%d").to_string();
+        let now = Utc::now();
+        let now_str = now.format("%Y-%m-%d").to_string();
+        let now_rfc = now.format("%Y-%m-%dT%H:%M:%SZ").to_string();
         let id = self.next_id;
         self.next_id += 1;
 
+        let expires_at = ttl_seconds.map(|secs| {
+            (now + chrono::Duration::seconds(secs as i64))
+                .format("%Y-%m-%dT%H:%M:%SZ")
+                .to_string()
+        });
+
         let entry = MemoryEntry {
             id,
-            source: source.to_string(),
+            source: source.label,
+            source_session_uuid: source.session_uuid,
+            source_host: source.host,
             category,
+            scope,
             content: content_trimmed.to_string(),
             importance,
             tags: String::new(),
-            created_at: Some(now.clone()),
-            last_accessed_at: Some(now),
+            created_at: Some(now_str.clone()),
+            last_verified_at: Some(now_rfc.clone()),
+            expires_at,
+            last_accessed_at: Some(now_str),
             access_count: 0,
         };
 
@@ -101,8 +143,10 @@ impl MemoryManager {
         let query_words: Vec<String> = query.split_whitespace().map(|w| w.to_lowercase()).collect();
 
         if query_words.is_empty() {
-            // Return entries sorted by importance when query is empty
-            let mut indices: Vec<usize> = (0..self.entries.len()).collect();
+            // Return active entries sorted by importance when query is empty
+            let mut indices: Vec<usize> = (0..self.entries.len())
+                .filter(|&i| !Self::is_expired(&self.entries[i]))
+                .collect();
             indices.sort_by(|a, b| {
                 self.entries[*b]
                     .importance
@@ -113,7 +157,7 @@ impl MemoryManager {
                 .into_iter()
                 .take(limit)
                 .map(|i| &self.entries[i])
-                .collect();
+ .collect();
         }
 
         let now = Utc::now().format("%Y-%m-%d").to_string();
@@ -121,6 +165,9 @@ impl MemoryManager {
         // Compute relevance scores
         let mut scored: Vec<(usize, f64)> = Vec::new();
         for (idx, entry) in self.entries.iter().enumerate() {
+            if Self::is_expired(entry) {
+                continue;
+            }
             let content_lower = entry.content.to_lowercase();
             let match_count = query_words
                 .iter()
@@ -176,6 +223,66 @@ impl MemoryManager {
         &self.entries
     }
 
+    /// Re-verify a memory entry by ID: updates `last_verified_at` to today.
+    /// If `new_ttl_seconds` is provided, also resets `expires_at`.
+    /// Returns true if the entry was found and updated.
+    pub fn verify(
+        &mut self,
+        id: i64,
+        new_ttl_seconds: Option<u64>,
+    ) -> aish_core::Result<bool> {
+        let now = Utc::now();
+        let now_rfc = now.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+        let mut found = false;
+        for entry in &mut self.entries {
+            if entry.id == id {
+                entry.last_verified_at = Some(now_rfc.clone());
+                if let Some(secs) = new_ttl_seconds {
+                    entry.expires_at = Some(
+                        (now + chrono::Duration::seconds(secs as i64))
+                            .format("%Y-%m-%dT%H:%M:%SZ")
+                            .to_string(),
+                    );
+                }
+                found = true;
+                break;
+            }
+        }
+        if found {
+            self.persist()?;
+        }
+        Ok(found)
+    }
+    /// Return IDs of all expired entries (expires_at < now).
+    pub fn expired_entry_ids(&self) -> Vec<i64> {
+        let now = Utc::now();
+        self.entries
+            .iter()
+            .filter(|e| Self::is_expired_inner(e, &now))
+            .map(|e| e.id)
+            .collect()
+    }
+
+    /// Check whether a single entry is expired.
+    pub fn is_expired(entry: &MemoryEntry) -> bool {
+        Self::is_expired_inner(entry, &Utc::now())
+    }
+
+    fn is_expired_inner(entry: &MemoryEntry, now: &DateTime<Utc>) -> bool {
+        let Some(exp) = &entry.expires_at else {
+            return false;
+        };
+        // Try RFC3339 first, fall back to date-only (%Y-%m-%d)
+        if let Ok(dt) = DateTime::parse_from_rfc3339(exp) {
+            return dt.with_timezone(&Utc) < *now;
+        }
+        if let Ok(date) = chrono::NaiveDate::parse_from_str(exp, "%Y-%m-%d") {
+            let expiry = date.and_hms_opt(23, 59, 59).unwrap_or_default().and_utc();
+            return expiry < *now;
+        }
+        false
+    }
+
     /// Generate a system prompt section describing the memory system.
     /// This should be appended to the LLM system prompt when memory is enabled.
     pub fn get_system_prompt_section(&self) -> String {
@@ -185,43 +292,106 @@ impl MemoryManager {
              1. Before relying on prior preferences, environment details, or project decisions, use the memory tool with action search.\n\
              2. When the user shares an important durable fact, use the memory tool with action store.\n\
              3. Keep stored memories short, factual, and reusable. Avoid saving transient chatter.\n\
-             4. The memory file lives in {}.\n",
+             4. Expired memories are not injected; use /memory to review and renew them.\n\
+             5. The memory file lives in {}.\n",
             self.memory_file.display()
         )
     }
 
     /// Get the full memory file content for session context injection.
-    /// Returns an empty string if no entries exist.
+    /// Expired entries are excluded; a summary of expired entries is appended
+    /// so the user is prompted to review them.
+    /// Returns an empty string if no active entries exist.
     pub fn get_session_context(&self) -> String {
-        if self.entries.is_empty() {
+        let active: Vec<&MemoryEntry> = self
+            .entries
+            .iter()
+            .filter(|e| !Self::is_expired(e))
+            .collect();
+        let expired: Vec<&MemoryEntry> = self
+            .entries
+            .iter()
+            .filter(|e| Self::is_expired(e))
+            .collect();
+
+        if active.is_empty() && expired.is_empty() {
             return String::new();
         }
+
         let mut out = String::from(HEADER);
-        for entry in &self.entries {
+        for entry in &active {
             let category = format_category(&entry.category);
-            let date = entry.created_at.as_deref().unwrap_or("unknown");
             out.push_str(&format!(
-                "\n## [{}] [{}] Source: {} | {}\n{}\n",
-                entry.id, category, entry.source, date, entry.content,
+                "\n## [{}] [{}] [{}]\n{}\n",
+                entry.id,
+                category,
+                format_scope(&entry.scope),
+                entry.content,
             ));
+        }
+        if !expired.is_empty() {
+            out.push_str(&format!(
+                "\n## Expired Memories ({} — use /memory to review)\n",
+                expired.len()
+            ));
+            for entry in &expired {
+                let category = format_category(&entry.category);
+                out.push_str(&format!(
+                    "  #{} [{}] {} (expired: {})\n",
+                    entry.id,
+                    category,
+                    entry.content,
+                    entry.expires_at.as_deref().unwrap_or("?"),
+                ));
+            }
         }
         out
     }
 
     /// Persist the full entry list to the MEMORY.md file.
+    ///
+    /// New format (v2) uses `> key: value` metadata lines under the header:
+    /// ```text
+    /// ## [id] [Category]
+    /// > scope: user
+    /// > source: auto
+    /// > source_session: <uuid>
+    /// > source_host: <host>
+    /// > created: 2026-01-01
+    /// > verified: 2026-01-01
+    /// > expires: 2026-08-01
+    /// > importance: 0.8
+    /// <content>
+    /// ```
+    /// Old format (`## [id] [Category] Source: src | date`) is still readable
+    /// by the parser for backward compatibility.
     fn persist(&self) -> aish_core::Result<()> {
-        // Pre-allocate: header + entries with average size ~100 chars each
-        let estimated_size = HEADER.len() + self.entries.len() * 100;
+        let estimated_size = HEADER.len() + self.entries.len() * 200;
         let mut out = String::with_capacity(estimated_size);
         out.push_str(HEADER);
 
         for entry in &self.entries {
             let category = format_category(&entry.category);
-            let date = entry.created_at.as_deref().unwrap_or("unknown");
-            out.push_str(&format!(
-                "\n## [{}] [{}] Source: {} | {}\n{}\n",
-                entry.id, category, entry.source, date, entry.content,
-            ));
+            out.push_str(&format!("\n## [{}] [{}]\n", entry.id, category));
+            out.push_str(&format!("> scope: {}\n", format_scope(&entry.scope)));
+            out.push_str(&format!("> source: {}\n", entry.source));
+            if let Some(uuid) = &entry.source_session_uuid {
+                out.push_str(&format!("> source_session: {}\n", uuid));
+            }
+            if let Some(host) = &entry.source_host {
+                out.push_str(&format!("> source_host: {}\n", host));
+            }
+            if let Some(date) = &entry.created_at {
+                out.push_str(&format!("> created: {}\n", date));
+            }
+            if let Some(date) = &entry.last_verified_at {
+                out.push_str(&format!("> verified: {}\n", date));
+            }
+            if let Some(exp) = &entry.expires_at {
+                out.push_str(&format!("> expires: {}\n", exp));
+            }
+            out.push_str(&format!("> importance: {}\n", entry.importance));
+            out.push_str(&format!("{}\n", entry.content));
         }
 
         std::fs::write(&self.memory_file, out)
@@ -234,34 +404,58 @@ impl MemoryManager {
 // ---------------------------------------------------------------------------
 
 /// Parse an existing MEMORY.md file into a list of entries.
+///
+/// Supports two formats:
+/// - **v2**: `## [id] [Category]` header followed by `> key: value` metadata
+///   lines, then the content body.
+/// - **v1 (legacy)**: `## [id] [Category] Source: src | date` single-line
+///   header, followed by the content body.
 fn parse_file(path: &Path) -> aish_core::Result<Vec<MemoryEntry>> {
     let content = std::fs::read_to_string(path)
         .map_err(|e| AishError::Memory(format!("cannot read memory file {:?}: {}", path, e)))?;
 
     let mut entries = Vec::new();
-    let mut current_lines: Vec<String> = Vec::new();
+    let mut current_body: Vec<String> = Vec::new();
     let mut current_meta: Option<ParsedMeta> = None;
 
     for line in content.lines() {
         if let Some(rest) = line.strip_prefix("## [") {
             // Flush previous entry
             if let Some(meta) = current_meta.take() {
-                let body = current_lines.join("\n").trim().to_string();
+                let body = current_body.join("\n").trim().to_string();
                 entries.push(build_entry(meta, body));
-                current_lines.clear();
+                current_body.clear();
             }
-            // Parse new header
-            if let Some(meta) = parse_header(rest) {
-                current_meta = Some(meta);
+            current_meta = parse_header(rest);
+        } else if line.starts_with("> ") {
+            // v2 metadata line — attach to current meta if present
+            if let Some(meta) = current_meta.as_mut() {
+                let kv = &line[2..];
+                if let Some((key, value)) = kv.split_once(':') {
+                    let value = value.trim().to_string();
+                    match key.trim() {
+                        "scope" => meta.scope = parse_scope(&value),
+                        "source" => meta.source = value,
+                        "source_session" => meta.source_session_uuid = Some(value),
+                        "source_host" => meta.source_host = Some(value),
+                        "created" => meta.created_at = Some(value),
+                        "verified" => meta.last_verified_at = Some(value),
+                        "expires" => meta.expires_at = Some(value),
+                        "importance" => {
+                            meta.importance = value.parse().unwrap_or(1.0)
+                        }
+                        _ => {}
+                    }
+                }
             }
         } else if current_meta.is_some() {
-            current_lines.push(line.to_string());
+            current_body.push(line.to_string());
         }
     }
 
     // Flush last entry
     if let Some(meta) = current_meta.take() {
-        let body = current_lines.join("\n").trim().to_string();
+        let body = current_body.join("\n").trim().to_string();
         entries.push(build_entry(meta, body));
     }
 
@@ -271,13 +465,20 @@ fn parse_file(path: &Path) -> aish_core::Result<Vec<MemoryEntry>> {
 struct ParsedMeta {
     id: i64,
     category: MemoryCategory,
+    scope: MemoryScope,
     source: String,
-    date: Option<String>,
+    source_session_uuid: Option<String>,
+    source_host: Option<String>,
+    created_at: Option<String>,
+    last_verified_at: Option<String>,
+    expires_at: Option<String>,
+    importance: f64,
 }
 
 /// Parse a header line after the leading `## [` has been stripped.
 ///
-/// Expected format: `id] [Category] Source: source | date`
+/// v2 format: `id] [Category]`
+/// v1 format: `id] [Category] Source: source | date`
 fn parse_header(rest: &str) -> Option<ParsedMeta> {
     // Find `]` to get the id
     let bracket_pos = rest.find(']')?;
@@ -290,14 +491,26 @@ fn parse_header(rest: &str) -> Option<ParsedMeta> {
     let bracket2 = rest.find(']')?;
     let category_str = &rest[..bracket2];
     let category = parse_category(category_str)?;
-    let rest = &rest[bracket2 + 1..];
+    let rest = &rest[bracket2 + 1..].trim_start();
 
-    // Find "Source: ..."
-    let rest = rest.trim_start();
-    let rest = rest.strip_prefix("Source:")?;
-    let rest = rest.trim_start();
+    // v2 format: nothing after [Category] — metadata comes via `> ` lines
+    if rest.is_empty() {
+        return Some(ParsedMeta {
+            id,
+            category,
+            scope: MemoryScope::User,
+            source: String::new(),
+            source_session_uuid: None,
+            source_host: None,
+            created_at: None,
+            last_verified_at: None,
+            expires_at: None,
+            importance: 1.0,
+        });
+    }
 
-    // Split on "|"
+    // v1 legacy format: `Source: source | date`
+    let rest = rest.strip_prefix("Source:").map(|r| r.trim_start()).unwrap_or("");
     let mut parts = rest.splitn(2, '|');
     let source = parts.next().unwrap_or("").trim().to_string();
     let date = parts.next().map(|d| d.trim().to_string());
@@ -305,20 +518,34 @@ fn parse_header(rest: &str) -> Option<ParsedMeta> {
     Some(ParsedMeta {
         id,
         category,
+        scope: MemoryScope::User,
         source,
-        date,
+        source_session_uuid: None,
+        source_host: None,
+        created_at: date,
+        last_verified_at: None,
+        expires_at: None,
+        importance: 1.0,
     })
 }
 
 fn build_entry(meta: ParsedMeta, content: String) -> MemoryEntry {
+    let created = meta.created_at.clone().unwrap_or_else(|| {
+        Utc::now().format("%Y-%m-%d").to_string()
+    });
     MemoryEntry {
         id: meta.id,
         source: meta.source,
+        source_session_uuid: meta.source_session_uuid,
+        source_host: meta.source_host,
         category: meta.category,
+        scope: meta.scope,
         content,
-        importance: 1.0,
+        importance: meta.importance,
         tags: String::new(),
-        created_at: meta.date,
+        created_at: Some(created),
+        last_verified_at: meta.last_verified_at,
+        expires_at: meta.expires_at,
         last_accessed_at: None,
         access_count: 0,
     }
@@ -342,6 +569,22 @@ fn parse_category(s: &str) -> Option<MemoryCategory> {
         "Pattern" => Some(MemoryCategory::Pattern),
         "Other" => Some(MemoryCategory::Other),
         _ => None,
+    }
+}
+
+fn format_scope(scope: &MemoryScope) -> &'static str {
+    match scope {
+        MemoryScope::User => "user",
+        MemoryScope::Host => "host",
+        MemoryScope::Project => "project",
+    }
+}
+
+fn parse_scope(s: &str) -> MemoryScope {
+    match s.trim() {
+        "host" => MemoryScope::Host,
+        "project" => MemoryScope::Project,
+        _ => MemoryScope::User,
     }
 }
 
@@ -458,10 +701,146 @@ mod tests {
 
     #[test]
     fn test_parse_header() {
+        // v1 legacy format
         let meta = parse_header("1] [Preference] Source: auto | 2024-01-01").unwrap();
         assert_eq!(meta.id, 1);
         assert_eq!(meta.source, "auto");
-        assert_eq!(meta.date.as_deref(), Some("2024-01-01"));
+        assert_eq!(meta.created_at.as_deref(), Some("2024-01-01"));
+        assert_eq!(meta.scope, MemoryScope::User);
+
+        // v2 format — metadata comes via `> ` lines, not the header
+        let meta = parse_header("2] [Environment]").unwrap();
+        assert_eq!(meta.id, 2);
+        assert_eq!(meta.source, "");
+        assert!(meta.created_at.is_none());
+    }
+
+    #[test]
+    fn test_v2_roundtrip_with_provenance() {
+        let dir = std::env::temp_dir().join("aish_memory_test_v2");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("MEMORY.md");
+
+        let mut mgr = MemoryManager::new(path.clone()).unwrap();
+        let id = mgr
+            .store_with_provenance(
+                "db port is 5432",
+                MemoryCategory::Environment,
+                MemoryScope::Host,
+                MemorySource {
+                    label: "explicit".to_string(),
+                    session_uuid: Some("sess-abc".to_string()),
+                    host: Some("prod-srv".to_string()),
+                },
+                0.9,
+                Some(86400),
+            )
+            .unwrap();
+        assert_eq!(id, 1);
+
+        // Reload and verify all fields survive
+        let mgr2 = MemoryManager::new(path).unwrap();
+        let e = &mgr2.list()[0];
+        assert_eq!(e.content, "db port is 5432");
+        assert_eq!(e.source, "explicit");
+        assert_eq!(e.source_session_uuid.as_deref(), Some("sess-abc"));
+        assert_eq!(e.source_host.as_deref(), Some("prod-srv"));
+        assert_eq!(e.scope, MemoryScope::Host);
+        assert!(e.expires_at.is_some());
+        assert!(e.last_verified_at.is_some());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_v1_backward_compat() {
+        let dir = std::env::temp_dir().join("aish_memory_test_v1_compat");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("MEMORY.md");
+
+        // Write old v1 format directly
+        std::fs::write(
+            &path,
+            "# Memory\n\n## [1] [Preference] Source: auto | 2024-01-01\nI prefer dark theme\n",
+        )
+        .unwrap();
+
+        let mgr = MemoryManager::new(path).unwrap();
+        assert_eq!(mgr.list().len(), 1);
+        let e = &mgr.list()[0];
+        assert_eq!(e.id, 1);
+        assert_eq!(e.content, "I prefer dark theme");
+        assert_eq!(e.source, "auto");
+        assert_eq!(e.created_at.as_deref(), Some("2024-01-01"));
+        assert_eq!(e.scope, MemoryScope::User);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_verify_updates_last_verified() {
+        let dir = std::env::temp_dir().join("aish_memory_test_verify");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("MEMORY.md");
+
+        let mut mgr = MemoryManager::new(path).unwrap();
+        let id = mgr
+            .store("test entry", MemoryCategory::Other, "test", 1.0)
+            .unwrap();
+        let old_verified = mgr.list()[0].last_verified_at.clone();
+
+        std::thread::sleep(std::time::Duration::from_secs(2));
+        assert!(mgr.verify(id, None).unwrap());
+        let new_verified = mgr.list()[0].last_verified_at.clone();
+        assert_ne!(old_verified, new_verified);
+
+        // Non-existent ID
+        assert!(!mgr.verify(999, None).unwrap());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_expired_filtering() {
+        let dir = std::env::temp_dir().join("aish_memory_test_expired");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("MEMORY.md");
+
+        let mut mgr = MemoryManager::new(path).unwrap();
+        // Active entry (no TTL)
+        mgr.store("active", MemoryCategory::Other, "test", 1.0)
+            .unwrap();
+        // Expired entry (TTL = 1 second)
+        mgr.store_with_provenance(
+            "expired",
+            MemoryCategory::Other,
+            MemoryScope::User,
+            MemorySource {
+                label: "test".to_string(),
+                session_uuid: None,
+                host: None,
+            },
+            1.0,
+            Some(1),
+        )
+        .unwrap();
+
+        // Wait for it to expire
+        std::thread::sleep(std::time::Duration::from_secs(2));
+
+        assert_eq!(mgr.list().len(), 2);
+        assert_eq!(mgr.expired_entry_ids().len(), 1);
+
+        // recall should skip expired
+        let results = mgr.recall("", 10);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].content, "active");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/aish-memory/src/models.rs
+++ b/crates/aish-memory/src/models.rs
@@ -1,15 +1,31 @@
-use aish_core::MemoryCategory;
+use aish_core::{MemoryCategory, MemoryScope};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryEntry {
     pub id: i64,
     pub source: String,
+    pub source_session_uuid: Option<String>,
+    pub source_host: Option<String>,
     pub category: MemoryCategory,
+    pub scope: MemoryScope,
     pub content: String,
     pub importance: f64,
     pub tags: String,
     pub created_at: Option<String>,
+    pub last_verified_at: Option<String>,
+    pub expires_at: Option<String>,
     pub last_accessed_at: Option<String>,
     pub access_count: i32,
+}
+
+/// Provenance metadata for a memory entry, captured at store time.
+#[derive(Debug, Clone)]
+pub struct MemorySource {
+    /// Human-readable label: "explicit", "auto", "host_note", etc.
+    pub label: String,
+    /// UUID of the session that created this entry, if available.
+    pub session_uuid: Option<String>,
+    /// Hostname of the machine the entry originated on, if available.
+    pub host: Option<String>,
 }

--- a/crates/aish-shell/src/ai_handler.rs
+++ b/crates/aish-shell/src/ai_handler.rs
@@ -6,9 +6,9 @@ use aish_context::ContextMessage;
 use aish_context::{
     ContextBudgetPolicy, ContextCompactReport, ContextManager, ContextPressureLevel,
 };
-use aish_core::{LlmEvent, MemoryCategory, MemoryType, PlanModeState, PlanPhase};
+use aish_core::{LlmEvent, MemoryCategory, MemoryScope, MemoryType, PlanModeState, PlanPhase};
 use aish_llm::{ChatMessage, LlmCallbackResult, LlmSession, MessageContent, Tool};
-use aish_memory::MemoryManager;
+use aish_memory::{MemoryManager, MemorySource};
 use aish_prompts::PromptManager;
 use aish_session::SessionContextMessage;
 use aish_skills::SkillManager;
@@ -785,6 +785,9 @@ impl AiHandler {
     }
 
     /// Auto-retain user preferences and facts based on pattern matching.
+    /// Auto-retain entries get a short default TTL (7 days) to prevent stale
+    /// facts from accumulating — the user already expressed intent via
+    /// "remember that..." patterns so no confirmation gate is needed.
     fn auto_retain_memory(&mut self, question: &str, _response: &str) {
         if !self.memory_config.auto_retain {
             return;
@@ -794,7 +797,18 @@ impl AiHandler {
             let facts = extract_retainable_facts(question);
             for fact in facts {
                 let category = categorize_fact(&fact);
-                let _ = mm.store(&fact, category, "auto", 1.0);
+                let _ = mm.store_with_provenance(
+                    &fact,
+                    category,
+                    MemoryScope::User,
+                    MemorySource {
+                        label: "auto".to_string(),
+                        session_uuid: None,
+                        host: None,
+                    },
+                    1.0,
+                    Some(604_800), // 7 days
+                );
             }
         }
     }

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -1763,6 +1763,11 @@ impl AishShell {
                         }
                         // Stop progress spinner started at ToolExecutionStart.
                         animation_ref.stop();
+                        // Also stop the sub-agent thinking animation so its
+                        // background thread does not keep overwriting the
+                        // terminal line with \r\x1b[K while we print the
+                        // tool result and status indicator below.
+                        sub_agent_animation_ref.stop();
                         let tool_ok = event
                             .data
                             .get("ok")

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -1086,35 +1086,37 @@ impl AishShell {
                 }
             }),
             // store callback — extended signature with scope and ttl
-            Box::new(move |content, category, source, importance, scope, ttl_seconds| {
-                let mut guard = mm_for_store.lock().unwrap();
-                if let Some(ref mut mm) = *guard {
-                    let cat = parse_category_str(category);
-                    let mem_scope = parse_scope_str(scope);
-                    let mem_source = aish_memory::MemorySource {
-                        label: source.to_string(),
-                        session_uuid: Some(mem_session_uuid.clone()),
-                        host: mem_audit_host.clone(),
-                    };
-                    match mm.store_with_provenance(
-                        content,
-                        cat,
-                        mem_scope,
-                        mem_source,
-                        importance as f64,
-                        ttl_seconds,
-                    ) {
-                        Ok(id) => id.to_string(),
-                        Err(e) => {
-                            let mut args = std::collections::HashMap::new();
-                            args.insert("error".to_string(), e.to_string());
-                            t_with_args("shell.general_error", &args)
+            Box::new(
+                move |content, category, source, importance, scope, ttl_seconds| {
+                    let mut guard = mm_for_store.lock().unwrap();
+                    if let Some(ref mut mm) = *guard {
+                        let cat = parse_category_str(category);
+                        let mem_scope = parse_scope_str(scope);
+                        let mem_source = aish_memory::MemorySource {
+                            label: source.to_string(),
+                            session_uuid: Some(mem_session_uuid.clone()),
+                            host: mem_audit_host.clone(),
+                        };
+                        match mm.store_with_provenance(
+                            content,
+                            cat,
+                            mem_scope,
+                            mem_source,
+                            importance as f64,
+                            ttl_seconds,
+                        ) {
+                            Ok(id) => id.to_string(),
+                            Err(e) => {
+                                let mut args = std::collections::HashMap::new();
+                                args.insert("error".to_string(), e.to_string());
+                                t_with_args("shell.general_error", &args)
+                            }
                         }
+                    } else {
+                        "memory not available".to_string()
                     }
-                } else {
-                    "memory not available".to_string()
-                }
-            }),
+                },
+            ),
             // delete callback
             Box::new(move |id| {
                 let mut guard = mm_for_delete.lock().unwrap();
@@ -1225,7 +1227,6 @@ impl AishShell {
         for (_name, tool) in tools {
             llm_session.register_tool(tool);
         }
-
 
         // Open audit store when audit is enabled in the security policy.
         let audit_enabled = security_manager.policy().audit_enabled;
@@ -3750,7 +3751,10 @@ impl AishShell {
                         line.push_str(&format!(" @{}", created));
                     }
                     if aish_memory::MemoryManager::is_expired(e) {
-                        line.push_str(&format!(" \x1b[31m[{}]\x1b[0m", t("tools.memory.expired_tag")));
+                        line.push_str(&format!(
+                            " \x1b[31m[{}]\x1b[0m",
+                            t("tools.memory.expired_tag")
+                        ));
                     } else if let Some(exp) = &e.expires_at {
                         line.push_str(&format!(" ({}: {})", t("tools.memory.field_expires"), exp));
                     }
@@ -3778,7 +3782,10 @@ impl AishShell {
                     Ok(true) => {
                         let mut args = std::collections::HashMap::new();
                         args.insert("id".to_string(), id.to_string());
-                        println!("\x1b[36m{}\x1b[0m", t_with_args("tools.memory.verified", &args));
+                        println!(
+                            "\x1b[36m{}\x1b[0m",
+                            t_with_args("tools.memory.verified", &args)
+                        );
                     }
                     Ok(false) => {
                         let mut args = std::collections::HashMap::new();
@@ -3813,7 +3820,10 @@ impl AishShell {
                     Ok(true) => {
                         let mut args = std::collections::HashMap::new();
                         args.insert("id".to_string(), id.to_string());
-                        println!("\x1b[36m{}\x1b[0m", t_with_args("tools.memory.forgot", &args));
+                        println!(
+                            "\x1b[36m{}\x1b[0m",
+                            t_with_args("tools.memory.forgot", &args)
+                        );
                     }
                     Ok(false) => {
                         let mut args = std::collections::HashMap::new();
@@ -3839,7 +3849,10 @@ impl AishShell {
                 }
                 let mut args = std::collections::HashMap::new();
                 args.insert("count".to_string(), count.to_string());
-                println!("\x1b[36m{}\x1b[0m", t_with_args("tools.memory.cleared_expired", &args));
+                println!(
+                    "\x1b[36m{}\x1b[0m",
+                    t_with_args("tools.memory.cleared_expired", &args)
+                );
             }
             _ => {
                 let mut args = std::collections::HashMap::new();

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -666,6 +666,11 @@ pub struct AishShell {
     last_ctrl_c: Option<std::time::Instant>,
     /// Shared animation spinner, stored so it can be stopped on cancellation.
     animation: Arc<SharedAnimation>,
+    /// Sub-agent thinking animation (`  └─ explore · 思考中`), stored so it
+    /// can be stopped on cancellation — without this, a Ctrl+C during a
+    /// sub-agent tool loop leaks the animation thread, which keeps
+    /// overwriting the terminal line.
+    sub_agent_animation: Arc<SubAgentThinkingAnimation>,
     /// Session history of collapsed outputs for Ctrl+O browsing.
     expand_history: Arc<Mutex<crate::expand_history::ExpandHistory>>,
     /// Shared terminal session recorder for asciinema v2 recording.
@@ -1341,6 +1346,12 @@ impl AishShell {
         }
 
         let shared_recorder_cb = shared_recorder.clone();
+        // Capture the cancellation token so the event callback can check
+        // is_cancelled() before starting animations — late LLM events
+        // arriving after Ctrl+C would otherwise restart the animation
+        // thread, leaking it.
+        let cancel_token_for_cb = llm_session.cancellation_token_arc();
+
         let event_callback: Arc<dyn Fn(LlmEvent) -> Option<LlmCallbackResult> + Send + Sync> =
             Arc::new(move |event: LlmEvent| {
                 // Helper: clear multi-line reasoning overlay and reset state.
@@ -1368,7 +1379,9 @@ impl AishShell {
                         reasoning_active_ref.store(false, Ordering::SeqCst);
                         compaction_active_ref.store(false, Ordering::SeqCst);
                         compaction_notice_shown_ref.store(false, Ordering::SeqCst);
-                        animation_ref.start(&t("shell.status.thinking"));
+                        if !cancel_token_for_cb.is_cancelled() {
+                            animation_ref.start(&t("shell.status.thinking"));
+                        }
                     }
                     LlmEventType::OpEnd if crate::llm_event_ui::sub_agent_llm_event(&event) => {
                         // A sub-agent OpEnd marks one sub-session finishing, not the
@@ -1397,7 +1410,9 @@ impl AishShell {
                         *thinking_start_ref.lock().unwrap() = None;
                     }
                     LlmEventType::ContextCompactionStart => {
-                        if !compaction_active_ref.swap(true, Ordering::SeqCst) {
+                        if !compaction_active_ref.swap(true, Ordering::SeqCst)
+                            && !cancel_token_for_cb.is_cancelled()
+                        {
                             animation_ref.start(&t("shell.status.compacting_context"));
                         }
                     }
@@ -1410,12 +1425,17 @@ impl AishShell {
                             }
                         }
                     }
-                    LlmEventType::GenerationStart if react_agent_llm_event(&event) => {}
                     LlmEventType::GenerationStart
                         if crate::llm_event_ui::sub_agent_llm_event(&event) =>
                     {
                         animation_ref.stop();
                         clear_reasoning();
+                        // Late sub-agent events arriving after Ctrl+C would
+                        // restart the animation thread — bail out instead.
+                        if cancel_token_for_cb.is_cancelled() {
+                            sub_agent_animation_ref.stop();
+                            return None;
+                        }
                         if let Some(prefix) =
                             crate::llm_event_ui::sub_agent_thinking_animation_prefix(&event)
                         {
@@ -1436,7 +1456,9 @@ impl AishShell {
                         reasoning_buf_ref.lock().unwrap().clear();
                         reasoning_frame_ref.store(0, Ordering::SeqCst);
                         renderer_ref.lock().unwrap().reset();
-                        if sub_agent_active_count_ref.load(Ordering::SeqCst) == 0 {
+                        if sub_agent_active_count_ref.load(Ordering::SeqCst) == 0
+                            && !cancel_token_for_cb.is_cancelled()
+                        {
                             animation_ref.start(&t("shell.status.thinking"));
                         }
                     }
@@ -1681,6 +1703,7 @@ impl AishShell {
                                 && !react_agent_llm_event(&event)
                                 && !is_interactive_tool
                                 && !bash_needs_tty
+                                && !cancel_token_for_cb.is_cancelled()
                             {
                                 animation_ref.start(&theme::tool_status_label(name));
                             }
@@ -2095,6 +2118,7 @@ impl AishShell {
             interruption: InterruptionState::default(),
             last_ctrl_c: None,
             animation,
+            sub_agent_animation: sub_agent_animation.clone(),
             expand_history,
             shared_recorder,
             inline_ai: None,
@@ -2552,6 +2576,7 @@ impl AishShell {
                                 }
                                 Err(aish_core::AishError::Cancelled) => {
                                     self.animation.stop();
+                                    self.sub_agent_animation.stop();
                                     crate::recorder::shared_record_output(
                                         &self.shared_recorder,
                                         &format!("{}\r\n", theme::warning("Interrupted")),
@@ -2622,6 +2647,7 @@ impl AishShell {
                     match result {
                         Ok(response) => {
                             if self.ai_handler.cancellation_token().is_cancelled() {
+                                self.sub_agent_animation.stop();
                                 // Agent short-circuit cancel returns Ok("") — show the same
                                 // user-facing line as Err(Cancelled). Do not treat as success
                                 // (no plan approval / history-as-ok).
@@ -2793,6 +2819,7 @@ impl AishShell {
                         }
                         Err(aish_core::AishError::Cancelled) => {
                             self.animation.stop();
+                            self.sub_agent_animation.stop();
                             println!("{}", theme::warning(&t("shell.interrupted")));
                         }
                         Err(e) => {
@@ -2961,6 +2988,7 @@ impl AishShell {
                                 match result {
                                     Ok(response) => {
                                         if self.ai_handler.cancellation_token().is_cancelled() {
+                                            self.sub_agent_animation.stop();
                                             // Same as Err(Cancelled): do not persist/history as success.
                                             println!("{}", theme::warning(&t("shell.interrupted")));
                                         } else {
@@ -2982,6 +3010,7 @@ impl AishShell {
                                     }
                                     Err(aish_core::AishError::Cancelled) => {
                                         self.animation.stop();
+                                        self.sub_agent_animation.stop();
                                         println!("{}", theme::warning(&t("shell.interrupted")));
                                     }
                                     Err(e) => {
@@ -3320,6 +3349,7 @@ impl AishShell {
                 match result {
                     Ok(response) => {
                         if self.ai_handler.cancellation_token().is_cancelled() {
+                            self.sub_agent_animation.stop();
                             println!("{}", theme::warning(&t("shell.interrupted")));
                         } else if !did_stream && !response.trim().is_empty() {
                             let mut sep = ShellRenderer::new();
@@ -3330,6 +3360,7 @@ impl AishShell {
                         }
                     }
                     Err(aish_core::AishError::Cancelled) => {
+                        self.sub_agent_animation.stop();
                         println!("{}", theme::warning(&t("shell.interrupted")));
                     }
                     Err(e) => {
@@ -4725,6 +4756,7 @@ impl AishShell {
         esc_watcher.stop();
         Self::restore_ai_sigint_handler(old_sigint);
         self.animation.stop();
+        self.sub_agent_animation.stop();
 
         match result {
             Ok(_) => {
@@ -4732,6 +4764,7 @@ impl AishShell {
                 // and outcome (trusted on Low/Medium, quarantined on High).
             }
             Err(aish_core::AishError::Cancelled) => {
+                self.sub_agent_animation.stop();
                 println!(
                     "\n{}",
                     t_with_args("shell.skill.vetter.cancelled", &name_args)
@@ -5661,6 +5694,7 @@ impl AishShell {
         let report = match diagnose_result {
             Ok(parsed) => parsed,
             Err(aish_core::AishError::Cancelled) => {
+                self.sub_agent_animation.stop();
                 println!("{}", theme::warning(&t("shell.command_cancelled")));
                 return;
             }
@@ -7644,6 +7678,7 @@ impl AishShell {
                 );
             }
             Err(aish_core::AishError::Cancelled) => {
+                self.sub_agent_animation.stop();
                 eprintln!("{}", theme::warning(&t("shell.setup.cancelled")));
             }
             Err(e) => {

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -671,6 +671,11 @@ pub struct AishShell {
     /// sub-agent tool loop leaks the animation thread, which keeps
     /// overwriting the terminal line.
     sub_agent_animation: Arc<SubAgentThinkingAnimation>,
+    /// Monotonic operation generation counter, bumped before each AI turn.
+    /// The event callback captures the generation at callback-build time and
+    /// rejects events from stale (older) operations to avoid restarting
+    /// animations after cancellation + new-operation reset.
+    ai_op_generation: Arc<std::sync::atomic::AtomicU64>,
     /// Session history of collapsed outputs for Ctrl+O browsing.
     expand_history: Arc<Mutex<crate::expand_history::ExpandHistory>>,
     /// Shared terminal session recorder for asciinema v2 recording.
@@ -1279,6 +1284,8 @@ impl AishShell {
         let sub_agent_active_count_ref = sub_agent_active_count.clone();
         let sub_agent_animation = Arc::new(SubAgentThinkingAnimation::new());
         let sub_agent_animation_ref = sub_agent_animation.clone();
+        let ai_op_generation = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let ai_op_generation_cb = ai_op_generation.clone();
 
         // Shared history of collapsed bash outputs for Ctrl+O browsing.
         let expand_history = Arc::new(Mutex::new(crate::expand_history::ExpandHistory::new()));
@@ -1352,6 +1359,12 @@ impl AishShell {
         // thread, leaking it.
         let cancel_token_for_cb = llm_session.cancellation_token_arc();
 
+        // Per-operation generation: the callback captures the generation
+        // at OpStart and rejects events whose generation is stale (from a
+        // prior cancelled operation whose token was reset).
+        let op_gen = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let ai_op_generation_cb_ref = ai_op_generation_cb.clone();
+
         let event_callback: Arc<dyn Fn(LlmEvent) -> Option<LlmCallbackResult> + Send + Sync> =
             Arc::new(move |event: LlmEvent| {
                 // Helper: clear multi-line reasoning overlay and reset state.
@@ -1368,6 +1381,34 @@ impl AishShell {
                     reasoning_active_ref.store(false, Ordering::SeqCst);
                 };
 
+                // Reject events from a stale (older) operation whose token
+                // was reset by a newer operation.
+                let is_stale = || {
+                    op_gen.load(Ordering::SeqCst) != ai_op_generation_cb_ref.load(Ordering::SeqCst)
+                };
+
+                // Start `anim` with label only if the operation has not been
+                // cancelled and is not stale.  Re-check after start() to
+                // close the TOCTOU window between is_cancelled() and start().
+                let guarded_start = |anim: &SharedAnimation, label: &str| {
+                    if !cancel_token_for_cb.is_cancelled() && !is_stale() {
+                        anim.start(label);
+                        if cancel_token_for_cb.is_cancelled() {
+                            anim.stop();
+                        }
+                    }
+                };
+                // Same guard for sub-agent animation (two-arg start).
+                let guarded_start_sub =
+                    |anim: &SubAgentThinkingAnimation, prefix: &str, label: &str| {
+                        if !cancel_token_for_cb.is_cancelled() && !is_stale() {
+                            anim.start(prefix, label);
+                            if cancel_token_for_cb.is_cancelled() {
+                                anim.stop();
+                            }
+                        }
+                    };
+
                 match event.event_type {
                     LlmEventType::OpStart => {
                         // Operation begins — start thinking animation
@@ -1379,9 +1420,11 @@ impl AishShell {
                         reasoning_active_ref.store(false, Ordering::SeqCst);
                         compaction_active_ref.store(false, Ordering::SeqCst);
                         compaction_notice_shown_ref.store(false, Ordering::SeqCst);
-                        if !cancel_token_for_cb.is_cancelled() {
-                            animation_ref.start(&t("shell.status.thinking"));
-                        }
+                        op_gen.store(
+                            ai_op_generation_cb_ref.load(Ordering::SeqCst),
+                            Ordering::SeqCst,
+                        );
+                        guarded_start(&animation_ref, &t("shell.status.thinking"));
                     }
                     LlmEventType::OpEnd if crate::llm_event_ui::sub_agent_llm_event(&event) => {
                         // A sub-agent OpEnd marks one sub-session finishing, not the
@@ -1409,12 +1452,10 @@ impl AishShell {
                         }
                         *thinking_start_ref.lock().unwrap() = None;
                     }
-                    LlmEventType::ContextCompactionStart => {
-                        if !compaction_active_ref.swap(true, Ordering::SeqCst)
-                            && !cancel_token_for_cb.is_cancelled()
-                        {
-                            animation_ref.start(&t("shell.status.compacting_context"));
-                        }
+                    LlmEventType::ContextCompactionStart
+                        if !compaction_active_ref.swap(true, Ordering::SeqCst) =>
+                    {
+                        guarded_start(&animation_ref, &t("shell.status.compacting_context"));
                     }
                     LlmEventType::ContextCompactionEnd => {
                         compaction_active_ref.store(false, Ordering::SeqCst);
@@ -1432,14 +1473,18 @@ impl AishShell {
                         clear_reasoning();
                         // Late sub-agent events arriving after Ctrl+C would
                         // restart the animation thread — bail out instead.
-                        if cancel_token_for_cb.is_cancelled() {
+                        if cancel_token_for_cb.is_cancelled() || is_stale() {
                             sub_agent_animation_ref.stop();
                             return None;
                         }
                         if let Some(prefix) =
                             crate::llm_event_ui::sub_agent_thinking_animation_prefix(&event)
                         {
-                            sub_agent_animation_ref.start(&prefix, &t("shell.sub_agent.thinking"));
+                            guarded_start_sub(
+                                &sub_agent_animation_ref,
+                                &prefix,
+                                &t("shell.sub_agent.thinking"),
+                            );
                         }
                     }
                     LlmEventType::GenerationStart => {
@@ -1456,10 +1501,8 @@ impl AishShell {
                         reasoning_buf_ref.lock().unwrap().clear();
                         reasoning_frame_ref.store(0, Ordering::SeqCst);
                         renderer_ref.lock().unwrap().reset();
-                        if sub_agent_active_count_ref.load(Ordering::SeqCst) == 0
-                            && !cancel_token_for_cb.is_cancelled()
-                        {
-                            animation_ref.start(&t("shell.status.thinking"));
+                        if sub_agent_active_count_ref.load(Ordering::SeqCst) == 0 {
+                            guarded_start(&animation_ref, &t("shell.status.thinking"));
                         }
                     }
                     LlmEventType::GenerationEnd if react_agent_llm_event(&event) => {}
@@ -1703,9 +1746,8 @@ impl AishShell {
                                 && !react_agent_llm_event(&event)
                                 && !is_interactive_tool
                                 && !bash_needs_tty
-                                && !cancel_token_for_cb.is_cancelled()
                             {
-                                animation_ref.start(&theme::tool_status_label(name));
+                                guarded_start(&animation_ref, &theme::tool_status_label(name));
                             }
                         }
                     }
@@ -1906,6 +1948,7 @@ impl AishShell {
                             println!("{}", theme::accent(prompt_text));
                         }
                     }
+                    _ => {}
                 }
                 None // Always continue
             });
@@ -2119,6 +2162,7 @@ impl AishShell {
             last_ctrl_c: None,
             animation,
             sub_agent_animation: sub_agent_animation.clone(),
+            ai_op_generation,
             expand_history,
             shared_recorder,
             inline_ai: None,
@@ -2153,6 +2197,10 @@ impl AishShell {
 
         // Clear any leftover cancellation state from a previous operation.
         self.ai_handler.cancellation_token().reset();
+        // Bump the operation generation so the event callback can reject
+        // stale events from a prior (cancelled) operation.
+        self.ai_op_generation
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
         let token_ptr = self.ai_handler.cancellation_token() as *const CancellationToken;
         CANCEL_TOKEN_PTR.store(token_ptr as *mut (), Ordering::SeqCst);
@@ -7931,6 +7979,8 @@ impl AishShell {
     pub fn shutdown(&mut self) {
         self.set_phase(ShellPhase::Exiting);
         self.lock_pty().stop();
+        self.animation.stop();
+        self.sub_agent_animation.stop();
     }
 
     fn restart_pty_with_notice(&mut self, show_notice: bool) -> aish_core::Result<()> {

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -3685,6 +3685,7 @@ impl AishShell {
             Some("/forget-approvals") => self.handle_forget_approvals(),
             Some("/audit") => self.handle_audit_command(&parts),
             Some("/memory") => self.handle_memory_command(&parts),
+            Some("/skill") => self.handle_skill_command(&parts),
             Some("/export") => self.handle_export_command(&parts),
             Some("/fork") => self.handle_fork_command(),
             Some("/sessions") => self.handle_sessions_command(),

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -8,7 +8,7 @@ use aish_context::{
     context_window_hard_min_tokens, context_window_warn_below_tokens,
     effective_reserved_output_tokens, resolve_context_window_tokens, ContextBudgetPolicy,
 };
-use aish_core::{AuditEventType, AuditSink, LlmEvent, LlmEventType, MemoryCategory};
+use aish_core::{AuditEventType, AuditSink, LlmEvent, LlmEventType, MemoryCategory, MemoryScope};
 use aish_i18n::{t, t_with_args};
 use aish_llm::{
     langfuse::{LangfuseClient, LangfuseConfig},
@@ -1033,6 +1033,22 @@ impl AishShell {
         // AgentTool is registered after skill loading so the parent session already
         // has SkillTool when general-purpose / troubleshoot inherit the tool pool.
 
+        // Open session store (best-effort) — moved before memory tool
+        // registration so the session UUID and host are available to the
+        // memory store callback as provenance metadata.
+        let session_store = match &config.session_db_path {
+            Some(path) => SessionStore::open(Some(std::path::Path::new(path))).ok(),
+            None => SessionStore::open(None).ok(),
+        };
+        let session_uuid = if let Some(ref store) = session_store {
+            match store.create_session(&config.model, Some(&config.api_base)) {
+                Ok(record) => record.session_uuid,
+                Err(_) => uuid::Uuid::new_v4().to_string(),
+            }
+        } else {
+            uuid::Uuid::new_v4().to_string()
+        };
+        let audit_host = sysinfo::System::host_name();
         // Initialize shared memory manager (best-effort)
         let memory_manager: SharedMemoryManager = Arc::new(Mutex::new(
             MemoryManager::new(MemoryManager::default_path()).ok(),
@@ -1043,6 +1059,8 @@ impl AishShell {
         let mm_for_store = memory_manager.clone();
         let mm_for_delete = memory_manager.clone();
         let mm_for_list = memory_manager.clone();
+        let mem_session_uuid = session_uuid.clone();
+        let mem_audit_host = audit_host.clone();
 
         let memory_tool = aish_tools::MemoryTool::new(
             // search callback
@@ -1056,18 +1074,36 @@ impl AishShell {
                             id: e.id as usize,
                             content: e.content.clone(),
                             category: format!("{:?}", e.category).to_lowercase(),
+                            source: e.source.clone(),
+                            scope: format!("{:?}", e.scope).to_lowercase(),
+                            created_at: e.created_at.clone(),
+                            expires_at: e.expires_at.clone(),
+                            expired: aish_memory::MemoryManager::is_expired(&e),
                         })
                         .collect()
                 } else {
                     vec![]
                 }
             }),
-            // store callback
-            Box::new(move |content, category, source, importance| {
+            // store callback — extended signature with scope and ttl
+            Box::new(move |content, category, source, importance, scope, ttl_seconds| {
                 let mut guard = mm_for_store.lock().unwrap();
                 if let Some(ref mut mm) = *guard {
                     let cat = parse_category_str(category);
-                    match mm.store(content, cat, source, importance as f64) {
+                    let mem_scope = parse_scope_str(scope);
+                    let mem_source = aish_memory::MemorySource {
+                        label: source.to_string(),
+                        session_uuid: Some(mem_session_uuid.clone()),
+                        host: mem_audit_host.clone(),
+                    };
+                    match mm.store_with_provenance(
+                        content,
+                        cat,
+                        mem_scope,
+                        mem_source,
+                        importance as f64,
+                        ttl_seconds,
+                    ) {
                         Ok(id) => id.to_string(),
                         Err(e) => {
                             let mut args = std::collections::HashMap::new();
@@ -1088,7 +1124,7 @@ impl AishShell {
                     false
                 }
             }),
-            // list callback
+            // list callback — enriched with source/scope/expiry
             Box::new(move |limit| {
                 let guard = mm_for_list.lock().unwrap();
                 if let Some(ref mm) = *guard {
@@ -1100,6 +1136,11 @@ impl AishShell {
                             id: e.id as usize,
                             content: e.content.clone(),
                             category: format!("{:?}", e.category).to_lowercase(),
+                            source: e.source.clone(),
+                            scope: format!("{:?}", e.scope).to_lowercase(),
+                            created_at: e.created_at.clone(),
+                            expires_at: e.expires_at.clone(),
+                            expired: aish_memory::MemoryManager::is_expired(&e),
                         })
                         .collect()
                 } else {
@@ -1185,21 +1226,6 @@ impl AishShell {
             llm_session.register_tool(tool);
         }
 
-        // Open session store (best-effort)
-        let session_store = match &config.session_db_path {
-            Some(path) => SessionStore::open(Some(std::path::Path::new(path))).ok(),
-            None => SessionStore::open(None).ok(),
-        };
-
-        // Create session record if store is available
-        let session_uuid = if let Some(ref store) = session_store {
-            match store.create_session(&config.model, Some(&config.api_base)) {
-                Ok(record) => record.session_uuid,
-                Err(_) => uuid::Uuid::new_v4().to_string(),
-            }
-        } else {
-            uuid::Uuid::new_v4().to_string()
-        };
 
         // Open audit store when audit is enabled in the security policy.
         let audit_enabled = security_manager.policy().audit_enabled;
@@ -1234,7 +1260,6 @@ impl AishShell {
             None
         };
         let audit_user = current_user_name();
-        let audit_host = sysinfo::System::host_name();
 
         // Resolve memory config (use defaults if not specified)
         let memory_config = config.memory.clone().unwrap_or_default();
@@ -3657,9 +3682,9 @@ impl AishShell {
                     }
                 }
             }
-            Some("/audit") => self.handle_audit_command(&parts),
             Some("/forget-approvals") => self.handle_forget_approvals(),
-            Some("/skill") => self.handle_skill_command(&parts),
+            Some("/audit") => self.handle_audit_command(&parts),
+            Some("/memory") => self.handle_memory_command(&parts),
             Some("/export") => self.handle_export_command(&parts),
             Some("/fork") => self.handle_fork_command(),
             Some("/sessions") => self.handle_sessions_command(),
@@ -3689,6 +3714,138 @@ impl AishShell {
             "\x1b[36m{}\x1b[0m",
             t_with_args("shell.forget_approvals_cleared", &args)
         );
+    }
+
+    /// `/memory` — view, verify, or forget long-term memories.
+    ///
+    /// Subcommands:
+    /// - `/memory` or `/memory list` — list all entries (active + expired)
+    /// - `/memory verify <id>` — re-verify an entry (renews last_verified_at, clears expiry)
+    /// - `/memory forget <id>` — delete an entry by ID
+    /// - `/memory clear-expired` — remove all expired entries
+    fn handle_memory_command(&mut self, parts: &[&str]) {
+        let sub = parts.get(1).copied().unwrap_or("list");
+        let mut guard = self.memory_manager.lock().unwrap();
+        let Some(mm) = guard.as_mut() else {
+            eprintln!("{}", t("tools.memory.not_available"));
+            return;
+        };
+        match sub {
+            "list" => {
+                let entries = mm.list();
+                if entries.is_empty() {
+                    println!("\x1b[36m{}\x1b[0m", t("tools.memory.empty"));
+                    return;
+                }
+                println!("\x1b[36m{}\x1b[0m", t("tools.memory.list_header"));
+                for e in entries.iter().rev() {
+                    let cat = format!("{:?}", e.category).to_lowercase();
+                    let scope = format_scope_short(&e.scope);
+                    let mut line = format!("  #{} [{}] {} [{}]", e.id, cat, e.content, scope);
+                    if !e.source.is_empty() {
+                        line.push_str(&format!(" ({})", e.source));
+                    }
+                    if let Some(created) = &e.created_at {
+                        line.push_str(&format!(" @{}", created));
+                    }
+                    if aish_memory::MemoryManager::is_expired(e) {
+                        line.push_str(&format!(" \x1b[31m[{}]\x1b[0m", t("tools.memory.expired_tag")));
+                    } else if let Some(exp) = &e.expires_at {
+                        line.push_str(&format!(" ({}: {})", t("tools.memory.field_expires"), exp));
+                    }
+                    println!("{}", line);
+                }
+            }
+            "verify" => {
+                let id_str = match parts.get(2) {
+                    Some(s) => s,
+                    None => {
+                        eprintln!("{}", t("tools.memory.verify_usage"));
+                        return;
+                    }
+                };
+                let id: i64 = match id_str.parse() {
+                    Ok(v) => v,
+                    Err(_) => {
+                        let mut args = std::collections::HashMap::new();
+                        args.insert("id".to_string(), id_str.to_string());
+                        eprintln!("{}", t_with_args("tools.memory.invalid_id", &args));
+                        return;
+                    }
+                };
+                match mm.verify(id, None) {
+                    Ok(true) => {
+                        let mut args = std::collections::HashMap::new();
+                        args.insert("id".to_string(), id.to_string());
+                        println!("\x1b[36m{}\x1b[0m", t_with_args("tools.memory.verified", &args));
+                    }
+                    Ok(false) => {
+                        let mut args = std::collections::HashMap::new();
+                        args.insert("id".to_string(), id.to_string());
+                        eprintln!("{}", t_with_args("tools.memory.not_found", &args));
+                    }
+                    Err(e) => {
+                        let mut args = std::collections::HashMap::new();
+                        args.insert("error".to_string(), e.to_string());
+                        eprintln!("{}", t_with_args("shell.general_error", &args));
+                    }
+                }
+            }
+            "forget" => {
+                let id_str = match parts.get(2) {
+                    Some(s) => s,
+                    None => {
+                        eprintln!("{}", t("tools.memory.forget_usage"));
+                        return;
+                    }
+                };
+                let id: i64 = match id_str.parse() {
+                    Ok(v) => v,
+                    Err(_) => {
+                        let mut args = std::collections::HashMap::new();
+                        args.insert("id".to_string(), id_str.to_string());
+                        eprintln!("{}", t_with_args("tools.memory.invalid_id", &args));
+                        return;
+                    }
+                };
+                match mm.remove(id) {
+                    Ok(true) => {
+                        let mut args = std::collections::HashMap::new();
+                        args.insert("id".to_string(), id.to_string());
+                        println!("\x1b[36m{}\x1b[0m", t_with_args("tools.memory.forgot", &args));
+                    }
+                    Ok(false) => {
+                        let mut args = std::collections::HashMap::new();
+                        args.insert("id".to_string(), id.to_string());
+                        eprintln!("{}", t_with_args("tools.memory.not_found", &args));
+                    }
+                    Err(e) => {
+                        let mut args = std::collections::HashMap::new();
+                        args.insert("error".to_string(), e.to_string());
+                        eprintln!("{}", t_with_args("shell.general_error", &args));
+                    }
+                }
+            }
+            "clear-expired" => {
+                let expired_ids = mm.expired_entry_ids();
+                if expired_ids.is_empty() {
+                    println!("\x1b[36m{}\x1b[0m", t("tools.memory.no_expired"));
+                    return;
+                }
+                let count = expired_ids.len();
+                for id in &expired_ids {
+                    let _ = mm.remove(*id);
+                }
+                let mut args = std::collections::HashMap::new();
+                args.insert("count".to_string(), count.to_string());
+                println!("\x1b[36m{}\x1b[0m", t_with_args("tools.memory.cleared_expired", &args));
+            }
+            _ => {
+                let mut args = std::collections::HashMap::new();
+                args.insert("subcommand".to_string(), sub.to_string());
+                eprintln!("{}", t_with_args("tools.memory.unknown_subcommand", &args));
+            }
+        }
     }
 
     /// `/export [md]` — export the current session (AI conversation + command
@@ -11223,6 +11380,26 @@ fn parse_category_str(s: &str) -> MemoryCategory {
         "solution" => MemoryCategory::Solution,
         "pattern" => MemoryCategory::Pattern,
         _ => MemoryCategory::Other,
+    }
+}
+
+/// Parse a scope string (from the LLM tool call) into a MemoryScope.
+/// Falls back to `User` for unrecognized values — never promote host facts
+/// to global scope by default.
+fn parse_scope_str(s: &str) -> MemoryScope {
+    match s.to_lowercase().as_str() {
+        "host" => MemoryScope::Host,
+        "project" => MemoryScope::Project,
+        _ => MemoryScope::User,
+    }
+}
+
+/// Format a MemoryScope as a short lowercase string for display.
+fn format_scope_short(scope: &MemoryScope) -> &'static str {
+    match scope {
+        MemoryScope::User => "user",
+        MemoryScope::Host => "host",
+        MemoryScope::Project => "project",
     }
 }
 

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -63,6 +63,10 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
         "/rollback",
         "Review and roll back AI file edits (edit_file/write_file) this session",
     ),
+    (
+        "/memory",
+        "View, verify, or forget long-term memories (list/verify/forget/clear-expired)",
+    ),
 ];
 
 // ---------------------------------------------------------------------------
@@ -850,7 +854,7 @@ mod tests {
                 cmd
             );
         }
-        assert_eq!(SLASH_COMMANDS.len(), 23);
+        assert_eq!(SLASH_COMMANDS.len(), 24);
     }
 
     #[test]

--- a/crates/aish-shell/tests/slash_popup_commands.rs
+++ b/crates/aish-shell/tests/slash_popup_commands.rs
@@ -30,7 +30,7 @@ fn each_builtin_command_enter_executes() {
 
 #[test]
 fn slash_commands_table_has_expected_count() {
-    assert_eq!(SLASH_COMMANDS.len(), 23);
+    assert_eq!(SLASH_COMMANDS.len(), 24);
 }
 
 #[test]

--- a/crates/aish-tools/src/memory_tool/memory_tool.rs
+++ b/crates/aish-tools/src/memory_tool/memory_tool.rs
@@ -8,9 +8,8 @@ pub type MemorySearchFn = Box<dyn Fn(&str, usize) -> Vec<MemorySearchResult> + S
 /// Callback type for memory store operations.
 /// Returns the assigned ID as a string.
 /// Arguments: content, category, source, importance, scope, ttl_seconds.
-pub type MemoryStoreFn = Box<
-    dyn Fn(&str, &str, &str, f32, &str, Option<u64>) -> String + Send + Sync,
->;
+pub type MemoryStoreFn =
+    Box<dyn Fn(&str, &str, &str, f32, &str, Option<u64>) -> String + Send + Sync>;
 /// Callback type for memory delete operations.
 pub type MemoryDeleteFn = Box<dyn Fn(usize) -> bool + Send + Sync>;
 /// Callback type for memory list operations.
@@ -56,9 +55,7 @@ impl MemoryTool {
     pub fn noop() -> Self {
         Self {
             search: Box::new(|_, _| Vec::new()),
-            store: Box::new(|_, _, _, _, _, _| {
-                aish_i18n::t("tools.memory.not_available")
-            }),
+            store: Box::new(|_, _, _, _, _, _| aish_i18n::t("tools.memory.not_available")),
             delete: Box::new(|_| false),
             list: Box::new(|_| Vec::new()),
         }
@@ -116,15 +113,9 @@ impl Tool for MemoryTool {
                     .get("category")
                     .and_then(|v| v.as_str())
                     .unwrap_or("other");
-                let scope = args
-                    .get("scope")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("user");
+                let scope = args.get("scope").and_then(|v| v.as_str()).unwrap_or("user");
                 let ttl = args.get("ttl_seconds").and_then(|v| v.as_u64());
-                let reason = args
-                    .get("reason")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
+                let reason = args.get("reason").and_then(|v| v.as_str()).unwrap_or("");
 
                 let mut msg = format!(
                     "{}\n  {}\n  {}: {} | {}: {}",
@@ -136,10 +127,18 @@ impl Tool for MemoryTool {
                     scope,
                 );
                 if let Some(t) = ttl {
-                    msg.push_str(&format!(" | {}: {}s", aish_i18n::t("tools.memory.field_ttl"), t));
+                    msg.push_str(&format!(
+                        " | {}: {}s",
+                        aish_i18n::t("tools.memory.field_ttl"),
+                        t
+                    ));
                 }
                 if !reason.is_empty() {
-                    msg.push_str(&format!("\n  {}: {}", aish_i18n::t("tools.memory.field_reason"), reason));
+                    msg.push_str(&format!(
+                        "\n  {}: {}",
+                        aish_i18n::t("tools.memory.field_reason"),
+                        reason
+                    ));
                 }
 
                 PreflightResult::Confirm {
@@ -167,17 +166,14 @@ impl Tool for MemoryTool {
                         }
                     }
                 };
-                let reason = args
-                    .get("reason")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let mut msg = format!(
-                    "{} #{}",
-                    aish_i18n::t("tools.memory.confirm_forget"),
-                    id,
-                );
+                let reason = args.get("reason").and_then(|v| v.as_str()).unwrap_or("");
+                let mut msg = format!("{} #{}", aish_i18n::t("tools.memory.confirm_forget"), id,);
                 if !reason.is_empty() {
-                    msg.push_str(&format!("\n  {}: {}", aish_i18n::t("tools.memory.field_reason"), reason));
+                    msg.push_str(&format!(
+                        "\n  {}: {}",
+                        aish_i18n::t("tools.memory.field_reason"),
+                        reason
+                    ));
                 }
 
                 PreflightResult::Confirm {
@@ -229,10 +225,7 @@ impl Tool for MemoryTool {
                     .get("category")
                     .and_then(|v| v.as_str())
                     .unwrap_or("other");
-                let scope = args
-                    .get("scope")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("user");
+                let scope = args.get("scope").and_then(|v| v.as_str()).unwrap_or("user");
                 let ttl_seconds = args.get("ttl_seconds").and_then(|v| v.as_u64());
                 let id = (self.store)(content, category, "explicit", 0.8, scope, ttl_seconds);
                 let mut args_map = std::collections::HashMap::new();
@@ -284,7 +277,11 @@ fn format_search_result(r: &MemorySearchResult) -> String {
     }
     if let Some(ref exp) = r.expires_at {
         if !r.expired {
-            line.push_str(&format!(" ({}: {})", aish_i18n::t("tools.memory.field_expires"), exp));
+            line.push_str(&format!(
+                " ({}: {})",
+                aish_i18n::t("tools.memory.field_expires"),
+                exp
+            ));
         }
     }
     line
@@ -302,7 +299,11 @@ fn format_list_result(r: &MemorySearchResult) -> String {
     if r.expired {
         line.push_str(&format!(" [{}]", aish_i18n::t("tools.memory.expired_tag")));
     } else if let Some(ref exp) = r.expires_at {
-        line.push_str(&format!(" ({}: {})", aish_i18n::t("tools.memory.field_expires"), exp));
+        line.push_str(&format!(
+            " ({}: {})",
+            aish_i18n::t("tools.memory.field_expires"),
+            exp
+        ));
     }
     line
 }

--- a/crates/aish-tools/src/memory_tool/memory_tool.rs
+++ b/crates/aish-tools/src/memory_tool/memory_tool.rs
@@ -1,20 +1,32 @@
 use aish_i18n;
-use aish_llm::{Tool, ToolResult};
+use aish_llm::{PreflightResult, PreflightSecurityContext, SecurityPanelMode, Tool, ToolResult};
 
 use super::prompt;
 
-/// Callback type for memory operations.
+/// Callback type for memory search operations.
 pub type MemorySearchFn = Box<dyn Fn(&str, usize) -> Vec<MemorySearchResult> + Send + Sync>;
-pub type MemoryStoreFn = Box<dyn Fn(&str, &str, &str, f32) -> String + Send + Sync>;
+/// Callback type for memory store operations.
+/// Returns the assigned ID as a string.
+/// Arguments: content, category, source, importance, scope, ttl_seconds.
+pub type MemoryStoreFn = Box<
+    dyn Fn(&str, &str, &str, f32, &str, Option<u64>) -> String + Send + Sync,
+>;
+/// Callback type for memory delete operations.
 pub type MemoryDeleteFn = Box<dyn Fn(usize) -> bool + Send + Sync>;
+/// Callback type for memory list operations.
 pub type MemoryListFn = Box<dyn Fn(usize) -> Vec<MemorySearchResult> + Send + Sync>;
 
-/// A single memory search result.
+/// A single memory search result enriched with provenance and expiry info.
 #[derive(Debug, Clone)]
 pub struct MemorySearchResult {
     pub id: usize,
     pub content: String,
     pub category: String,
+    pub source: String,
+    pub scope: String,
+    pub created_at: Option<String>,
+    pub expires_at: Option<String>,
+    pub expired: bool,
 }
 
 /// Tool for searching, storing, and managing long-term memories.
@@ -44,7 +56,9 @@ impl MemoryTool {
     pub fn noop() -> Self {
         Self {
             search: Box::new(|_, _| Vec::new()),
-            store: Box::new(|_, _, _, _| aish_i18n::t("tools.memory.not_available")),
+            store: Box::new(|_, _, _, _, _, _| {
+                aish_i18n::t("tools.memory.not_available")
+            }),
             delete: Box::new(|_| false),
             list: Box::new(|_| Vec::new()),
         }
@@ -68,6 +82,119 @@ impl Tool for MemoryTool {
         prompt::PROMPT
     }
 
+    fn preflight(&self, args: &serde_json::Value) -> PreflightResult {
+        let action = match args.get("action").and_then(|v| v.as_str()) {
+            Some(a) => a,
+            None => {
+                return PreflightResult::Block {
+                    message: aish_i18n::t("tools.memory.missing_action"),
+                    security: Some(PreflightSecurityContext::fallback(
+                        "memory",
+                        None,
+                        aish_i18n::t("tools.memory.missing_action"),
+                        SecurityPanelMode::Blocked,
+                    )),
+                }
+            }
+        };
+
+        match action {
+            "store" => {
+                let content = args.get("content").and_then(|v| v.as_str()).unwrap_or("");
+                if content.trim().is_empty() {
+                    return PreflightResult::Block {
+                        message: aish_i18n::t("tools.memory.store_missing_content"),
+                        security: Some(PreflightSecurityContext::fallback(
+                            "memory",
+                            None,
+                            aish_i18n::t("tools.memory.store_missing_content"),
+                            SecurityPanelMode::Blocked,
+                        )),
+                    };
+                }
+                let category = args
+                    .get("category")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("other");
+                let scope = args
+                    .get("scope")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("user");
+                let ttl = args.get("ttl_seconds").and_then(|v| v.as_u64());
+                let reason = args
+                    .get("reason")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+
+                let mut msg = format!(
+                    "{}\n  {}\n  {}: {} | {}: {}",
+                    aish_i18n::t("tools.memory.confirm_store"),
+                    content,
+                    aish_i18n::t("tools.memory.field_category"),
+                    category,
+                    aish_i18n::t("tools.memory.field_scope"),
+                    scope,
+                );
+                if let Some(t) = ttl {
+                    msg.push_str(&format!(" | {}: {}s", aish_i18n::t("tools.memory.field_ttl"), t));
+                }
+                if !reason.is_empty() {
+                    msg.push_str(&format!("\n  {}: {}", aish_i18n::t("tools.memory.field_reason"), reason));
+                }
+
+                PreflightResult::Confirm {
+                    message: msg.clone(),
+                    security: Some(PreflightSecurityContext::fallback(
+                        "memory",
+                        Some(content.to_string()),
+                        msg,
+                        SecurityPanelMode::Confirm,
+                    )),
+                }
+            }
+            "forget" => {
+                let id = match args.get("memory_id").and_then(|v| v.as_u64()) {
+                    Some(id) => id,
+                    None => {
+                        return PreflightResult::Block {
+                            message: aish_i18n::t("tools.memory.forget_missing_id"),
+                            security: Some(PreflightSecurityContext::fallback(
+                                "memory",
+                                None,
+                                aish_i18n::t("tools.memory.forget_missing_id"),
+                                SecurityPanelMode::Blocked,
+                            )),
+                        }
+                    }
+                };
+                let reason = args
+                    .get("reason")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let mut msg = format!(
+                    "{} #{}",
+                    aish_i18n::t("tools.memory.confirm_forget"),
+                    id,
+                );
+                if !reason.is_empty() {
+                    msg.push_str(&format!("\n  {}: {}", aish_i18n::t("tools.memory.field_reason"), reason));
+                }
+
+                PreflightResult::Confirm {
+                    message: msg.clone(),
+                    security: Some(PreflightSecurityContext::fallback(
+                        "memory",
+                        Some(id.to_string()),
+                        msg,
+                        SecurityPanelMode::Confirm,
+                    )),
+                }
+            }
+            // search and list are read-only — no confirmation needed
+            _ => PreflightResult::Allow,
+        }
+    }
+
     fn execute(&self, args: serde_json::Value) -> ToolResult {
         let action = match args.get("action").and_then(|v| v.as_str()) {
             Some(a) => a,
@@ -86,10 +213,7 @@ impl Tool for MemoryTool {
                 if results.is_empty() {
                     return ToolResult::success(aish_i18n::t("tools.memory.no_results"));
                 }
-                let output: Vec<String> = results
-                    .iter()
-                    .map(|r| format!("  [{}] {} (id={})", r.category, r.content, r.id))
-                    .collect();
+                let output: Vec<String> = results.iter().map(format_search_result).collect();
                 ToolResult::success(output.join("\n"))
             }
             "store" => {
@@ -105,7 +229,12 @@ impl Tool for MemoryTool {
                     .get("category")
                     .and_then(|v| v.as_str())
                     .unwrap_or("other");
-                let id = (self.store)(content, category, "explicit", 0.8);
+                let scope = args
+                    .get("scope")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("user");
+                let ttl_seconds = args.get("ttl_seconds").and_then(|v| v.as_u64());
+                let id = (self.store)(content, category, "explicit", 0.8, scope, ttl_seconds);
                 let mut args_map = std::collections::HashMap::new();
                 args_map.insert("id".to_string(), id.clone());
                 ToolResult::success(aish_i18n::t_with_args("tools.memory.stored", &args_map))
@@ -132,10 +261,7 @@ impl Tool for MemoryTool {
                 if results.is_empty() {
                     return ToolResult::success(aish_i18n::t("tools.memory.empty"));
                 }
-                let output: Vec<String> = results
-                    .iter()
-                    .map(|r| format!("  #{} [{}] {}", r.id, r.category, r.content))
-                    .collect();
+                let output: Vec<String> = results.iter().map(format_list_result).collect();
                 ToolResult::success(output.join("\n"))
             }
             _ => {
@@ -148,4 +274,35 @@ impl Tool for MemoryTool {
             }
         }
     }
+}
+
+/// Format a search result with source and expiry info.
+fn format_search_result(r: &MemorySearchResult) -> String {
+    let mut line = format!("  [{}] {} (id={})", r.category, r.content, r.id);
+    if r.expired {
+        line.push_str(&format!(" [{}]", aish_i18n::t("tools.memory.expired_tag")));
+    }
+    if let Some(ref exp) = r.expires_at {
+        if !r.expired {
+            line.push_str(&format!(" ({}: {})", aish_i18n::t("tools.memory.field_expires"), exp));
+        }
+    }
+    line
+}
+
+/// Format a list result with source, scope, and age info.
+fn format_list_result(r: &MemorySearchResult) -> String {
+    let mut line = format!("  #{} [{}] {} [{}]", r.id, r.category, r.content, r.scope);
+    if !r.source.is_empty() {
+        line.push_str(&format!(" ({})", r.source));
+    }
+    if let Some(ref created) = r.created_at {
+        line.push_str(&format!(" @{}", created));
+    }
+    if r.expired {
+        line.push_str(&format!(" [{}]", aish_i18n::t("tools.memory.expired_tag")));
+    } else if let Some(ref exp) = r.expires_at {
+        line.push_str(&format!(" ({}: {})", aish_i18n::t("tools.memory.field_expires"), exp));
+    }
+    line
 }

--- a/crates/aish-tools/src/memory_tool/prompt.rs
+++ b/crates/aish-tools/src/memory_tool/prompt.rs
@@ -4,9 +4,12 @@ pub(crate) const PROMPT: &str = r#"Use this tool for long-term memory operations
 
 Usage:
 - Use search to recall relevant saved knowledge before acting on user preferences or prior context.
-- Use store only for durable facts that are likely useful later.
-- Use list to inspect recent memories.
-- Use forget to remove outdated or incorrect memory entries by id."#;
+- Use store only for durable facts that are likely useful later. Storing and forgetting require user confirmation.
+- Use list to inspect recent memories, including expired ones.
+- Use forget to remove outdated or incorrect memory entries by id. Forgetting requires user confirmation.
+- scope: "user" (default) for personal facts, "host" for machine-specific facts, "project" for codebase facts.
+- ttl_seconds: optional expiry. Expired entries are not injected into context. Use /memory to review expired entries.
+- reason: briefly explain why the memory is being stored or forgotten."#;
 
 pub(crate) fn parameters() -> serde_json::Value {
     serde_json::json!({
@@ -29,6 +32,19 @@ pub(crate) fn parameters() -> serde_json::Value {
                 "type": "string",
                 "enum": ["preference", "environment", "solution", "pattern", "other"],
                 "description": "Category for stored memory. Defaults to other."
+            },
+            "scope": {
+                "type": "string",
+                "enum": ["user", "host", "project"],
+                "description": "Scope of the memory. Defaults to user. Use host for machine-specific facts, project for codebase facts."
+            },
+            "ttl_seconds": {
+                "type": "integer",
+                "description": "Optional time-to-live in seconds. When set, the memory expires after this duration and is excluded from context injection. Use 604800 for 7 days, 2592000 for 30 days."
+            },
+            "reason": {
+                "type": "string",
+                "description": "Brief reason for storing or forgetting this memory. Shown in the confirmation prompt."
             },
             "memory_id": {
                 "type": "integer",

--- a/tests/repro_subagent_anim_leak.py
+++ b/tests/repro_subagent_anim_leak.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Reproduce/verify the sub_agent_animation leak bug.
+
+Spawns aish in a PTY (stdout+stderr merged), triggers a sub-agent via an
+AI prompt, sends Ctrl+C while the sub-agent is thinking, drains all
+buffered output, then checks whether NEW animation frames keep arriving.
+
+- Bug:   the animation thread keeps running; new "思考中" frames flow.
+- Fixed: the animation thread is stopped; no new frames after drain.
+
+Usage:
+    AISH_BIN=target/debug/aish python3 tests/repro_subagent_anim_leak.py
+"""
+
+import fcntl
+import os
+import re
+import select
+import struct
+import subprocess
+import sys
+import termios
+import time
+
+import pty
+
+
+def read_available(fd: int, timeout: float = 0.5) -> bytes:
+    data = b""
+    end = time.time() + timeout
+    while time.time() < end:
+        r, _, _ = select.select([fd], [], [], 0.1)
+        if r:
+            try:
+                chunk = os.read(fd, 65536)
+                if chunk:
+                    data += chunk
+            except OSError:
+                break
+    return data
+
+
+def main() -> int:
+    aish_bin = os.environ.get("AISH_BIN", "target/debug/aish")
+    if not os.path.isfile(aish_bin):
+        print(f"aish binary not found: {aish_bin}")
+        return 2
+
+    real_config_home = os.path.expanduser("~/.config")
+    tmp_config = os.environ.get("XDG_CONFIG_HOME", "/tmp/aish-repro-config")
+    os.makedirs(tmp_config, exist_ok=True)
+    dst = os.path.join(tmp_config, "aish")
+    if not os.path.exists(dst):
+        os.symlink(os.path.join(real_config_home, "aish"), dst)
+
+    env = os.environ.copy()
+    env["XDG_CONFIG_HOME"] = tmp_config
+    env["TERM"] = "xterm-256color"
+    env["RUST_LOG"] = "warn"
+
+    master, slave = pty.openpty()
+    winsize = struct.pack("HHHH", 40, 120, 0, 0)
+    fcntl.ioctl(master, termios.TIOCSWINSZ, winsize)
+
+    proc = subprocess.Popen(
+        [aish_bin],
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        env=env,
+        close_fds=True,
+    )
+    os.close(slave)
+    flags = fcntl.fcntl(master, fcntl.F_GETFL)
+    fcntl.fcntl(master, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+    try:
+        # Wait for prompt.
+        end = time.time() + 20
+        while time.time() < end:
+            data = read_available(master, 1.0)
+            text = data.decode("utf-8", errors="replace")
+            if "●" in text and "->" in text:
+                print("--- aish prompt reached ---")
+                break
+        else:
+            print("--- timeout waiting for prompt ---")
+            return 4
+
+        # Send AI prompt that triggers explore sub-agent (long-running task
+        # so the animation thread has time to build up frames).
+        prompt = ("; Please use the explore sub-agent to do a deep dive into "
+                  "the entire workspace structure, read all Cargo.toml files, "
+                  "and provide a comprehensive summary of every crate and its "
+                  "dependencies. This requires thorough exploration.\r")
+        os.write(master, prompt.encode())
+        print("--- AI prompt sent ---")
+
+        # Wait for sub-agent thinking line.
+        end = time.time() + 30
+        saw_sub_agent = False
+        while time.time() < end:
+            data = read_available(master, 2.0)
+            if b"explore" in data and b"\xe6\x80\x9d\xe8\x80\x83" in data:
+                saw_sub_agent = True
+                print("--- sub-agent thinking line detected ---")
+                break
+        else:
+            print("--- sub-agent not triggered; skipping ---")
+            os.write(master, b"\x03\x03")
+            return 77
+
+        # Let animation build up (3 s ensures the sub-agent's tool loop is
+        # actively running and emitting "思考中" frames).
+        time.sleep(3.0)
+        read_available(master, 0.5)
+
+        # Send Ctrl+C.
+        os.write(master, b"\x03")
+        print("--- Ctrl+C sent ---")
+        # Phase 1: drain ALL buffered output (3 s quiet period).
+        end = time.time() + 20
+        last_data = time.time()
+        drained = b""
+        while time.time() < end:
+            data = read_available(master, 0.5)
+            drained += data
+            if data:
+                last_data = time.time()
+            elif time.time() - last_data > 3.0:
+                break
+        print(f"--- drained {len(drained)} bytes ---")
+
+        # Phase 2: check for NEW output (animation still running?).
+        new_data = b""
+        end = time.time() + 5.0
+        while time.time() < end:
+            data = read_available(master, 0.5)
+            new_data += data
+
+        new_text = new_data.decode("utf-8", errors="replace")
+        new_timers = re.findall(r"(\d+\.\d+)s", new_text)
+        print(f"--- new output after drain: {len(new_data)} bytes, {len(new_timers)} timer frames ---")
+
+        if len(new_data) > 100 or len(new_timers) > 0:
+            print("\n--- BUG REPRODUCED: animation still running after Ctrl+C ---")
+            return 1
+        else:
+            print("\n--- FIX VERIFIED: animation stopped after Ctrl+C ---")
+            return 0
+
+    finally:
+        try:
+            os.write(master, b"\x03\x03")
+            proc.terminate()
+            proc.wait(timeout=5)
+        except Exception:
+            pass
+        os.close(master)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repro_subagent_anim_leak.py
+++ b/tests/repro_subagent_anim_leak.py
@@ -19,10 +19,14 @@ import select
 import struct
 import subprocess
 import sys
+import tempfile
 import termios
 import time
 
 import pty
+
+# UTF-8 bytes for "思考中" (think indicator).
+THINKING_BYTES = "\u601d\u8003\u4e2d".encode("utf-8")
 
 
 def read_available(fd: int, timeout: float = 0.5) -> bytes:
@@ -47,8 +51,7 @@ def main() -> int:
         return 2
 
     real_config_home = os.path.expanduser("~/.config")
-    tmp_config = os.environ.get("XDG_CONFIG_HOME", "/tmp/aish-repro-config")
-    os.makedirs(tmp_config, exist_ok=True)
+    tmp_config = tempfile.mkdtemp(prefix="aish-repro-")
     dst = os.path.join(tmp_config, "aish")
     if not os.path.exists(dst):
         os.symlink(os.path.join(real_config_home, "aish"), dst)
@@ -80,7 +83,7 @@ def main() -> int:
         while time.time() < end:
             data = read_available(master, 1.0)
             text = data.decode("utf-8", errors="replace")
-            if "●" in text and "->" in text:
+            if "\u25cf" in text and "->" in text:
                 print("--- aish prompt reached ---")
                 break
         else:
@@ -89,10 +92,12 @@ def main() -> int:
 
         # Send AI prompt that triggers explore sub-agent (long-running task
         # so the animation thread has time to build up frames).
-        prompt = ("; Please use the explore sub-agent to do a deep dive into "
-                  "the entire workspace structure, read all Cargo.toml files, "
-                  "and provide a comprehensive summary of every crate and its "
-                  "dependencies. This requires thorough exploration.\r")
+        prompt = (
+            "; Please use the explore sub-agent to do a deep dive into "
+            "the entire workspace structure, read all Cargo.toml files, "
+            "and provide a comprehensive summary of every crate and its "
+            "dependencies. This requires thorough exploration.\r"
+        )
         os.write(master, prompt.encode())
         print("--- AI prompt sent ---")
 
@@ -101,7 +106,7 @@ def main() -> int:
         saw_sub_agent = False
         while time.time() < end:
             data = read_available(master, 2.0)
-            if b"explore" in data and b"\xe6\x80\x9d\xe8\x80\x83" in data:
+            if b"explore" in data and THINKING_BYTES in data:
                 saw_sub_agent = True
                 print("--- sub-agent thinking line detected ---")
                 break
@@ -113,7 +118,15 @@ def main() -> int:
         # Let animation build up (3 s ensures the sub-agent's tool loop is
         # actively running and emitting "思考中" frames).
         time.sleep(3.0)
-        read_available(master, 0.5)
+        pre_ctrl_c = read_available(master, 0.5)
+        # Confirm the sub-agent animation is actually emitting frames.
+        if THINKING_BYTES not in pre_ctrl_c:
+            print(
+                "--- sub-agent animation not emitting frames before "
+                "Ctrl+C; inconclusive ---"
+            )
+            return 77
+        print("--- thinking frames confirmed before Ctrl+C ---")
 
         # Send Ctrl+C.
         os.write(master, b"\x03")
@@ -138,25 +151,57 @@ def main() -> int:
             data = read_available(master, 0.5)
             new_data += data
 
-        new_text = new_data.decode("utf-8", errors="replace")
-        new_timers = re.findall(r"(\d+\.\d+)s", new_text)
-        print(f"--- new output after drain: {len(new_data)} bytes, {len(new_timers)} timer frames ---")
+        # Verify the aish process is still alive (the leak is a
+        # background thread, not a crash).
+        if proc.poll() is not None:
+            print("--- aish process exited unexpectedly ---")
+            return 3
 
-        if len(new_data) > 100 or len(new_timers) > 0:
-            print("\n--- BUG REPRODUCED: animation still running after Ctrl+C ---")
+        # The key signal: new "思考中" frames after drain.
+        new_text = new_data.decode("utf-8", errors="replace")
+        new_thinking_frames = new_text.count(THINKING_BYTES.decode("utf-8"))
+        new_timers = re.findall(r"(\d+\.\d+)s", new_text)
+        print(
+            f"--- new output after drain: {len(new_data)} bytes, "
+            f"{new_thinking_frames} thinking frames, "
+            f"{len(new_timers)} timer frames ---"
+        )
+
+        if new_thinking_frames > 0:
+            print(
+                "\n--- BUG REPRODUCED: animation still running after "
+                "Ctrl+C ---"
+            )
             return 1
         else:
-            print("\n--- FIX VERIFIED: animation stopped after Ctrl+C ---")
+            print(
+                "\n--- FIX VERIFIED: animation stopped after Ctrl+C ---"
+            )
             return 0
 
     finally:
+        cleanup_proc(proc, master)
+
+
+def cleanup_proc(proc: subprocess.Popen, master: int) -> None:
+    """Ensure the child process and PTY are cleaned up."""
+    try:
+        os.write(master, b"\x03\x03")
+    except OSError:
+        pass
+    try:
+        proc.terminate()
+        proc.wait(timeout=5)
+    except Exception:
         try:
-            os.write(master, b"\x03\x03")
-            proc.terminate()
+            proc.kill()
             proc.wait(timeout=5)
         except Exception:
             pass
+    try:
         os.close(master)
+    except OSError:
+        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Problem: Long-term Memory was directly modifiable by the model without user oversight, lacked source provenance, had no expiry mechanism, and provided no human management interface.
- Changes: Added user confirmation gates for store/forget, source provenance tracking, TTL expiry with auto-filtering, enriched list/search output, `/memory` slash command, and v2 backward-compatible storage format.
- Related Issue: #472

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Other

## Scope

- [ ] Core shell / PTY
- [ ] AI agent / LLM
- [x] Skills / Tools
- [ ] Security
- [ ] Configuration
- [x] CLI / Interface
- [ ] Packaging / Installation
- [ ] CI/CD
- [ ] Documentation

## User-visible Changes

- `/memory` slash command with subcommands: `list`, `verify <id>`, `forget <id>`, `clear-expired`
- AI store/forget operations now show a confirmation panel before writing
- Memory entries display source, scope, creation date, and expiry info
- Auto-retain memories get a 7-day TTL; expired entries are excluded from AI context
- `MemoryScope` enum: `user` (default), `host`, `project` for scoped memory

## Compatibility

- Backward compatible? Yes — v1 memory file format is parsed transparently; v2 metadata lines are optional
- Config changes? No

## Testing

- `cargo test --workspace` — 410+ tests pass, 0 failures
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- pexpect smoke test: 7/7 `/memory` subcommand tests pass
- Regression tests added: `test_verify_none_clears_expiry`, `test_parse_content_with_blockquote`

Closes #472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `/memory` command to list, verify, forget, and clear expired long-term memories.
  - Added memory scopes, source information, expiration dates, verification, and confirmation prompts.
  - Memory search and listings now display provenance, scope, creation time, and expiration status.
  - Automatic memories are retained for seven days.
- **Localization**
  - Added complete `/memory` translations for English, German, Spanish, French, Japanese, and Chinese.
- **Bug Fixes**
  - Improved shell input detection to prevent payloads from bypassing input safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->