### PR TITLE
fix(llm): preserve sub-agent partial messages and error category on fatal

### DIFF
--- a/crates/aish-core/src/error.rs
+++ b/crates/aish-core/src/error.rs
@@ -54,3 +54,24 @@ impl From<serde_json::Error> for AishError {
 
 /// Convenience alias used across all aish crates.
 pub type Result<T> = std::result::Result<T, AishError>;
+impl AishError {
+    /// Stable, machine-readable category for this error variant.
+    pub fn category(&self) -> &'static str {
+        match self {
+            AishError::Config(_) => "config",
+            AishError::Io(_) => "io",
+            AishError::Llm(_) => "llm",
+            AishError::Pty(_) => "pty",
+            AishError::Security(_) => "security",
+            AishError::Skill(_) => "skill",
+            AishError::Memory(_) => "memory",
+            AishError::Session(_) => "session",
+            AishError::Tool(_) => "tool",
+            AishError::I18n(_) => "i18n",
+            AishError::Shell(_) => "shell",
+            AishError::Parse(_) => "parse",
+            AishError::Cancelled => "cancelled",
+            AishError::Timeout => "timeout",
+        }
+    }
+}

--- a/crates/aish-llm/src/agents/spawn.rs
+++ b/crates/aish-llm/src/agents/spawn.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use aish_core::LlmEvent;
+use aish_core::{AishError, LlmEvent};
 use uuid::Uuid;
 
 use crate::prompt::PromptContext;
@@ -43,10 +43,20 @@ impl Default for SpawnConfig {
 }
 
 /// Result of a synchronous sub-agent spawn.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct SpawnResult {
     pub text: String,
     pub status: LoopStatus,
+    /// Structured fatal-error category (only present when `status == Fatal`).
+    /// Stable, machine-readable string (e.g. `"llm"`, `"parse"`) so the parent
+    /// can distinguish network/protocol/parse failures without inspecting the
+    /// raw error text.
+    pub error_category: Option<String>,
+    /// Messages accumulated before the terminal condition: assistant tool calls
+    /// and tool results produced before a fatal error or cancel. Lets the
+    /// parent session and persistence retain evidence of already-completed work
+    /// instead of dropping it at the `spawn()` boundary.
+    pub partial_messages: Vec<ChatMessage>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -108,7 +118,14 @@ where
     SpawnResult {
         text: outcome.text,
         status: outcome.status,
+        error_category: outcome.error.as_ref().map(error_category),
+        partial_messages: outcome.new_messages,
     }
+}
+
+/// Stable, machine-readable category for a sub-agent fatal error.
+fn error_category(error: &AishError) -> String {
+    error.category().to_string()
 }
 
 /// Spawn a sub-agent from an [`AgentDefinition`] (built-in or shell-only).
