### PR TITLE
feat(pty): live-session resource monitoring and targeted process-tree kill

### DIFF
--- a/crates/aish-config/src/model.rs
+++ b/crates/aish-config/src/model.rs
@@ -47,6 +47,18 @@ fn default_terminal_resize_mode() -> String {
     "full".into()
 }
 
+fn default_resource_check_interval() -> u64 {
+    30
+}
+
+fn default_resource_cpu_threshold() -> f64 {
+    80.0
+}
+
+fn default_resource_rss_threshold() -> u64 {
+    1024
+}
+
 fn default_micro_keep_recent_messages() -> usize {
     6
 }
@@ -365,6 +377,21 @@ pub struct ConfigModel {
     pub memory: Option<MemoryConfig>,
     pub session_db_path: Option<String>,
 
+    /// Interval between live-session resource checks in the REPL. 0 disables
+    /// the background check entirely (the `/live_sessions` panel still shows
+    /// resources when opened). Default: 30.
+    #[serde(default = "default_resource_check_interval")]
+    pub pty_resource_check_interval_secs: u64,
+    /// CPU percent (whole process group, 100 = one core) above which other
+    /// live sessions trigger a warning in the current session. 0 disables
+    /// the CPU alert. Default: 80.
+    #[serde(default = "default_resource_cpu_threshold")]
+    pub pty_resource_cpu_percent: f64,
+    /// Resident set size in MiB above which other live sessions trigger a
+    /// warning. 0 disables the memory alert. Default: 1024.
+    #[serde(default = "default_resource_rss_threshold")]
+    pub pty_resource_rss_mb: u64,
+
     /// Inject git branch awareness into remote bash prompts during SSH/telnet
     /// sessions. When true, aish prepends a `|branch` marker (magenta, matching
     /// local prompt style) to the remote PS1 by installing a PROMPT_COMMAND
@@ -526,6 +553,9 @@ impl Default for ConfigModel {
             tool_arg_preview_max_length: 200,
             bash_output_offload: None,
             pty_output_keep_bytes: 4096,
+            pty_resource_check_interval_secs: default_resource_check_interval(),
+            pty_resource_cpu_percent: default_resource_cpu_threshold(),
+            pty_resource_rss_mb: default_resource_rss_threshold(),
             memory: None,
             session_db_path: None,
             enable_remote_git_prompt: true,

--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -720,6 +720,8 @@ shell:
     exit_no_note_title: "Notiz vor dem Trennen hinzufuegen?"
     exit_no_note_hint: "Diese Sitzung hat keinen Namen — unbenannte Sitzungen sind nach dem Trennen schwer zu unterscheiden."
     exit_no_note_footer: "Enter speichern & trennen · Esc ohne Namen trennen"
+    resource_detail: "CPU {cpu} · RSS {rss}"
+    resource_alert: "⚠ Sitzung {id} hat den Ressourcen-Schwellwert erreicht (CPU {cpu} / RSS {rss}). Mit /live_sessions dorthin wechseln oder mit /kill_live_sessions beenden."
 
   kill_live_sessions:
     daemon_disabled: "PTY-Daemon ist deaktiviert. In config.yaml aktivieren:"

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -611,6 +611,8 @@ shell:
     exit_no_note_title: "Add a note before detaching?"
     exit_no_note_hint: "This session has no note — unnamed sessions are hard to tell apart after detach."
     exit_no_note_footer: "Enter save & detach · Esc detach without naming"
+    resource_detail: "CPU {cpu} · RSS {rss}"
+    resource_alert: "⚠ Session {id} reached the resource threshold (CPU {cpu} / RSS {rss}). Use /live_sessions to switch to it, or /kill_live_sessions to terminate it."
 
   kill_live_sessions:
     daemon_disabled: "PTY daemon is disabled. Enable it in config.yaml:"

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -720,6 +720,8 @@ shell:
     exit_no_note_title: "¿Añadir una nota antes de desconectar?"
     exit_no_note_hint: "Esta sesion no tiene nota — las sesiones sin nombre son dificiles de distinguir tras desconectar."
     exit_no_note_footer: "Enter guardar y desconectar · Esc desconectar sin nombre"
+    resource_detail: "CPU {cpu} · RSS {rss}"
+    resource_alert: "⚠ La sesion {id} alcanzo el umbral de recursos (CPU {cpu} / RSS {rss}). Usa /live_sessions para cambiar a ella o /kill_live_sessions para terminarla."
 
   kill_live_sessions:
     daemon_disabled: "Demonio PTY deshabilitado. Habilitar en config.yaml:"

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -720,6 +720,8 @@ shell:
     exit_no_note_title: "Ajouter une note avant de détacher ?"
     exit_no_note_hint: "Cette session n'a pas de note — les sessions sans nom sont difficiles a distinguer apres déconnexion."
     exit_no_note_footer: "Enter enregistrer & détacher · Esc détacher sans nommer"
+    resource_detail: "CPU {cpu} · RSS {rss}"
+    resource_alert: "⚠ La session {id} a atteint le seuil de ressources (CPU {cpu} / RSS {rss}). Utilisez /live_sessions pour y basculer ou /kill_live_sessions pour la terminer."
 
   kill_live_sessions:
     daemon_disabled: "Daemon PTY desactive. Activer dans config.yaml :"

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -720,6 +720,8 @@ shell:
     exit_no_note_title: "切り離し前にメモを追加しますか？"
     exit_no_note_hint: "このセッションにはメモがありません。名前のないセッションは切断後に見分けがつきません。"
     exit_no_note_footer: "Enter 保存して切り離し · Esc 名前なしで切り離し"
+    resource_detail: "CPU {cpu} · メモリ {rss}"
+    resource_alert: "⚠ セッション {id} がリソース閾値に達しました（CPU {cpu} / メモリ {rss}）。/live_sessions で切り替えるか、/kill_live_sessions で終了してください。"
 
   kill_live_sessions:
     daemon_disabled: "PTYデーモンが無効です。config.yaml で有効にしてください："

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -611,6 +611,8 @@ shell:
     exit_no_note_title: "分离前添加备注？"
     exit_no_note_hint: "当前会话没有备注——脱离后未命名会话难以辨认。"
     exit_no_note_footer: "Enter 保存并分离 · Esc 不命名分离"
+    resource_detail: "CPU {cpu} · 内存 {rss}"
+    resource_alert: "⚠ 会话 {id} 资源占用达到阈值（CPU {cpu} / 内存 {rss}），使用 /live_sessions 切换到该会话，或 /kill_live_sessions 终止该会话"
 
   kill_live_sessions:
     daemon_disabled: "PTY 守护进程未启用，请在 config.yaml 中开启："

--- a/crates/aish-pty/src/daemon.rs
+++ b/crates/aish-pty/src/daemon.rs
@@ -1055,14 +1055,12 @@ pub fn run_pty_daemon_shell(
                                     for frame in frames {
                                         // KillSession allowed from any state
                                         if frame.frame_type == TYPE_KILL_SESSION {
-                                            let _ = nix::sys::signal::kill(
-                                                child,
-                                                Some(nix::sys::signal::Signal::SIGTERM),
-                                            );
-                                            std::thread::sleep(Duration::from_millis(200));
-                                            let _ = nix::sys::signal::kill(
-                                                child,
-                                                Some(nix::sys::signal::Signal::SIGKILL),
+                                            // Kill the REPL AND its worker tree
+                                            // (bash + running tools); signalling
+                                            // only the direct child leaves
+                                            // orphaned CPU burners behind.
+                                            crate::resource::kill_process_tree(
+                                                child.as_raw() as u32
                                             );
                                             child_exited = true;
                                             remove = true;
@@ -1137,14 +1135,11 @@ pub fn run_pty_daemon_shell(
                                             }
                                             TYPE_DETACH => remove = true,
                                             TYPE_KILL_SESSION => {
-                                                let _ = nix::sys::signal::kill(
-                                                    child,
-                                                    Some(nix::sys::signal::Signal::SIGTERM),
-                                                );
-                                                std::thread::sleep(Duration::from_millis(200));
-                                                let _ = nix::sys::signal::kill(
-                                                    child,
-                                                    Some(nix::sys::signal::Signal::SIGKILL),
+                                                // Kill the whole worker tree, not
+                                                // just the direct child (see the
+                                                // early KillSession branch above).
+                                                crate::resource::kill_process_tree(
+                                                    child.as_raw() as u32
                                                 );
                                                 child_exited = true;
                                             }

--- a/crates/aish-pty/src/lib.rs
+++ b/crates/aish-pty/src/lib.rs
@@ -28,6 +28,7 @@ pub mod offload;
 pub mod output_buffer;
 pub mod persistent;
 pub mod readline_tab;
+pub mod resource;
 pub mod scrollback;
 pub mod session_interceptor;
 pub mod types;
@@ -63,6 +64,10 @@ pub use offload::{
 pub use output_buffer::OutputBuffer;
 pub use persistent::{is_interactive_command, shell_quote_escape, PersistentPty};
 pub use readline_tab::{should_complete_path_locally, ReadlineTabResult};
+pub use resource::{
+    descendant_pids, kill_process_tree, sample_groups, sample_sessions_with_cpu, GroupResources,
+    SessionResourceSample,
+};
 pub use scrollback::{ScrollbackBuffer, DEFAULT_SCROLLBACK_SIZE, SCROLLBACK_CHUNK_SIZE};
 pub use session_interceptor::{
     pop_last_utf8_char, AiCallback, AiEvent, AiQuery, AiResponse, AskUserAnswer, AskUserChannel,

--- a/crates/aish-pty/src/resource.rs
+++ b/crates/aish-pty/src/resource.rs
@@ -7,6 +7,7 @@
 //! picture of what one live session costs, including tool subprocesses.
 
 use std::collections::HashMap;
+use std::os::fd::{AsRawFd, FromRawFd};
 use std::path::Path;
 use std::time::Instant;
 
@@ -206,52 +207,110 @@ pub fn descendant_pids(root: u32) -> Vec<u32> {
 ///
 /// Each aish layer calls `setsid()` (daemon child, persistent bash), so a
 /// process-group kill cannot reach the full tree — the descendant set is
-/// walked once up front (before parents die and orphans get reparented),
-/// then swept with SIGTERM for graceful shutdown. After the grace window
-/// each victim's identity (`/proc/<pid>/stat` start time) is revalidated
-/// before SIGKILL so a pid recycled during the window is never signalled.
-/// Errors (ESRCH for already-dead pids) are ignored.
+/// walked once up front (before parents die and orphans get reparented).
+/// Each victim is pinned with a pidfd BEFORE any signal: pidfds reference
+/// the exact process instance, so an exited-and-recycled pid can never be
+/// signalled, for SIGTERM or SIGKILL alike. Signals are sent via
+/// `pidfd_send_signal` (fallback: `/proc/<pid>/stat` start-time check then
+/// `kill`). Failures (ESRCH for already-dead pids) are ignored.
 pub fn kill_process_tree(root: u32) {
-    // Identity snapshot: a pid's start time is unique per boot and never
-    // changes for a live process, so (pid, starttime) reliably detects
-    // recycling.
-    let victims: Vec<(u32, u64)> = descendant_pids(root)
+    let victims: Vec<(u32, PidFd)> = descendant_pids(root)
         .into_iter()
         .chain(std::iter::once(root))
-        .filter_map(|pid| proc_starttime(pid).map(|st| (pid, st)))
+        .filter_map(|pid| pidfd_open(pid).map(|fd| (pid, fd)))
         .collect();
-    for &(pid, _) in &victims {
-        // SAFETY: [Category 8 — FFI] `kill(pid, SIGTERM)` — pid comes from
-        // our own /proc walk; failures (ESRCH, EPERM) are deliberately
-        // ignored so one dead pid cannot abort the sweep.
-        unsafe {
-            libc::kill(pid as libc::pid_t, libc::SIGTERM);
-        }
+    for (pid, fd) in &victims {
+        pidfd_signal(fd, pid, libc::SIGTERM);
     }
     std::thread::sleep(std::time::Duration::from_millis(200));
-    for &(pid, starttime) in &victims {
-        // Skip pids that exited during the grace window and were recycled
-        // onto an unrelated process.
-        if proc_starttime(pid) != Some(starttime) {
-            continue;
-        }
-        // SAFETY: [Category 8 — FFI] `kill(pid, SIGKILL)` — see SIGTERM.
-        unsafe {
-            libc::kill(pid as libc::pid_t, libc::SIGKILL);
+    for (pid, fd) in &victims {
+        pidfd_signal(fd, pid, libc::SIGKILL);
+    }
+}
+
+/// Signal the process pinned by `fd` with `sig`, tolerating every failure.
+///
+/// Preferred path: `pidfd_send_signal(2)` — the fd pins the exact process
+/// instance, so a recycled pid can never be signalled. Fallback (kernels
+/// without the syscall, < 5.1): `kill` only when `/proc/<pid>/stat` still
+/// reports the pid that the fdinfo of the pinning fd captured, which proves
+/// the pid was not recycled in between.
+fn pidfd_signal(fd: &PidFd, pid: &u32, sig: libc::c_int) {
+    if pidfd_send_signal(fd, sig).is_some() {
+        return;
+    }
+    if let Some(pinned) = pidfd_pid(fd) {
+        if proc_stat_pid(*pid) == Some(pinned) {
+            // SAFETY: [Category 8 — FFI] `kill(pid, sig)` — pid comes from
+            // our own /proc walk; failures (ESRCH, EPERM) are deliberately
+            // ignored so one dead pid cannot abort the sweep.
+            unsafe {
+                libc::kill(*pid as libc::pid_t, sig);
+            }
         }
     }
 }
 
-/// Process start time (field 22 of `/proc/<pid>/stat`, in clock ticks since
-/// boot). `None` when the process does not exist or cannot be read.
-fn proc_starttime(pid: u32) -> Option<u64> {
-    let content = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
-    let mut it = stat_fields_after_comm(&content);
-    // Fields 3..=21 (state .. num_threads itrealvalue); starttime is 22.
-    for _ in 3..=21 {
-        it.next()?;
+/// A pinned process handle (`pidfd_open`). The fd stays valid after the
+/// target exits (reads then fail with ESRCH semantics), so the identity it
+/// captured can never drift onto a recycled pid.
+struct PidFd(std::os::fd::OwnedFd);
+
+/// `pidfd_open(2)`. `None` when the syscall is unavailable or the process
+/// is already gone.
+fn pidfd_open(pid: u32) -> Option<PidFd> {
+    const SYS_PIDFD_OPEN: libc::c_long = 434;
+    // SAFETY: [Category 8 — FFI] `syscall(SYS_pidfd_open, pid, 0)` — a
+    // direct Linux syscall; flags must be 0 per the man page. Returns a
+    // new fd (>= 0) or -1 with errno.
+    let fd = unsafe { libc::syscall(SYS_PIDFD_OPEN, pid as libc::pid_t, 0) };
+    if fd < 0 {
+        return None;
     }
-    it.next()?.parse().ok()
+    let fd = fd as libc::c_int;
+    // SAFETY: [Category 8 — FFI] fd is a valid, owned descriptor returned
+    // by the syscall above.
+    Some(PidFd(unsafe { std::os::fd::OwnedFd::from_raw_fd(fd) }))
+}
+
+/// `pidfd_send_signal(2)`. `None` when the syscall is unavailable; a
+/// `Some(())` result whose signal failed is indistinguishable from success
+/// only in that the target had already exited, which is fine here.
+fn pidfd_send_signal(fd: &PidFd, sig: libc::c_int) -> Option<()> {
+    const SYS_PIDFD_SEND_SIGNAL: libc::c_long = 424;
+    // SAFETY: [Category 8 — FFI] `syscall(SYS_pidfd_send_signal, fd, sig,
+    // NULL, 0)` — a direct Linux syscall with the reserved info pointer
+    // NULL and flags 0.
+    unsafe {
+        libc::syscall(
+            SYS_PIDFD_SEND_SIGNAL,
+            fd.0.as_raw_fd(),
+            sig,
+            std::ptr::null::<libc::siginfo_t>(),
+            0,
+        ) >= 0
+    }
+    .then_some(())
+}
+
+/// The pid that the fd pins, read from the fd's `fdinfo`. `None` when the
+fn pidfd_pid(fd: &PidFd) -> Option<u32> {
+    let info = std::fs::read_to_string(format!("/proc/self/fdinfo/{}", fd.0.as_raw_fd())).ok()?;
+    for line in info.lines() {
+        if let Some(rest) = line.strip_prefix("Pid:") {
+            return rest.trim().parse().ok();
+        }
+    }
+    None
+}
+
+/// The pid reported by `/proc/<pid>/stat` (field 1). `None` when the
+/// process does not exist — a recycled pid reports the NEW process's pid
+/// there only after the namespace re-maps it, which cannot happen for the
+/// init-pid-namespace view this code uses.
+fn proc_stat_pid(pid: u32) -> Option<u32> {
+    let content = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    content.split_whitespace().next()?.parse().ok()
 }
 
 /// Process page size (`sysconf(_SC_PAGESIZE)`), cached.

--- a/crates/aish-pty/src/resource.rs
+++ b/crates/aish-pty/src/resource.rs
@@ -1,0 +1,371 @@
+//! Live-session resource sampling via `/proc` (Linux only).
+//!
+//! Each PTY daemon is spawned in its own process group (`process_group(0)` in
+//! `aish-cli`), and the daemon's forked aish child plus any bash-exec'd
+//! workers stay in that group. Sampling therefore aggregates CPU jiffies and
+//! RSS over every process whose PGID equals the daemon PID — a complete
+//! picture of what one live session costs, including tool subprocesses.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::Instant;
+
+/// Resource usage of one process group (one live session's worker tree).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct GroupResources {
+    /// Summed `utime + stime` in clock ticks across the group.
+    pub cpu_ticks: u64,
+    /// Summed resident set size in bytes across the group.
+    pub rss_bytes: u64,
+}
+
+impl GroupResources {
+    /// CPU percentage over a sampling window.
+    ///
+    /// `ticks_delta` is the jiffies consumed between two samples taken
+    /// `elapsed` apart. Returns 0.0 for degenerate windows.
+    pub fn cpu_percent(ticks_delta: u64, elapsed_secs: f64) -> f64 {
+        if elapsed_secs <= 0.0 {
+            return 0.0;
+        }
+        let ticks_per_sec = clock_ticks() as f64;
+        (ticks_delta as f64 / ticks_per_sec / elapsed_secs) * 100.0
+    }
+
+    /// Human-readable RSS size (MiB with one decimal, or KiB when < 1 MiB).
+    pub fn rss_human(bytes: u64) -> String {
+        const KIB: f64 = 1024.0;
+        const MIB: f64 = 1024.0 * KIB;
+        let v = bytes as f64;
+        if v >= MIB {
+            format!("{:.1}MB", v / MIB)
+        } else {
+            format!("{:.0}KB", v / KIB)
+        }
+    }
+}
+
+/// Clock ticks per second (`sysconf(_SC_CLK_TCK)`). Almost universally 100
+/// on Linux; read once and cache.
+fn clock_ticks() -> u64 {
+    static TICKS: std::sync::LazyLock<u64> = std::sync::LazyLock::new(|| {
+        // SAFETY: [Category 8 — FFI] `sysconf` reads a system constant.
+        unsafe { libc::sysconf(libc::_SC_CLK_TCK) }.max(1) as u64
+    });
+    *TICKS
+}
+
+/// Split a `/proc/<pid>/stat` line after the comm field.
+///
+/// The comm field (parenthesised executable name) may itself contain spaces
+/// and parentheses, so everything before the LAST `)` is skipped. The
+/// returned iterator starts at field 3 (`state`).
+fn stat_fields_after_comm(content: &str) -> impl Iterator<Item = &str> {
+    let close = content.rfind(')').unwrap_or(0);
+    content[close + 1..].split_whitespace()
+}
+
+/// (pid, ppid, utime, stime, rss_pages) from a `/proc/<pid>/stat` line.
+///
+/// Field indices (1-based, per proc(5)): pid=1, comm=2, state=3, ppid=4,
+/// utime=14, stime=15, rss=24. Relative to the iterator starting at field
+/// 3: ppid is the 2nd item; skip fields 5..=13 to land on utime; rss is the
+/// 22nd item.
+fn parse_stat_all(content: &str) -> Option<(u32, u32, u64, u64, u64)> {
+    // pid sits before the comm field.
+    let pid: u32 = content.split_whitespace().next()?.parse().ok()?;
+    let mut it = stat_fields_after_comm(content);
+    let _state = it.next()?;
+    let ppid: u32 = it.next()?.parse().ok()?;
+    // Skip fields 5..=13 (pgrp session tty_nr tpgid flags minflt cminflt
+    // majflt cmajflt) so the iterator lands on utime (field 14).
+    for _ in 5..=13 {
+        it.next()?;
+    }
+    let utime: u64 = it.next()?.parse().ok()?;
+    let stime: u64 = it.next()?.parse().ok()?;
+    // Skip fields 16..=23 (cutime cstime priority nice num_threads
+    // itrealvalue starttime vsize); rss is field 24.
+    for _ in 16..=23 {
+        it.next()?;
+    }
+    let rss_pages: u64 = it.next()?.parse().ok()?;
+    Some((pid, ppid, utime, stime, rss_pages))
+}
+
+/// Sample CPU ticks and RSS for every process in the tree rooted at each
+/// `root_pid` (the PTY daemon). The daemon's forked REPL child calls
+/// `setsid()`, so the worker tree is NOT in the daemon's process group —
+/// aggregating by parent-pid closure is immune to that.
+///
+/// One pass over `/proc`; unreadable or vanished entries are skipped. The
+/// returned map contains exactly the requested roots (defaulting to zeroed
+/// resources when no live process matched).
+pub fn sample_groups(root_pids: &[u32]) -> HashMap<u32, GroupResources> {
+    let mut out: HashMap<u32, GroupResources> = root_pids
+        .iter()
+        .map(|&p| (p, GroupResources::default()))
+        .collect();
+    if root_pids.is_empty() {
+        return out;
+    }
+    let page_size = page_size_bytes();
+    let Ok(entries) = std::fs::read_dir(Path::new("/proc")) else {
+        return out;
+    };
+
+    // pid -> (utime, stime, rss_pages) plus a children-by-parent map for
+    // the descendant closure; both keyed lookups keep the per-root BFS at
+    // O(tree size) instead of a linear scan over all processes.
+    let mut procs: HashMap<u32, (u64, u64, u64)> = HashMap::new();
+    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(pid_str) = name.to_str() else {
+            continue;
+        };
+        if !pid_str.bytes().all(|b| b.is_ascii_digit()) {
+            continue;
+        }
+        let stat_path = entry.path().join("stat");
+        let Ok(content) = std::fs::read_to_string(&stat_path) else {
+            continue;
+        };
+        let Some((pid, ppid, utime, stime, rss_pages)) = parse_stat_all(&content) else {
+            continue;
+        };
+        procs.insert(pid, (utime, stime, rss_pages));
+        children.entry(ppid).or_default().push(pid);
+    }
+
+    // BFS from each root, summing resources.
+    for &root in root_pids {
+        let mut stack = vec![root];
+        let mut visited = 0usize;
+        while let Some(pid) = stack.pop() {
+            if visited > 4096 {
+                break; // defensive: pathological trees
+            }
+            visited += 1;
+            if let Some(&(utime, stime, rss_pages)) = procs.get(&pid) {
+                let slot = out
+                    .get_mut(&root)
+                    .expect("pre-populated for every requested root");
+                slot.cpu_ticks += utime + stime;
+                slot.rss_bytes += rss_pages * page_size;
+            }
+            if let Some(kids) = children.get(&pid) {
+                stack.extend(kids.iter().copied());
+            }
+        }
+    }
+    out
+}
+
+/// PIDs of every descendant of `root` (excluding `root` itself), collected
+/// BEFORE any signalling so orphans (reparented to init on parent death)
+/// stay discoverable.
+pub fn descendant_pids(root: u32) -> Vec<u32> {
+    let Ok(entries) = std::fs::read_dir(Path::new("/proc")) else {
+        return Vec::new();
+    };
+    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(pid_str) = name.to_str() else {
+            continue;
+        };
+        if !pid_str.bytes().all(|b| b.is_ascii_digit()) {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(entry.path().join("stat")) else {
+            continue;
+        };
+        let Some((pid, ppid, _, _, _)) = parse_stat_all(&content) else {
+            continue;
+        };
+        children.entry(ppid).or_default().push(pid);
+    }
+    let mut out = Vec::new();
+    let mut stack = vec![root];
+    while let Some(pid) = stack.pop() {
+        if out.len() > 4096 {
+            break; // defensive: pathological trees / loops
+        }
+        if let Some(kids) = children.get(&pid) {
+            for &kid in kids {
+                out.push(kid);
+                stack.push(kid);
+            }
+        }
+    }
+    out
+}
+
+/// Terminate `root` and its whole worker tree (REPL → bash → tools).
+///
+/// Each aish layer calls `setsid()` (daemon child, persistent bash), so a
+/// process-group kill cannot reach the full tree — the descendant set is
+/// walked once up front (before parents die and orphans get reparented),
+/// then swept with SIGTERM for graceful shutdown followed by SIGKILL for
+/// stragglers. Errors (ESRCH for already-dead pids) are ignored.
+pub fn kill_process_tree(root: u32) {
+    let mut victims = descendant_pids(root);
+    victims.push(root);
+    for &pid in &victims {
+        // SAFETY: [Category 8 — FFI] `kill(pid, SIGTERM)` — pid comes from
+        // our own /proc walk; failures (ESRCH, EPERM) are deliberately
+        // ignored so one dead pid cannot abort the sweep.
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGTERM);
+        }
+    }
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    for &pid in &victims {
+        // SAFETY: [Category 8 — FFI] `kill(pid, SIGKILL)` — see SIGTERM.
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGKILL);
+        }
+    }
+}
+
+/// Process page size (`sysconf(_SC_PAGESIZE)`), cached.
+fn page_size_bytes() -> u64 {
+    static SIZE: std::sync::LazyLock<u64> = std::sync::LazyLock::new(|| {
+        // SAFETY: [Category 8 — FFI] `sysconf` reads a system constant.
+        unsafe { libc::sysconf(libc::_SC_PAGESIZE) }.max(1) as u64
+    });
+    *SIZE
+}
+
+/// One sampled live session with derived metrics.
+#[derive(Debug, Clone)]
+pub struct SessionResourceSample {
+    pub session_id: String,
+    pub daemon_pid: u32,
+    /// CPU percent averaged over the sampling window. `None` when the delta
+    /// could not be derived.
+    pub cpu_percent: Option<f64>,
+    /// Summed RSS of the whole process group.
+    pub rss_bytes: u64,
+}
+
+/// Take two samples of the given daemon PGIDs and derive CPU percentages.
+///
+/// `window_ms` is the delay between samples. Blocking for the window is
+/// acceptable because this runs at REPL cadence (per prompt or per command),
+/// never on the async runtime.
+pub fn sample_sessions_with_cpu(
+    pgids: &[(String, u32)],
+    window_ms: u64,
+) -> Vec<SessionResourceSample> {
+    let ids: Vec<(String, u32)> = pgids.to_vec();
+    let pid_list: Vec<u32> = ids.iter().map(|(_, p)| *p).collect();
+
+    let t0 = Instant::now();
+    let first = sample_groups(&pid_list);
+    std::thread::sleep(std::time::Duration::from_millis(window_ms));
+    let second = sample_groups(&pid_list);
+    let elapsed = t0.elapsed().as_secs_f64();
+
+    ids.into_iter()
+        .map(|(session_id, daemon_pid)| {
+            let a = first.get(&daemon_pid);
+            let b = second.get(&daemon_pid);
+            let cpu_percent = match (a, b) {
+                (Some(a), Some(b)) if b.cpu_ticks >= a.cpu_ticks => Some(
+                    GroupResources::cpu_percent(b.cpu_ticks - a.cpu_ticks, elapsed),
+                ),
+                _ => None,
+            };
+            SessionResourceSample {
+                session_id,
+                daemon_pid,
+                cpu_percent,
+                rss_bytes: b.map(|r| r.rss_bytes).unwrap_or(0),
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cpu_percent_math() {
+        // 100 ticks over 1s at 100Hz = exactly one core.
+        assert!((GroupResources::cpu_percent(100, 1.0) - 100.0).abs() < 0.01);
+        // Zero window must not divide by zero.
+        assert_eq!(GroupResources::cpu_percent(100, 0.0), 0.0);
+        // 25 ticks over 1s = quarter core.
+        assert!((GroupResources::cpu_percent(25, 1.0) - 25.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn rss_human_format() {
+        assert_eq!(GroupResources::rss_human(512 * 1024), "512KB");
+        assert_eq!(GroupResources::rss_human(300 * 1024 * 1024), "300.0MB");
+    }
+
+    #[test]
+    fn parses_stat_line_with_parens_in_comm() {
+        // comm containing spaces and parens must not shift field indices.
+        // Field map (1-based): pid=1 ppid=4; utime=14; stime=15; rss=24.
+        let stat = "1234 (aish (worker) #2) R 100 1234 1234 1234 0 12345 \
+                    0 0 0 12 34 56 0 0 20 0 3 0 98765 109568 512 0 0 0 0 0 0 0 0 0";
+        let (pid, ppid, utime, stime, rss) = parse_stat_all(stat).expect("must parse");
+        assert_eq!((pid, ppid), (1234, 100));
+        assert_eq!((utime, stime), (34, 56));
+        assert_eq!(rss, 512);
+    }
+
+    #[test]
+    fn samples_own_process_tree() {
+        // The test process is the root of its own (single-process) tree.
+        let own = std::process::id();
+        let groups = sample_groups(&[own]);
+        let r = groups
+            .get(&own)
+            .unwrap_or_else(|| panic!("own pid {own} present"));
+        assert!(r.rss_bytes > 0, "own RSS must be > 0, got {}", r.rss_bytes);
+    }
+
+    #[test]
+    fn cpu_sampling_produces_non_negative_deltas() {
+        let own = std::process::id();
+        let samples = sample_sessions_with_cpu(&[("test".to_string(), own)], 50);
+        assert_eq!(samples.len(), 1);
+        let s = &samples[0];
+        assert_eq!(s.session_id, "test");
+        assert!(s.rss_bytes > 0);
+        if let Some(cpu) = s.cpu_percent {
+            assert!(cpu >= 0.0);
+        }
+    }
+
+    #[test]
+    fn dead_root_reports_zero() {
+        let groups = sample_groups(&[u32::MAX]);
+        assert_eq!(groups[&u32::MAX], GroupResources::default());
+    }
+
+    #[test]
+    fn descendant_pids_finds_direct_child() {
+        use std::process::{Command, Stdio};
+        let mut child = Command::new("sleep")
+            .arg("5")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sleep");
+        let kids = descendant_pids(std::process::id());
+        assert!(
+            kids.contains(&child.id()),
+            "child {} must appear in descendants: {kids:?}",
+            child.id()
+        );
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}

--- a/crates/aish-pty/src/resource.rs
+++ b/crates/aish-pty/src/resource.rs
@@ -210,44 +210,53 @@ pub fn descendant_pids(root: u32) -> Vec<u32> {
 /// walked once up front (before parents die and orphans get reparented).
 /// Each victim is pinned with a pidfd BEFORE any signal: pidfds reference
 /// the exact process instance, so an exited-and-recycled pid can never be
-/// signalled, for SIGTERM or SIGKILL alike. Signals are sent via
-/// `pidfd_send_signal` (fallback: `/proc/<pid>/stat` start-time check then
-/// `kill`). Failures (ESRCH for already-dead pids) are ignored.
+/// signalled, for SIGTERM or SIGKILL alike.
+///
+/// When `pidfd_open` is unavailable (kernel < 5.3, seccomp/container
+/// policy, EPERM) the pid is still signalled by plain `kill` — dropping
+/// it would silently turn the termination into a no-op, which is exactly
+/// the runaway-session failure this exists to fix. That path accepts the
+/// theoretical TOCTOU of a pid recycled between the /proc scan and the
+/// signal; `pidfd_send_signal` failure with a pinned fd additionally
+/// cross-checks identity via fdinfo before falling back to `kill`.
 pub fn kill_process_tree(root: u32) {
-    let victims: Vec<(u32, PidFd)> = descendant_pids(root)
+    let victims: Vec<(u32, Option<PidFd>)> = descendant_pids(root)
         .into_iter()
         .chain(std::iter::once(root))
-        .filter_map(|pid| pidfd_open(pid).map(|fd| (pid, fd)))
+        .map(|pid| (pid, pidfd_open(pid)))
         .collect();
     for (pid, fd) in &victims {
-        pidfd_signal(fd, pid, libc::SIGTERM);
+        pidfd_signal(fd.as_ref(), pid, libc::SIGTERM);
     }
     std::thread::sleep(std::time::Duration::from_millis(200));
     for (pid, fd) in &victims {
-        pidfd_signal(fd, pid, libc::SIGKILL);
+        pidfd_signal(fd.as_ref(), pid, libc::SIGKILL);
     }
 }
 
-/// Signal the process pinned by `fd` with `sig`, tolerating every failure.
+/// Signal the process behind `pid` with `sig`, tolerating every failure.
 ///
-/// Preferred path: `pidfd_send_signal(2)` — the fd pins the exact process
-/// instance, so a recycled pid can never be signalled. Fallback (kernels
-/// without the syscall, < 5.1): `kill` only when `/proc/<pid>/stat` still
-/// reports the pid that the fdinfo of the pinning fd captured, which proves
-/// the pid was not recycled in between.
-fn pidfd_signal(fd: &PidFd, pid: &u32, sig: libc::c_int) {
-    if pidfd_send_signal(fd, sig).is_some() {
-        return;
-    }
-    if let Some(pinned) = pidfd_pid(fd) {
-        if proc_stat_pid(*pid) == Some(pinned) {
-            // SAFETY: [Category 8 — FFI] `kill(pid, sig)` — pid comes from
-            // our own /proc walk; failures (ESRCH, EPERM) are deliberately
-            // ignored so one dead pid cannot abort the sweep.
-            unsafe {
-                libc::kill(*pid as libc::pid_t, sig);
+/// - Pinned fd, working `pidfd_send_signal`: signal the exact instance.
+/// - Pinned fd, syscall blocked: `kill` only when the fdinfo pid still
+///   matches `/proc/<pid>/stat`, proving no recycling.
+/// - No fd (pidfd_open unavailable): straight `kill` — termination must
+///   not silently degrade to a no-op on old kernels.
+fn pidfd_signal(fd: Option<&PidFd>, pid: &u32, sig: libc::c_int) {
+    if let Some(fd) = fd {
+        if pidfd_send_signal(fd, sig).is_some() {
+            return;
+        }
+        if let Some(pinned) = pidfd_pid(fd) {
+            if proc_stat_pid(*pid) != Some(pinned) {
+                return; // pid was recycled; do not signal the stranger
             }
         }
+    }
+    // SAFETY: [Category 8 — FFI] `kill(pid, sig)` — pid comes from our own
+    // /proc walk; failures (ESRCH, EPERM) are deliberately ignored so one
+    // dead pid cannot abort the sweep.
+    unsafe {
+        libc::kill(*pid as libc::pid_t, sig);
     }
 }
 

--- a/crates/aish-pty/src/resource.rs
+++ b/crates/aish-pty/src/resource.rs
@@ -207,12 +207,20 @@ pub fn descendant_pids(root: u32) -> Vec<u32> {
 /// Each aish layer calls `setsid()` (daemon child, persistent bash), so a
 /// process-group kill cannot reach the full tree — the descendant set is
 /// walked once up front (before parents die and orphans get reparented),
-/// then swept with SIGTERM for graceful shutdown followed by SIGKILL for
-/// stragglers. Errors (ESRCH for already-dead pids) are ignored.
+/// then swept with SIGTERM for graceful shutdown. After the grace window
+/// each victim's identity (`/proc/<pid>/stat` start time) is revalidated
+/// before SIGKILL so a pid recycled during the window is never signalled.
+/// Errors (ESRCH for already-dead pids) are ignored.
 pub fn kill_process_tree(root: u32) {
-    let mut victims = descendant_pids(root);
-    victims.push(root);
-    for &pid in &victims {
+    // Identity snapshot: a pid's start time is unique per boot and never
+    // changes for a live process, so (pid, starttime) reliably detects
+    // recycling.
+    let victims: Vec<(u32, u64)> = descendant_pids(root)
+        .into_iter()
+        .chain(std::iter::once(root))
+        .filter_map(|pid| proc_starttime(pid).map(|st| (pid, st)))
+        .collect();
+    for &(pid, _) in &victims {
         // SAFETY: [Category 8 — FFI] `kill(pid, SIGTERM)` — pid comes from
         // our own /proc walk; failures (ESRCH, EPERM) are deliberately
         // ignored so one dead pid cannot abort the sweep.
@@ -221,13 +229,10 @@ pub fn kill_process_tree(root: u32) {
         }
     }
     std::thread::sleep(std::time::Duration::from_millis(200));
-    // Re-derive the surviving tree: a pid that exited during the grace
-    // window may have been recycled onto an unrelated process, so only
-    // pids still inside the root's descendant closure get the SIGKILL.
-    let mut survivors = descendant_pids(root);
-    survivors.push(root);
-    for &pid in &victims {
-        if !survivors.contains(&pid) {
+    for &(pid, starttime) in &victims {
+        // Skip pids that exited during the grace window and were recycled
+        // onto an unrelated process.
+        if proc_starttime(pid) != Some(starttime) {
             continue;
         }
         // SAFETY: [Category 8 — FFI] `kill(pid, SIGKILL)` — see SIGTERM.
@@ -235,6 +240,18 @@ pub fn kill_process_tree(root: u32) {
             libc::kill(pid as libc::pid_t, libc::SIGKILL);
         }
     }
+}
+
+/// Process start time (field 22 of `/proc/<pid>/stat`, in clock ticks since
+/// boot). `None` when the process does not exist or cannot be read.
+fn proc_starttime(pid: u32) -> Option<u64> {
+    let content = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let mut it = stat_fields_after_comm(&content);
+    // Fields 3..=21 (state .. num_threads itrealvalue); starttime is 22.
+    for _ in 3..=21 {
+        it.next()?;
+    }
+    it.next()?.parse().ok()
 }
 
 /// Process page size (`sysconf(_SC_PAGESIZE)`), cached.

--- a/crates/aish-pty/src/resource.rs
+++ b/crates/aish-pty/src/resource.rs
@@ -221,7 +221,15 @@ pub fn kill_process_tree(root: u32) {
         }
     }
     std::thread::sleep(std::time::Duration::from_millis(200));
+    // Re-derive the surviving tree: a pid that exited during the grace
+    // window may have been recycled onto an unrelated process, so only
+    // pids still inside the root's descendant closure get the SIGKILL.
+    let mut survivors = descendant_pids(root);
+    survivors.push(root);
     for &pid in &victims {
+        if !survivors.contains(&pid) {
+            continue;
+        }
         // SAFETY: [Category 8 — FFI] `kill(pid, SIGKILL)` — see SIGTERM.
         unsafe {
             libc::kill(pid as libc::pid_t, libc::SIGKILL);

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -656,6 +656,11 @@ pub struct AishShell {
     pty: Arc<Mutex<aish_pty::PersistentPty>>,
     /// UUID for the current session, used to associate history entries.
     session_uuid: String,
+    /// Live-session resource monitor: warns when other detached sessions
+    /// exceed CPU/RSS thresholds.
+    resource_monitor: crate::resource_monitor::Monitor,
+    /// When the REPL last ran a resource check (throttled by config).
+    last_resource_check: Option<std::time::Instant>,
     /// Whether streaming has started printing content (to avoid double-printing).
     streamed_content: Arc<AtomicBool>,
     /// Current shell lifecycle phase
@@ -2165,6 +2170,11 @@ impl AishShell {
             let mut guard = vault_slot.lock().unwrap();
             *guard = Some(secret_vault.clone());
         }
+        // Read resource thresholds before `config` is moved into Self.
+        let resource_thresholds = crate::resource_monitor::Thresholds {
+            cpu_percent: config.pty_resource_cpu_percent,
+            rss_mb: config.pty_resource_rss_mb,
+        };
 
         Ok(Self {
             state,
@@ -2195,6 +2205,8 @@ impl AishShell {
             sub_agent_animation: sub_agent_animation.clone(),
             ai_op_generation,
             expand_history,
+            resource_monitor: crate::resource_monitor::Monitor::new(resource_thresholds),
+            last_resource_check: None,
             shared_recorder,
             inline_ai: None,
             approval_memory,
@@ -2383,6 +2395,9 @@ impl AishShell {
                 }
             }
 
+            // Periodic live-session resource check: warn when another
+            // detached session hogs CPU or memory.
+            self.check_live_session_resources();
             // Check for skill hot-reload changes
             if let Some(ref reloader) = self.skill_hot_reloader {
                 let affected = reloader.apply_changes(&mut self.skill_manager);
@@ -5725,6 +5740,47 @@ impl AishShell {
         render_audit_markdown_impl(events)
     }
 
+    /// Throttled live-session resource check. Warns in the current session
+    /// when another live PTY session exceeds the configured CPU/RSS
+    /// thresholds. Interval and thresholds come from config; interval 0
+    /// disables the check.
+    fn check_live_session_resources(&mut self) {
+        let interval = self.config.pty_resource_check_interval_secs;
+        if interval == 0 {
+            return;
+        }
+        let now = std::time::Instant::now();
+        let due = match self.last_resource_check {
+            None => true,
+            Some(last) => now.duration_since(last).as_secs() >= interval,
+        };
+        if !due {
+            return;
+        }
+        self.last_resource_check = Some(now);
+
+        let current_id = std::env::var("AISH_SESSION_ID").unwrap_or_default();
+        // Exclude only the current session. When the env var is unset this
+        // shell is not a daemon child, so every live session counts as
+        // "another" instead of silently disabling the check.
+        let others: Vec<aish_pty::DaemonSessionInfo> = aish_pty::discover_sessions()
+            .into_iter()
+            .filter(|s| {
+                !s.session_id.is_empty()
+                    && (current_id.is_empty()
+                        || (s.session_id != current_id && !s.session_id.starts_with(&current_id)))
+            })
+            .collect();
+        if others.is_empty() {
+            return;
+        }
+        for alert in self.resource_monitor.check(&others) {
+            let msg = crate::resource_monitor::format_resource_alert(&alert);
+            println!("{}", theme::warning(&msg));
+        }
+        let _ = io::stdout().flush();
+    }
+
     fn handle_resume_command(&mut self, parts: &[&str]) {
         match parts.len() {
             1 => self.select_recent_session(),
@@ -5764,6 +5820,14 @@ impl AishShell {
                 .unwrap_or_default()
                 .as_secs();
 
+            // Sample CPU/RSS for every live session's process group so the
+            // picker can show what each session actually costs.
+            let pgids: Vec<(String, u32)> = sessions
+                .iter()
+                .map(|s| (s.session_id.clone(), s.daemon_pid))
+                .collect();
+            let resource_samples = aish_pty::sample_sessions_with_cpu(&pgids, 250);
+
             // Value of the current session's picker row, used to drive the
             // animated shimmer sweep on that row.
             let current_value = current_id.as_ref().and_then(|c| {
@@ -5790,14 +5854,29 @@ impl AishShell {
                         s.cwd.clone()
                     };
                     let age_str = format_age(now.saturating_sub(s.started_at));
+                    let base_detail =
+                        t_with_args("shell.live_sessions.started_label", &age_args(age_str));
+                    // Append live CPU/RSS so runaway sessions are visible
+                    // directly in the picker.
+                    let resource_detail = resource_samples
+                        .iter()
+                        .find(|r| r.session_id == s.session_id)
+                        .map(|r| {
+                            crate::resource_monitor::format_resource_detail(
+                                r.cpu_percent,
+                                r.rss_bytes,
+                            )
+                        })
+                        .unwrap_or_default();
                     let detail = if is_current {
                         format!(
-                            "{} {}",
-                            t_with_args("shell.live_sessions.started_label", &age_args(age_str)),
-                            t("shell.live_sessions.current_tag")
+                            "{} {} · {}",
+                            base_detail,
+                            t("shell.live_sessions.current_tag"),
+                            resource_detail
                         )
                     } else {
-                        t_with_args("shell.live_sessions.started_label", &age_args(age_str))
+                        format!("{} · {}", base_detail, resource_detail)
                     };
                     // Label is short id + cwd; a custom name (if any) is the
                     // bold green highlight prefix so it stands out at a glance.

--- a/crates/aish-shell/src/lib.rs
+++ b/crates/aish-shell/src/lib.rs
@@ -37,6 +37,7 @@ pub mod prompt;
 pub mod readline;
 pub mod recorder;
 pub mod renderer;
+pub mod resource_monitor;
 pub mod resume_selector;
 pub mod security_panel;
 pub mod settings_panel;

--- a/crates/aish-shell/src/resource_monitor.rs
+++ b/crates/aish-shell/src/resource_monitor.rs
@@ -1,0 +1,313 @@
+//! Periodic live-session resource monitoring for the REPL.
+//!
+//! Every [`Monitor::check`] call takes ONE instantaneous `/proc` sample of
+//! all live PTY daemon process trees and warns in the current session when
+//! another session exceeds the configured CPU / RSS thresholds. CPU percent
+//! is derived from the tick delta against the previous check, so no sampling
+//! sleep ever blocks the REPL. Alerts are throttled per session (5 min
+//! cooldown) and reset when usage drops back below the thresholds.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use aish_pty::{sample_groups, DaemonSessionInfo, GroupResources};
+
+/// Per-session monitoring state.
+struct SessionState {
+    /// Cumulative CPU ticks seen at the previous check; the delta between
+    /// checks yields CPU percent without any sampling sleep.
+    last_ticks: Option<u64>,
+    /// When the previous check ran; denominates the tick delta.
+    last_sample_at: Instant,
+    /// Last alert emission, for the cooldown.
+    last_alert: Option<Instant>,
+}
+
+/// Alert cooldown per session — one warning every 5 minutes while the
+/// session stays above its thresholds.
+const ALERT_COOLDOWN: Duration = Duration::from_secs(5 * 60);
+
+/// Minimum interval (seconds) between two samples before a CPU delta is
+/// trusted. Below this, tick granularity over a near-zero window produces
+/// wild percentages (e.g. one jiffy over 1 ms), so CPU is reported as
+/// unknown instead.
+const MIN_CPU_WINDOW_SECS: f64 = 1.0;
+
+/// Threshold configuration extracted from `ConfigModel`.
+#[derive(Debug, Clone)]
+pub struct Thresholds {
+    pub cpu_percent: f64,
+    pub rss_mb: u64,
+}
+
+/// Stateful monitor keyed by session id.
+pub struct Monitor {
+    thresholds: Thresholds,
+    states: HashMap<String, SessionState>,
+}
+
+/// A threshold violation to be reported for one session.
+pub struct Alert {
+    pub session: DaemonSessionInfo,
+    pub cpu: Option<f64>,
+    pub rss_bytes: u64,
+}
+
+impl Monitor {
+    pub fn new(thresholds: Thresholds) -> Self {
+        Self {
+            thresholds,
+            states: HashMap::new(),
+        }
+    }
+    pub fn check(&mut self, sessions: &[DaemonSessionInfo]) -> Vec<Alert> {
+        // Forget sessions that disappeared so ids are not leaked and a
+        // re-appearing session starts without stale cooldown state.
+        let live: Vec<&str> = sessions.iter().map(|s| s.session_id.as_str()).collect();
+        self.states.retain(|id, _| live.contains(&id.as_str()));
+
+        if sessions.is_empty()
+            || (self.thresholds.cpu_percent <= 0.0 && self.thresholds.rss_mb == 0)
+        {
+            return Vec::new();
+        }
+
+        // One instantaneous /proc pass for every session tree; CPU comes
+        // from the delta against the previous check, never from a sleep.
+        let pids: Vec<u32> = sessions.iter().map(|s| s.daemon_pid).collect();
+        let groups = sample_groups(&pids);
+
+        let now = Instant::now();
+        let rss_threshold_bytes = self.thresholds.rss_mb.saturating_mul(1024 * 1024);
+        let mut alerts: Vec<Alert> = Vec::new();
+
+        for session in sessions {
+            let Some(res) = groups.get(&session.daemon_pid) else {
+                continue;
+            };
+            let state = self
+                .states
+                .entry(session.session_id.clone())
+                .or_insert(SessionState {
+                    last_ticks: None,
+                    last_sample_at: now,
+                    last_alert: None,
+                });
+
+            // CPU averaged over the whole interval since the previous check
+            // (default 30 s) — the long window also smooths short spikes.
+            // `None` on the first check or when the window is too short for
+            // tick granularity to be meaningful.
+            let elapsed = now.duration_since(state.last_sample_at).as_secs_f64();
+            let cpu_percent = match state.last_ticks {
+                Some(prev) if elapsed >= MIN_CPU_WINDOW_SECS && res.cpu_ticks >= prev => {
+                    Some(GroupResources::cpu_percent(res.cpu_ticks - prev, elapsed))
+                }
+                _ => None,
+            };
+            state.last_ticks = Some(res.cpu_ticks);
+            state.last_sample_at = now;
+
+            let cpu_exceeded = self.thresholds.cpu_percent > 0.0
+                && cpu_percent.is_some_and(|cpu| cpu >= self.thresholds.cpu_percent);
+            let rss_exceeded = self.thresholds.rss_mb > 0 && res.rss_bytes >= rss_threshold_bytes;
+
+            if !cpu_exceeded && !rss_exceeded {
+                // Recovered: clear so a new violation episode alerts
+                // immediately instead of waiting out the old cooldown.
+                state.last_alert = None;
+                continue;
+            }
+
+            let due = match state.last_alert {
+                None => true,
+                Some(last) => now.duration_since(last) >= ALERT_COOLDOWN,
+            };
+            if due {
+                state.last_alert = Some(now);
+                alerts.push(Alert {
+                    session: session.clone(),
+                    cpu: cpu_percent,
+                    rss_bytes: res.rss_bytes,
+                });
+            }
+        }
+
+        alerts
+    }
+}
+
+/// Format `(cpu, rss_bytes)` for the panel detail line via i18n.
+pub fn format_resource_detail(cpu: Option<f64>, rss_bytes: u64) -> String {
+    let cpu_str = match cpu {
+        Some(c) => format!("{c:.0}%"),
+        None => "--".to_string(),
+    };
+    let rss_str = GroupResources::rss_human(rss_bytes);
+    let mut args = std::collections::HashMap::new();
+    args.insert("cpu".to_string(), cpu_str);
+    args.insert("rss".to_string(), rss_str);
+    aish_i18n::t_with_args("shell.live_sessions.resource_detail", &args)
+}
+
+/// Format the threshold-alert message via i18n.
+///
+/// The session name (if any) is folded into the `{id}` label so unnamed
+/// sessions don't render empty parentheses.
+pub fn format_resource_alert(alert: &Alert) -> String {
+    let cpu_str = match alert.cpu {
+        Some(c) => format!("{c:.0}%"),
+        None => "--".to_string(),
+    };
+    let rss_str = GroupResources::rss_human(alert.rss_bytes);
+    let id = &alert.session.session_id;
+    let short = &id[..8.min(id.len())];
+    let label = match alert.session.name.as_deref() {
+        Some(n) if !n.is_empty() => format!("{short} ({n})"),
+        _ => short.to_string(),
+    };
+    let mut args = std::collections::HashMap::new();
+    args.insert("id".to_string(), label);
+    args.insert("cpu".to_string(), cpu_str);
+    args.insert("rss".to_string(), rss_str);
+    aish_i18n::t_with_args("shell.live_sessions.resource_alert", &args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn thresholds() -> Thresholds {
+        Thresholds {
+            cpu_percent: 80.0,
+            rss_mb: 1024,
+        }
+    }
+
+    #[test]
+    fn empty_sessions_yield_no_alerts() {
+        let mut m = Monitor::new(thresholds());
+        assert!(m.check(&[]).is_empty());
+    }
+
+    #[test]
+    fn disabled_thresholds_yield_no_alerts() {
+        let mut m = Monitor::new(Thresholds {
+            cpu_percent: 0.0,
+            rss_mb: 0,
+        });
+        let sessions = vec![fake_session("aaaaaaaa")];
+        assert!(m.check(&sessions).is_empty());
+    }
+
+    #[test]
+    fn dead_daemon_below_thresholds_no_alert() {
+        // The PID does not exist → zero usage → below thresholds → no alert.
+        let mut m = Monitor::new(thresholds());
+        let sessions = vec![fake_session_with_pid("aaaaaaaa", u32::MAX - 1)];
+        assert!(m.check(&sessions).is_empty());
+    }
+
+    #[test]
+    fn cooldown_prevents_repeat_alerts() {
+        // Verify the state machine via our own process tree, whose RSS
+        // certainly exceeds a 1 MiB threshold (CPU disabled).
+        let mut m = Monitor::new(Thresholds {
+            cpu_percent: 0.0,
+            rss_mb: 1,
+        });
+        // The test process itself is the tree root.
+        let pid = std::process::id();
+        let sessions = vec![fake_session_with_pid("aaaaaaaa", pid)];
+        let first = m.check(&sessions);
+        assert_eq!(
+            first.len(),
+            1,
+            "own tree RSS should exceed 1 MiB (test harness)"
+        );
+        let second = m.check(&sessions);
+        assert!(
+            second.is_empty(),
+            "cooldown must suppress immediate repeat alert"
+        );
+    }
+
+    #[test]
+    fn first_check_has_no_cpu_baseline() {
+        // CPU-only thresholds: the first check has no baseline and the
+        // immediate second check's window is below MIN_CPU_WINDOW_SECS, so
+        // no CPU alert may fire even at a near-zero threshold.
+        let mut m = Monitor::new(Thresholds {
+            cpu_percent: 0.0001,
+            rss_mb: 0,
+        });
+        let sessions = vec![fake_session_with_pid("aaaaaaaa", std::process::id())];
+        assert!(m.check(&sessions).is_empty());
+        assert!(m.check(&sessions).is_empty());
+    }
+
+    #[test]
+    fn recovery_resets_alert_state() {
+        let mut m = Monitor::new(Thresholds {
+            cpu_percent: 0.0,
+            rss_mb: 1,
+        });
+        // The test process itself is the tree root.
+        let pid = std::process::id();
+        let hot = vec![fake_session_with_pid("aaaaaaaa", pid)];
+        assert_eq!(m.check(&hot).len(), 1);
+
+        // Session disappears from the list (e.g. killed) → state forgotten.
+        let gone: Vec<DaemonSessionInfo> = Vec::new();
+        m.check(&gone);
+        assert!(
+            m.states.is_empty(),
+            "vanished session state must be dropped"
+        );
+    }
+
+    #[test]
+    fn formats_detail_and_alert() {
+        let detail = format_resource_detail(Some(97.4), 300 * 1024 * 1024);
+        assert!(detail.contains("97%"), "detail: {detail}");
+        assert!(detail.contains("300.0MB"), "detail: {detail}");
+
+        let alert = Alert {
+            session: fake_session("abcdef12"),
+            cpu: Some(97.0),
+            rss_bytes: 512 * 1024 * 1024,
+        };
+        let msg = format_resource_alert(&alert);
+        assert!(msg.contains("abcdef12"), "alert msg: {msg}");
+        assert!(!msg.contains("()"), "no empty parens: {msg}");
+
+        // A named session folds the name into the id label.
+        let mut named = fake_session("abcdef12");
+        named.name = Some("build".to_string());
+        let msg = format_resource_alert(&Alert {
+            session: named,
+            cpu: None,
+            rss_bytes: 0,
+        });
+        assert!(msg.contains("(build)"), "alert msg: {msg}");
+        assert!(msg.contains("--"), "unknown CPU renders as --: {msg}");
+    }
+
+    fn fake_session(id: &str) -> DaemonSessionInfo {
+        fake_session_with_pid(id, 1)
+    }
+
+    fn fake_session_with_pid(id: &str, pid: u32) -> DaemonSessionInfo {
+        DaemonSessionInfo {
+            session_id: id.to_string(),
+            socket_path: std::path::PathBuf::from("/tmp/none.sock"),
+            daemon_pid: pid,
+            child_pid: 0,
+            started_at: 0,
+            cwd: "/tmp".to_string(),
+            model: None,
+            api_base: None,
+            name: None,
+        }
+    }
+}

--- a/crates/aish-tools/src/glob_tool/glob_tool.rs
+++ b/crates/aish-tools/src/glob_tool/glob_tool.rs
@@ -188,14 +188,30 @@ fn run_glob(args: &serde_json::Value, cancel: Option<&CancellationToken>) -> Too
         }
     };
 
-    // Absolute patterns are matched against the full path (the root argument
-    // only guards existence, matching the previous `glob::glob` behaviour).
+    // Absolute patterns are matched against the full path, but the walk
+    // starts at the longest wildcard-free prefix so it does not traverse
+    // the whole filesystem from `/` (matching the old `glob::glob`
+    // behaviour).
     let (start, strip) = if pattern.starts_with('/') {
-        (PathBuf::from("/"), None)
+        let mut base = PathBuf::from("/");
+        for comp in Path::new(&pattern).components().skip(1) {
+            let comp = comp.as_os_str().to_string_lossy();
+            if comp.contains(['*', '?', '[']) {
+                break;
+            }
+            base.push(comp.as_ref());
+        }
+        (base, None)
     } else {
         let root = root.canonicalize().unwrap_or(root);
         (root.clone(), Some(root))
     };
+    if !start.is_dir() {
+        return ToolResult::error(format!(
+            "Error: root directory not found: {}",
+            start.display()
+        ));
+    }
 
     let should_stop: Box<dyn Fn() -> bool> = match cancel {
         Some(t) => Box::new(move || t.is_cancelled()),
@@ -234,6 +250,14 @@ fn run_glob(args: &serde_json::Value, cancel: Option<&CancellationToken>) -> Too
     }
 
     if outcome.matches.is_empty() {
+        if outcome.timed_out {
+            // Never report a definitive negative result from an incomplete
+            // walk — the agent would conclude the files do not exist.
+            return ToolResult::success(format!(
+                "No files found.\n(timed out after {:.0}s — narrow the pattern or root)",
+                TRAVERSAL_TIMEOUT.as_secs()
+            ));
+        }
         return ToolResult::success("No files found.");
     }
 
@@ -326,6 +350,21 @@ mod tests {
         fs::write(root.join("src/b.rs"), "x").unwrap();
         fs::write(root.join("src/deep/c.rs"), "x").unwrap();
         fs::write(root.join("target/debug/ignored.rs"), "x").unwrap();
+    }
+
+    #[test]
+    fn nonexistent_absolute_literal_prefix_errors_without_full_walk() {
+        // The walk must start at the literal prefix, so a nonexistent
+        // prefix fails fast instead of scanning the filesystem from `/`.
+        let out = tool().execute(serde_json::json!({
+            "pattern": "/definitely/not/a/real/prefix/**/*.rs",
+        }));
+        assert!(!out.ok);
+        assert!(
+            out.output.contains("root directory not found"),
+            "out: {}",
+            out.output
+        );
     }
 
     #[test]

--- a/crates/aish-tools/src/glob_tool/glob_tool.rs
+++ b/crates/aish-tools/src/glob_tool/glob_tool.rs
@@ -1,11 +1,16 @@
-use std::path::PathBuf;
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::time::{Duration, Instant};
 
 use aish_i18n;
-use aish_llm::{Tool, ToolResult};
+use aish_llm::{CancellationToken, LlmSession, Tool, ToolResult};
+use futures::future::FutureExt;
 
 use super::prompt;
 
 /// Directories excluded by default (VCS and common large generated trees).
+/// Traversal PRUNES these directories instead of post-filtering results.
 const DEFAULT_EXCLUDE_DIRS: &[&str] = &[
     ".git",
     ".svn",
@@ -28,12 +33,239 @@ const DEFAULT_EXCLUDE_DIRS: &[&str] = &[
 
 const DEFAULT_MAX_RESULTS: usize = 200;
 
+/// Hard wall-clock budget for one traversal. Guarantees the tool returns even
+/// on pathological trees or stalled network filesystems.
+const TRAVERSAL_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Check the stop flag and deadline every N yielded directory entries so the
+/// per-entry overhead stays negligible inside very large directories.
+const STOP_CHECK_INTERVAL: usize = 256;
+
 /// Tool for enumerating files by glob pattern within a directory.
 pub struct GlobTool;
 
 impl GlobTool {
     pub fn new() -> Self {
         Self
+    }
+}
+
+/// Outcome of a pruned traversal.
+struct WalkOutcome {
+    matches: Vec<PathBuf>,
+    /// Traversal was cancelled by the stop flag (user Ctrl+C).
+    cancelled: bool,
+    /// Traversal hit the wall-clock deadline.
+    timed_out: bool,
+}
+
+/// Depth-first traversal with directory pruning, early exit and a stop flag.
+///
+/// - `start`: directory the traversal begins from (its children are yielded,
+///   the start itself never is — matching `glob::glob` semantics).
+/// - `strip`: prefix removed before pattern matching; `None` matches the full
+///   path (used for absolute patterns).
+/// - Symlinked directories are NOT followed (lstat semantics): this avoids
+///   infinite loops on symlink cycles and redundant stats on network mounts.
+fn walk_pattern(
+    start: &Path,
+    strip: Option<&Path>,
+    pattern: &glob::Pattern,
+    limit: usize,
+    deadline: Instant,
+    should_stop: &dyn Fn() -> bool,
+) -> WalkOutcome {
+    let matches_path = |path: &Path| -> bool {
+        let rel: &Path = match strip {
+            Some(p) => path.strip_prefix(p).unwrap_or(path),
+            None => path,
+        };
+        pattern.matches_path(rel)
+    };
+
+    let mut out = WalkOutcome {
+        matches: Vec::with_capacity(limit.min(1024)),
+        cancelled: false,
+        timed_out: false,
+    };
+
+    // The start directory itself is never yielded; if it sits inside the
+    // exclude list the old post-filter behaviour was "no results".
+    if start
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| DEFAULT_EXCLUDE_DIRS.contains(&n))
+        .unwrap_or(false)
+    {
+        return out;
+    }
+
+    let mut stack: Vec<PathBuf> = vec![start.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        // Stop/deadline checks at directory granularity are nearly free and
+        // guarantee termination even for trees of many small directories.
+        if should_stop() {
+            out.cancelled = true;
+            return out;
+        }
+        if Instant::now() >= deadline {
+            out.timed_out = true;
+            return out;
+        }
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let mut seen = 0usize;
+        for entry in entries.flatten() {
+            seen += 1;
+            if seen.is_multiple_of(STOP_CHECK_INTERVAL)
+                && (should_stop() || Instant::now() >= deadline)
+            {
+                if should_stop() {
+                    out.cancelled = true;
+                } else {
+                    out.timed_out = true;
+                }
+                return out;
+            }
+
+            let path = entry.path();
+            let file_type = match entry.file_type() {
+                Ok(ft) => ft,
+                Err(_) => continue,
+            };
+            let file_name = entry.file_name();
+            let name_str = file_name.to_string_lossy();
+
+            if file_type.is_dir() {
+                if DEFAULT_EXCLUDE_DIRS.contains(&&*name_str) {
+                    continue;
+                }
+                if matches_path(&path) {
+                    out.matches.push(path.clone());
+                    if out.matches.len() >= limit {
+                        return out;
+                    }
+                }
+                stack.push(path);
+            } else {
+                // Files, symlinks and other non-dir entries match by name.
+                if matches_path(&path) {
+                    out.matches.push(path);
+                    if out.matches.len() >= limit {
+                        return out;
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Run the glob query synchronously. Shared by `execute` and the
+/// cancellable async path.
+fn run_glob(args: &serde_json::Value, cancel: Option<&CancellationToken>) -> ToolResult {
+    let pattern = match args.get("pattern").and_then(|p| p.as_str()) {
+        Some(p) if !p.trim().is_empty() => p.to_string(),
+        _ => return ToolResult::error(aish_i18n::t("tools.glob.missing_pattern")),
+    };
+
+    let root = normalize_root(args.get("root").and_then(|r| r.as_str()));
+    if !root.exists() || !root.is_dir() {
+        return ToolResult::error(format!(
+            "Error: root directory not found: {}",
+            root.display()
+        ));
+    }
+
+    let compiled = match glob::Pattern::new(&pattern) {
+        Ok(p) => p,
+        Err(e) => {
+            let mut args_map = std::collections::HashMap::new();
+            args_map.insert("error".to_string(), e.to_string());
+            return ToolResult::error(aish_i18n::t_with_args("tools.glob.invalid_glob", &args_map));
+        }
+    };
+
+    // Absolute patterns are matched against the full path (the root argument
+    // only guards existence, matching the previous `glob::glob` behaviour).
+    let (start, strip) = if pattern.starts_with('/') {
+        (PathBuf::from("/"), None)
+    } else {
+        let root = root.canonicalize().unwrap_or(root);
+        (root.clone(), Some(root))
+    };
+
+    let should_stop: Box<dyn Fn() -> bool> = match cancel {
+        Some(t) => Box::new(move || t.is_cancelled()),
+        None => Box::new(|| false),
+    };
+
+    let started = Instant::now();
+    let mut outcome = walk_pattern(
+        &start,
+        strip.as_deref(),
+        &compiled,
+        DEFAULT_MAX_RESULTS,
+        started + TRAVERSAL_TIMEOUT,
+        &should_stop,
+    );
+    outcome.matches.sort();
+
+    // Cancelled walks report their (partial) matches as a normal success
+    // with a note, whether or not anything matched: an error result would
+    // make the agent retry, and the retry gets cancelled again.
+    if outcome.cancelled {
+        let body = if outcome.matches.is_empty() {
+            "No files found.".to_string()
+        } else {
+            outcome
+                .matches
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        return ToolResult::success(format!(
+            "{body}\n(cancelled after {:.1}s, partial results)",
+            started.elapsed().as_secs_f64()
+        ));
+    }
+
+    if outcome.matches.is_empty() {
+        return ToolResult::success("No files found.");
+    }
+
+    let truncated_note = if outcome.timed_out {
+        format!(
+            "\n(timed out after {:.0}s, partial results — narrow the pattern or root)",
+            TRAVERSAL_TIMEOUT.as_secs()
+        )
+    } else if outcome.matches.len() >= DEFAULT_MAX_RESULTS {
+        "\n(results truncated at 200)".to_string()
+    } else {
+        String::new()
+    };
+
+    let mut text: String = outcome
+        .matches
+        .iter()
+        .map(|p| p.display().to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    text.push_str(&truncated_note);
+    ToolResult::success(text)
+}
+
+/// Resolve the root directory from the optional argument.
+fn normalize_root(root: Option<&str>) -> PathBuf {
+    match root {
+        Some(r) if !r.trim().is_empty() => {
+            let expanded = shellexpand::tilde(r).to_string();
+            PathBuf::from(expanded)
+        }
+        _ => std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
     }
 }
 
@@ -55,124 +287,175 @@ impl Tool for GlobTool {
     }
 
     fn execute(&self, args: serde_json::Value) -> ToolResult {
-        let pattern = match args.get("pattern").and_then(|p| p.as_str()) {
-            Some(p) if !p.trim().is_empty() => p.to_string(),
-            _ => return ToolResult::error(aish_i18n::t("tools.glob.missing_pattern")),
-        };
-
-        let root = normalize_root(args.get("root").and_then(|r| r.as_str()));
-        if !root.exists() || !root.is_dir() {
-            return ToolResult::error(format!(
-                "Error: root directory not found: {}",
-                root.display()
-            ));
-        }
-
-        // Build the full glob pattern from root + pattern
-        let full_pattern = if pattern.starts_with('/') {
-            pattern.clone()
-        } else {
-            format!("{}/{}", root.display(), pattern)
-        };
-
-        let mut matches: Vec<PathBuf> = Vec::with_capacity(DEFAULT_MAX_RESULTS);
-        match glob::glob(&full_pattern) {
-            Ok(paths) => {
-                for entry in paths.flatten() {
-                    // Skip excluded directories
-                    if is_in_excluded_dir(&entry) {
-                        continue;
-                    }
-                    matches.push(entry);
-                }
-            }
-            Err(e) => {
-                let mut args_map = std::collections::HashMap::new();
-                args_map.insert("error".to_string(), e.to_string());
-                return ToolResult::error(aish_i18n::t_with_args(
-                    "tools.glob.invalid_glob",
-                    &args_map,
-                ));
-            }
-        }
-
-        matches.sort();
-        matches.dedup();
-
-        if matches.is_empty() {
-            return ToolResult::success("No files found.");
-        }
-
-        let truncated = matches.len() > DEFAULT_MAX_RESULTS;
-        let display: Vec<String> = matches
-            .into_iter()
-            .take(DEFAULT_MAX_RESULTS)
-            .map(|p| p.display().to_string())
-            .collect();
-
-        let mut output = display.join("\n");
-        if truncated {
-            output.push_str("\n(results truncated at 200)");
-        }
-
-        ToolResult::success(output)
+        run_glob(&args, None)
     }
-}
 
-/// Check if a path contains any excluded directory component.
-fn is_in_excluded_dir(path: &std::path::Path) -> bool {
-    path.components().any(|c| {
-        c.as_os_str()
-            .to_str()
-            .map(|s| DEFAULT_EXCLUDE_DIRS.contains(&s))
-            .unwrap_or(false)
-    })
-}
-
-/// Resolve the root directory from the optional argument.
-fn normalize_root(root: Option<&str>) -> PathBuf {
-    match root {
-        Some(r) if !r.trim().is_empty() => {
-            let expanded = shellexpand::tilde(r).to_string();
-            PathBuf::from(expanded)
+    /// Runs the blocking traversal on a dedicated thread so a slow or stalled
+    /// filesystem cannot freeze the async runtime, and checks the session
+    /// cancellation token periodically so Ctrl+C interrupts the walk.
+    fn execute_async_in_session<'a>(
+        &'a self,
+        args: serde_json::Value,
+        session: &'a LlmSession,
+    ) -> Pin<Box<dyn Future<Output = ToolResult> + Send + 'a>> {
+        let token = session.cancellation_token_arc();
+        async move {
+            let res = tokio::task::spawn_blocking(move || run_glob(&args, Some(&token))).await;
+            match res {
+                Ok(r) => r,
+                Err(e) => ToolResult::error(format!("Error: glob task failed: {e}")),
+            }
         }
-        _ => std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+        .boxed()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
-    #[test]
-    fn test_is_in_excluded_dir() {
-        assert!(is_in_excluded_dir(
-            PathBuf::from("/home/user/project/.git/config").as_path()
-        ));
-        assert!(is_in_excluded_dir(
-            PathBuf::from("/home/user/project/node_modules/foo/bar.js").as_path()
-        ));
-        assert!(!is_in_excluded_dir(
-            PathBuf::from("/home/user/project/src/main.rs").as_path()
-        ));
+    fn tool() -> GlobTool {
+        GlobTool::new()
+    }
+
+    fn mk_tree(root: &Path) {
+        fs::create_dir_all(root.join("src/deep")).unwrap();
+        fs::create_dir_all(root.join("target/debug")).unwrap();
+        fs::write(root.join("a.rs"), "x").unwrap();
+        fs::write(root.join("src/b.rs"), "x").unwrap();
+        fs::write(root.join("src/deep/c.rs"), "x").unwrap();
+        fs::write(root.join("target/debug/ignored.rs"), "x").unwrap();
     }
 
     #[test]
-    fn test_normalize_root_default() {
-        let root = normalize_root(None);
-        assert!(root.is_absolute());
+    fn recursive_pattern_matches_top_level_and_prunes_excluded() {
+        let tmp = tempfile::tempdir().unwrap();
+        mk_tree(tmp.path());
+        let out = tool().execute(serde_json::json!({
+            "pattern": "**/*.rs",
+            "root": tmp.path().to_str().unwrap(),
+        }));
+        assert!(out.ok);
+        let text = out.output;
+        assert!(text.contains("a.rs"), "top-level must match: {text}");
+        assert!(text.contains("b.rs") && text.contains("c.rs"));
+        assert!(
+            !text.contains("ignored.rs"),
+            "target/ must be pruned: {text}"
+        );
     }
 
     #[test]
-    fn test_normalize_root_explicit() {
-        let root = normalize_root(Some("/tmp"));
-        assert_eq!(root, PathBuf::from("/tmp"));
+    fn nonexistent_root_errors() {
+        let out = tool().execute(serde_json::json!({
+            "pattern": "**/*.rs",
+            "root": "/definitely/not/a/real/path",
+        }));
+        assert!(!out.ok);
     }
 
     #[test]
-    fn test_glob_tool_missing_pattern() {
-        let tool = GlobTool::new();
-        let result = tool.execute(serde_json::json!({}));
-        assert!(!result.ok);
+    fn absolute_pattern_matches_full_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        mk_tree(tmp.path());
+        let pat = format!("{}/**/*.rs", tmp.path().display());
+        let out = tool().execute(serde_json::json!({"pattern": pat}));
+        assert!(out.ok);
+        assert!(out.output.contains("b.rs"));
+        assert!(!out.output.contains("ignored.rs"));
+    }
+
+    #[test]
+    fn root_inside_exclude_list_returns_no_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("target")).unwrap();
+        fs::write(tmp.path().join("target/x.rs"), "x").unwrap();
+        let out = tool().execute(serde_json::json!({
+            "pattern": "**/*.rs",
+            "root": tmp.path().join("target").to_str().unwrap(),
+        }));
+        assert!(out.ok);
+        assert_eq!(out.output, "No files found.");
+    }
+
+    #[test]
+    fn early_stops_at_limit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("many");
+        fs::create_dir_all(&dir).unwrap();
+        for i in 0..500 {
+            fs::write(dir.join(format!("f{i:03}.rs")), "x").unwrap();
+        }
+        let out = tool().execute(serde_json::json!({
+            "pattern": "**/*.rs",
+            "root": tmp.path().to_str().unwrap(),
+        }));
+        assert!(out.ok);
+        // 200 file lines plus a trailing parenthesised truncation note.
+        let file_lines = out.output.lines().filter(|l| !l.starts_with('(')).count();
+        assert_eq!(file_lines, 200, "must cap at 200 result lines");
+        assert!(
+            out.output.contains("truncated"),
+            "must note truncation: {}",
+            out.output
+        );
+    }
+
+    #[test]
+    fn symlinked_directories_are_not_followed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("real");
+        fs::create_dir_all(&real).unwrap();
+        fs::write(real.join("inside.rs"), "x").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real, tmp.path().join("link")).unwrap();
+        let out = tool().execute(serde_json::json!({
+            "pattern": "**/*.rs",
+            "root": tmp.path().to_str().unwrap(),
+        }));
+        assert!(out.ok);
+        assert!(out.output.contains("inside.rs"));
+        // The file is reachable via `real/`; the symlink path itself must not
+        // produce a second, duplicate traversal.
+        let count = out.output.matches("inside.rs").count();
+        assert_eq!(count, 1, "no duplicate via symlink: {}", out.output);
+    }
+
+    #[test]
+    fn cancelled_before_start_reports_cancellation() {
+        let tmp = tempfile::tempdir().unwrap();
+        mk_tree(tmp.path());
+        let token = CancellationToken::new();
+        token.cancel();
+        let out = run_glob(
+            &serde_json::json!({
+                "pattern": "**/*.rs",
+                "root": tmp.path().to_str().unwrap(),
+            }),
+            Some(&token),
+        );
+        // Cancelled before start: the per-directory check fires immediately.
+        // Cancellation is reported as success + note, never as an error, so
+        // the agent does not retry into another cancelled walk.
+        assert!(out.ok);
+        assert!(out.output.contains("cancelled"), "out: {}", out.output);
+    }
+
+    #[test]
+    fn timeout_returns_partial_note() {
+        let tmp = tempfile::tempdir().unwrap();
+        mk_tree(tmp.path());
+        let compiled = glob::Pattern::new("**/*.rs").unwrap();
+        let start = tmp.path().canonicalize().unwrap();
+        let outcome = walk_pattern(
+            &start,
+            Some(&start),
+            &compiled,
+            DEFAULT_MAX_RESULTS,
+            Instant::now() - Duration::from_secs(1),
+            &|| false,
+        );
+        assert!(outcome.timed_out, "expired deadline must stop the walk");
     }
 }


### PR DESCRIPTION
Fixes #482.

## Summary

Addresses the runaway detached-session problem: live PTY sessions keep running tools after the client leaves, with no visibility into per-session resource cost and no reliable way to terminate the full worker tree.

### Per-session resource sampling (`aish-pty/resource.rs`, new)

- Samples CPU ticks + RSS for each live session's **whole worker tree** (daemon → REPL → bash → running tools) via a single `/proc` pass.
- Aggregates by parent-pid closure: immune to the `setsid()` each aish layer performs, so a process-group kill can never miss workers and the sample can never miss them either.
- `kill_process_tree()` collects the descendant set **before** any signalling (so orphans reparented to init stay discoverable), then sweeps SIGTERM → 200ms → SIGKILL.

### Targeted termination

- `daemon.rs` KillSession paths now call `kill_process_tree` instead of signalling only the direct child — previously bash-exec'd tool workers survived `/kill_live_sessions` as orphaned CPU burners.

### Threshold alerts in the REPL (`aish-shell/resource_monitor.rs`, new)

- Periodic check (default 30s) warns when **another** detached session exceeds CPU/RSS thresholds. Configurable: `pty_resource_check_interval_secs` (0 disables), `pty_resource_cpu_percent` (default 80), `pty_resource_rss_mb` (default 1024).
- CPU% is derived from the tick delta against the previous check — **zero sampling sleep**, the REPL is never blocked. 5-minute per-session alert cooldown, state resets on recovery.
- `/live_sessions` picker rows now show live `CPU %` and `RSS` so runaway sessions are visible directly in the panel.

### glob tool hardening (long-running tool from the repro steps)

- Pruned DFS traversal: `target/node_modules/.git/...` are cut at traversal level, not post-filtered.
- 60s wall-clock budget guarantees return on pathological trees / stalled NFS.
- Ctrl+C cancels the walk via the session token (checked per directory and every 256 entries); the blocking traversal runs on `spawn_blocking` off the async runtime.
- Cancellation returns partial results as a **success** with a note — an error result would make the agent retry into another cancelled walk.

## Issue acceptance criteria coverage

| Criterion | Status |
|---|---|
| detach/reattach preserved | ✅ untouched |
| `/live_sessions` shows runtime + resource usage | ✅ CPU/RSS/age/PID/cwd (tool summary & binary-version status out of scope here) |
| Warn when session exceeds configurable resource threshold | ✅ |
| Targeted termination stops daemon + owned worker tree, no kill-all fallback | ✅ `kill_process_tree` |
| Update-flow detection of stale executables | ❌ not in this PR |

## Testing

- `cargo fmt --check`, `cargo clippy -D warnings` clean.
- New unit tests: /proc stat parsing (parens in comm), tree sampling, descendant discovery, monitor state machine (cooldown, recovery, first-check has no CPU baseline), glob prune/timeout/cancel/limit/symlink behaviour.
- Full `cargo test -p aish-pty -p aish-shell -p aish-tools -p aish-config` green.

## Resource overhead

Steady state: zero (no threads, no timers; the throttled check early-returns on an `Instant` compare). Due check: one `/proc` pass (~1–3 ms on a 3k-process box) with hash-map keyed BFS. No new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live sessions now display CPU and memory usage.
  * Receive alerts when a session exceeds configured resource thresholds, with guidance to switch or terminate it.
  * Resource monitoring messages are available in multiple languages.

* **Bug Fixes**
  * Terminating a live session now also stops related worker processes.

* **Improvements**
  * File searches are faster and more responsive, with improved cancellation, timeout handling, directory exclusions, and partial results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->