### PR TITLE
fix(ui): serialize animation frames against tracing log lines

### DIFF
--- a/crates/aish-cli/src/main.rs
+++ b/crates/aish-cli/src/main.rs
@@ -14,7 +14,21 @@
 )]
 
 use clap::{Parser, Subcommand};
+use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::EnvFilter;
+
+/// Routes tracing log lines through the shell animation's terminal lock so a
+/// `WARN` emitted during an active `Thinking` animation starts on a fresh
+/// line instead of gluing onto the partially rendered frame (issue #490).
+struct AnimationAwareMakeWriter;
+
+impl<'a> MakeWriter<'a> for AnimationAwareMakeWriter {
+    type Writer = aish_shell::animation::LogLineWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        aish_shell::animation::LogLineWriter::new()
+    }
+}
 
 mod install_channel;
 mod models_auth;
@@ -265,6 +279,7 @@ fn main() {
         .map(|c| c.log_level)
         .unwrap_or_else(|_| "warn".to_string());
     tracing_subscriber::fmt()
+        .with_writer(AnimationAwareMakeWriter)
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(log_level)),
         )

--- a/crates/aish-shell/src/animation.rs
+++ b/crates/aish-shell/src/animation.rs
@@ -8,6 +8,59 @@ use std::time::{Duration, Instant};
 
 use crate::theme;
 
+/// Global lock that serializes animation frame rendering against ad-hoc
+/// terminal writes (notably tracing log lines). Both the animation threads
+/// and [`LogLineWriter`] must hold this lock while emitting bytes to stdout,
+/// guaranteeing a log event can never interleave with a partial frame.
+static FRAME_LOCK: Mutex<()> = Mutex::new(());
+
+/// Whether an animation frame is currently on screen. Read by
+/// [`LogLineWriter`] to decide whether the current line must be wiped
+/// before a log line is emitted.
+static ANIMATION_FRAME_VISIBLE: AtomicBool = AtomicBool::new(false);
+
+/// `io::Write` adapter used by the tracing subscriber (via `MakeWriter`) so
+/// log lines never glue onto an in-flight animation frame. When a frame is
+/// visible, the line is cleared first; the animation redraws on its next
+/// tick once the log line (terminated by `\n`) has been emitted.
+pub struct LogLineWriter {
+    started: bool,
+}
+
+impl LogLineWriter {
+    pub fn new() -> Self {
+        Self { started: false }
+    }
+}
+
+impl Default for LogLineWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl io::Write for LogLineWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let _guard = FRAME_LOCK.lock();
+        if !self.started {
+            self.started = true;
+            if ANIMATION_FRAME_VISIBLE.load(Ordering::SeqCst) {
+                // Wipe the partially rendered animation line so the log
+                // starts on a fresh, independent line instead of gluing
+                // onto "Thinking 1.7s".
+                print!("\r\x1b[2K");
+                ANIMATION_FRAME_VISIBLE.store(false, Ordering::SeqCst);
+            }
+        }
+        io::stdout().write_all(buf)?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let _ = io::stdout().flush();
+        Ok(())
+    }
+}
 /// Thread-safe animation wrapper that displays a spinner with elapsed time
 /// in a background thread.
 ///