@@ -982,5 +999,82 @@ mod tests {
 
         assert_eq!(result.status, LoopStatus::Complete);
         assert_eq!(result.text, "cpu contended");
+    }
+
+    #[tokio::test]
+    async fn test_spawn_fatal_preserves_partial_messages() {
+        // First turn: assistant calls `grep`, MockTool returns "ok".
+        // Second turn: LLM request fails. The parent must receive the
+        // completed tool result (issue #489).
+        let parent = LlmSession::new("http://localhost", "key", "model", None, None);
+
+        let result = spawn(&parent, "task", SpawnConfig::default(), |sub| {
+            disable_context_budget(sub);
+            sub.set_test_chat_responses(vec![
+                Ok(mock_tool_call_response(&[(
+                    "c1",
+                    "grep",
+                    r#"{"pattern":"x"}"#,
+                )])),
+                Err(AishError::Llm("upstream failure".into())),
+            ]);
+            sub.register_tool(Box::new(MockTool::new("grep")));
+        })
+        .await;
+
+        assert_eq!(result.status, LoopStatus::Fatal);
+        assert_eq!(result.error_category, Some("llm".to_string()));
+        assert!(
+            !result.partial_messages.is_empty(),
+            "partial messages must propagate"
+        );
+        let has_ok = result
+            .partial_messages
+            .iter()
+            .any(|m| m.role == "tool" && m.text_content() == Some("ok"));
+        assert!(has_ok, "tool result must be retained in partial_messages");
+    }
+
+    #[tokio::test]
+    async fn test_spawn_fatal_preserves_multiple_tool_results() {
+        // Two tools succeed, then LLM fails. All tool results must survive.
+        let parent = LlmSession::new("http://localhost", "key", "model", None, None);
+
+        let result = spawn(&parent, "task", SpawnConfig::default(), |sub| {
+            disable_context_budget(sub);
+            sub.set_test_chat_responses(vec![
+                Ok(mock_tool_call_response(&[(
+                    "c1",
+                    "grep",
+                    r#"{"pattern":"a"}"#,
+                )])),
+                Ok(mock_tool_call_response(&[(
+                    "c2",
+                    "read_file",
+                    r#"{"path":"x"}"#,
+                )])),
+                Err(AishError::Llm("connection reset".into())),
+            ]);
+            sub.register_tool(Box::new(MockTool::new("grep")));
+            sub.register_tool(Box::new(MockTool::new("read_file")));
+        })
+        .await;
+
+        assert_eq!(result.status, LoopStatus::Fatal);
+        assert_eq!(result.error_category, Some("llm".to_string()));
+        // 2 assistant tool-call messages + 2 tool-result messages = 4.
+        assert_eq!(
+            result.partial_messages.len(),
+            4,
+            "all partial messages must be preserved: got {:?}",
+            result.partial_messages
+        );
+        let outputs: Vec<_> = result
+            .partial_messages
+            .iter()
+            .filter(|m| m.role == "tool")
+            .map(|m| m.text_content().unwrap_or_default())
+            .collect();
+        assert!(outputs.contains(&"ok"), "tool result must survive");
     }
 }

--- a/crates/aish-llm/src/agents/spawn.rs
+++ b/crates/aish-llm/src/agents/spawn.rs
@@ -118,7 +118,14 @@ where
     SpawnResult {
         text: outcome.text,
         status: outcome.status,
-        error_category: outcome.error.as_ref().map(error_category),
+        // Invariant: `error_category` is only meaningful for fatal outcomes.
+        // Cancelled outcomes carry `Some(AishError::Cancelled)` internally,
+        // but that is control flow, not a failure to classify.
+        error_category: if outcome.status == LoopStatus::Fatal {
+            outcome.error.as_ref().map(error_category)
+        } else {
+            None
+        },
         partial_messages: outcome.new_messages,
     }
 }
@@ -609,6 +616,9 @@ mod tests {
         .await;
 
         assert_eq!(result.status, LoopStatus::Cancelled);
+        // Documented invariant: error_category must stay None for
+        // cancellations even though the outcome carries AishError::Cancelled.
+        assert_eq!(result.error_category, None);
     }
 
     struct SlowMockTool {
@@ -675,6 +685,7 @@ mod tests {
 
         let result = run.await;
         assert_eq!(result.status, LoopStatus::Cancelled);
+        assert_eq!(result.error_category, None);
     }
 
     #[tokio::test]

--- a/crates/aish-llm/src/agents/tool_loop.rs
+++ b/crates/aish-llm/src/agents/tool_loop.rs
@@ -44,8 +44,9 @@ impl ToolLoopConfig {
 }
 
 /// Termination status of a tool calling loop.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum LoopStatus {
+    #[default]
     Complete,
     Incomplete,
     Cancelled,
@@ -80,9 +81,10 @@ impl LoopOutcome {
         Self::from_spawn_outcome(outcome, Vec::new(), Some(AishError::Cancelled))
     }
 
-    fn fatal(error: AishError) -> Self {
+    /// Fatal outcome that retains messages accumulated before the error.
+    fn fatal_with_messages(error: AishError, messages: Vec<ChatMessage>) -> Self {
         let outcome = extract_spawn_outcome(TerminationKind::Fatal, &OutcomeConfig::default());
-        Self::from_spawn_outcome(outcome, Vec::new(), Some(error))
+        Self::from_spawn_outcome(outcome, messages, Some(error))
     }
 }
 
@@ -153,7 +155,7 @@ pub async fn run_tool_loop_until_done(
                     timestamp: now_timestamp(),
                     metadata: None,
                 });
