### PR TITLE
fix(llm): preserve AI tool-call history in main session context

### DIFF
--- a/crates/aish-context/src/budget.rs
+++ b/crates/aish-context/src/budget.rs
@@ -4,6 +4,10 @@ const DEFAULT_RESERVED_OUTPUT_TOKENS: usize = 20_000;
 const DEFAULT_AUTO_COMPACT_BUFFER_TOKENS: usize = 13_000;
 const DEFAULT_WARNING_BUFFER_TOKENS: usize = 20_000;
 const DEFAULT_BLOCKING_BUFFER_TOKENS: usize = 3_000;
+
+/// Default suffix depth below which microcompact may rewrite messages;
+/// deeper (cache-warm) messages are left for full compaction.
+const DEFAULT_CACHE_WARM_SUFFIX_TOKENS: usize = 8_000;
 const MIN_EFFECTIVE_CONTEXT_WINDOW_TOKENS: usize = 1_000;
 const MIN_PROMPT_BUDGET_TOKENS: usize = 8_000;
 const CONTEXT_WINDOW_WARN_BELOW_TOKENS: usize = 8_000;
@@ -54,6 +58,11 @@ pub struct ContextBudgetPolicy {
     pub blocking_buffer_tokens: usize,
     pub micro_keep_recent_messages: usize,
     pub shell_keep_recent_commands: usize,
+    /// Messages whose trailing suffix exceeds this many estimated tokens
+    /// sit inside the provider's warm prompt-cache prefix and are never
+    /// rewritten by microcompact; full compaction reclaims them. 0
+    /// disables the guard.
+    pub cache_warm_suffix_tokens: usize,
     pub max_consecutive_failures: usize,
     pub summary_max_tokens: usize,
     pub enable_token_estimation: bool,
@@ -72,6 +81,7 @@ impl Default for ContextBudgetPolicy {
             blocking_buffer_tokens: DEFAULT_BLOCKING_BUFFER_TOKENS,
             micro_keep_recent_messages: 6,
             shell_keep_recent_commands: 8,
+            cache_warm_suffix_tokens: DEFAULT_CACHE_WARM_SUFFIX_TOKENS,
             max_consecutive_failures: 3,
             summary_max_tokens: 4_000,
             enable_token_estimation: true,

--- a/crates/aish-context/src/manager.rs
+++ b/crates/aish-context/src/manager.rs
@@ -374,7 +374,19 @@ impl ContextManager {
 
         for idx in 0..self.messages.len() {
             let msg = &mut self.messages[idx];
-            if msg.role == "system" || msg.content.starts_with(SUMMARY_TAG) {
+            if msg.content.starts_with(SUMMARY_TAG) {
+                continue;
+            }
+            if msg.role == "system" {
+                // Aged per-turn transient blocks (env cwd updates, memory
+                // recall) are compacted to a minimal placeholder; every
+                // other system message (static core, skills, summaries)
+                // stays verbatim. No length guard: aging, not size, is
+                // the trigger.
+                if idx < recent_start && is_transient_system(&msg.content) {
+                    msg.content = "[cleared]".to_string();
+                    changed_messages += 1;
+                }
                 continue;
             }
 
@@ -702,6 +714,10 @@ fn tool_call_groups(messages: &[ContextMessage]) -> Vec<Vec<usize>> {
     groups
 }
 
+fn estimate_tokens_rough(text: &str) -> usize {
+    (text.len() / 4).max(1)
+}
+
 fn normalize_summary(summary: String) -> String {
     let trimmed = summary.trim();
     if trimmed.starts_with(SUMMARY_TAG) {
@@ -713,20 +729,12 @@ fn normalize_summary(summary: String) -> String {
     )
 }
 
-fn estimate_tokens_rough(text: &str) -> usize {
-    (text.len() / 4).max(1)
-}
-
 fn is_low_value_output(content: &str) -> bool {
     content.contains("<stdout>")
         || content.contains("<stderr>")
         || content.contains("<offload>")
         || content.contains("</stdout>")
         || content.contains("</stderr>")
-        // Per-turn transient blocks (env cwd updates, memory recall) age
-        // into low value immediately after their turn passes.
-        || content.contains("**Environment Update:**")
-        || content.contains("<long-term-memory")
         || content.len() > 8_000
 }
 
@@ -1332,5 +1340,50 @@ mod tests {
         assert!(candidates
             .iter()
             .all(|m| m.tool_calls.is_none() && m.role != "tool"));
+    }
+
+    #[test]
+    fn microcompact_clears_aged_transient_system_blocks_only() {
+        let mut cm = ContextManager::new();
+        cm.set_budget_policy(ContextBudgetPolicy {
+            micro_keep_recent_messages: 2,
+            enable_token_estimation: false,
+            ..ContextBudgetPolicy::default()
+        });
+        cm.add_message("system", "static skills appendix", MemoryType::Knowledge);
+        cm.add_memory(
+            MemoryType::Llm,
+            ContextMessage {
+                role: "system".to_string(),
+                content: "**Environment Update:**\n- Current directory: /old/path".to_string(),
+                memory_type: MemoryType::Llm,
+                name: None,
+                tool_call_id: None,
+                tool_calls: None,
+            },
+        );
+        cm.add_memory(
+            MemoryType::Llm,
+            ContextMessage {
+                role: "system".to_string(),
+                content:
+                    "<long-term-memory source=\"recall\">\n- [Env] old fact\n</long-term-memory>"
+                        .to_string(),
+                memory_type: MemoryType::Llm,
+                name: None,
+                tool_call_id: None,
+                tool_calls: None,
+            },
+        );
+        // Recent tail keeps the current turn intact.
+        cm.add_message("user", "current question", MemoryType::Llm);
+        cm.add_message("assistant", "current answer", MemoryType::Llm);
+
+        let report = cm.microcompact();
+        assert_eq!(report.changed_messages, 2);
+        assert_eq!(cm.messages[0].content, "static skills appendix");
+        assert!(!cm.messages[1].content.contains("/old/path"));
+        assert!(!cm.messages[2].content.contains("old fact"));
+        assert_eq!(cm.messages[3].content, "current question");
     }
 }

--- a/crates/aish-context/src/manager.rs
+++ b/crates/aish-context/src/manager.rs
@@ -123,6 +123,7 @@ impl ContextManager {
                 name: None,
                 tool_call_id: None,
                 tool_calls: None,
+                reasoning_content: None,
             },
         );
     }
@@ -179,15 +180,16 @@ impl ContextManager {
     }
 
     pub fn estimate_message_tokens(&self, msg: &ContextMessage) -> usize {
-        // Tool-call arguments can be kilobytes (bash/write_file payloads)
-        // and must count toward the budget or compaction triggers late.
+        // Tool-call arguments (bash/write_file payloads) and reasoning
+        // content must count toward the budget or compaction triggers late.
         let tool_calls_len: usize = msg
             .tool_calls
             .iter()
             .flatten()
             .map(|tc| tc.name.len() + tc.arguments.len())
             .sum();
-        self.estimate_tokens(&msg.content) + tool_calls_len / 4
+        let reasoning_len = msg.reasoning_content.as_ref().map(|r| r.len()).unwrap_or(0);
+        self.estimate_tokens(&msg.content) + (tool_calls_len + reasoning_len) / 4
     }
 
     /// Return the total number of stored messages.
@@ -195,7 +197,6 @@ impl ContextManager {
         self.messages.len()
     }
 
-    /// Get statistics about the current context state.
     pub fn get_context_stats(&self) -> ContextStats {
         let mut stats = ContextStats {
             total_messages: self.messages.len(),
@@ -659,6 +660,7 @@ impl ContextManager {
             name: None,
             tool_call_id: None,
             tool_calls: None,
+            reasoning_content: None,
         });
         new_messages.extend(self.messages.iter().skip(recent_start).cloned());
 
@@ -1187,6 +1189,7 @@ mod tests {
                 name: name.to_string(),
                 arguments: "{}".to_string(),
             }]),
+            reasoning_content: None,
         }
     }
 
@@ -1198,6 +1201,7 @@ mod tests {
             name: Some("bash".to_string()),
             tool_call_id: Some(id.to_string()),
             tool_calls: None,
+            reasoning_content: None,
         }
     }
 
