### PR TITLE
feat(memory): category-aware TTL policy with permanent flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,7 @@ dependencies = [
  "aish-core",
  "aish-i18n",
  "aish-llm",
+ "aish-memory",
  "aish-pty",
  "aish-security",
  "aish-skills",

--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -679,6 +679,13 @@ shell:
     store_unavailable: "Sitzungsspeicher nicht verfügbar; Export nicht möglich"
     not_found: "aktuelle Sitzung im Speicher nicht gefunden"
     load_failed: "Laden der Sitzung fehlgeschlagen: {error}"
+  audit_export:
+    usage: "Verwendung: /audit export [--user U] [--host H] [--event-type T] [--session S] [--since T] [--until T] [--limit N]\n  gibt ein Verzeichnis mit audit.md, events.jsonl und manifest.json aus"
+    no_events: "keine Audit-Ereignisse für die angegebenen Filter gefunden"
+    mkdir_failed: "temporäres Verzeichnis konnte nicht erstellt werden: {error}"
+    build_failed: "Audit-Paket konnte nicht erstellt werden: {error}"
+    publish_failed: "Audit-Paket konnte nicht veröffentlicht werden: {error}"
+    exported: "Audit-Paket nach {path} exportiert ({events} Ereignisse, {files} Dateien)"
   fork:
     forked: "Sitzung verzweigt {short} (von {parent})"
     switch_failed: "Verzweigung erstellt, aber Wechsel fehlgeschlagen: {error}"

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -679,6 +679,13 @@ shell:
     store_unavailable: "almacén de sesiones no disponible; no se puede exportar"
     not_found: "sesión actual no encontrada en el almacén"
     load_failed: "fallo al cargar la sesión: {error}"
+  audit_export:
+    usage: "uso: /audit export [--user U] [--host H] [--event-type T] [--session S] [--since T] [--until T] [--limit N]\n  genera un directorio con audit.md, events.jsonl y manifest.json"
+    no_events: "no se encontraron eventos de auditoría para los filtros indicados"
+    mkdir_failed: "no se pudo crear el directorio temporal: {error}"
+    build_failed: "no se pudo construir el paquete de auditoría: {error}"
+    publish_failed: "no se pudo publicar el paquete de auditoría: {error}"
+    exported: "paquete de auditoría exportado a {path} ({events} eventos, {files} archivos)"
   fork:
     forked: "sesión bifurcada {short} (de {parent})"
     switch_failed: "bifurcación creada pero el cambio falló: {error}"

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -679,6 +679,13 @@ shell:
     store_unavailable: "stockage de session indisponible ; export impossible"
     not_found: "session actuelle introuvable dans le stockage"
     load_failed: "échec du chargement de la session : {error}"
+  audit_export:
+    usage: "usage : /audit export [--user U] [--host H] [--event-type T] [--session S] [--since T] [--until T] [--limit N]\n  produit un répertoire avec audit.md, events.jsonl et manifest.json"
+    no_events: "aucun événement d'audit trouvé pour ces filtres"
+    mkdir_failed: "impossible de créer le répertoire temporaire : {error}"
+    build_failed: "impossible de construire le paquet d'audit : {error}"
+    publish_failed: "impossible de publier le paquet d'audit : {error}"
+    exported: "paquet d'audit exporté vers {path} ({events} événements, {files} fichiers)"
   fork:
     forked: "session bifurquée {short} (depuis {parent})"
     switch_failed: "bifurcation créée mais le changement a échoué : {error}"

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -679,6 +679,13 @@ shell:
     store_unavailable: "セッションストアが利用できません；エクスポートできません"
     not_found: "ストアに現在のセッションが見つかりません"
     load_failed: "セッションの読み込みに失敗しました: {error}"
+  audit_export:
+    usage: "使い方: /audit export [--user U] [--host H] [--event-type T] [--session S] [--since T] [--until T] [--limit N]\n  audit.md、events.jsonl、manifest.json を含むディレクトリを出力します"
+    no_events: "指定したフィルタに一致する監査イベントが見つかりません"
+    mkdir_failed: "一時ディレクトリの作成に失敗しました: {error}"
+    build_failed: "監査パッケージの構築に失敗しました: {error}"
+    publish_failed: "監査パッケージの公開に失敗しました: {error}"
+    exported: "監査パッケージを {path} にエクスポートしました（{events} イベント、{files} ファイル）"
   fork:
     forked: "セッションをフォークしました {short}（親 {parent}）"
     switch_failed: "フォークを作成しましたが切り替えに失敗しました: {error}"

--- a/crates/aish-i18n/src/manager.rs
+++ b/crates/aish-i18n/src/manager.rs
@@ -334,4 +334,33 @@ shell:
             }
         }
     }
+
+    #[test]
+    fn audit_export_keys_present_in_all_embedded_locales() {
+        // Regression guard: /audit export initially shipped its keys in
+        // en-US/zh-CN only, so four locales rendered raw dotted keys.
+        // Build the manager straight from the embedded YAML so a host-side
+        // locale file override cannot mask a missing embedded key.
+        for &(tag, yaml) in EMBEDDED_LOCALES {
+            let mgr = I18nManager {
+                translations: parse_yaml(yaml),
+                locale: tag.to_string(),
+            };
+            for key in [
+                "shell.audit_export.usage",
+                "shell.audit_export.no_events",
+                "shell.audit_export.mkdir_failed",
+                "shell.audit_export.build_failed",
+                "shell.audit_export.publish_failed",
+                "shell.audit_export.exported",
+            ] {
+                let val = mgr.t(key);
+                assert_ne!(
+                    val, key,
+                    "embedded locale {:?} is missing key {:?} (returned the key itself)",
+                    tag, key
+                );
+            }
+        }
+    }
 }