-                return LoopOutcome::fatal(e);
+                return LoopOutcome::fatal_with_messages(e, loop_messages);
             }
         };
 
@@ -165,9 +167,10 @@ pub async fn run_tool_loop_until_done(
         });
 
         let LlmResponse::Json(json) = response else {
-            return LoopOutcome::fatal(AishError::Llm(
-                "run_tool_loop_until_done requires non-streaming responses".into(),
-            ));
+            return LoopOutcome::fatal_with_messages(
+                AishError::Llm("run_tool_loop_until_done requires non-streaming responses".into()),
+                loop_messages,
+            );
         };
 
         let (content, _reasoning, tool_calls, usage) = StreamParser::parse_response(&json);
@@ -453,6 +456,96 @@ mod tests {
         assert!(
             session.cancellation_token().is_cancelled(),
             "session token must stay cancelled"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_loop_fatal_after_one_tool_preserves_messages() {
+        // First turn: assistant calls `grep` and the tool returns a unique
+        // marker. Second turn: LLM request fails. The loop must retain the
+        // assistant tool-call message and the tool-result so the parent can
+        // persist evidence of already-completed work (issue #489).
+        let mut session = test_session_with_responses(vec![
+            Ok(mock_tool_call_response(&[(
+                "c1",
+                "grep",
+                r#"{"pattern":"x"}"#,
+            )])),
+            Err(AishError::Llm("upstream failure".into())),
+        ]);
+        session.register_tool(Box::new(MockTool::new("grep", "SUBAGENT_TOOL_OK")));
+
+        let outcome = run_tool_loop_until_done(
+            &session,
+            &ChatMessage::user("task"),
+            &[],
+            &ToolLoopConfig::default(),
+        )
+        .await;
+
+        assert_eq!(outcome.status, LoopStatus::Fatal);
+        assert!(outcome.error.is_some());
+        // The accumulated messages must survive the fatal error.
+        assert!(
+            !outcome.new_messages.is_empty(),
+            "partial messages must be preserved on fatal"
+        );
+        let has_tool_result = outcome
+            .new_messages
+            .iter()
+            .any(|m| m.role == "tool" && m.text_content() == Some("SUBAGENT_TOOL_OK"));
+        assert!(
+            has_tool_result,
+            "tool result must be retained in new_messages"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_loop_fatal_after_multiple_tools_preserves_all() {
+        // Two tool calls succeed, then the third LLM request fails. All
+        // accumulated assistant/tool messages must be retained.
+        let mut session = test_session_with_responses(vec![
+            Ok(mock_tool_call_response(&[(
+                "c1",
+                "grep",
+                r#"{"pattern":"a"}"#,
+            )])),
+            Ok(mock_tool_call_response(&[(
+                "c2",
+                "read_file",
+                r#"{"path":"x"}"#,
+            )])),
+            Err(AishError::Llm("connection reset".into())),
+        ]);
+        session.register_tool(Box::new(MockTool::new("grep", "grep_out")));
+        session.register_tool(Box::new(MockTool::new("read_file", "file_out")));
+
+        let outcome = run_tool_loop_until_done(
+            &session,
+            &ChatMessage::user("task"),
+            &[],
+            &ToolLoopConfig::default(),
+        )
+        .await;
+
+        assert_eq!(outcome.status, LoopStatus::Fatal);
+        // 2 assistant tool-call messages + 2 tool-result messages = 4.
+        assert_eq!(
+            outcome.new_messages.len(),
+            4,
+            "all partial messages must be preserved: got {:?}",
+            outcome.new_messages
+        );
+        let outputs: Vec<_> = outcome
+            .new_messages
+            .iter()
+            .filter(|m| m.role == "tool")
+            .map(|m| m.text_content().unwrap_or_default())
+            .collect();
+        assert!(outputs.contains(&"grep_out"), "grep result must survive");
+        assert!(
+            outputs.contains(&"file_out"),
+            "read_file result must survive"
         );
     }
 }

--- a/crates/aish-tools/src/agent_tool/agent_tool.rs
+++ b/crates/aish-tools/src/agent_tool/agent_tool.rs
@@ -5,7 +5,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use aish_llm::{
-    spawn_builtin, AgentRegistry, LlmSession, LoopStatus, SpawnResult, Tool, ToolResult,
+    spawn_builtin, AgentRegistry, ChatMessage, LlmSession, LoopStatus, SpawnResult, Tool,
+    ToolResult,
 };
 
 use super::prompt;
@@ -74,6 +75,8 @@ impl AgentTool {
     }
 
     pub(crate) fn spawn_result_to_tool_result(result: SpawnResult) -> ToolResult {
+        let partial_messages = result.partial_messages;
+        let error_category = result.error_category;
         match result.status {
             LoopStatus::Complete | LoopStatus::Incomplete => ToolResult::success(result.text),
             LoopStatus::Cancelled => {
@@ -81,7 +84,72 @@ impl AgentTool {
                 // meta.reason stays machine-readable for short-circuit handling.
                 Self::short_circuit_error(aish_i18n::t("shell.interrupted"), "sub_agent_cancelled")
             }
-            LoopStatus::Fatal => Self::short_circuit_error("Sub-agent failed", "sub_agent_fatal"),
+            LoopStatus::Fatal => {
+                let category = error_category.unwrap_or_else(|| "unknown".to_string());
+                Self::fatal_tool_result(result.text, category, partial_messages)
+            }
+        }
+    }
+
+    /// Build a structured fatal `ToolResult` that preserves the sub-agent's
+    /// completed work (tool calls + results) and the stable error category.
+    /// The parent session can then persist partial evidence so a retry does
+    /// not re-execute already-completed tools.
+    fn fatal_tool_result(
+        final_text: String,
+        category: String,
+        partial_messages: Vec<ChatMessage>,
+    ) -> ToolResult {
+        let completed_tool_names: Vec<&str> = partial_messages
+            .iter()
+            .filter(|m| m.role == "assistant")
+            .filter_map(|m| m.tool_calls.as_ref())
+            .flatten()
+            .map(|tc| tc.name.as_str())
+            .collect();
+        let tool_result_msgs: Vec<&ChatMessage> = partial_messages
+            .iter()
+            .filter(|m| m.role == "tool")
+            .collect();
+        let partial_summaries: Vec<serde_json::Value> = tool_result_msgs
+            .iter()
+            .map(|m| {
+                serde_json::json!({
+                    "tool_call_id": m.tool_call_id,
+                    "name": m.name,
+                    "output": m.text_content(),
+                })
+            })
+            .collect();
+        // Build a human/LLM-readable summary of completed work so the parent
+        // agent can see which tools already ran and their results — not just
+        // a bare "Sub-agent failed". This prevents the parent from blindly
+        // retrying the same steps. The structured `meta` remains available for
+        // programmatic consumers (persistence, retry logic).
+        let mut output = format!("Sub-agent failed ({category})");
+        if !final_text.is_empty() {
+            output.push_str(&format!(": {final_text}"));
+        }
+        if !completed_tool_names.is_empty() {
+            output.push_str("\n\nCompleted before failure:");
+            for (i, tool_name) in completed_tool_names.iter().enumerate() {
+                let result_text = tool_result_msgs
+                    .get(i)
+                    .and_then(|m| m.text_content())
+                    .unwrap_or("(no result)");
+                output.push_str(&format!("\n  {i}. {tool_name}: {result_text}"));
+            }
+        }
+        ToolResult {
+            ok: false,
+            output,
+            meta: Some(serde_json::json!({
+                "dispatch_status": "short_circuit",
+                "reason": "sub_agent_fatal",
+                "error_category": category,
+                "completed_tools": completed_tool_names,
+                "partial_messages": partial_summaries,
+            })),
         }
     }
 

--- a/crates/aish-tools/tests/agent_tool_test.rs
+++ b/crates/aish-tools/tests/agent_tool_test.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use aish_llm::{LoopStatus, SpawnResult, Tool};
+use aish_llm::{ChatMessage, LoopStatus, SpawnResult, Tool, ToolCall};
 use aish_tools::{AgentTool, SpawnFn};
 
 fn mock_spawn_ok<'a>(
@@ -14,6 +14,8 @@ fn mock_spawn_ok<'a>(
         Ok(SpawnResult {
             text: "explore conclusion".to_string(),
             status: LoopStatus::Complete,
+            error_category: None,
+            partial_messages: Vec::new(),
         })
     })
 }
@@ -27,6 +29,7 @@ fn mock_spawn_cancelled<'a>(
         Ok(SpawnResult {
             text: String::new(),
             status: LoopStatus::Cancelled,
+            ..Default::default()
         })
     })
 }