@@ -1310,6 +1314,7 @@ mod tests {
             name: None,
             tool_call_id: None,
             tool_calls: None,
+            reasoning_content: None,
         };
         let with_calls = ContextMessage {
             tool_calls: Some(vec![aish_core::ContextToolCall {
@@ -1360,6 +1365,7 @@ mod tests {
                 name: None,
                 tool_call_id: None,
                 tool_calls: None,
+                reasoning_content: None,
             },
         );
         cm.add_memory(
@@ -1373,6 +1379,7 @@ mod tests {
                 name: None,
                 tool_call_id: None,
                 tool_calls: None,
+                reasoning_content: None,
             },
         );
         // Recent tail keeps the current turn intact.

--- a/crates/aish-context/src/manager.rs
+++ b/crates/aish-context/src/manager.rs
@@ -12,6 +12,13 @@ const CLEARED_SHELL_OUTPUT: &str =
 const CLEARED_LLM_OUTPUT: &str = "[old low-value output cleared by context microcompact]";
 const SUMMARY_TAG: &str = "<conversation-summary";
 
+/// A message whose suffix (all messages after it) exceeds this many
+/// estimated tokens sits deep inside the provider's warm prompt-cache
+/// prefix: rewriting it forces the provider to re-write the entire suffix
+/// at cache-write premium. Microcompact skips such messages; full
+/// compaction (which rebuilds the cache anyway) reclaims them.
+const CACHE_WARM_SUFFIX_TOKENS: usize = 8_000;
+
 /// Statistics about the current context state.
 #[derive(Debug, Clone)]
 pub struct ContextStats {
@@ -356,6 +363,22 @@ impl ContextManager {
         let keep_recent_messages = self.budget_policy.micro_keep_recent_messages;
         let recent_start = self.messages.len().saturating_sub(keep_recent_messages);
 
+        // Cache-warm suffix guard (modeled on oh-my-pi's
+        // cacheWarmSuffixTokens): rewriting a message whose suffix already
+        // went on the wire forces the provider to re-write that entire
+        // suffix at cache-write premium. Messages deeper than
+        // CACHE_WARM_SUFFIX_TOKENS from the end are left for full
+        // compaction (which rebuilds the cache anyway); microcompact only
+        // reclaims from the cold tail.
+        let mut suffix_tokens = vec![0usize; self.messages.len() + 1];
+        for idx in (0..self.messages.len()).rev() {
+            suffix_tokens[idx] =
+                suffix_tokens[idx + 1] + self.estimate_message_tokens(&self.messages[idx]);
+        }
+        let cache_warm = |idx: usize| {
+            suffix_tokens.get(idx + 1).copied().unwrap_or(0) > CACHE_WARM_SUFFIX_TOKENS
+        };
+
         let shell_indices: Vec<usize> = self
             .messages
             .iter()
@@ -374,6 +397,9 @@ impl ContextManager {
             .collect();
 
         for idx in 0..self.messages.len() {
+            if cache_warm(idx) {
+                continue;
+            }
             let msg = &mut self.messages[idx];
             if msg.content.starts_with(SUMMARY_TAG) {
                 continue;
@@ -1392,5 +1418,48 @@ mod tests {
         assert!(!cm.messages[1].content.contains("/old/path"));
         assert!(!cm.messages[2].content.contains("old fact"));
         assert_eq!(cm.messages[3].content, "current question");
+    }
+
+    #[test]
+    fn microcompact_skips_messages_inside_warm_cache_suffix() {
+        // An old low-value output followed by >8k tokens of conversation
+        // sits in the provider's warm prefix: rewriting it would bust the
+        // cache for the whole suffix. It must be skipped; only the cold
+        // tail (small suffix) is compacted.
+        let mut cm = ContextManager::new();
+        cm.set_budget_policy(ContextBudgetPolicy {
+            micro_keep_recent_messages: 2,
+            enable_token_estimation: false,
+            ..ContextBudgetPolicy::default()
+        });
+        // Warm message: old, low-value, big suffix.
+        cm.add_message(
+            "user",
+            &format!("<stdout>{}</stdout>", "warm old output ".repeat(64)),
+            MemoryType::Llm,
+        );
+        // >8k tokens after it (32k chars of content / 4).
+        for i in 0..8 {
+            cm.add_message(
+                "assistant",
+                &format!("turn-{i}-{}", "x".repeat(4_000)),
+                MemoryType::Llm,
+            );
+        }
+        // Cold message: low-value, tiny suffix.
+        cm.add_message(
+            "user",
+            &format!("<stdout>{}</stdout>", "cold old output ".repeat(64)),
+            MemoryType::Llm,
+        );
+        cm.add_message("assistant", "after cold", MemoryType::Llm);
+        cm.add_message("user", "recent question", MemoryType::Llm);
+        cm.add_message("assistant", "recent answer", MemoryType::Llm);
+
+        let report = cm.microcompact();
+        // Exactly the cold message is rewritten; the warm one is skipped.
+        assert_eq!(report.changed_messages, 1);
+        assert!(cm.messages[0].content.contains("warm old output"));
+        assert!(cm.messages[9].content.contains("cleared"));
     }
 }

--- a/crates/aish-context/src/manager.rs
+++ b/crates/aish-context/src/manager.rs
@@ -122,6 +122,7 @@ impl ContextManager {
                 memory_type,
                 name: None,
                 tool_call_id: None,
+                tool_calls: None,
             },
         );
     }
@@ -146,6 +147,9 @@ impl ContextManager {
                 }
                 if let Some(ref id) = m.tool_call_id {
                     obj.insert("tool_call_id".into(), serde_json::Value::String(id.clone()));
+                }
+                if let Some(ref calls) = m.tool_calls {
+                    obj.insert("tool_calls".into(), serde_json::json!(calls));
                 }
                 serde_json::Value::Object(obj)
             })
@@ -175,7 +179,15 @@ impl ContextManager {
     }
 
     pub fn estimate_message_tokens(&self, msg: &ContextMessage) -> usize {
-        self.estimate_tokens(&msg.content)
+        // Tool-call arguments can be kilobytes (bash/write_file payloads)
+        // and must count toward the budget or compaction triggers late.
+        let tool_calls_len: usize = msg
+            .tool_calls
+            .iter()
+            .flatten()
+            .map(|tc| tc.name.len() + tc.arguments.len())
+            .sum();
+        self.estimate_tokens(&msg.content) + tool_calls_len / 4
     }
 
     /// Return the total number of stored messages.
@@ -239,14 +251,37 @@ impl ContextManager {
     }
 
     pub fn full_compact_candidate_messages(&self) -> Vec<ContextMessage> {
-        let keep_recent = self.budget_policy.micro_keep_recent_messages.max(2);
-        let recent_start = self.messages.len().saturating_sub(keep_recent);
+        let recent_start = self.snapped_recent_start();
         self.messages
             .iter()
             .take(recent_start)
             .filter(|m| m.role != "system" && !m.content.starts_with(SUMMARY_TAG))
             .cloned()
             .collect()
+    }
+
+    /// Raw recent-window boundary snapped outward so an assistant tool-call
+    /// group is never split: either the whole group stays in the kept recent
+    /// tail, or the whole group is summarized away. Both
+    /// `full_compact_candidate_messages` and `rewrite_with_summary` must use
+    /// this same boundary or a straddling group would be duplicated into
+    /// both the summary and the retained tail.
+    fn snapped_recent_start(&self) -> usize {
+        let keep_recent = self.budget_policy.micro_keep_recent_messages.max(2);
+        let raw = self.messages.len().saturating_sub(keep_recent);
+        let mut boundary = raw;
+        while boundary > 0 && self.messages[boundary - 1].role == "tool" {
+            boundary -= 1;
+        }
+        if boundary > 0
+            && self.messages[boundary - 1]
+                .tool_calls
+                .as_ref()
+                .is_some_and(|c| !c.is_empty())
+        {
+            boundary -= 1;
+        }
+        boundary
     }
 
     pub fn apply_full_compact_summary(
@@ -455,41 +490,50 @@ impl ContextManager {
 
     /// Remove the oldest non-system messages of a given type until we are
     /// within the specified limit.
+    ///
+    /// Assistant tool-call messages and their tool results form atomic
+    /// groups: removing either side would leave a dangling tool_call_id or
+    /// an orphan tool result, both rejected by provider APIs. Groups are
+    /// counted and removed as a unit.
     fn trim_by_type(&mut self, memory_type: MemoryType, limit: usize) {
-        let count = self
-            .messages
+        let groups = tool_call_groups(&self.messages);
+        let count: usize = groups
             .iter()
-            .filter(|m| m.memory_type == memory_type && m.role != "system")
-            .count();
+            .filter(|g| {
+                g.iter().any(|&i| {
+                    self.messages[i].memory_type == memory_type && self.messages[i].role != "system"
+                })
+            })
+            .map(|g| g.len())
+            .sum();
 
         if count <= limit {
             return;
         }
 
         let to_remove = count - limit;
-        let mut removed = 0;
-
-        self.messages.retain(|m| {
+        let mut removed = 0usize;
+        let mut remove_indices: Vec<usize> = Vec::new();
+        for group in &groups {
             if removed >= to_remove {
-                return true;
+                break;
             }
-            if m.memory_type == memory_type && m.role != "system" {
-                removed += 1;
-                debug!(role = %m.role, ?memory_type, "trimmed message");
-                false
-            } else {
-                true
+            if group.iter().any(|&i| {
+                self.messages[i].memory_type == memory_type && self.messages[i].role != "system"
+            }) {
+                removed += group.len();
+                remove_indices.extend_from_slice(group);
             }
-        });
+        }
+        self.retain_indices(&remove_indices);
     }
 
     /// Remove the oldest non-system messages until the total token count is
     /// within the budget.
     ///
-    /// Uses `retain()` for a single O(n) pass instead of O(n^2) repeated
-    /// `remove()` calls.
+    /// Assistant tool-call groups are removed as atomic units so the
+    /// remaining sequence stays protocol-valid.
     fn trim_to_token_budget(&mut self, budget: usize) {
-        // Calculate total tokens.
         let total_tokens: usize = self
             .messages
             .iter()
@@ -500,28 +544,40 @@ impl ContextManager {
             return;
         }
 
-        // Walk forward to compute how many tokens we need to shed, recording
-        // which messages should be removed. We stop as soon as the budget is
-        // satisfied.
+        // Walk groups forward to compute how many tokens we need to shed,
+        // recording which messages should be removed. We stop as soon as
+        // the budget is satisfied.
         let mut current = total_tokens;
-        let mut should_remove = vec![false; self.messages.len()];
+        let mut remove_indices: Vec<usize> = Vec::new();
 
-        for (i, m) in self.messages.iter().enumerate() {
+        for group in tool_call_groups(&self.messages) {
             if current <= budget {
                 break;
             }
-            if m.role != "system" {
-                let tokens = self.estimate_tokens(&m.content);
-                current = current.saturating_sub(tokens);
-                debug!(role = %m.role, tokens, "trimmed message for token budget");
-                should_remove[i] = true;
+            if group.len() == 1 && self.messages[group[0]].role == "system" {
+                continue;
             }
+            let group_tokens: usize = group
+                .iter()
+                .map(|&i| self.estimate_tokens(&self.messages[i].content))
+                .sum();
+            current = current.saturating_sub(group_tokens);
+            debug!(
+                roles = ?group.iter().map(|&i| self.messages[i].role.as_str()).collect::<Vec<_>>(),
+                group_tokens,
+                "trimmed message group for token budget"
+            );
+            remove_indices.extend_from_slice(&group);
         }
+        self.retain_indices(&remove_indices);
+    }
 
-        // Single-pass retain: O(n) instead of O(n^2).
+    /// Remove the given message indices (single O(n) retain pass).
+    fn retain_indices(&mut self, remove: &[usize]) {
+        let to_drop: std::collections::HashSet<usize> = remove.iter().copied().collect();
         let mut idx = 0;
         self.messages.retain(|_| {
-            let keep = !should_remove[idx];
+            let keep = !to_drop.contains(&idx);
             idx += 1;
             keep
         });
@@ -570,8 +626,7 @@ impl ContextManager {
         }
 
         let before_tokens = self.total_estimated_tokens();
-        let keep_recent = self.budget_policy.micro_keep_recent_messages.max(2);
-        let recent_start = self.messages.len().saturating_sub(keep_recent);
+        let recent_start = self.snapped_recent_start();
 
         let mut new_messages = Vec::with_capacity(32);
         for (idx, msg) in self.messages.iter().enumerate() {
@@ -588,6 +643,7 @@ impl ContextManager {
             memory_type: MemoryType::Knowledge,
             name: None,
             tool_call_id: None,
+            tool_calls: None,
         });
         new_messages.extend(self.messages.iter().skip(recent_start).cloned());
 
@@ -612,6 +668,35 @@ impl ContextManager {
             summary_tokens,
         })
     }
+}
+
+/// Partition message indices into atomic groups.
+///
+/// An assistant message carrying tool_calls starts a group that extends
+/// through all immediately-following `tool` messages (their results).
+/// Everything else forms single-message groups. Trimming and compaction
+/// operate on whole groups so provider tool-call pairing is never broken.
+fn tool_call_groups(messages: &[ContextMessage]) -> Vec<Vec<usize>> {
+    let mut groups = Vec::new();
+    let mut i = 0;
+    while i < messages.len() {
+        if messages[i]
+            .tool_calls
+            .as_ref()
+            .is_some_and(|calls| !calls.is_empty())
+        {
+            let start = i;
+            i += 1;
+            while i < messages.len() && messages[i].role == "tool" {
+                i += 1;
+            }
+            groups.push((start..i).collect::<Vec<usize>>());
+        } else {
+            groups.push(vec![i]);
+            i += 1;
+        }
+    }
+    groups
 }
 
 fn normalize_summary(summary: String) -> String {
@@ -1066,5 +1151,172 @@ mod tests {
         assert_eq!(cm.compact_consecutive_failures(), 1);
         let second = cm.compact_for_send(None);
         assert!(second.skipped_full_compact_due_to_fuse);
+    }
+
+    fn tool_call_msg(id: &str, name: &str) -> ContextMessage {
+        ContextMessage {
+            role: "assistant".to_string(),
+            content: String::new(),
+            memory_type: MemoryType::Llm,
+            name: None,
+            tool_call_id: None,
+            tool_calls: Some(vec![aish_core::ContextToolCall {
+                id: id.to_string(),
+                name: name.to_string(),
+                arguments: "{}".to_string(),
+            }]),
+        }
+    }
+
+    fn tool_result_msg(id: &str, output: &str) -> ContextMessage {
+        ContextMessage {
+            role: "tool".to_string(),
+            content: output.to_string(),
+            memory_type: MemoryType::Llm,
+            name: Some("bash".to_string()),
+            tool_call_id: Some(id.to_string()),
+            tool_calls: None,
+        }
+    }
+
+    #[test]
+    fn trim_by_type_keeps_tool_call_groups_atomic() {
+        let mut cm = ContextManager::with_limits(3, 10, 10);
+        cm.add_message("user", "q1", MemoryType::Llm);
+        cm.add_memory(MemoryType::Llm, tool_call_msg("t1", "bash"));
+        cm.add_memory(MemoryType::Llm, tool_result_msg("t1", "output1"));
+        cm.add_message("user", "q2", MemoryType::Llm);
+        cm.add_memory(MemoryType::Llm, tool_call_msg("t2", "bash"));
+        cm.add_memory(MemoryType::Llm, tool_result_msg("t2", "output2"));
+        cm.trim();
+
+        // With a limit of 3 messages the oldest group (q1 + t1 pair = 3
+        // messages) is removed as a unit; the t2 pair stays intact.
+        let roles: Vec<&str> = cm.messages.iter().map(|m| m.role.as_str()).collect();
+        assert_eq!(roles, vec!["user", "assistant", "tool"]);
+        let assistant = &cm.messages[1];
+        assert!(assistant
+            .tool_calls
+            .as_ref()
+            .is_some_and(|c| c[0].id == "t2"));
+        assert_eq!(cm.messages[2].tool_call_id.as_deref(), Some("t2"));
+    }
+
+    #[test]
+    fn trim_to_token_budget_removes_groups_atomically() {
+        let mut cm = ContextManager::new();
+        cm.set_token_budget(Some(1)); // force maximum trimming
+        cm.add_message("user", &"x".repeat(64), MemoryType::Llm);
+        cm.add_memory(MemoryType::Llm, tool_call_msg("t1", "bash"));
+        cm.add_memory(MemoryType::Llm, tool_result_msg("t1", "output"));
+        cm.trim();
+
+        // Either the whole group survives or nothing does — never an
+        // orphan tool result or a dangling tool_call.
+        let has_tool = cm.messages.iter().any(|m| m.role == "tool");
+        let has_tool_calls = cm
+            .messages
+            .iter()
+            .any(|m| m.tool_calls.as_ref().is_some_and(|c| !c.is_empty()));
+        assert_eq!(has_tool, has_tool_calls);
+    }
+
+    #[test]
+    fn rewrite_with_summary_does_not_split_tool_call_group() {
+        let mut cm = ContextManager::new();
+        cm.set_budget_policy(ContextBudgetPolicy {
+            context_window_tokens: 2_000,
+            reserved_output_tokens: 200,
+            auto_compact_buffer_tokens: 200,
+            warning_buffer_tokens: 200,
+            blocking_buffer_tokens: 100,
+            micro_keep_recent_messages: 2,
+            enable_token_estimation: false,
+            ..ContextBudgetPolicy::default()
+        });
+        for idx in 0..8 {
+            cm.add_message(
+                "user",
+                &format!("investigate {idx} {}", "x".repeat(1200)),
+                MemoryType::Llm,
+            );
+        }
+        cm.add_memory(MemoryType::Llm, tool_call_msg("t9", "bash"));
+        cm.add_memory(MemoryType::Llm, tool_result_msg("t9", "recent output"));
+
+        let report = cm.compact_for_send(None);
+        assert!(report.full_compact.is_some());
+
+        // The recent tool-call group must survive full compaction intact.
+        let tail: Vec<&str> = cm.messages.iter().map(|m| m.role.as_str()).collect();
+        let last_two = &tail[tail.len() - 2..];
+        assert_eq!(last_two, vec!["assistant", "tool"]);
+    }
+
+    #[test]
+    fn legacy_snapshot_without_tool_calls_deserializes() {
+        let legacy = r#"{
+            "role": "assistant",
+            "content": "hello",
+            "memory_type": "Llm",
+            "name": null,
+            "tool_call_id": null
+        }"#;
+        let msg: ContextMessage = serde_json::from_str(legacy).expect("legacy snapshot must parse");
+        assert_eq!(msg.role, "assistant");
+        assert!(msg.tool_calls.is_none());
+    }
+
+    #[test]
+    fn as_messages_includes_tool_calls() {
+        let mut cm = ContextManager::new();
+        cm.add_memory(MemoryType::Llm, tool_call_msg("t1", "bash"));
+        let messages = cm.as_messages();
+        let tc = messages[0].get("tool_calls").expect("tool_calls present");
+        let call = &tc[0];
+        assert_eq!(call["id"], "t1");
+        assert_eq!(call["name"], "bash");
+    }
+
+    #[test]
+    fn estimate_message_tokens_counts_tool_call_arguments() {
+        let cm = ContextManager::new();
+        let plain = ContextMessage {
+            role: "assistant".to_string(),
+            content: "x".repeat(400),
+            memory_type: MemoryType::Llm,
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        };
+        let with_calls = ContextMessage {
+            tool_calls: Some(vec![aish_core::ContextToolCall {
+                id: "t1".to_string(),
+                name: "bash".to_string(),
+                arguments: "y".repeat(400),
+            }]),
+            ..plain.clone()
+        };
+        assert!(cm.estimate_message_tokens(&with_calls) > cm.estimate_message_tokens(&plain));
+    }
+
+    #[test]
+    fn full_compact_candidates_use_snapped_group_boundary() {
+        let mut cm = ContextManager::new();
+        cm.set_budget_policy(ContextBudgetPolicy {
+            micro_keep_recent_messages: 2,
+            enable_token_estimation: false,
+            ..ContextBudgetPolicy::default()
+        });
+        cm.add_message("user", "q1", MemoryType::Llm);
+        cm.add_memory(MemoryType::Llm, tool_call_msg("t9", "bash"));
+        cm.add_memory(MemoryType::Llm, tool_result_msg("t9", "recent output"));
+
+        // Raw boundary (len - keep_recent) = 1 lands between the assistant
+        // and its result; the snapped boundary must exclude the whole group.
+        let candidates = cm.full_compact_candidate_messages();
+        assert!(candidates
+            .iter()
+            .all(|m| m.tool_calls.is_none() && m.role != "tool"));
     }
 }

--- a/crates/aish-context/src/manager.rs
+++ b/crates/aish-context/src/manager.rs
@@ -12,13 +12,6 @@ const CLEARED_SHELL_OUTPUT: &str =
 const CLEARED_LLM_OUTPUT: &str = "[old low-value output cleared by context microcompact]";
 const SUMMARY_TAG: &str = "<conversation-summary";
 
-/// A message whose suffix (all messages after it) exceeds this many
-/// estimated tokens sits deep inside the provider's warm prompt-cache
-/// prefix: rewriting it forces the provider to re-write the entire suffix
-/// at cache-write premium. Microcompact skips such messages; full
-/// compaction (which rebuilds the cache anyway) reclaims them.
-const CACHE_WARM_SUFFIX_TOKENS: usize = 8_000;
-
 /// Statistics about the current context state.
 #[derive(Debug, Clone)]
 pub struct ContextStats {
@@ -358,7 +351,6 @@ impl ContextManager {
     }
 
     pub fn microcompact(&mut self) -> MicrocompactReport {
-        let before_tokens = self.total_estimated_tokens();
         let mut changed_messages = 0usize;
         let keep_recent_messages = self.budget_policy.micro_keep_recent_messages;
         let recent_start = self.messages.len().saturating_sub(keep_recent_messages);
@@ -366,18 +358,20 @@ impl ContextManager {
         // Cache-warm suffix guard (modeled on oh-my-pi's
         // cacheWarmSuffixTokens): rewriting a message whose suffix already
         // went on the wire forces the provider to re-write that entire
-        // suffix at cache-write premium. Messages deeper than
-        // CACHE_WARM_SUFFIX_TOKENS from the end are left for full
+        // suffix at cache-write premium. Messages deeper than the
+        // cache_warm_suffix_tokens budget from the end are left for full
         // compaction (which rebuilds the cache anyway); microcompact only
-        // reclaims from the cold tail.
+        // reclaims from the cold tail. The suffix sums double as the
+        // before-token total, saving a separate full tokenization pass.
         let mut suffix_tokens = vec![0usize; self.messages.len() + 1];
         for idx in (0..self.messages.len()).rev() {
             suffix_tokens[idx] =
                 suffix_tokens[idx + 1] + self.estimate_message_tokens(&self.messages[idx]);
         }
-        let cache_warm = |idx: usize| {
-            suffix_tokens.get(idx + 1).copied().unwrap_or(0) > CACHE_WARM_SUFFIX_TOKENS
-        };
+        let before_tokens = suffix_tokens[0];
+        let warm_threshold = self.budget_policy.cache_warm_suffix_tokens;
+        let cache_warm =
+            |idx: usize| suffix_tokens.get(idx + 1).copied().unwrap_or(0) > warm_threshold;
 
         let shell_indices: Vec<usize> = self
             .messages

--- a/crates/aish-context/src/manager.rs
+++ b/crates/aish-context/src/manager.rs
@@ -633,7 +633,10 @@ impl ContextManager {
             if idx >= recent_start {
                 break;
             }
-            if msg.role == "system" && !msg.content.starts_with(SUMMARY_TAG) {
+            if msg.role == "system"
+                && !msg.content.starts_with(SUMMARY_TAG)
+                && !is_transient_system(&msg.content)
+            {
                 new_messages.push(msg.clone());
             }
         }
@@ -720,7 +723,18 @@ fn is_low_value_output(content: &str) -> bool {
         || content.contains("<offload>")
         || content.contains("</stdout>")
         || content.contains("</stderr>")
+        // Per-turn transient blocks (env cwd updates, memory recall) age
+        // into low value immediately after their turn passes.
+        || content.contains("**Environment Update:**")
+        || content.contains("<long-term-memory")
         || content.len() > 8_000
+}
+
+/// Per-turn transient system blocks. They ride at the natural turn position
+/// for cache stability but must not survive full compaction — the current
+/// turn's env/recall is re-appended every turn anyway.
+fn is_transient_system(content: &str) -> bool {
+    content.contains("**Environment Update:**") || content.contains("<long-term-memory")
 }
 
 fn compact_shell_content(content: &str) -> Option<String> {

--- a/crates/aish-context/src/types.rs
+++ b/crates/aish-context/src/types.rs
@@ -15,4 +15,9 @@ pub struct ContextMessage {
     /// persisted before this field existed still deserialize.
     #[serde(default)]
     pub tool_calls: Option<Vec<aish_core::ContextToolCall>>,
+    /// DeepSeek-style reasoning content. Providers require it to be echoed
+    /// back; persisting it keeps the replayed prefix byte-identical to the
+    /// live turn instead of busting the prompt cache every turn.
+    #[serde(default)]
+    pub reasoning_content: Option<String>,
 }

--- a/crates/aish-context/src/types.rs
+++ b/crates/aish-context/src/types.rs
@@ -11,4 +11,8 @@ pub struct ContextMessage {
     /// Tool name for role="tool" messages.
     pub name: Option<String>,
     pub tool_call_id: Option<String>,
+    /// Tool calls attached to an assistant message. Optional so snapshots
+    /// persisted before this field existed still deserialize.
+    #[serde(default)]
+    pub tool_calls: Option<Vec<aish_core::ContextToolCall>>,
 }

--- a/crates/aish-core/src/types.rs
+++ b/crates/aish-core/src/types.rs
@@ -66,6 +66,21 @@ pub enum MemoryType {
     Knowledge,
 }
 
+/// A tool call recorded on an assistant context message.
+///
+/// Shared by aish-context and aish-session so persisted conversation
+/// snapshots can round-trip the assistant tool_calls -> tool-result pairing
+/// required by provider APIs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextToolCall {
+    /// Provider-issued tool call id (matches the tool result's tool_call_id).
+    pub id: String,
+    /// Tool name the model requested.
+    pub name: String,
+    /// Raw JSON-encoded arguments string.
+    pub arguments: String,
+}
+
 // ---------------------------------------------------------------------------
 // Skills
 // ---------------------------------------------------------------------------

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -78,6 +78,10 @@ pub struct LlmSession {
     langfuse_session_id: std::sync::Mutex<Option<String>>,
     /// Monotonic turn counter for naming spans within the session trace.
     langfuse_turn_counter: std::sync::atomic::AtomicU32,
+    /// Monotonic turn sequence (always incremented, unlike the Langfuse
+    /// counter) used to make synthetic tool-call ids unique across turns —
+    /// persisted history replays ids from previous turns alongside new ones.
+    turn_seq: std::sync::atomic::AtomicU32,
     /// Maximum context token budget. Messages are trimmed when exceeded.
     max_context_tokens: usize,
     context_budget_policy: ContextBudgetPolicy,
@@ -151,6 +155,7 @@ impl LlmSession {
             langfuse: None,
             langfuse_session_id: std::sync::Mutex::new(None),
             langfuse_turn_counter: std::sync::atomic::AtomicU32::new(0),
+            turn_seq: std::sync::atomic::AtomicU32::new(0),
             max_context_tokens: 100_000,
             context_budget_policy: ContextBudgetPolicy::default(),
             compact_consecutive_failures: std::sync::Mutex::new(0),
@@ -606,6 +611,9 @@ impl LlmSession {
     ) -> Result<crate::types::ProcessResult, AishError> {
         self.cancellation_token.reset();
         self.last_turn_compaction.lock().unwrap().take();
+        let turn_seq = self
+            .turn_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
         // Emit operation start event
         self.emit_event(LlmEvent {
@@ -1098,8 +1106,10 @@ impl LlmSession {
                         .filter_map(|(seq_idx, (orig_idx, (id, name, args)))| {
                             // Some providers omit the id in streaming deltas.
                             // Fall back to a synthetic id so the tool call can still execute.
+                            // The turn sequence keeps ids unique across turns
+                            // now that tool-call history persists in context.
                             let id = if id.is_empty() {
-                                format!("tc_{orig_idx}")
+                                format!("tc_{turn_seq}_{orig_idx}")
                             } else {
                                 id
                             };
@@ -1604,6 +1614,7 @@ impl LlmSession {
             context_budget_policy: self.context_budget_policy.clone(),
             compact_consecutive_failures: std::sync::Mutex::new(0),
             rotation: None,
+            turn_seq: std::sync::atomic::AtomicU32::new(0),
             plan_state: Arc::new(Mutex::new(PlanModeState::default())),
             token_stats: std::sync::Mutex::new(crate::usage::TokenStats::default()),
             last_prompt_estimate: std::sync::atomic::AtomicU64::new(0),
@@ -1813,9 +1824,8 @@ impl LlmSession {
     ) -> Vec<ChatMessage> {
         let policy = &self.context_budget_policy;
         if !policy.enabled {
-            return trim_messages(messages, self.max_context_tokens, 5);
+            return sanitize_tool_pairs(trim_messages(messages, self.max_context_tokens, 5));
         }
-
         let before_tokens = estimate_chat_tokens(&messages, policy);
         let before_state = policy.state_for_tokens(before_tokens);
         let mut compaction_changed = false;
@@ -1892,11 +1902,11 @@ impl LlmSession {
             );
         }
 
-        trim_messages(
+        sanitize_tool_pairs(trim_messages(
             messages,
             self.max_context_tokens,
             policy.micro_keep_recent_messages.max(5),
-        )
+        ))
     }
 
     async fn full_compact_chat_messages_with_model(
@@ -2119,7 +2129,15 @@ fn estimate_one_chat_message(message: &ChatMessage, _policy: &ContextBudgetPolic
         .as_ref()
         .map(|c| c.len())
         .unwrap_or(0);
-    ((content_len + reasoning_len) / 4).max(1)
+    // Tool-call arguments (raw JSON, can be kilobytes) ride on assistant
+    // messages and must count or compaction triggers late.
+    let tool_calls_len: usize = message
+        .tool_calls
+        .iter()
+        .flatten()
+        .map(|tc| tc.name.len() + tc.arguments.len())
+        .sum();
+    ((content_len + reasoning_len + tool_calls_len) / 4).max(1)
 }
 
 fn microcompact_chat_messages(
@@ -2364,6 +2382,74 @@ fn trim_messages(
     let mut result = system;
     result.extend(kept_middle);
     result.extend(recent);
+    result
+}
+
+/// Repair provider tool-call pairing in a message sequence before send.
+///
+/// Defensive layer for history rebuilt from persisted context: drops tool
+/// results with no preceding assistant tool_call, and removes tool_calls
+/// that never received a tool result (backfilling a synthetic result is not
+/// possible here because the tool never ran).
+fn sanitize_tool_pairs(messages: Vec<ChatMessage>) -> Vec<ChatMessage> {
+    use std::collections::HashSet;
+
+    // Pass 1a: ids the assistants actually requested.
+    let called: HashSet<String> = messages
+        .iter()
+        .filter(|m| m.role == "assistant")
+        .flat_map(|m| m.tool_calls.iter().flatten())
+        .map(|c| c.id.clone())
+        .collect();
+    // Pass 1b: ids that received a tool result.
+    let answered: HashSet<String> = messages
+        .iter()
+        .filter(|m| m.role == "tool")
+        .filter_map(|m| m.tool_call_id.clone())
+        .filter(|id| called.contains(id))
+        .collect();
+
+    // Pass 2: drop orphan tool results; prune unanswered tool_calls from
+    // assistant messages (dropping the whole message if it becomes empty
+    // of both content and tool_calls).
+    let mut result = Vec::with_capacity(messages.len());
+    for mut msg in messages {
+        if msg.role == "tool" {
+            match msg.tool_call_id.as_deref() {
+                Some(id) if called.contains(id) => result.push(msg),
+                _ => {
+                    tracing::warn!(
+                        "dropping orphan tool result without matching tool_call before send"
+                    );
+                }
+            }
+            continue;
+        }
+        if msg.role == "assistant" {
+            if let Some(ref calls) = msg.tool_calls {
+                let kept: Vec<ToolCall> = calls
+                    .iter()
+                    .filter(|c| answered.contains(&c.id))
+                    .cloned()
+                    .collect();
+                if kept.len() < calls.len() {
+                    tracing::warn!(
+                        dropped = calls.len() - kept.len(),
+                        "dropping unanswered tool_calls from assistant message before send"
+                    );
+                }
+                if kept.is_empty() {
+                    msg.tool_calls = None;
+                    if msg.text_byte_len() == 0 {
+                        continue;
+                    }
+                } else {
+                    msg.tool_calls = Some(kept);
+                }
+            }
+        }
+        result.push(msg);
+    }
     result
 }
 
@@ -2891,6 +2977,13 @@ mod tests {
         });
 
         let mut msgs = vec![make_msg("system", "sys")];
+        let mut assistant_call = ChatMessage::assistant("");
+        assistant_call.tool_calls = Some(vec![ToolCall {
+            id: "call-old".to_string(),
+            name: "bash".to_string(),
+            arguments: "{}".to_string(),
+        }]);
+        msgs.push(assistant_call);
         msgs.push(ChatMessage::tool_result(
             "call-old",
             format!(
@@ -3762,5 +3855,54 @@ mod tests {
             expected, answered,
             "every tool_call_id must have a tool_result"
         );
+    }
+
+    #[test]
+    fn sanitize_tool_pairs_repairs_dangling_sequences() {
+        let mut assistant = ChatMessage::assistant("working on it");
+        assistant.tool_calls = Some(vec![
+            ToolCall {
+                id: "answered".to_string(),
+                name: "bash".to_string(),
+                arguments: "{}".to_string(),
+            },
+            ToolCall {
+                id: "unanswered".to_string(),
+                name: "read".to_string(),
+                arguments: "{}".to_string(),
+            },
+        ]);
+        let messages = vec![
+            make_msg("system", "sys"),
+            assistant,
+            ChatMessage::tool_result("answered", "ok"),
+            ChatMessage::tool_result("orphan", "no matching call"),
+            make_msg("user", "next question"),
+        ];
+
+        let sanitized = sanitize_tool_pairs(messages);
+        let roles: Vec<&str> = sanitized.iter().map(|m| m.role.as_str()).collect();
+        assert_eq!(roles, vec!["system", "assistant", "tool", "user"]);
+
+        // The unanswered tool_call is pruned; the answered one is kept.
+        let calls = sanitized[1].tool_calls.as_ref().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "answered");
+        assert_eq!(sanitized[2].tool_call_id.as_deref(), Some("answered"));
+    }
+
+    #[test]
+    fn sanitize_tool_pairs_drops_empty_assistant_after_pruning() {
+        let mut assistant = ChatMessage::assistant("");
+        assistant.tool_calls = Some(vec![ToolCall {
+            id: "never".to_string(),
+            name: "bash".to_string(),
+            arguments: "{}".to_string(),
+        }]);
+        let messages = vec![make_msg("user", "q"), assistant, make_msg("user", "next")];
+
+        let sanitized = sanitize_tool_pairs(messages);
+        let roles: Vec<&str> = sanitized.iter().map(|m| m.role.as_str()).collect();
+        assert_eq!(roles, vec!["user", "user"]);
     }
 }

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use aish_context::{ContextBudgetPolicy, ContextMessage, ContextPressureLevel, MicrocompactReport};
+use aish_context::{ContextBudgetPolicy, ContextMessage};
 use aish_core::{
     AishError, AuditEvent, AuditSink, LlmEvent, LlmEventType, MemoryType, PlanModeState, PlanPhase,
 };
@@ -85,7 +85,6 @@ pub struct LlmSession {
     /// Maximum context token budget. Messages are trimmed when exceeded.
     max_context_tokens: usize,
     context_budget_policy: ContextBudgetPolicy,
-    compact_consecutive_failures: std::sync::Mutex<usize>,
     /// Plan mode state for dynamic tool filtering.
     plan_state: Arc<Mutex<PlanModeState>>,
     /// Cumulative token usage statistics for this session.
@@ -158,7 +157,6 @@ impl LlmSession {
             turn_seq: std::sync::atomic::AtomicU32::new(0),
             max_context_tokens: 100_000,
             context_budget_policy: ContextBudgetPolicy::default(),
-            compact_consecutive_failures: std::sync::Mutex::new(0),
             plan_state: Arc::new(Mutex::new(PlanModeState::default())),
             token_stats: std::sync::Mutex::new(crate::usage::TokenStats::default()),
             last_prompt_estimate: std::sync::atomic::AtomicU64::new(0),
@@ -385,6 +383,13 @@ impl LlmSession {
     /// `Some("microcompact")` — only stale tool output was cleared.
     pub fn last_turn_compaction(&self) -> Option<&'static str> {
         *self.last_turn_compaction.lock().unwrap()
+    }
+
+    /// Report the compaction mode applied by the persistent context layer
+    /// for the current turn, so the UI flag keeps working now that the
+    /// send path no longer compacts outgoing copies.
+    pub fn set_last_turn_compaction(&self, mode: Option<&'static str>) {
+        *self.last_turn_compaction.lock().unwrap() = mode;
     }
 
     /// Return a snapshot of cumulative token usage statistics.
@@ -1612,7 +1617,6 @@ impl LlmSession {
             langfuse_turn_counter: std::sync::atomic::AtomicU32::new(0),
             max_context_tokens: self.max_context_tokens,
             context_budget_policy: self.context_budget_policy.clone(),
-            compact_consecutive_failures: std::sync::Mutex::new(0),
             rotation: None,
             turn_seq: std::sync::atomic::AtomicU32::new(0),
             plan_state: Arc::new(Mutex::new(PlanModeState::default())),
@@ -1820,134 +1824,22 @@ impl LlmSession {
 
     pub(crate) async fn prepare_messages_for_send(
         &self,
-        mut messages: Vec<ChatMessage>,
+        messages: Vec<ChatMessage>,
     ) -> Vec<ChatMessage> {
+        // No copy-level compaction here. The persistent context layer
+        // (ContextManager via compact_context_before_send) is the single
+        // compaction authority: rewriting an outgoing COPY per request
+        // makes the wire bytes a moving function of token pressure, so the
+        // replayed history diverges between turns and busts the provider
+        // prefix cache. This path only enforces the hard budget with a
+        // head-preserving trim (equivalent to a compaction boundary) and
+        // repairs tool-call pairing.
         let policy = &self.context_budget_policy;
-        if !policy.enabled {
-            return sanitize_tool_pairs(trim_messages(messages, self.max_context_tokens, 5));
-        }
-        let before_tokens = estimate_chat_tokens(&messages, policy);
-        let before_state = policy.state_for_tokens(before_tokens);
-        let mut compaction_changed = false;
-        let mut emitted_compaction_start = false;
-        let mut compaction_mode = "microcompact";
-
-        if matches!(
-            before_state.pressure,
-            ContextPressureLevel::Warning
-                | ContextPressureLevel::AutoCompact
-                | ContextPressureLevel::Blocking
-        ) {
-            let report = microcompact_chat_messages(&mut messages, policy);
-            if report.changed_messages > 0 {
-                compaction_changed = true;
-                *self.last_turn_compaction.lock().unwrap() = Some("microcompact");
-                tracing::info!(
-                    changed_messages = report.changed_messages,
-                    reclaimed_tokens = report.reclaimed_tokens,
-                    compaction = "microcompact",
-                    "send-path context microcompact completed"
-                );
-            }
-        }
-
-        let after_micro_tokens = estimate_chat_tokens(&messages, policy);
-        let after_micro_state = policy.state_for_tokens(after_micro_tokens);
-        if after_micro_state.is_above_auto_compact_threshold && policy.full_compact_enabled {
-            self.emit_context_compaction_start("send_path", "full_compact");
-            emitted_compaction_start = true;
-            compaction_mode = "full_compact";
-            let failures = *self.compact_consecutive_failures.lock().unwrap();
-            if failures >= policy.max_consecutive_failures {
-                tracing::warn!(
-                    failures,
-                    "send-path full compact skipped because failure fuse is open"
-                );
-            } else {
-                match self
-                    .full_compact_chat_messages_with_model(messages.clone(), policy)
-                    .await
-                {
-                    Ok(_compacted) => {
-                        *self.compact_consecutive_failures.lock().unwrap() = 0;
-                        compaction_changed = true;
-                        *self.last_turn_compaction.lock().unwrap() = Some("full_compact");
-                        tracing::info!(
-                            compaction = "full_compact",
-                            "send-path full compact completed, compaction flag set"
-                        );
-                        messages = _compacted;
-                    }
-                    Err(err) => {
-                        let mut guard = self.compact_consecutive_failures.lock().unwrap();
-                        *guard = (*guard).saturating_add(1);
-                        tracing::warn!(
-                            error = %err,
-                            failures = *guard,
-                            "send-path full compact failed; falling back to final trim"
-                        );
-                    }
-                }
-            }
-        }
-
-        if emitted_compaction_start || compaction_changed {
-            let after_tokens = estimate_chat_tokens(&messages, policy);
-            self.emit_context_compaction_end(
-                "send_path",
-                compaction_mode,
-                before_tokens,
-                after_tokens,
-                compaction_changed,
-            );
-        }
-
         sanitize_tool_pairs(trim_messages(
             messages,
             self.max_context_tokens,
             policy.micro_keep_recent_messages.max(5),
         ))
-    }
-
-    async fn full_compact_chat_messages_with_model(
-        &self,
-        messages: Vec<ChatMessage>,
-        policy: &ContextBudgetPolicy,
-    ) -> Result<Vec<ChatMessage>, String> {
-        let keep_recent = policy.micro_keep_recent_messages.max(2);
-        let recent_start = messages.len().saturating_sub(keep_recent);
-        let old_messages: Vec<ChatMessage> = messages
-            .iter()
-            .take(recent_start)
-            .filter(|m| m.role != "system")
-            .cloned()
-            .collect();
-        if old_messages.is_empty() {
-            return Err("no old chat messages available for full compact".to_string());
-        }
-
-        let prompt = build_chat_summary_prompt(&old_messages, policy.summary_max_tokens);
-        let summary = self
-            .generate_compact_summary(prompt, policy.summary_max_tokens)
-            .await
-            .map_err(|err| err.to_string())?;
-
-        let mut compacted = Vec::new();
-        for (idx, msg) in messages.iter().enumerate() {
-            if idx >= recent_start {
-                break;
-            }
-            if msg.role == "system" {
-                compacted.push(msg.clone());
-            }
-        }
-        compacted.push(ChatMessage::system(summary));
-        compacted.extend(messages.into_iter().skip(recent_start));
-        tracing::info!(
-            compacted_messages = old_messages.len(),
-            "send-path model full compact completed"
-        );
-        Ok(compacted)
     }
 
     async fn generate_compact_summary(
@@ -2031,34 +1923,6 @@ fn build_context_summary_prompt(
     prompt
 }
 
-fn build_chat_summary_prompt(messages: &[ChatMessage], summary_max_tokens: usize) -> String {
-    let mut prompt = String::new();
-    prompt.push_str("Summarize the older in-flight chat/tool context below for AI Shell.\n");
-    prompt.push_str("Preserve user intent, command/tool results, failures, important stderr, and pending next steps. Drop verbose stdout and repeated low-value details.\n");
-    prompt.push_str(&format!(
-        "Target summary budget: about {} tokens.\n\n",
-        summary_max_tokens
-    ));
-    prompt.push_str("Return exactly one <conversation-summary> block.\n\n");
-    for (idx, msg) in messages.iter().enumerate() {
-        let content = msg.text_content().unwrap_or("");
-        prompt.push_str(&format!(
-            "\n<message index=\"{}\" role=\"{}\">\n{}\n</message>\n",
-            idx,
-            msg.role,
-            truncate_for_summary_prompt(content, 4_000)
-        ));
-        if let Some(reasoning) = &msg.reasoning_content {
-            prompt.push_str(&format!(
-                "<reasoning index=\"{}\">\n{}\n</reasoning>\n",
-                idx,
-                truncate_for_summary_prompt(reasoning, 1_000)
-            ));
-        }
-    }
-    prompt
-}
-
 fn memory_type_label(memory_type: &MemoryType) -> &'static str {
     match memory_type {
         MemoryType::Llm => "llm",
@@ -2138,164 +2002,6 @@ fn estimate_one_chat_message(message: &ChatMessage, _policy: &ContextBudgetPolic
         .map(|tc| tc.name.len() + tc.arguments.len())
         .sum();
     ((content_len + reasoning_len + tool_calls_len) / 4).max(1)
-}
-
-fn microcompact_chat_messages(
-    messages: &mut [ChatMessage],
-    policy: &ContextBudgetPolicy,
-) -> MicrocompactReport {
-    let before_tokens = estimate_chat_tokens(messages, policy);
-    let recent_start = messages
-        .len()
-        .saturating_sub(policy.micro_keep_recent_messages);
-    let mut changed_messages = 0usize;
-
-    for (idx, msg) in messages.iter_mut().enumerate() {
-        if idx >= recent_start || msg.role == "system" {
-            continue;
-        }
-
-        let mut changed = false;
-        if msg.role == "tool" {
-            if let Some(content) = msg.text_content() {
-                if content.len() > 256 || is_low_value_chat_output(content) {
-                    let mut replacement = String::from(
-                        "[old tool output cleared by context microcompact; key metadata retained]",
-                    );
-                    if let Some(id) = &msg.tool_call_id {
-                        replacement.push_str(&format!("\ntool_call_id: {}", id));
-                    }
-                    if let Some(return_code) = extract_return_code(content) {
-                        replacement.push_str(&format!("\nreturn_code: {}", return_code));
-                    }
-                    msg.content = Some(MessageContent::Text(replacement));
-                    changed = true;
-                }
-            }
-        }
-
-        if msg
-            .reasoning_content
-            .as_ref()
-            .is_some_and(|s| s.len() > 512)
-        {
-            msg.reasoning_content =
-                Some("[old reasoning content cleared by context microcompact]".to_string());
-            changed = true;
-        }
-
-        if changed {
-            changed_messages += 1;
-        }
-    }
-
-    let after_tokens = estimate_chat_tokens(messages, policy);
-    MicrocompactReport {
-        changed_messages,
-        reclaimed_tokens: before_tokens.saturating_sub(after_tokens),
-    }
-}
-
-#[cfg(test)]
-fn full_compact_chat_messages(
-    messages: Vec<ChatMessage>,
-    policy: &ContextBudgetPolicy,
-) -> Result<Vec<ChatMessage>, String> {
-    let keep_recent = policy.micro_keep_recent_messages.max(2);
-    let recent_start = messages.len().saturating_sub(keep_recent);
-    let old_messages: Vec<ChatMessage> = messages
-        .iter()
-        .take(recent_start)
-        .filter(|m| m.role != "system")
-        .cloned()
-        .collect();
-    if old_messages.is_empty() {
-        return Err("no old chat messages available for full compact".to_string());
-    }
-
-    let summary = build_chat_summary(&old_messages, policy.summary_max_tokens);
-    if summary.trim().is_empty() {
-        return Err("chat compact summary is empty".to_string());
-    }
-
-    let mut compacted = Vec::new();
-    for (idx, msg) in messages.iter().enumerate() {
-        if idx >= recent_start {
-            break;
-        }
-        if msg.role == "system" {
-            compacted.push(msg.clone());
-        }
-    }
-    compacted.push(ChatMessage::system(summary));
-    compacted.extend(messages.into_iter().skip(recent_start));
-    tracing::info!(
-        compacted_messages = old_messages.len(),
-        "send-path full compact completed"
-    );
-    Ok(compacted)
-}
-
-#[cfg(test)]
-fn build_chat_summary(old_messages: &[ChatMessage], summary_max_tokens: usize) -> String {
-    let mut lines = vec![
-        "<conversation-summary source=\"send_path_auto_compact\">".to_string(),
-        "Summary:".to_string(),
-        format!("- Compacted older chat messages: {}.", old_messages.len()),
-    ];
-    for msg in old_messages
-        .iter()
-        .rev()
-        .take(10)
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
-    {
-        let content = msg.text_content().unwrap_or("");
-        lines.push(format!(
-            "- {}: {}",
-            msg.role,
-            summarize_chat_line(content, 220)
-        ));
-    }
-    lines.push("</conversation-summary>".to_string());
-    let mut summary = lines.join("\n");
-    let max_chars = summary_max_tokens.saturating_mul(4).max(512);
-    if summary.len() > max_chars {
-        let mut end = max_chars.min(summary.len());
-        while end > 0 && !summary.is_char_boundary(end) {
-            end -= 1;
-        }
-        summary.truncate(end);
-        summary.push_str("\n</conversation-summary>");
-    }
-    summary
-}
-
-#[cfg(test)]
-fn summarize_chat_line(content: &str, max_chars: usize) -> String {
-    let one_line = content
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .take(4)
-        .collect::<Vec<_>>()
-        .join(" | ");
-    if one_line.len() <= max_chars {
-        return one_line;
-    }
-    let mut end = max_chars.min(one_line.len());
-    while end > 0 && !one_line.is_char_boundary(end) {
-        end -= 1;
-    }
-    format!("{}...", &one_line[..end])
-}
-
-fn is_low_value_chat_output(content: &str) -> bool {
-    content.contains("<stdout>")
-        || content.contains("<stderr>")
-        || content.contains("<offload>")
-        || content.len() > 8_000
 }
 
 fn extract_return_code(content: &str) -> Option<String> {
@@ -2902,55 +2608,6 @@ mod tests {
     }
 
     #[test]
-    fn test_microcompact_chat_messages_clears_old_tool_output() {
-        let policy = ContextBudgetPolicy {
-            micro_keep_recent_messages: 1,
-            enable_token_estimation: false,
-            ..ContextBudgetPolicy::default()
-        };
-        let mut msgs = vec![
-            make_msg("system", "sys"),
-            ChatMessage::tool_result(
-                "call-old",
-                "<stdout>very noisy output</stdout>\n<return_code>0</return_code>",
-            ),
-            ChatMessage::tool_result("call-new", "<stdout>recent output</stdout>"),
-        ];
-
-        let report = microcompact_chat_messages(&mut msgs, &policy);
-        assert_eq!(report.changed_messages, 1);
-        assert!(msgs[1]
-            .text_content()
-            .unwrap()
-            .contains("old tool output cleared"));
-        assert!(msgs[2].text_content().unwrap().contains("recent output"));
-    }
-
-    #[test]
-    fn test_full_compact_chat_messages_adds_summary_and_preserves_recent() {
-        let policy = ContextBudgetPolicy {
-            micro_keep_recent_messages: 2,
-            summary_max_tokens: 200,
-            ..ContextBudgetPolicy::default()
-        };
-        let msgs = vec![
-            make_msg("system", "sys"),
-            make_msg("user", "old request"),
-            make_msg("assistant", "old answer"),
-            make_msg("user", "recent request"),
-            make_msg("assistant", "recent answer"),
-        ];
-
-        let result = full_compact_chat_messages(msgs, &policy).unwrap();
-        assert_eq!(result[0].role, "system");
-        assert!(result.iter().any(|m| m
-            .text_content()
-            .unwrap_or("")
-            .contains("conversation-summary")));
-        assert_eq!(result.last().unwrap().text_content(), Some("recent answer"));
-    }
-
-    #[test]
     fn test_format_compact_summary_wraps_model_text() {
         let formatted = format_compact_summary(
             "<analysis>scratch</analysis><summary>Current Goal:\n- Diagnose nginx</summary>"
@@ -2961,8 +2618,12 @@ mod tests {
         assert!(!formatted.contains("scratch"));
     }
 
+    /// Send path no longer compacts an outgoing copy (that made wire bytes
+    /// a moving function of token pressure and busted prefix caches).
+    /// It must pass the messages through byte-preserved (only head-trim
+    /// when the hard budget is exceeded — not the case here).
     #[tokio::test]
-    async fn test_prepare_messages_for_send_triggers_microcompact_without_model() {
+    async fn test_prepare_messages_for_send_preserves_wire_bytes() {
         let mut session = LlmSession::new("http://localhost", "key", "model", None, None);
         session.set_context_budget_policy(ContextBudgetPolicy {
             context_window_tokens: 2_000,
@@ -2978,6 +2639,7 @@ mod tests {
 
         let mut msgs = vec![make_msg("system", "sys")];
         let mut assistant_call = ChatMessage::assistant("");
+        assistant_call.content = None;
         assistant_call.tool_calls = Some(vec![ToolCall {
             id: "call-old".to_string(),
             name: "bash".to_string(),
@@ -2986,37 +2648,14 @@ mod tests {
         msgs.push(assistant_call);
         msgs.push(ChatMessage::tool_result(
             "call-old",
-            format!(
-                "<stdout>{}</stdout>\n<return_code>1</return_code>",
-                "old noisy output\n".repeat(400)
-            ),
-        ));
-        let mut assistant_call2 = ChatMessage::assistant("");
-        assistant_call2.tool_calls = Some(vec![ToolCall {
-            id: "call-old-2".to_string(),
-            name: "bash".to_string(),
-            arguments: "{}".to_string(),
-        }]);
-        msgs.push(assistant_call2);
-        msgs.push(ChatMessage::tool_result(
-            "call-old-2",
-            format!(
-                "<stdout>{}</stdout>\n<return_code>1</return_code>",
-                "more old noisy output\n".repeat(400)
-            ),
+            "<stdout>noisy output under no pressure</stdout>\n<return_code>1</return_code>",
         ));
         msgs.push(make_msg("user", "recent request"));
         msgs.push(make_msg("assistant", "recent answer"));
 
+        let expected = serde_json::to_string(&msgs).unwrap();
         let prepared = session.prepare_messages_for_send(msgs).await;
-        assert!(prepared.iter().any(|m| m
-            .text_content()
-            .unwrap_or("")
-            .contains("old tool output cleared")));
-        assert_eq!(
-            prepared.last().unwrap().text_content(),
-            Some("recent answer")
-        );
+        assert_eq!(serde_json::to_string(&prepared).unwrap(), expected);
     }
 
     #[test]

--- a/crates/aish-llm/src/session.rs
+++ b/crates/aish-llm/src/session.rs
@@ -2991,6 +2991,20 @@ mod tests {
                 "old noisy output\n".repeat(400)
             ),
         ));
+        let mut assistant_call2 = ChatMessage::assistant("");
+        assistant_call2.tool_calls = Some(vec![ToolCall {
+            id: "call-old-2".to_string(),
+            name: "bash".to_string(),
+            arguments: "{}".to_string(),
+        }]);
+        msgs.push(assistant_call2);
+        msgs.push(ChatMessage::tool_result(
+            "call-old-2",
+            format!(
+                "<stdout>{}</stdout>\n<return_code>1</return_code>",
+                "more old noisy output\n".repeat(400)
+            ),
+        ));
         msgs.push(make_msg("user", "recent request"));
         msgs.push(make_msg("assistant", "recent answer"));
 

--- a/crates/aish-llm/src/types.rs
+++ b/crates/aish-llm/src/types.rs
@@ -338,7 +338,11 @@ impl ChatMessage {
     pub fn tool_result(tool_call_id: impl Into<String>, content: impl Into<String>) -> Self {
         Self {
             role: "tool".into(),
-            content: Some(MessageContent::Text(content.into())),
+            // Cap at construction so the exact bytes that go on the wire
+            // are the bytes persisted for later-turn replay — a later
+            // truncate would silently diverge the replayed prefix from
+            // what the provider already saw and bust its prompt cache.
+            content: Some(MessageContent::Text(cap_tool_output(content))),
             tool_calls: None,
             tool_call_id: Some(tool_call_id.into()),
             name: None,
@@ -402,6 +406,26 @@ pub struct ProcessResult {
     /// tool_result pairs). Callers should extend their conversation
     /// history with these to preserve tool execution context.
     pub new_messages: Vec<ChatMessage>,
+}
+
+/// Hard cap for a single tool result entering the message stream.
+///
+/// Applied once, at message construction, so the wire bytes and the
+/// persisted replay bytes stay identical (prompt-cache prefix stability).
+pub const MAX_TOOL_RESULT_BYTES: usize = 4 * 1024;
+
+/// Cap a tool-result output at [`MAX_TOOL_RESULT_BYTES`] on a UTF-8
+/// character boundary, appending an explicit truncation marker.
+pub fn cap_tool_output(content: impl Into<String>) -> String {
+    let content = content.into();
+    if content.len() <= MAX_TOOL_RESULT_BYTES {
+        return content;
+    }
+    let mut end = MAX_TOOL_RESULT_BYTES;
+    while end > 0 && !content.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...(truncated)", &content[..end])
 }
 
 /// Specification of a function tool exposed to the LLM.

--- a/crates/aish-session/src/models.rs
+++ b/crates/aish-session/src/models.rs
@@ -26,6 +26,10 @@ pub struct SessionContextMessage {
     pub memory_type: MemoryType,
     pub name: Option<String>,
     pub tool_call_id: Option<String>,
+    /// Tool calls attached to an assistant message. Optional so snapshots
+    /// persisted before this field existed still deserialize.
+    #[serde(default)]
+    pub tool_calls: Option<Vec<aish_core::ContextToolCall>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/crates/aish-session/src/models.rs
+++ b/crates/aish-session/src/models.rs
@@ -30,6 +30,9 @@ pub struct SessionContextMessage {
     /// persisted before this field existed still deserialize.
     #[serde(default)]
     pub tool_calls: Option<Vec<aish_core::ContextToolCall>>,
+    /// Reasoning content echoed back by reasoning-model providers.
+    #[serde(default)]
+    pub reasoning_content: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/crates/aish-session/src/store.rs
+++ b/crates/aish-session/src/store.rs
@@ -738,6 +738,7 @@ mod tests {
                 name: None,
                 tool_call_id: None,
                 tool_calls: None,
+                reasoning_content: None,
             }],
             updated_at: Some(Utc::now()),
         };
@@ -972,6 +973,7 @@ mod tests {
                 name: None,
                 tool_call_id: None,
                 tool_calls: None,
+                reasoning_content: None,
             }],
             updated_at: Some(Utc::now()),
         };

--- a/crates/aish-session/src/store.rs
+++ b/crates/aish-session/src/store.rs
@@ -699,6 +699,7 @@ mod tests {
                 memory_type: MemoryType::Llm,
                 name: None,
                 tool_call_id: None,
+                tool_calls: None,
             }],
             updated_at: Some(Utc::now()),
         };
@@ -932,6 +933,7 @@ mod tests {
                 memory_type: MemoryType::Llm,
                 name: None,
                 tool_call_id: None,
+                tool_calls: None,
             }],
             updated_at: Some(Utc::now()),
         };

--- a/crates/aish-session/src/store.rs
+++ b/crates/aish-session/src/store.rs
@@ -96,6 +96,13 @@ impl SessionStore {
             AishError::Session(format!("failed to open session db at {:?}: {e}", db_path))
         })?;
 
+        // The database holds conversation snapshots (including tool outputs
+        // and command arguments) and audit events; SQLite creates it with
+        // the process umask (typically 0644). Tighten to owner-only, also
+        // covering pre-existing files from older builds and the WAL/SHM
+        // siblings SQLite creates at runtime.
+        restrict_db_permissions(&db_path);
+
         // Enable WAL for better concurrent read performance.
         conn.execute_batch("PRAGMA journal_mode=WAL;")
             .map_err(|e| AishError::Session(format!("failed to enable WAL mode: {e}")))?;
@@ -605,6 +612,37 @@ fn row_to_session_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRec
     })
 }
 
+/// Restrict the session database (and its WAL/SHM siblings) to owner-only
+/// permissions on Unix. Best-effort: failures are logged, not fatal — the
+/// store still works if the filesystem rejects chmod.
+#[cfg(unix)]
+fn restrict_db_permissions(db_path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut candidates = vec![db_path.to_path_buf()];
+    if let Some(stem) = db_path.file_name().and_then(|n| n.to_str()) {
+        let parent = db_path.parent().unwrap_or_else(|| Path::new("."));
+        candidates.push(parent.join(format!("{stem}-wal")));
+        candidates.push(parent.join(format!("{stem}-shm")));
+    }
+    for path in candidates {
+        let Ok(meta) = std::fs::metadata(&path) else {
+            continue;
+        };
+        let mode = meta.permissions().mode();
+        if mode & 0o077 != 0 {
+            let mut perms = meta.permissions();
+            perms.set_mode(mode & 0o600);
+            if let Err(e) = std::fs::set_permissions(&path, perms) {
+                tracing::warn!(path = ?path, error = %e, "failed to restrict session db permissions");
+            }
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn restrict_db_permissions(_db_path: &Path) {}
+
 /// Add columns introduced after the initial schema (`parent_session_uuid`,
 /// `branch_point_message_id`) to databases created by older builds. Idempotent:
 /// each column is added only when missing, detected via `PRAGMA table_info`.
@@ -1097,5 +1135,33 @@ mod tests {
         let roots = store.session_roots().unwrap();
         assert_eq!(roots.len(), 1);
         assert_eq!(roots[0].session_uuid, "legacy-1");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn session_db_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("sessions.db");
+        let _store = SessionStore::open(Some(&db_path)).unwrap();
+        let mode = std::fs::metadata(&db_path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "newly created db must be owner-only");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preexisting_world_readable_db_is_tightened() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("sessions.db");
+        // Simulate a database created by an older build with default umask.
+        std::fs::write(&db_path, []).unwrap();
+        std::fs::set_permissions(&db_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let _store = SessionStore::open(Some(&db_path)).unwrap();
+        let mode = std::fs::metadata(&db_path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "existing loose db must be tightened");
     }
 }

--- a/crates/aish-shell/src/ai_handler.rs
+++ b/crates/aish-shell/src/ai_handler.rs
@@ -177,6 +177,9 @@ pub struct AiHandler {
     prompt_manager: PromptManager,
     token_store: crate::token_store::TokenUsageStore,
     auto_search: bool,
+    /// Optional secret redactor applied to tool outputs before they enter
+    /// the persistent context (memory + session snapshot).
+    secret_redactor: Option<Arc<dyn Fn(&str) -> String + Send + Sync>>,
 }
 
 impl AiHandler {
@@ -209,7 +212,13 @@ impl AiHandler {
                 crate::token_store::TokenUsageStore::default_path(),
             ),
             auto_search,
+            secret_redactor: None,
         }
+    }
+
+    /// Set the secret redactor used before persisting tool outputs.
+    pub fn set_secret_redactor(&mut self, redactor: Arc<dyn Fn(&str) -> String + Send + Sync>) {
+        self.secret_redactor = Some(redactor);
     }
 
     /// Set the event callback for real-time LLM streaming display.
@@ -262,6 +271,7 @@ impl AiHandler {
                 memory_type: message.memory_type,
                 name: message.name,
                 tool_call_id: message.tool_call_id,
+                tool_calls: message.tool_calls,
             })
             .collect()
     }
@@ -275,6 +285,7 @@ impl AiHandler {
                 memory_type: message.memory_type,
                 name: message.name,
                 tool_call_id: message.tool_call_id,
+                tool_calls: message.tool_calls,
             })
             .collect();
         self.restore_context_messages(restored);
@@ -534,9 +545,18 @@ impl AiHandler {
             .await?;
         let response = process_result.text;
 
-        // Step 7: Store the exchange in context
+        // Step 7: Store the exchange in context.
+        //
+        // For turns with tool calls, persist the full intermediate history
+        // (assistant tool_calls + tool results) so the next turn — and a
+        // resumed session — can see what the AI executed. `new_messages`
+        // never contains the final assistant text, so the response is
+        // appended unconditionally without duplication.
         self.context_manager
             .add_message("user", &question_processed, MemoryType::Llm);
+        for ctx_msg in self.redact_turn_messages(&process_result.new_messages) {
+            self.context_manager.add_memory(MemoryType::Llm, ctx_msg);
+        }
         self.context_manager
             .add_message("assistant", &response, MemoryType::Llm);
         self.context_manager.trim();
@@ -548,6 +568,100 @@ impl AiHandler {
         self.persist_token_usage();
 
         Ok(response)
+    }
+
+    /// Convert a turn's intermediate ChatMessages into persistable
+    /// ContextMessages, applying secret redaction and a size cap to tool
+    /// results before they enter long-lived context.
+    fn redact_turn_messages(&self, messages: &[ChatMessage]) -> Vec<ContextMessage> {
+        const MAX_TOOL_OUTPUT: usize = 4 * 1024;
+
+        // Write-time pairing repair: only persist tool_calls that actually
+        // received results, and drop orphan results, so the stored context
+        // is self-consistent without relying on the send-path sanitizer.
+        let called: std::collections::HashSet<&str> = messages
+            .iter()
+            .filter(|m| m.role == "assistant")
+            .flat_map(|m| m.tool_calls.iter().flatten())
+            .map(|tc| tc.id.as_str())
+            .collect();
+        let answered: std::collections::HashSet<&str> = messages
+            .iter()
+            .filter(|m| m.role == "tool")
+            .filter_map(|m| m.tool_call_id.as_deref())
+            .filter(|id| called.contains(id))
+            .collect();
+
+        messages
+            .iter()
+            .filter(|m| m.content.is_none() || m.text_content().is_some())
+            .filter(|m| {
+                m.role != "tool"
+                    || m.tool_call_id
+                        .as_deref()
+                        .is_some_and(|id| called.contains(id))
+            })
+            .filter_map(|m| {
+                let kept_calls: Option<Vec<aish_core::ContextToolCall>> =
+                    m.tool_calls.as_ref().map(|calls| {
+                        calls
+                            .iter()
+                            .filter(|tc| answered.contains(tc.id.as_str()))
+                            .map(|tc| {
+                                // Arguments routinely echo secrets (e.g.
+                                // bearer tokens inside bash commands); the
+                                // audit path redacts them (session.rs
+                                // execute_tool), so must the persistence
+                                // path. Redaction is string-preserving, so
+                                // the JSON arguments stay valid.
+                                let arguments = match &self.secret_redactor {
+                                    Some(redactor) => redactor(&tc.arguments),
+                                    None => tc.arguments.clone(),
+                                };
+                                aish_core::ContextToolCall {
+                                    id: tc.id.clone(),
+                                    name: tc.name.clone(),
+                                    arguments,
+                                }
+                            })
+                            .collect()
+                    });
+                if m.role == "assistant"
+                    && m.tool_calls.as_ref().is_some_and(|c| !c.is_empty())
+                    && kept_calls.as_ref().is_none_or(|c| c.is_empty())
+                    && m.text_content().is_none_or(|t| t.is_empty())
+                {
+                    return None;
+                }
+
+                // Non-text content (image blocks) cannot round-trip through
+                // ContextMessage and is skipped above. Tool-call assistant
+                // messages commonly have null content — keep them with an
+                // empty string so their tool_calls stay paired with results.
+                let mut content = m.text_content().unwrap_or("").to_string();
+                if m.role == "tool" {
+                    if let Some(redactor) = &self.secret_redactor {
+                        content = redactor(&content);
+                    }
+                    if content.len() > MAX_TOOL_OUTPUT {
+                        let mut end = MAX_TOOL_OUTPUT;
+                        while end > 0 && !content.is_char_boundary(end) {
+                            end -= 1;
+                        }
+                        content = format!("{}...(truncated)", &content[..end]);
+                    }
+                }
+
+                Some(ContextMessage {
+                    role: m.role.clone(),
+                    content,
+                    memory_type: MemoryType::Llm,
+                    name: m.name.clone(),
+                    tool_call_id: m.tool_call_id.clone(),
+                    tool_calls: kept_calls.filter(|c| !c.is_empty()),
+                })
+            })
+            .collect()
     }
 
     /// Handle error correction: analyze a failed command and suggest a fix.
@@ -904,28 +1018,28 @@ If the user's request is NOT covered by any loaded skill above, follow this work
 
     /// Build context messages from the context manager into ChatMessage format.
     fn build_context_messages(&self) -> Vec<ChatMessage> {
+        // Map from the typed snapshot so tool_call pairing survives the
+        // round-trip into the next provider request.
         self.context_manager
-            .as_messages()
-            .iter()
-            .map(|v| {
-                let role = v
-                    .get("role")
-                    .and_then(|r| r.as_str())
-                    .unwrap_or("user")
-                    .to_string();
-                let content = v
-                    .get("content")
-                    .and_then(|c| c.as_str())
-                    .map(|s| MessageContent::Text(s.to_string()));
-                ChatMessage {
-                    role,
-                    content,
-                    tool_calls: None,
-                    tool_call_id: None,
-                    name: None,
-                    reasoning_content: None,
-                    cache_control: None,
-                }
+            .messages_snapshot()
+            .into_iter()
+            .map(|m| ChatMessage {
+                role: m.role,
+                content: Some(MessageContent::Text(m.content)),
+                tool_calls: m.tool_calls.map(|calls| {
+                    calls
+                        .into_iter()
+                        .map(|tc| aish_llm::ToolCall {
+                            id: tc.id,
+                            name: tc.name,
+                            arguments: tc.arguments,
+                        })
+                        .collect()
+                }),
+                tool_call_id: m.tool_call_id,
+                name: m.name,
+                reasoning_content: None,
+                cache_control: None,
             })
             .collect()
     }
@@ -1983,5 +2097,156 @@ mod tests {
             block_reason: Some("blocked".into()),
         }]);
         assert_eq!(unknown, FailureDiagnoseConclusion::CannotDetermine);
+    }
+
+    fn test_handler() -> AiHandler {
+        AiHandler::new(
+            LlmSession::new("http://localhost", "key", "model", None, None),
+            Arc::new(Mutex::new(None)),
+            SkillManager::new(),
+            MemoryConfig::default(),
+            50,
+            50,
+            None,
+            ContextBudgetPolicy::default(),
+            false,
+        )
+    }
+
+    fn turn_with_tool_call() -> Vec<ChatMessage> {
+        let mut assistant = ChatMessage::assistant("");
+        assistant.tool_calls = Some(vec![aish_llm::ToolCall {
+            id: "call_1".to_string(),
+            name: "bash".to_string(),
+            arguments: r#"{"command":"printf '__AISH_TOOL_CONTEXT__\\n'}"#.to_string(),
+        }]);
+        vec![
+            assistant,
+            ChatMessage::tool_result("call_1", "__AISH_TOOL_CONTEXT__\nSECRET_TOKEN"),
+        ]
+    }
+
+    /// Issue #491 core scenario: after a tool turn, the next turn's context
+    /// messages must contain the assistant tool_call and its paired tool
+    /// result — redacted — so the model can see what it just executed.
+    #[test]
+    fn tool_turn_round_trips_into_next_context() {
+        let mut handler = test_handler();
+        handler.set_secret_redactor(Arc::new(|text: &str| {
+            text.replace("SECRET_TOKEN", "[REDACTED]")
+        }));
+
+        // Persist the turn exactly like handle_question does.
+        handler
+            .context_manager
+            .add_message("user", "run the marker command", MemoryType::Llm);
+        for msg in handler.redact_turn_messages(&turn_with_tool_call()) {
+            handler.context_manager.add_memory(MemoryType::Llm, msg);
+        }
+
+        let context = handler.build_context_messages();
+        let roles: Vec<&str> = context.iter().map(|m| m.role.as_str()).collect();
+        assert_eq!(roles, vec!["user", "assistant", "tool"]);
+
+        let calls = context[1]
+            .tool_calls
+            .as_ref()
+            .expect("tool_calls preserved");
+        assert_eq!(calls[0].id, "call_1");
+        assert_eq!(calls[0].name, "bash");
+        assert_eq!(context[2].tool_call_id.as_deref(), Some("call_1"));
+        assert!(context[2]
+            .text_content()
+            .unwrap()
+            .contains("__AISH_TOOL_CONTEXT__"));
+        assert!(context[2].text_content().unwrap().contains("[REDACTED]"));
+        assert!(!context[2].text_content().unwrap().contains("SECRET_TOKEN"));
+    }
+
+    #[test]
+    fn oversized_tool_output_is_truncated_before_persisting() {
+        let handler = test_handler();
+        let messages = vec![
+            turn_with_tool_call()[0].clone(),
+            ChatMessage::tool_result("call_1", "x".repeat(10 * 1024)),
+        ];
+        let persisted = handler.redact_turn_messages(&messages);
+        assert!(persisted[1].content.len() <= 4 * 1024 + 32);
+        assert!(persisted[1].content.ends_with("...(truncated)"));
+    }
+
+    #[test]
+    fn session_snapshot_preserves_tool_call_pairing() {
+        let mut handler = test_handler();
+        handler
+            .context_manager
+            .add_message("user", "run the marker command", MemoryType::Llm);
+        for msg in handler.redact_turn_messages(&turn_with_tool_call()) {
+            handler.context_manager.add_memory(MemoryType::Llm, msg);
+        }
+
+        // Export → restore → rebuild, as /resume does.
+        let snapshot = handler.export_session_context_snapshot();
+        let mut restored = test_handler();
+        restored.restore_session_context_snapshot(snapshot);
+        let context = restored.build_context_messages();
+
+        assert!(context[1].tool_calls.is_some());
+        assert_eq!(context[2].tool_call_id.as_deref(), Some("call_1"));
+    }
+
+    #[test]
+    fn tool_call_arguments_are_redacted_before_persisting() {
+        let mut handler = test_handler();
+        handler.set_secret_redactor(Arc::new(|text: &str| {
+            text.replace("SECRET_TOKEN", "[REDACTED]")
+        }));
+        let mut messages = turn_with_tool_call();
+        messages[0].tool_calls.as_mut().unwrap()[0].arguments =
+            r#"{"command":"curl -H 'Authorization: Bearer SECRET_TOKEN' http://x"}"#.to_string();
+
+        let persisted = handler.redact_turn_messages(&messages);
+        let args = persisted[0].tool_calls.as_ref().unwrap()[0]
+            .arguments
+            .clone();
+        assert!(args.contains("[REDACTED]"));
+        assert!(!args.contains("SECRET_TOKEN"));
+        // String-preserving redaction keeps the JSON arguments valid.
+        assert!(serde_json::from_str::<serde_json::Value>(&args).is_ok());
+    }
+
+    #[test]
+    fn write_time_persists_only_paired_tool_calls() {
+        let handler = test_handler();
+        let mut messages = turn_with_tool_call();
+        // Second declared call never received a result.
+        messages[0]
+            .tool_calls
+            .as_mut()
+            .unwrap()
+            .push(aish_llm::ToolCall {
+                id: "call_never".to_string(),
+                name: "read".to_string(),
+                arguments: "{}".to_string(),
+            });
+        // Orphan result without any assistant call.
+        messages.push(ChatMessage::tool_result("call_orphan", "stray"));
+
+        let persisted = handler.redact_turn_messages(&messages);
+        let roles: Vec<&str> = persisted.iter().map(|m| m.role.as_str()).collect();
+        assert_eq!(roles, vec!["assistant", "tool"]);
+        let calls = persisted[0].tool_calls.as_ref().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call_1");
+        assert_eq!(persisted[1].tool_call_id.as_deref(), Some("call_1"));
+    }
+
+    #[test]
+    fn empty_assistant_with_only_unanswered_calls_is_dropped() {
+        let handler = test_handler();
+        let mut messages = turn_with_tool_call();
+        messages.pop(); // remove the tool result
+        let persisted = handler.redact_turn_messages(&messages);
+        assert!(persisted.is_empty());
     }
 }

--- a/crates/aish-shell/src/ai_handler.rs
+++ b/crates/aish-shell/src/ai_handler.rs
@@ -574,8 +574,6 @@ impl AiHandler {
     /// ContextMessages, applying secret redaction and a size cap to tool
     /// results before they enter long-lived context.
     fn redact_turn_messages(&self, messages: &[ChatMessage]) -> Vec<ContextMessage> {
-        const MAX_TOOL_OUTPUT: usize = 4 * 1024;
-
         // Write-time pairing repair: only persist tool_calls that actually
         // received results, and drop orphan results, so the stored context
         // is self-consistent without relying on the send-path sanitizer.
@@ -643,13 +641,15 @@ impl AiHandler {
                     if let Some(redactor) = &self.secret_redactor {
                         content = redactor(&content);
                     }
-                    if content.len() > MAX_TOOL_OUTPUT {
-                        let mut end = MAX_TOOL_OUTPUT;
-                        while end > 0 && !content.is_char_boundary(end) {
-                            end -= 1;
-                        }
-                        content = format!("{}...(truncated)", &content[..end]);
-                    }
+                    // Backstop only: construction already capped the wire
+                    // bytes (ChatMessage::tool_result), so for fresh turns
+                    // this is a no-op and replay stays byte-identical. It
+                    // still guards tool outputs restored from legacy
+                    // snapshots that predate the construction-time cap.
+                    // Redaction itself is the one accepted divergence:
+                    // secrets must not persist even at the cost of a cache
+                    // re-write for that (rare) turn.
+                    content = aish_llm::cap_tool_output(content);
                 }
 
                 Some(ContextMessage {
@@ -1023,23 +1023,36 @@ If the user's request is NOT covered by any loaded skill above, follow this work
         self.context_manager
             .messages_snapshot()
             .into_iter()
-            .map(|m| ChatMessage {
-                role: m.role,
-                content: Some(MessageContent::Text(m.content)),
-                tool_calls: m.tool_calls.map(|calls| {
-                    calls
-                        .into_iter()
-                        .map(|tc| aish_llm::ToolCall {
-                            id: tc.id,
-                            name: tc.name,
-                            arguments: tc.arguments,
-                        })
-                        .collect()
-                }),
-                tool_call_id: m.tool_call_id,
-                name: m.name,
-                reasoning_content: None,
-                cache_control: None,
+            .map(|m| {
+                let has_tool_calls = m.tool_calls.as_ref().is_some_and(|c| !c.is_empty());
+                let role = m.role.clone();
+                // An assistant tool-call message with empty content was
+                // sent with content ABSENT (null) during the live turn;
+                // replay it the same way so the serialized prefix stays
+                // byte-identical and the provider prompt cache holds.
+                let content = if m.content.is_empty() && role == "assistant" && has_tool_calls {
+                    None
+                } else {
+                    Some(MessageContent::Text(m.content.clone()))
+                };
+                ChatMessage {
+                    role,
+                    content,
+                    tool_calls: m.tool_calls.map(|calls| {
+                        calls
+                            .into_iter()
+                            .map(|tc| aish_llm::ToolCall {
+                                id: tc.id,
+                                name: tc.name,
+                                arguments: tc.arguments,
+                            })
+                            .collect()
+                    }),
+                    tool_call_id: m.tool_call_id,
+                    name: m.name,
+                    reasoning_content: None,
+                    cache_control: None,
+                }
             })
             .collect()
     }
@@ -2115,6 +2128,8 @@ mod tests {
 
     fn turn_with_tool_call() -> Vec<ChatMessage> {
         let mut assistant = ChatMessage::assistant("");
+        // Live streaming turns produce null content on tool-call messages.
+        assistant.content = None;
         assistant.tool_calls = Some(vec![aish_llm::ToolCall {
             id: "call_1".to_string(),
             name: "bash".to_string(),
@@ -2193,6 +2208,63 @@ mod tests {
 
         assert!(context[1].tool_calls.is_some());
         assert_eq!(context[2].tool_call_id.as_deref(), Some("call_1"));
+    }
+
+    /// Prompt-cache invariant: the replayed turn must serialize to the
+    /// exact bytes the provider already saw during the live turn (no
+    /// redactor set, output under the construction-time cap). Any
+    /// divergence here busts the provider prefix cache at that point.
+    #[test]
+    fn replayed_turn_is_byte_identical_to_wire() {
+        let mut handler = test_handler();
+        let user = ChatMessage::user("run the marker command");
+        let turn = turn_with_tool_call();
+
+        // What process_input actually sent during the live tool loop.
+        let wire: Vec<ChatMessage> = vec![user.clone(), turn[0].clone(), turn[1].clone()];
+
+        // Persist exactly like handle_question (final assistant text
+        // appended after the replayed prefix, as turn N+1 sends it), then
+        // rebuild and compare the replayed turn-N prefix.
+        handler
+            .context_manager
+            .add_message("user", "run the marker command", MemoryType::Llm);
+        for msg in handler.redact_turn_messages(&turn) {
+            handler.context_manager.add_memory(MemoryType::Llm, msg);
+        }
+        handler
+            .context_manager
+            .add_message("assistant", "CHECK_DONE", MemoryType::Llm);
+        let replayed = handler.build_context_messages();
+        let replayed_prefix: Vec<ChatMessage> = replayed[..wire.len()].to_vec();
+
+        assert_eq!(
+            serde_json::to_string(&wire).unwrap(),
+            serde_json::to_string(&replayed_prefix).unwrap(),
+            "replayed turn-N prefix must be byte-identical to the wire bytes"
+        );
+        assert_eq!(replayed[wire.len()].text_content(), Some("CHECK_DONE"));
+    }
+
+    /// Large outputs are capped at construction, so even oversized tool
+    /// results replay byte-identically (no persist-time re-truncation).
+    #[test]
+    fn oversized_tool_output_replays_byte_identically() {
+        let mut handler = test_handler();
+        let mut turn = turn_with_tool_call();
+        turn[1] = ChatMessage::tool_result("call_1", "y".repeat(64 * 1024));
+
+        let wire: Vec<ChatMessage> = turn.clone();
+        for msg in handler.redact_turn_messages(&turn) {
+            handler.context_manager.add_memory(MemoryType::Llm, msg);
+        }
+        let replayed = handler.build_context_messages();
+
+        assert!(wire[1].text_content().unwrap().len() <= 4 * 1024 + 32);
+        assert_eq!(
+            serde_json::to_string(&wire).unwrap(),
+            serde_json::to_string(&replayed).unwrap()
+        );
     }
 
     #[test]

--- a/crates/aish-shell/src/ai_handler.rs
+++ b/crates/aish-shell/src/ai_handler.rs
@@ -488,13 +488,25 @@ impl AiHandler {
         }
 
         // Step 5: Build context and system messages.
-        // Split system message into static core (cached) and dynamic env block.
-        // The static core goes as the main system_message; the env block is
-        // prepended to context_messages so the cache breakpoint lands on the
-        // stable prefix.
+        // The static core goes as the main system_message (stable prefix).
+        // The dynamic env block (cwd) is appended as a persistent message
+        // at the natural turn position — right before this turn's user
+        // message — so it replays byte-identically next turn. Placing it
+        // in front of the history instead would bust the whole prefix
+        // whenever cwd changes.
         let (static_core, env_block) = self.system_message_parts();
-        let mut context_messages = self.build_context_messages();
-        context_messages.insert(0, ChatMessage::system(&env_block));
+        self.context_manager.add_memory(
+            MemoryType::Llm,
+            ContextMessage {
+                role: "system".to_string(),
+                content: env_block,
+                memory_type: MemoryType::Llm,
+                name: None,
+                tool_call_id: None,
+                tool_calls: None,
+            },
+        );
+        let context_messages = self.build_context_messages();
 
         // Step 6: Extract images from the question text
         let extracted = crate::image::extract_images(&question_processed);
@@ -544,6 +556,17 @@ impl AiHandler {
             .process_input(&user_msg, &context_messages, Some(&static_core), true)
             .await?;
         let response = process_result.text;
+
+        // Surface the persistent-layer compaction mode to the UI (the send
+        // path no longer compacts outgoing copies).
+        let compaction_mode: Option<&'static str> = if compact_report.full_compact.is_some() {
+            Some("full_compact")
+        } else if compact_report.microcompact.changed_messages > 0 {
+            Some("microcompact")
+        } else {
+            None
+        };
+        self.llm_session.set_last_turn_compaction(compaction_mode);
 
         // Step 7: Store the exchange in context.
         //
@@ -862,9 +885,10 @@ impl AiHandler {
             };
             let results = mm.recall(&search_query, self.memory_config.recall_limit);
             if results.is_empty() {
-                // No results — clear stale recall to keep context clean
-                self.context_manager
-                    .inject_knowledge_stable("memory_recall", "");
+                // Append-only: keep previous recall blocks in history as
+                // plain turn-scoped facts. Deleting the old block would
+                // open a hole mid-history and bust the provider prefix
+                // cache from that point on.
                 return;
             }
 
@@ -915,11 +939,22 @@ impl AiHandler {
                         .join(", ")
                 )
             };
-
-            // Stable injection — only replaces if content actually changed,
-            // preserving cache prefix stability across calls.
-            self.context_manager
-                .inject_knowledge_stable("memory_recall", &content);
+            // Append the recall at the natural turn position (right before
+            // this turn's user message) instead of replacing a stable-slot
+            // message. The wire bytes of every past turn stay identical on
+            // replay, so the provider prefix cache holds; old recall blocks
+            // are compacted later like any other low-value output.
+            self.context_manager.add_memory(
+                MemoryType::Llm,
+                ContextMessage {
+                    role: "system".to_string(),
+                    content,
+                    memory_type: MemoryType::Llm,
+                    name: None,
+                    tool_call_id: None,
+                    tool_calls: None,
+                },
+            );
         }
     }
 

--- a/crates/aish-shell/src/ai_handler.rs
+++ b/crates/aish-shell/src/ai_handler.rs
@@ -272,6 +272,7 @@ impl AiHandler {
                 name: message.name,
                 tool_call_id: message.tool_call_id,
                 tool_calls: message.tool_calls,
+                reasoning_content: message.reasoning_content,
             })
             .collect()
     }
@@ -286,6 +287,7 @@ impl AiHandler {
                 name: message.name,
                 tool_call_id: message.tool_call_id,
                 tool_calls: message.tool_calls,
+                reasoning_content: message.reasoning_content,
             })
             .collect();
         self.restore_context_messages(restored);
@@ -515,6 +517,7 @@ impl AiHandler {
                     name: None,
                     tool_call_id: None,
                     tool_calls: None,
+                    reasoning_content: None,
                 },
             );
         }
@@ -694,6 +697,17 @@ impl AiHandler {
                     name: m.name.clone(),
                     tool_call_id: m.tool_call_id.clone(),
                     tool_calls: kept_calls.filter(|c| !c.is_empty()),
+                    // Reasoning content must replay byte-identically or the
+                    // provider prompt cache busts at this message on every
+                    // following turn (observed with DeepSeek-style
+                    // reasoning models). Redaction is string-preserving;
+                    // no truncation so replayed bytes equal wire bytes.
+                    reasoning_content: m.reasoning_content.as_ref().map(|r| {
+                        match &self.secret_redactor {
+                            Some(redactor) => redactor(r),
+                            None => r.clone(),
+                        }
+                    }),
                 })
             })
             .collect()
@@ -973,6 +987,7 @@ impl AiHandler {
                         name: None,
                         tool_call_id: None,
                         tool_calls: None,
+                        reasoning_content: None,
                     },
                 );
             }
@@ -1106,7 +1121,7 @@ If the user's request is NOT covered by any loaded skill above, follow this work
                     }),
                     tool_call_id: m.tool_call_id,
                     name: m.name,
-                    reasoning_content: None,
+                    reasoning_content: m.reasoning_content,
                     cache_control: None,
                 }
             })
@@ -2376,5 +2391,74 @@ mod tests {
         messages.pop(); // remove the tool result
         let persisted = handler.redact_turn_messages(&messages);
         assert!(persisted.is_empty());
+    }
+
+    #[test]
+    fn env_block_persists_once_for_unchanged_cwd() {
+        // Two turns with identical env blocks must append only one block.
+        let mut handler = test_handler();
+        let env = "\n**Environment Update:**\n- Current directory: /w";
+
+        let count_env = |h: &AiHandler| {
+            h.context_manager
+                .messages_snapshot()
+                .iter()
+                .filter(|m| m.content.contains("**Environment Update:**"))
+                .count()
+        };
+
+        for _ in 0..2 {
+            let last_unchanged = handler
+                .context_manager
+                .messages_snapshot()
+                .iter()
+                .rev()
+                .find(|m| m.role == "system" && m.content.contains("**Environment Update:**"))
+                .is_some_and(|m| m.content == env);
+            if !last_unchanged {
+                handler.context_manager.add_memory(
+                    MemoryType::Llm,
+                    ContextMessage {
+                        role: "system".to_string(),
+                        content: env.to_string(),
+                        memory_type: MemoryType::Llm,
+                        name: None,
+                        tool_call_id: None,
+                        tool_calls: None,
+                        reasoning_content: None,
+                    },
+                );
+            }
+            handler
+                .context_manager
+                .add_message("user", "q", MemoryType::Llm);
+        }
+        assert_eq!(count_env(&handler), 1);
+    }
+
+    /// Reasoning models (DeepSeek-style) require reasoning_content to be
+    /// echoed back; persisting and replaying it verbatim keeps the prefix
+    /// cache intact (observed busting every turn otherwise).
+    #[test]
+    fn reasoning_content_round_trips_byte_identically() {
+        let mut handler = test_handler();
+        let mut turn = turn_with_tool_call();
+        turn[0].reasoning_content = Some("用户想执行标记命令，我先调用 bash。".to_string());
+
+        let wire: Vec<ChatMessage> = turn.clone();
+        for msg in handler.redact_turn_messages(&turn) {
+            handler.context_manager.add_memory(MemoryType::Llm, msg);
+        }
+        let replayed = handler.build_context_messages();
+
+        assert_eq!(
+            serde_json::to_string(&wire).unwrap(),
+            serde_json::to_string(&replayed).unwrap(),
+            "replayed reasoning must be byte-identical to wire bytes"
+        );
+        assert_eq!(
+            replayed[0].reasoning_content.as_deref(),
+            Some("用户想执行标记命令，我先调用 bash。")
+        );
     }
 }

--- a/crates/aish-shell/src/ai_handler.rs
+++ b/crates/aish-shell/src/ai_handler.rs
@@ -495,17 +495,29 @@ impl AiHandler {
         // in front of the history instead would bust the whole prefix
         // whenever cwd changes.
         let (static_core, env_block) = self.system_message_parts();
-        self.context_manager.add_memory(
-            MemoryType::Llm,
-            ContextMessage {
-                role: "system".to_string(),
-                content: env_block,
-                memory_type: MemoryType::Llm,
-                name: None,
-                tool_call_id: None,
-                tool_calls: None,
-            },
-        );
+        // Append-only with consecutive dedupe: skip when cwd is unchanged
+        // so history does not accumulate identical env blocks; a change
+        // appends a new block at the natural turn position.
+        let last_env_unchanged = self
+            .context_manager
+            .messages_snapshot()
+            .iter()
+            .rev()
+            .find(|m| m.role == "system" && m.content.contains("**Environment Update:**"))
+            .is_some_and(|m| m.content == env_block);
+        if !last_env_unchanged {
+            self.context_manager.add_memory(
+                MemoryType::Llm,
+                ContextMessage {
+                    role: "system".to_string(),
+                    content: env_block,
+                    memory_type: MemoryType::Llm,
+                    name: None,
+                    tool_call_id: None,
+                    tool_calls: None,
+                },
+            );
+        }
         let context_messages = self.build_context_messages();
 
         // Step 6: Extract images from the question text
@@ -939,22 +951,31 @@ impl AiHandler {
                         .join(", ")
                 )
             };
-            // Append the recall at the natural turn position (right before
-            // this turn's user message) instead of replacing a stable-slot
-            // message. The wire bytes of every past turn stay identical on
-            // replay, so the provider prefix cache holds; old recall blocks
-            // are compacted later like any other low-value output.
-            self.context_manager.add_memory(
-                MemoryType::Llm,
-                ContextMessage {
-                    role: "system".to_string(),
-                    content,
-                    memory_type: MemoryType::Llm,
-                    name: None,
-                    tool_call_id: None,
-                    tool_calls: None,
-                },
-            );
+            // Append-only with consecutive dedupe: skip when the recall
+            // equals the most recent stored recall (same memory set) so
+            // repeated same-domain questions do not accumulate identical
+            // blocks. Old recall blocks age out via transient-system
+            // compaction.
+            let last_recall_unchanged = self
+                .context_manager
+                .messages_snapshot()
+                .iter()
+                .rev()
+                .find(|m| m.role == "system" && m.content.contains("<long-term-memory"))
+                .is_some_and(|m| m.content == content);
+            if !last_recall_unchanged {
+                self.context_manager.add_memory(
+                    MemoryType::Llm,
+                    ContextMessage {
+                        role: "system".to_string(),
+                        content,
+                        memory_type: MemoryType::Llm,
+                        name: None,
+                        tool_call_id: None,
+                        tool_calls: None,
+                    },
+                );
+            }
         }
     }
 

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -2072,7 +2072,7 @@ impl AishShell {
         llm_session.set_iteration_limit_callback(iteration_limit_callback);
 
         // Build AI handler with all subsystems
-        let ai_handler = AiHandler::new(
+        let mut ai_handler = AiHandler::new(
             llm_session,
             memory_manager.clone(),
             skill_manager,
@@ -2083,6 +2083,15 @@ impl AishShell {
             context_budget_policy,
             config.skills.auto_search,
         );
+
+        // Redact secrets from tool outputs before they enter persistent
+        // LLM context (same scanner as the audit path).
+        {
+            let scanner = security_manager.secret_scanner().clone();
+            ai_handler.set_secret_redactor(Arc::new(move |text: &str| {
+                aish_security::secret::redact_secrets(text, &scanner)
+            }));
+        }
 
         // Note: event_callback is already set on the LlmSession before AiHandler takes ownership
 


### PR DESCRIPTION
Fixes #491

## Summary

The main session stored only the user question and the final assistant text at the end of each AI turn, discarding `ProcessResult.new_messages` (assistant tool_calls + tool results). An adjacent follow-up ("what command did you just run?") could not see the just-executed tool calls and often misattributed them to the user. The SSH follow-up path already preserved `new_messages`; the main session was the inconsistent implementation. This PR persists the full turn history and keeps the assistant-tool_calls → tool-result pairing valid everywhere it travels: in-memory context, trims/compaction, provider requests, and `/resume`.

## User-visible Changes

- Follow-up questions after a tool-using AI turn now see the executed commands and their outputs — the AI can correctly state it ran them and cite results, instead of denying or misattributing them to the user.
- `/resume`d sessions restore the same tool-call facts.
- No behavior change for plain-text turns, user-executed shell commands, or the SSH follow-up path.

## Compatibility

- `ContextMessage` / `SessionContextMessage` gain `#[serde(default)] tool_calls` — session snapshots written by older builds still deserialize (covered by a legacy-snapshot test).
- Old binaries reading new snapshots ignore the unknown field (no `deny_unknown_fields` anywhere in the chain).
- `sessions.db` and pre-existing `-wal`/`-shm` siblings are tightened to owner-only (0600) on open; WAL/SHM files created later inherit the main DB permissions.
- MSRV unchanged (`is_none_or` already used elsewhere; workspace `rust-version = 1.89`).

## Testing

- aish-context: trim atomicity (by-type and token-budget), full compact never splits a group and candidate/retention boundaries agree, legacy snapshot deserialization, `as_messages` includes tool_calls, token estimation counts tool-call arguments.
- aish-llm: `sanitize_tool_pairs` repairs dangling sequences / drops emptied assistants; token estimator counts tool_calls payload.
- aish-shell: tool turn round-trips into next-turn context (pairing + redaction), tool-call arguments redacted with JSON validity preserved, write-time pairing repair (no unanswered calls, no orphan results), oversized tool output truncation, empty-assistant drop, snapshot export/restore preserves pairing.
- aish-session: fresh DB is 0600; a pre-existing 0644 DB is tightened on open.

`cargo test --workspace`: 1963 passed, 0 failed. `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean.

## Change Type

- [x] Bug fix (closes behavior bug #491)
- [x] Security hardening follow-up (redaction of tool-call arguments, 0600 session DB)

## Scope

- `aish-core`: shared `ContextToolCall { id, name, arguments }`.
- `aish-context`: `tool_calls` field, atomic-group trim/compact, group-snapped full-compact boundary, token estimation counts arguments.
- `aish-llm`: `sanitize_tool_pairs` on both `prepare_messages_for_send` paths, unique synthetic tool-call ids (`tc_{turn}_{idx}`), token estimator counts tool_calls.
- `aish-shell`: `handle_question` persists the full turn (write-time pairing repair, secret-redacted + size-capped tool outputs/arguments), `build_context_messages` passes tool fields through, snapshot export/restore round-trip, secret-scanner redactor injection.
- `aish-session`: `tool_calls` field, owner-only DB permissions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool calls and results are preserved across conversation history, snapshots, and restored sessions.
  * Context budgeting now includes tool-call data for more accurate estimates.

* **Security**
  * Tool arguments and outputs are redacted before storage.
  * Tool output is limited to 4 KB.
  * Session databases use owner-only permissions on supported systems.

* **Bug Fixes**
  * Trimming and compaction keep tool requests paired with results.
  * Older saved sessions remain compatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->