@@ -39,9 +92,11 @@ impl SharedAnimation {
         let handle = thread::Builder::new()
             .name("aish-animation".into())
             .spawn(move || {
+                let _frame = FRAME_LOCK.lock();
                 // Hide cursor
                 print!("\x1b[?25l");
                 let _ = io::stdout().flush();
+                drop(_frame);
 
                 while active.load(Ordering::SeqCst) {
                     // Auto-stop when a tool needs interactive terminal input
@@ -52,16 +107,20 @@ impl SharedAnimation {
                     let elapsed = start_time.elapsed().as_secs_f64();
                     let time_ms = start_time.elapsed().as_millis() as u64;
                     let shimmered = theme::shimmer_text(&text, time_ms);
-                    if elapsed > 0.1 {
-                        print!(
-                            "\r\x1b[K{} {}",
-                            shimmered,
-                            theme::dim(&format!("{:.1}s", elapsed))
-                        );
-                    } else {
-                        print!("\r\x1b[K{}", shimmered);
+                    {
+                        let _frame = FRAME_LOCK.lock();
+                        if elapsed > 0.1 {
+                            print!(
+                                "\r\x1b[K{} {}",
+                                shimmered,
+                                theme::dim(&format!("{:.1}s", elapsed))
+                            );
+                        } else {
+                            print!("\r\x1b[K{}", shimmered);
+                        }
+                        ANIMATION_FRAME_VISIBLE.store(true, Ordering::SeqCst);
+                        let _ = io::stdout().flush();
                     }
-                    let _ = io::stdout().flush();
                     for _ in 0..10 {
                         if !active.load(Ordering::SeqCst)
                             || aish_tools::bash::interactive_input_active()
@@ -73,7 +132,9 @@ impl SharedAnimation {
                 }
 
                 // Clear animation line and restore cursor
+                let _frame = FRAME_LOCK.lock();
                 print!("\r\x1b[2K\x1b[?25h");
+                ANIMATION_FRAME_VISIBLE.store(false, Ordering::SeqCst);
                 let _ = io::stdout().flush();
             })
             .ok();
@@ -133,24 +194,31 @@ impl SubAgentThinkingAnimation {
         let handle = thread::Builder::new()
             .name("aish-subagent-animation".into())
             .spawn(move || {
-                print!("\x1b[?25l");
-                let _ = io::stdout().flush();
+                {
+                    let _frame = FRAME_LOCK.lock();
+                    print!("\x1b[?25l");
+                    let _ = io::stdout().flush();
+                }
 
                 while active.load(Ordering::SeqCst) {
                     let elapsed = start_time.elapsed().as_secs_f64();
                     let time_ms = start_time.elapsed().as_millis() as u64;
                     let shimmered = theme::shimmer_text(&label, time_ms);
-                    if elapsed > 0.1 {
-                        print!(
-                            "\r\x1b[K{}{} {}",
-                            prefix,
-                            shimmered,
-                            theme::dim(&format!("{:.1}s", elapsed))
-                        );
-                    } else {
-                        print!("\r\x1b[K{}{}", prefix, shimmered);
+                    {
+                        let _frame = FRAME_LOCK.lock();
+                        if elapsed > 0.1 {
+                            print!(
+                                "\r\x1b[K{}{} {}",
+                                prefix,
+                                shimmered,
+                                theme::dim(&format!("{:.1}s", elapsed))
+                            );
+                        } else {
+                            print!("\r\x1b[K{}{}", prefix, shimmered);
+                        }
+                        ANIMATION_FRAME_VISIBLE.store(true, Ordering::SeqCst);
+                        let _ = io::stdout().flush();
                     }
-                    let _ = io::stdout().flush();
                     for _ in 0..10 {
                         if !active.load(Ordering::SeqCst) {
                             break;
@@ -159,8 +227,12 @@ impl SubAgentThinkingAnimation {
                     }
                 }
 
-                print!("\r\x1b[2K\x1b[?25h");
-                let _ = io::stdout().flush();
+                {
+                    let _frame = FRAME_LOCK.lock();
+                    print!("\r\x1b[2K\x1b[?25h");
+                    ANIMATION_FRAME_VISIBLE.store(false, Ordering::SeqCst);
+                    let _ = io::stdout().flush();
+                }
             })
             .ok();
 
@@ -184,5 +256,47 @@ impl Default for SubAgentThinkingAnimation {
 impl Drop for SubAgentThinkingAnimation {
     fn drop(&mut self) {
         self.stop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for issue #490: log lines written through
+    /// [`LogLineWriter`] while an animation is active must not deadlock and
+    /// must complete (frame lock serializes animation frames against log
+    /// writes). Output goes to the test-captured stdout; we assert the
+    /// interactions finish and the visibility flag is reset after stop.
+    #[test]
+    fn log_writer_and_animation_do_not_deadlock_or_leave_frame_visible() {
+        let anim = SharedAnimation::new();
+        anim.start("思考中");
+
+        let writer_threads: Vec<_> = (0..4)
+            .map(|_| {
+                thread::spawn(|| {
+                    for _ in 0..50 {
+                        let mut w = LogLineWriter::new();
+                        w.write_all(b"2026-01-01T00:00:00Z  WARN test: log line\n")
+                            .unwrap();
+                        w.flush().unwrap();
+                    }
+                })
+            })
+            .collect();
+
+        // Give writers time to interleave with animation frames.
+        thread::sleep(Duration::from_millis(200));
+        anim.stop();
+
+        for t in writer_threads {
+            t.join().expect("writer threads must finish");
+        }
+
+        assert!(
+            !ANIMATION_FRAME_VISIBLE.load(Ordering::SeqCst),
+            "animation stop must clear the frame-visible flag"
+        );
     }
 }


### PR DESCRIPTION
Fixes #490

## Problem

`LlmClient` retry warnings (`tracing::warn!`) and the `Thinking` animation both write directly to stdout with no coordination. During retries the warn line glued onto the in-flight animation frame (`Thinking 1.5s<TS> WARN ...`), and the next animation frame's `\r\x1b[K` then wiped the entire line including the log — making warn-level logs effectively invisible during LLM retries.

## Fix

- Add a global `FRAME_LOCK` (`parking_lot::Mutex`) plus `ANIMATION_FRAME_VISIBLE` flag in `aish-shell/src/animation.rs`; every animation terminal write (frame render, cursor hide/restore, line clear) now holds the frame lock.
- Add `LogLineWriter`, an `io::Write` adapter that, on the first write of a log event, wipes the current animation line (`\r\x1b[2K`) when a frame is visible — so every log line starts on a fresh, newline-terminated line; the animation redraws on its next tick.
- Route the tracing fmt subscriber through `AnimationAwareMakeWriter` in `aish-cli/src/main.rs`.
- Concurrency regression test: 4 writer threads × 50 log lines racing an active animation assert no deadlock and that the frame-visible flag resets after stop.

Retry count, backoff delays, error classification, and provider request semantics are unchanged.

## Verification

Same mock-LLM scenario (3× 429 → success, real PTY, `RUST_LOG=warn`) run against before/after binaries, asserting on raw PTY byte streams:

| Metric | Before | After |
|---|---|---|
| Log glued to animation frame | 3/3 | 0 |
| Log preceded by line wipe | 0/3 | 3/3 |
| Log newline-terminated | 3/3 | 3/3 |
| Animation redraws after log | — | 3/3 |
| Cursor restored | yes | yes |

`make ci-check` (fmt + clippy -D warnings + cargo test + packaging smoke) passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal output reliability while animations are running.
  - Prevented log messages and animation frames from overlapping or rendering out of order.
  - Reduced the risk of terminal deadlocks during concurrent logging and animation shutdown.
  - Ensured the terminal is restored cleanly after animations finish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->