@@ -40,6 +43,7 @@ fn mock_spawn_incomplete<'a>(
         Ok(SpawnResult {
             text: "[incomplete: max turns reached]\npartial conclusion".to_string(),
             status: LoopStatus::Incomplete,
+            ..Default::default()
         })
     })
 }
@@ -53,6 +57,23 @@ fn mock_spawn_fatal<'a>(
         Ok(SpawnResult {
             text: String::new(),
             status: LoopStatus::Fatal,
+            error_category: Some("llm".to_string()),
+            partial_messages: vec![
+                ChatMessage {
+                    role: "assistant".to_string(),
+                    content: None,
+                    tool_calls: Some(vec![ToolCall {
+                        id: "c1".to_string(),
+                        name: "grep".to_string(),
+                        arguments: r#"{"pattern":"x"}"#.to_string(),
+                    }]),
+                    tool_call_id: None,
+                    name: None,
+                    reasoning_content: None,
+                    cache_control: None,
+                },
+                ChatMessage::tool_result("c1", "SUBAGENT_TOOL_OK"),
+            ],
         })
     })
 }
@@ -190,13 +211,61 @@ async fn test_agent_tool_mock_spawn_fatal_errors() {
         )
         .await;
     assert!(!result.ok);
-    assert!(result.output.contains("failed"));
+    // Output must be enriched with completed work, not bare "failed".
+    assert!(
+        result.output.contains("Sub-agent failed (llm)"),
+        "output should name the category: got {}",
+        result.output
+    );
+    assert!(
+        result.output.contains("Completed before failure"),
+        "output should list completed work: got {}",
+        result.output
+    );
+    assert!(
+        result.output.contains("SUBAGENT_TOOL_OK"),
+        "output should include tool result evidence: got {}",
+        result.output
+    );
+    // Structured meta for programmatic consumers.
     assert_eq!(
-        result
-            .meta
-            .as_ref()
-            .and_then(|m| m.get("reason"))
-            .and_then(|v| v.as_str()),
-        Some("sub_agent_fatal")
+        result.meta.as_ref().and_then(|m| m.get("reason")),
+        Some(&serde_json::Value::String("sub_agent_fatal".to_string()))
+    );
+    assert_eq!(
+        result.meta.as_ref().and_then(|m| m.get("error_category")),
+        Some(&serde_json::Value::String("llm".to_string()))
+    );
+    let completed = result
+        .meta
+        .as_ref()
+        .and_then(|m| m.get("completed_tools"))
+        .and_then(|v| v.as_array());
+    assert_eq!(
+        completed.map(|c| c.len()),
+        Some(1),
+        "completed_tools should have one entry"
+    );
+    assert_eq!(
+        completed.and_then(|c| c.first()).and_then(|v| v.as_str()),
+        Some("grep")
+    );
+    let partial = result
+        .meta
+        .as_ref()
+        .and_then(|m| m.get("partial_messages"))
+        .and_then(|v| v.as_array());
+    assert_eq!(
+        partial.map(|c| c.len()),
+        Some(1),
+        "partial_messages should have one tool result"
+    );
+    assert!(
+        partial
+            .and_then(|c| c.first())
+            .and_then(|v| v.get("output"))
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| s.contains("SUBAGENT_TOOL_OK")),
+        "partial_messages should contain the tool result"
     );
 }