--- a/crates/aish-memory/src/lib.rs
+++ b/crates/aish-memory/src/lib.rs
@@ -15,6 +15,8 @@
 
 pub mod manager;
 pub mod models;
+pub mod ttl;
 
 pub use manager::MemoryManager;
 pub use models::{MemoryEntry, MemorySource};
+pub use ttl::{default_ttl, resolve_ttl, ENVIRONMENT_CAP_SECS, HOST_SCOPE_CAP_SECS};

--- a/crates/aish-memory/src/manager.rs
+++ b/crates/aish-memory/src/manager.rs
@@ -93,11 +93,22 @@ impl MemoryManager {
     ) -> aish_core::Result<i64> {
         let content_trimmed = content.trim();
 
-        // Duplicate detection: same content (case-insensitive) + same category
+        // Duplicate detection: same content (case-insensitive) + same category.
+        // The confirmed TTL of THIS store wins: a later re-store (e.g. the
+        // user confirms `permanent`) must refresh the existing entry's expiry
+        // instead of silently keeping the old one.
         let content_lower = content_trimmed.to_lowercase();
-        for entry in &self.entries {
+        for entry in &mut self.entries {
             if entry.category == category && entry.content.to_lowercase() == content_lower {
-                return Ok(entry.id);
+                let now = Utc::now();
+                entry.expires_at = ttl_seconds.and_then(|secs| {
+                    let secs = i64::try_from(secs).ok()?;
+                    now.checked_add_signed(chrono::Duration::seconds(secs))
+                        .map(|dt| dt.format("%Y-%m-%dT%H:%M:%SZ").to_string())
+                });
+                let id = entry.id;
+                self.persist()?;
+                return Ok(id);
             }
         }
 
@@ -270,6 +281,36 @@ impl MemoryManager {
         Self::is_expired_inner(entry, &Utc::now())
     }
 
+    /// Return IDs of entries that expire within `days` from now (not yet
+    /// expired). Used to nudge the user to review/renew before facts vanish.
+    pub fn expiring_soon_ids(&self, days: i64) -> Vec<i64> {
+        let now = Utc::now();
+        let horizon = now + chrono::Duration::days(days);
+        self.entries
+            .iter()
+            .filter(|e| {
+                !Self::is_expired_inner(e, &now)
+                    && e.expires_at
+                        .as_deref()
+                        .and_then(|exp| {
+                            DateTime::parse_from_rfc3339(exp)
+                                .map(|dt| dt.with_timezone(&Utc) <= horizon)
+                                .ok()
+                                .or_else(|| {
+                                    chrono::NaiveDate::parse_from_str(exp, "%Y-%m-%d")
+                                        .map(|d| {
+                                            d.and_hms_opt(0, 0, 0).unwrap_or_default().and_utc()
+                                                <= horizon
+                                        })
+                                        .ok()
+                                })
+                        })
+                        .unwrap_or(false)
+            })
+            .map(|e| e.id)
+            .collect()
+    }
+
     fn is_expired_inner(entry: &MemoryEntry, now: &DateTime<Utc>) -> bool {
         let Some(exp) = &entry.expires_at else {
             return false;
@@ -295,7 +336,13 @@ impl MemoryManager {
              2. When the user shares an important durable fact, use the memory tool with action store.\n\
              3. Keep stored memories short, factual, and reusable. Avoid saving transient chatter.\n\
              4. Expired memories are not injected; use /memory to review and renew them.\n\
-             5. The memory file lives in {}.\n",
+             5. The memory file lives in {}.\n\
+             6. CRITICAL: a fact is stored ONLY when the memory tool returns a\n\
+             result containing an entry id. NEVER tell the user something is\n\
+             recorded/remembered without having actually called the tool in\n\
+             THIS turn and seeing its result. Restating an earlier successful\n\
+             store does not store anything new: if the user asks to remember\n\
+             new or changed content, you must call the tool again.\n",
             self.memory_file.display()
         )
     }
@@ -898,6 +945,54 @@ mod tests {
     }
 
     #[test]
+    fn test_duplicate_reapplies_confirmed_ttl() {
+        let dir = std::env::temp_dir().join("aish_memory_test_dup_ttl");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("MEMORY.md");
+
+        let mut mgr = MemoryManager::new(path).unwrap();
+        // First store: Environment entry with a 7-day TTL.
+        let id1 = mgr
+            .store_with_provenance(
+                "prod db endpoint",
+                MemoryCategory::Environment,
+                MemoryScope::User,
+                MemorySource {
+                    label: "auto".to_string(),
+                    session_uuid: None,
+                    host: None,
+                },
+                1.0,
+                Some(7 * 24 * 3600),
+            )
+            .unwrap();
+        assert!(mgr.list()[0].expires_at.is_some());
+
+        // Re-store the same content as permanent: the confirmed TTL of THIS
+        // store must win, clearing the old expiry instead of keeping it.
+        let id2 = mgr
+            .store_with_provenance(
+                "prod db endpoint",
+                MemoryCategory::Environment,
+                MemoryScope::User,
+                MemorySource {
+                    label: "explicit".to_string(),
+                    session_uuid: None,
+                    host: None,
+                },
+                1.0,
+                None,
+            )
+            .unwrap();
+        assert_eq!(id1, id2);
+        assert_eq!(mgr.list().len(), 1);
+        assert!(mgr.list()[0].expires_at.is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn test_duplicate_case_insensitive() {
         let dir = std::env::temp_dir().join("aish_memory_test_dup_case");
         let _ = std::fs::remove_dir_all(&dir);
@@ -1070,6 +1165,50 @@ mod tests {
             "metadata-like line lost"
         );
         assert_eq!(entry.source, "test", "source corrupted by content line");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_expiring_soon_ids() {
+        let dir = std::env::temp_dir().join("aish_memory_test_expiring_soon");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("MEMORY.md");
+
+        let mut mgr = MemoryManager::new(path).unwrap();
+        let soon = mgr
+            .store_with_provenance(
+                "expires in 3 days",
+                MemoryCategory::Environment,
+                MemoryScope::User,
+                MemorySource {
+                    label: "test".to_string(),
+                    session_uuid: None,
+                    host: None,
+                },
+                0.8,
+                Some(3 * 24 * 3600),
+            )
+            .unwrap();
+        let far = mgr
+            .store_with_provenance(
+                "expires in 90 days",
+                MemoryCategory::Other,
+                MemoryScope::User,
+                MemorySource {
+                    label: "test".to_string(),
+                    session_uuid: None,
+                    host: None,
+                },
+                0.8,
+                Some(90 * 24 * 3600),
+            )
+            .unwrap();
+
+        let expiring = mgr.expiring_soon_ids(7);
+        assert!(expiring.contains(&soon), "3-day entry must be flagged");
+        assert!(!expiring.contains(&far), "90-day entry must not be flagged");
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/aish-memory/src/ttl.rs
+++ b/crates/aish-memory/src/ttl.rs
@@ -1,0 +1,200 @@
+//! TTL policy for long-term memories.
+//!
+//! Issue #472 asked for expiry specifically for *volatile* facts (temporary
+//! ports, test-host identities), not for everything. PR #478 shipped a flat
+//! 7-day TTL on all auto-retained entries, which silently ages out stable
+//! user preferences. This module restores the intent with a hybrid policy:
+//!
+//! - The **model** judges volatility per fact (`ttl_seconds` + `reason`).
+//! - The **policy** anchors defaults per category/scope and caps the maximum,
+//!   so a missing or over-long model value can never make a volatile host
+//!   fact permanent.
+
+use aish_core::{MemoryCategory, MemoryScope};
+
+/// Default TTL (seconds) when the caller does not supply one.
+///
+/// `None` = no expiry. The model has already judged volatility per the
+/// tool prompt (short TTL for temporary ports/test hosts, silence for
+/// durable facts), so silence means durable EXCEPT for the categories
+/// #472 targets: Environment facts (endpoints/ports/credentials) and
+/// host-scoped facts rot even when the model stays quiet. Imposing a
+/// default expiry on Other/Solution would silently age out durable facts
+/// the user never asked to expire.
+pub fn default_ttl(category: &MemoryCategory, scope: &MemoryScope) -> Option<u64> {
+    // Host-scoped facts are inherently volatile (machines get rebuilt, IPs
+    // change) and must never be permanent by default, regardless of category.
+    if matches!(scope, MemoryScope::Host) {
+        return Some(HOST_SCOPE_CAP_SECS);
+    }
+    match category {
+        MemoryCategory::Environment => Some(7 * 24 * 3600),
+        MemoryCategory::Preference
+        | MemoryCategory::Pattern
+        | MemoryCategory::Solution
+        | MemoryCategory::Other => None,
+    }
+}
+
+/// Hard cap (seconds) on any TTL for host-scoped entries. Even when the
+/// model explicitly proposes a long TTL, host facts cannot outlive this
+/// without a user verify/renew (`/memory verify`).
+pub const HOST_SCOPE_CAP_SECS: u64 = 30 * 24 * 3600;
+
+/// Hard cap (seconds) on any TTL for Environment entries in user scope:
+/// endpoints/ports/credentials rot, so a model-proposed "permanent" or
+/// multi-year value is clamped.
+pub const ENVIRONMENT_CAP_SECS: u64 = 90 * 24 * 3600;
+
+/// Minimum TTL (seconds). Proposals below this are treated as model noise
+/// and raised to one minute — an entry that expires instantly serves no
+/// recall purpose and pollutes the store.
+pub const MIN_TTL_SECS: u64 = 60;
+
+/// Resolve the effective TTL for a new entry.
+///
+/// - `proposed`: the model-supplied `ttl_seconds` (if any).
+/// - Returns the proposed value when it is within policy, the category
+///   default when absent, and clamps to the cap when the proposal exceeds it.
+///   `None` proposals for capped categories resolve to the default (not
+///   "permanent"), because "model stayed silent" must not mean "forever".
+///   Proposals below [`MIN_TTL_SECS`] are raised to it: a 1-second TTL is
+///   model noise, not a meaningful volatility signal.
+pub fn resolve_ttl(
+    proposed: Option<u64>,
+    category: &MemoryCategory,
+    scope: &MemoryScope,
+) -> Option<u64> {
+    let cap = if matches!(scope, MemoryScope::Host) {
+        Some(HOST_SCOPE_CAP_SECS)
+    } else if matches!(category, MemoryCategory::Environment) {
+        Some(ENVIRONMENT_CAP_SECS)
+    } else {
+        None
+    };
+
+    match (proposed, cap) {
+        // No proposal: fall back to the category/scope default. For stable
+        // categories that is None (permanent); capped categories get a
+        // bounded default.
+        (None, _) => default_ttl(category, scope),
+        (Some(secs), None) => Some(secs.max(MIN_TTL_SECS)),
+        (Some(secs), Some(cap)) => Some(secs.clamp(MIN_TTL_SECS, cap)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stable_categories_never_expire_by_default() {
+        assert_eq!(
+            default_ttl(&MemoryCategory::Preference, &MemoryScope::User),
+            None
+        );
+        assert_eq!(
+            default_ttl(&MemoryCategory::Pattern, &MemoryScope::User),
+            None
+        );
+    }
+
+    #[test]
+    fn environment_defaults_to_7_days() {
+        assert_eq!(
+            default_ttl(&MemoryCategory::Environment, &MemoryScope::User),
+            Some(7 * 24 * 3600)
+        );
+    }
+
+    #[test]
+    fn solution_and_other_silent_model_never_expire() {
+        // The model judged volatility already (prompt instructs short TTL
+        // for temp facts); silence on Other/Solution means durable.
+        // Defaulting these to an expiry would silently age out durable
+        // facts the user never asked to expire.
+        assert_eq!(
+            default_ttl(&MemoryCategory::Solution, &MemoryScope::User),
+            None
+        );
+        assert_eq!(
+            default_ttl(&MemoryCategory::Other, &MemoryScope::User),
+            None
+        );
+    }
+
+    #[test]
+    fn host_scope_always_capped() {
+        // Host facts are volatile even for stable categories.
+        assert_eq!(
+            default_ttl(&MemoryCategory::Preference, &MemoryScope::Host),
+            Some(HOST_SCOPE_CAP_SECS)
+        );
+        // Model proposal beyond the cap is clamped.
+        assert_eq!(
+            resolve_ttl(
+                Some(10 * 365 * 24 * 3600),
+                &MemoryCategory::Environment,
+                &MemoryScope::Host
+            ),
+            Some(HOST_SCOPE_CAP_SECS)
+        );
+        // Silent model still gets a bounded TTL, never permanent.
+        assert_eq!(
+            resolve_ttl(None, &MemoryCategory::Other, &MemoryScope::Host),
+            Some(HOST_SCOPE_CAP_SECS)
+        );
+    }
+
+    #[test]
+    fn environment_cap_clamps_user_scope() {
+        assert_eq!(
+            resolve_ttl(
+                Some(10 * 365 * 24 * 3600),
+                &MemoryCategory::Environment,
+                &MemoryScope::User
+            ),
+            Some(ENVIRONMENT_CAP_SECS)
+        );
+        assert_eq!(
+            resolve_ttl(None, &MemoryCategory::Environment, &MemoryScope::User),
+            Some(7 * 24 * 3600)
+        );
+    }
+
+    #[test]
+    fn sub_minute_proposals_raised_to_floor() {
+        // 1-second TTL is model noise, not a volatility signal.
+        assert_eq!(
+            resolve_ttl(Some(1), &MemoryCategory::Environment, &MemoryScope::User),
+            Some(MIN_TTL_SECS)
+        );
+        assert_eq!(
+            resolve_ttl(Some(0), &MemoryCategory::Preference, &MemoryScope::User),
+            Some(MIN_TTL_SECS)
+        );
+    }
+
+    #[test]
+    fn explicit_proposal_respected_within_policy() {
+        // Short proposal for a volatile fact is honored as-is.
+        assert_eq!(
+            resolve_ttl(Some(3600), &MemoryCategory::Environment, &MemoryScope::User),
+            Some(3600)
+        );
+        // No proposal for a stable preference stays permanent.
+        assert_eq!(
+            resolve_ttl(None, &MemoryCategory::Preference, &MemoryScope::User),
+            None
+        );
+        // Explicit proposal for a stable category is not clamped.
+        assert_eq!(
+            resolve_ttl(
+                Some(365 * 24 * 3600),
+                &MemoryCategory::Preference,
+                &MemoryScope::User
+            ),
+            Some(365 * 24 * 3600)
+        );
+    }
+}

--- a/crates/aish-security/src/policy.rs
+++ b/crates/aish-security/src/policy.rs
@@ -102,13 +102,19 @@ const DEFAULT_POLICY_TEMPLATE: &str = include_str!("../../../config/security_pol
 /// single security policy for all users on the machine.
 const DEFAULT_SYSTEM_POLICY_PATH: &str = "/etc/aish/security_policy.yaml";
 
-/// Resolve the system-level policy path. In tests this can be overridden
-/// via the `AISH_SYSTEM_POLICY_PATH` environment variable to avoid touching
-/// the real `/etc/aish/`.
+/// Resolve the system-level policy path.
+///
+/// The `AISH_SYSTEM_POLICY_PATH` override only exists in test and debug
+/// builds so unit/integration tests can point at a temp file. In release
+/// builds the path is fixed — otherwise any user could export
+/// `AISH_SYSTEM_POLICY_PATH=/nonexistent` and silently skip an
+/// administrator's enforced system-level policy.
 fn system_policy_path() -> PathBuf {
-    env::var_os("AISH_SYSTEM_POLICY_PATH")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(DEFAULT_SYSTEM_POLICY_PATH))
+    #[cfg(any(test, debug_assertions))]
+    if let Some(path) = env::var_os("AISH_SYSTEM_POLICY_PATH") {
+        return PathBuf::from(path);
+    }
+    PathBuf::from(DEFAULT_SYSTEM_POLICY_PATH)
 }
 
 fn user_security_policy_path() -> PathBuf {

--- a/crates/aish-shell/src/ai_handler.rs
+++ b/crates/aish-shell/src/ai_handler.rs
@@ -8,34 +8,22 @@ use aish_context::{
 };
 use aish_core::{LlmEvent, MemoryCategory, MemoryScope, MemoryType, PlanModeState, PlanPhase};
 use aish_llm::{ChatMessage, LlmCallbackResult, LlmSession, MessageContent, Tool};
+use aish_memory::ttl::default_ttl;
 use aish_memory::{MemoryManager, MemorySource};
 use aish_prompts::PromptManager;
 use aish_session::SessionContextMessage;
 use aish_skills::SkillManager;
-
 /// Shared handle for the memory manager, accessible from both AiHandler and tools.
 pub type SharedMemoryManager = Arc<Mutex<Option<MemoryManager>>>;
 
 /// Classify a fact string into a memory category using keyword matching.
 fn categorize_fact(fact: &str) -> MemoryCategory {
     let lower = fact.to_lowercase();
-
-    // Preference keywords
-    if lower.contains("prefer")
-        || lower.contains("like")
-        || lower.contains("always")
-        || lower.contains("never")
-        || lower.contains("favorite")
-        || lower.contains("favourite")
-        || lower.contains("default")
-        || lower.contains("want")
-        || lower.contains("don't like")
-        || lower.contains("avoid")
-    {
-        return MemoryCategory::Preference;
-    }
-
-    // Environment keywords
+    // Environment keywords — checked BEFORE preference/solution keywords:
+    // generic durability words ("always", "never") must not override
+    // environment indicators, otherwise "the server is always 10.0.0.1"
+    // would be mis-filed as a permanent Preference instead of a volatile
+    // Environment fact subject to the 7-day default TTL.
     if lower.contains("port")
         || lower.contains("host")
         || lower.contains("ip ")
@@ -56,6 +44,21 @@ fn categorize_fact(fact: &str) -> MemoryCategory {
         || lower.contains("credential")
     {
         return MemoryCategory::Environment;
+    }
+
+    // Preference keywords
+    if lower.contains("prefer")
+        || lower.contains("like")
+        || lower.contains("always")
+        || lower.contains("never")
+        || lower.contains("favorite")
+        || lower.contains("favourite")
+        || lower.contains("default")
+        || lower.contains("want")
+        || lower.contains("don't like")
+        || lower.contains("avoid")
+    {
+        return MemoryCategory::Preference;
     }
 
     // Solution keywords
@@ -777,6 +780,28 @@ impl AiHandler {
                 "<long-term-memory source=\"recall\">\n{}\n</long-term-memory>",
                 text
             );
+
+            // Nudge: entries expiring within 7 days may silently vanish from
+            // context later. Tell the model so it can mention renewal
+            // (/memory verify <id>) when it actually relies on such a fact.
+            let expiring = mm.expiring_soon_ids(7);
+            let content = if expiring.is_empty() {
+                content
+            } else {
+                format!(
+                    "{}\n[memory notice] {} entries expire within 7 days (ids: {}). \
+                     If your answer relies on them, tell the user they can renew \
+                     with /memory verify <id>.",
+                    content,
+                    expiring.len(),
+                    expiring
+                        .iter()
+                        .map(|id| id.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            };
+
             // Stable injection — only replaces if content actually changed,
             // preserving cache prefix stability across calls.
             self.context_manager
@@ -785,9 +810,10 @@ impl AiHandler {
     }
 
     /// Auto-retain user preferences and facts based on pattern matching.
-    /// Auto-retain entries get a short default TTL (7 days) to prevent stale
-    /// facts from accumulating — the user already expressed intent via
-    /// "remember that..." patterns so no confirmation gate is needed.
+    /// The TTL is category-aware (#472): volatile facts (Environment) get a
+    /// short default window, stable ones (Preference, Pattern) never expire.
+    /// The user already expressed intent via "remember that..." patterns so
+    /// no confirmation gate is needed.
     fn auto_retain_memory(&mut self, question: &str, _response: &str) {
         if !self.memory_config.auto_retain {
             return;
@@ -797,6 +823,7 @@ impl AiHandler {
             let facts = extract_retainable_facts(question);
             for fact in facts {
                 let category = categorize_fact(&fact);
+                let ttl = default_ttl(&category, &MemoryScope::User);
                 let _ = mm.store_with_provenance(
                     &fact,
                     category,
@@ -807,7 +834,7 @@ impl AiHandler {
                         host: None,
                     },
                     1.0,
-                    Some(604_800), // 7 days
+                    ttl,
                 );
             }
         }
@@ -1687,6 +1714,26 @@ mod tests {
         assert!(matches!(
             categorize_fact("API endpoint at /v1/chat"),
             MemoryCategory::Environment
+        ));
+    }
+
+    #[test]
+    fn test_categorize_environment_beats_preference_cues() {
+        // Generic durability words must not override environment indicators:
+        // otherwise this volatile fact would get a permanent Preference TTL
+        // instead of the 7-day Environment default.
+        assert!(matches!(
+            categorize_fact("the server is always 10.0.0.1"),
+            MemoryCategory::Environment
+        ));
+        assert!(matches!(
+            categorize_fact("I never store passwords in plain text files under config"),
+            MemoryCategory::Environment
+        ));
+        // Pure preference phrasing without environment cues stays Preference.
+        assert!(matches!(
+            categorize_fact("I always use vim"),
+            MemoryCategory::Preference
         ));
     }
 

--- a/crates/aish-tools/Cargo.toml
+++ b/crates/aish-tools/Cargo.toml
@@ -8,6 +8,7 @@ aish-config.workspace = true
 aish-core.workspace = true
 aish-i18n.workspace = true
 aish-llm.workspace = true
+aish-memory.workspace = true
 aish-pty.workspace = true
 aish-security.workspace = true
 aish-skills.workspace = true

--- a/crates/aish-tools/src/bash/bash.rs
+++ b/crates/aish-tools/src/bash/bash.rs
@@ -786,6 +786,13 @@ mod tests {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let _guard = EnvGuard::set("XDG_CONFIG_HOME", Some(xdg.as_path()));
+        // A system-level policy (/etc/aish/security_policy.yaml) takes
+        // precedence over the user-level file, so point the override at a
+        // non-existent path to keep this test isolated from the machine.
+        let _sys_guard = EnvGuard::set(
+            "AISH_SYSTEM_POLICY_PATH",
+            Some(dir.path().join("no-system-policy.yaml").as_path()),
+        );
 
         let mut tool = BashTool::new();
         let args = serde_json::json!({"command": "rm -rf /etc"});

--- a/crates/aish-tools/src/memory_tool/memory_tool.rs
+++ b/crates/aish-tools/src/memory_tool/memory_tool.rs
@@ -1,8 +1,9 @@
+use aish_core::{MemoryCategory, MemoryScope};
 use aish_i18n;
 use aish_llm::{PreflightResult, PreflightSecurityContext, SecurityPanelMode, Tool, ToolResult};
+use aish_memory::ttl::resolve_ttl;
 
 use super::prompt;
-
 /// Callback type for memory search operations.
 pub type MemorySearchFn = Box<dyn Fn(&str, usize) -> Vec<MemorySearchResult> + Send + Sync>;
 /// Callback type for memory store operations.
@@ -109,12 +110,11 @@ impl Tool for MemoryTool {
                         )),
                     };
                 }
-                let category = args
-                    .get("category")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("other");
-                let scope = args.get("scope").and_then(|v| v.as_str()).unwrap_or("user");
-                let ttl = args.get("ttl_seconds").and_then(|v| v.as_u64());
+                let (category, scope, ttl) = store_policy(&args);
+                let permanent = args
+                    .get("permanent")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
                 let reason = args.get("reason").and_then(|v| v.as_str()).unwrap_or("");
 
                 let mut msg = format!(
@@ -124,9 +124,15 @@ impl Tool for MemoryTool {
                     aish_i18n::t("tools.memory.field_category"),
                     category,
                     aish_i18n::t("tools.memory.field_scope"),
-                    scope,
+                    effective_scope(&scope),
                 );
-                if let Some(t) = ttl {
+                if permanent {
+                    // Prominent marker: permanent stores skip all expiry.
+                    msg.push_str(&format!(
+                        " | {}: PERMANENT (no expiry)",
+                        aish_i18n::t("tools.memory.field_ttl")
+                    ));
+                } else if let Some(t) = ttl {
                     msg.push_str(&format!(
                         " | {}: {}s",
                         aish_i18n::t("tools.memory.field_ttl"),
@@ -221,13 +227,8 @@ impl Tool for MemoryTool {
                         ))
                     }
                 };
-                let category = args
-                    .get("category")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("other");
-                let scope = args.get("scope").and_then(|v| v.as_str()).unwrap_or("user");
-                let ttl_seconds = args.get("ttl_seconds").and_then(|v| v.as_u64());
-                let id = (self.store)(content, category, "explicit", 0.8, scope, ttl_seconds);
+                let (category, scope, ttl_seconds) = store_policy(&args);
+                let id = (self.store)(content, &category, "explicit", 0.8, &scope, ttl_seconds);
                 let mut args_map = std::collections::HashMap::new();
                 args_map.insert("id".to_string(), id.clone());
                 ToolResult::success(aish_i18n::t_with_args("tools.memory.stored", &args_map))
@@ -306,4 +307,199 @@ fn format_list_result(r: &MemorySearchResult) -> String {
         ));
     }
     line
+}
+
+/// Extract the store-policy tuple (category, scope, effective TTL) from a
+/// store action's args. Shared by preflight (confirmation display) and
+/// execute (actual write) so the user always confirms the TTL that will be
+/// persisted.
+fn store_policy(args: &serde_json::Value) -> (String, String, Option<u64>) {
+    let category = args
+        .get("category")
+        .and_then(|v| v.as_str())
+        .unwrap_or("other")
+        .to_string();
+    let scope = args
+        .get("scope")
+        .and_then(|v| v.as_str())
+        .unwrap_or("user")
+        .to_string();
+    let proposed = args.get("ttl_seconds").and_then(|v| v.as_u64());
+    // An explicit user-requested permanent store bypasses TTL defaults and
+    // caps. The preflight panel highlights it so the user stays in control.
+    if args
+        .get("permanent")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        return (category, scope, None);
+    }
+    // Resolve against the *parsed* category/scope so TTL matches what the
+    // shell callback will actually persist.
+    let ttl = resolve_ttl(proposed, &parse_category(&category), &parse_scope(&scope));
+    (category, scope, ttl)
+}
+
+/// Short lowercase scope name matching what the shell callback persists
+/// after its own parse (invalid values fall back to "user").
+fn effective_scope(scope: &str) -> &str {
+    match parse_scope(scope) {
+        MemoryScope::User => "user",
+        MemoryScope::Host => "host",
+        MemoryScope::Project => "project",
+    }
+}
+
+/// Parse a category string (from the LLM tool call) into a MemoryCategory.
+/// Falls back to `Other` for unrecognized values, matching the shell-side
+/// `parse_category_str`.
+fn parse_category(s: &str) -> MemoryCategory {
+    match s.to_lowercase().as_str() {
+        "preference" => MemoryCategory::Preference,
+        "environment" => MemoryCategory::Environment,
+        "solution" => MemoryCategory::Solution,
+        "pattern" => MemoryCategory::Pattern,
+        _ => MemoryCategory::Other,
+    }
+}
+
+/// Parse a scope string (from the LLM tool call) into a MemoryScope.
+/// Falls back to `User` for unrecognized values — never promote host facts
+/// to global scope by default.
+fn parse_scope(s: &str) -> MemoryScope {
+    match s.to_lowercase().as_str() {
+        "host" => MemoryScope::Host,
+        "project" => MemoryScope::Project,
+        _ => MemoryScope::User,
+    }
+}
+
+#[cfg(test)]
+mod ttl_policy_tests {
+    use super::*;
+
+    /// Capture what the store callback receives for (scope, ttl).
+    fn tool_with_capture(
+        captured: std::sync::Arc<std::sync::Mutex<Vec<(String, Option<u64>)>>>,
+    ) -> MemoryTool {
+        MemoryTool::new(
+            Box::new(|_, _| Vec::new()),
+            Box::new(move |_c, _cat, _src, _imp, scope, ttl| {
+                captured.lock().unwrap().push((scope.to_string(), ttl));
+                "1".to_string()
+            }),
+            Box::new(|_| false),
+            Box::new(|_| Vec::new()),
+        )
+    }
+
+    #[test]
+    fn store_missing_ttl_uses_category_default() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let tool = tool_with_capture(captured.clone());
+        let res = tool.execute(serde_json::json!({
+            "action": "store",
+            "content": "prod db endpoint",
+            "category": "environment",
+        }));
+        assert!(res.ok);
+        let got = captured.lock().unwrap();
+        // Environment without a model proposal gets the 7-day default,
+        // not permanent.
+        assert_eq!(got[0].1, Some(7 * 24 * 3600));
+    }
+
+    #[test]
+    fn store_overlong_environment_proposal_clamped() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let tool = tool_with_capture(captured.clone());
+        let res = tool.execute(serde_json::json!({
+            "action": "store",
+            "content": "test host ip",
+            "category": "environment",
+            "ttl_seconds": 10 * 365 * 24 * 3600,
+        }));
+        assert!(res.ok);
+        let got = captured.lock().unwrap();
+        assert_eq!(got[0].1, Some(aish_memory::ttl::ENVIRONMENT_CAP_SECS));
+    }
+
+    #[test]
+    fn store_host_scope_silent_model_never_permanent() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let tool = tool_with_capture(captured.clone());
+        let res = tool.execute(serde_json::json!({
+            "action": "store",
+            "content": "machine fact",
+            "category": "preference",
+            "scope": "host",
+        }));
+        assert!(res.ok);
+        let got = captured.lock().unwrap();
+        // Host facts are capped regardless of category.
+        assert_eq!(got[0].0, "host");
+        assert_eq!(got[0].1, Some(aish_memory::ttl::HOST_SCOPE_CAP_SECS));
+    }
+
+    #[test]
+    fn store_explicit_permanent_bypasses_environment_default() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let tool = tool_with_capture(captured.clone());
+        let res = tool.execute(serde_json::json!({
+            "action": "store",
+            "content": "prod master db host",
+            "category": "environment",
+            "permanent": true,
+        }));
+        assert!(res.ok);
+        let got = captured.lock().unwrap();
+        // User explicitly requested permanent: no TTL despite the volatile
+        // category's 7-day default.
+        assert_eq!(got[0].1, None);
+    }
+
+    #[test]
+    fn store_explicit_permanent_bypasses_host_cap() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let tool = tool_with_capture(captured.clone());
+        let res = tool.execute(serde_json::json!({
+            "action": "store",
+            "content": "machine fact",
+            "category": "environment",
+            "scope": "host",
+            "permanent": true,
+        }));
+        assert!(res.ok);
+        let got = captured.lock().unwrap();
+        assert_eq!(got[0].1, None);
+    }
+
+    #[test]
+    fn store_permanent_false_falls_back_to_policy() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let tool = tool_with_capture(captured.clone());
+        let res = tool.execute(serde_json::json!({
+            "action": "store",
+            "content": "staging endpoint",
+            "category": "environment",
+            "permanent": false,
+        }));
+        assert!(res.ok);
+        let got = captured.lock().unwrap();
+        assert_eq!(got[0].1, Some(7 * 24 * 3600));
+    }
+
+    #[test]
+    fn store_stable_preference_without_ttl_stays_permanent() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let tool = tool_with_capture(captured.clone());
+        let res = tool.execute(serde_json::json!({
+            "action": "store",
+            "content": "prefers vim",
+            "category": "preference",
+        }));
+        assert!(res.ok);
+        let got = captured.lock().unwrap();
+        assert_eq!(got[0].1, None);
+    }
 }

--- a/crates/aish-tools/src/memory_tool/prompt.rs
+++ b/crates/aish-tools/src/memory_tool/prompt.rs
@@ -5,11 +5,17 @@ pub(crate) const PROMPT: &str = r#"Use this tool for long-term memory operations
 Usage:
 - Use search to recall relevant saved knowledge before acting on user preferences or prior context.
 - Use store only for durable facts that are likely useful later. Storing and forgetting require user confirmation.
+- NEVER claim something is stored/forgotten without calling this tool and reporting its exact result (which contains the entry id). Paraphrasing an earlier successful store as "recorded" for new content is a fabrication — each new or changed fact needs a fresh tool call.
 - Use list to inspect recent memories, including expired ones.
 - Use forget to remove outdated or incorrect memory entries by id. Forgetting requires user confirmation.
 - scope: "user" (default) for personal facts, "host" for machine-specific facts, "project" for codebase facts.
 - ttl_seconds: optional expiry. Expired entries are not injected into context. Use /memory to review expired entries.
-- reason: briefly explain why the memory is being stored or forgotten."#;
+- TTL volatility judgment (you decide, policy anchors). Judge by the USER'S STATED INTENT AND lifetime cues, not by the fact's topic:
+  - Volatile cues (short TTL <=604800): 临时/temporary, test/staging, 下线/回收 decommissioning soon, one-off ports, credentials that rotate.
+  - Durable cues (omit ttl_seconds, or permanent if the user says forever): 之后都/以后都 from now on, 长期 long-term, 一直 always, production/designated hosts, stable architecture, deployment intent (e.g. 'this server is our cloud-database host from now on'). A server being an 'endpoint' does NOT make it volatile if the user framed it as a lasting arrangement.
+  - If you omit ttl_seconds on an environment fact the policy still assigns a 7-day default; over-long proposals for volatile facts are capped. Host-scoped entries are always capped at 30 days. For durable facts outside the environment category, silence = no expiry.
+- permanent: set true ONLY when the user EXPLICITLY framed the fact as lasting (e.g. "永久记住", "always remember this", "之后都/以后都用它", "from now on this is...", "don't let this expire"). It bypasses TTL defaults and caps (including the host-scope cap) and stores without expiry. The confirmation panel highlights it, and the user can reject. Never set permanent on your own initiative from a merely factual statement — the user's wording must carry the lasting intent. Do not combine permanent with ttl_seconds.
+- reason: briefly explain why the memory is being stored or forgotten; for store, mention why the chosen TTL (or permanent) fits the fact's volatility and the user's words."#;
 
 pub(crate) fn parameters() -> serde_json::Value {
     serde_json::json!({
@@ -40,7 +46,11 @@ pub(crate) fn parameters() -> serde_json::Value {
             },
             "ttl_seconds": {
                 "type": "integer",
-                "description": "Optional time-to-live in seconds. When set, the memory expires after this duration and is excluded from context injection. Use 604800 for 7 days, 2592000 for 30 days."
+                "description": "Optional time-to-live in seconds. When set, the memory expires after this duration and is excluded from context injection. Use 604800 for 7 days, 2592000 for 30 days. Do not set together with permanent."
+            },
+            "permanent": {
+                "type": "boolean",
+                "description": "Set true ONLY when the user explicitly asked for this fact to be remembered forever. Bypasses TTL defaults and caps (no expiry). The confirmation panel highlights it for user approval."
             },
             "reason": {
                 "type": "string",


### PR DESCRIPTION
## Summary

- **Category-aware TTL policy** (`aish-memory/src/ttl.rs`): the model judges volatility per fact (`ttl_seconds`), the policy anchors defaults per category/scope and caps the maximum. Restores #472 intent after #478's flat 7-day TTL silently aged out stable preferences:
  - Environment (user scope): 7-day default, 90-day cap
  - Host scope: always capped at 30 days, never permanent by default
  - Preference/Pattern/Solution/Other: no default expiry; TTL floor of 60s raises sub-minute model noise
- **Explicit `permanent` flag**: user-requested no-expiry stores bypass TTL defaults and caps; preflight panel marks them `PERMANENT (no expiry)`.
- **Store confirmation fixes**: forbid fabricated store confirmations (prompt now requires the tool result with entry id from THIS turn); confirmation shows the effective scope after parsing.
- **Shared `store_policy` helper**: preflight (confirmation display) and execute (actual write) resolve the same TTL, so the user confirms what will be persisted.
- **Auto-retain TTL** (`ai_handler.rs"): "remember that..." pattern now uses `default_ttl(category)` instead of flat 7 days.
- **Expiring-soon nudge**: entries expiring within 7 days are surfaced to the model so it can mention `/memory verify <id>` when relying on such a fact.
- **i18n**: add missing `audit_export` keys to de/es/fr/ja locales + regression test guarding all embedded locales.
- **security**: restrict `AISH_SYSTEM_POLICY_PATH` override to test/debug builds; release builds keep the fixed `/etc/aish/` path so an administrator's system-level policy cannot be bypassed via env var.
- **test fix**: `bash_preflight_uses_live_policy_slot_over_disk` now isolates the system-level policy path — it failed on any dev machine with aish installed (`/etc/aish/security_policy.yaml` H-001 blocked the expected-Allow assertion) while passing in CI only because the container lacks `/etc/aish`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 0 failures (33 test binaries)
- [x] 7 ttl.rs unit tests + 7 memory_tool behavior tests covering defaults, caps, floor, permanent bypass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added category- and scope-aware memory expiration, including renewal notices for memories nearing expiry.
  * Added explicit permanent-memory support with clearer storage guidance and confirmation details.
  * Added localized `/audit export` messages in German, Spanish, French, and Japanese.

* **Bug Fixes**
  * Strengthened release-mode system policy enforcement against environment-based overrides.
  * Updated existing memories when storage settings change.

* **Tests**
  * Added coverage for expiration behavior, categorization, and required audit-export translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->