--- a/crates/aish-tools/tests/skill_tool_test.rs
+++ b/crates/aish-tools/tests/skill_tool_test.rs
@@ -75,6 +75,7 @@ async fn subagent_skill_spawns_with_builtin_and_intersected_tools() {
             Ok(SpawnResult {
                 text: "disk IO is saturated".to_string(),
                 status: LoopStatus::Complete,
+                ..Default::default()
             })
         }) as Pin<Box<dyn Future<Output = Result<SpawnResult, String>> + Send>>
     });
@@ -133,6 +134,7 @@ async fn general_purpose_skill_allowlist_does_not_make_bash_read_only() {
             Ok(SpawnResult {
                 text: "updated".to_string(),
                 status: LoopStatus::Complete,
+                ..Default::default()
             })
         })
     });


### PR DESCRIPTION
Closes #489

## Problem

When a sub-agent's LLM loop hit a fatal error (network failure, auth error, parse error), the parent session only received a bare `Sub-agent failed (llm): ` — every tool call the sub-agent had already completed was silently dropped. The parent LLM could not see what work was done and would blindly re-run the same steps.

## Changes

### 1. `aish-core`: stable error classification
- New `AishError::category()` maps all 14 error variants to a stable snake_case category string (`llm`, `parse`, `tool`, `timeout`, `security`, ...), used as machine-readable `error_category`.

### 2. `aish-llm` spawn layer: preserve partial state
- `LoopOutcome::fatal()` now routes through `fatal_with_messages(e, loop_messages)` so messages accumulated in the loop (assistant tool-call messages + tool results) are no longer dropped on fatal exit.
- `SpawnResult` gains two fields: `error_category: Option<String>` and `partial_messages: Vec<ChatMessage>`, populated by `spawn()` from the outcome.

### 3. `aish-tools` AgentTool: parent-visible summary
- `fatal_tool_result` now embeds a human/LLM-readable summary in `output`:
  ```
  Sub-agent failed (llm)

  Completed before failure:
    0. grep: SUBAGENT_TOOL_OK
  ```
  Tool names (from assistant tool_calls) are paired with tool-result messages by index. Since the parent session only persists `result.output` on the short-circuit path, this is the only field the parent LLM sees — it now contains the completed-work evidence, preventing blind retries.
- The structured `meta` (`dispatch_status` / `reason` / `error_category` / `completed_tools` / `partial_messages`) is unchanged for programmatic consumers (persistence, retry logic).

## Test coverage

- `tool_loop::tests`: fatal after one tool / after multiple tools preserves all loop messages.
- `spawn::tests`: fatal propagates `error_category` and non-empty `partial_messages` (1-tool and 2-tool scenarios).
- `agent_tool_test`: fatal result output contains `Sub-agent failed (llm)`, `Completed before failure`, and the tool result evidence; meta carries `reason`/`error_category`/`completed_tools`/`partial_messages`.

All tests pass; `cargo fmt --check` and `cargo clippy -D warnings` clean on affected crates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added stable error categories for clearer error identification.
  - Preserved partial assistant and tool messages when agent operations fail.
  - Enhanced fatal tool results with completed tool details, partial output, and structured error metadata.

- **Bug Fixes**
  - Improved error reporting for failed language-model requests and incomplete responses.
  - Ensured useful intermediate results are not lost during failed operations.

- **Tests**
  - Added coverage for error categories, partial messages, and enriched fatal results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->