### PR TITLE
fix: web_fetch returns failure on HTTP 4xx/5xx (#450)

### DIFF
--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -1376,6 +1376,7 @@ tools:
     content_too_large: "WebFetch response exceeded the 10MB limit"
     binary_unsupported: "WebFetch does not support binary content in this version"
     secondary_model_failed: "WebFetch fetched the page but failed to process it with the secondary model: {error}"
+    http_error: "WebFetch request failed: HTTP {code} {status}"
 
 help:
   labels:

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -1375,6 +1375,7 @@ tools:
     content_too_large: "WebFetch 响应超过 10MB 限制"
     binary_unsupported: "当前版本的 WebFetch 不支持二进制内容"
     secondary_model_failed: "WebFetch 已抓取页面，但使用二级模型处理失败: {error}"
+    http_error: "WebFetch 请求失败: HTTP {code} {status}"
 
 help:
   labels:

--- a/crates/aish-tools/src/web_fetch/prompt.rs
+++ b/crates/aish-tools/src/web_fetch/prompt.rs
@@ -11,6 +11,7 @@ Usage:
 - HTTP URLs are automatically upgraded to HTTPS.
 - HTML content is converted to readable text before being processed by a secondary model.
 - Results may be summarized or truncated when the page is very large.
+- HTTP 4xx/5xx responses (e.g. 404, 410, 429, 500) are returned as failures with `ok=false` and an `http_status` field in the result metadata. The error page body is not fetched, cached, or analyzed.
 - A 15-minute cache is used for repeated requests to the same URL.
 - If a URL redirects to a different host, call WebFetch again with the redirect URL returned by the tool.
 - For GitHub URLs, prefer gh via bash when repository metadata, issues, PRs, releases, or API data are needed."#;

--- a/crates/aish-tools/src/web_fetch/utils.rs
+++ b/crates/aish-tools/src/web_fetch/utils.rs
@@ -44,6 +44,7 @@ pub(crate) enum FetchFailure {
     Blocked(String),
     Request(String),
     Redirect(RedirectInfo),
+    HttpStatus(StatusCode),
 }
 
 #[derive(Debug)]
@@ -98,6 +99,10 @@ pub(crate) async fn fetch_url_content(raw_url: &str) -> Result<FetchedContent, F
         .and_then(|value| value.to_str().ok())
         .unwrap_or("")
         .to_string();
+
+    if is_error_status(status) {
+        return Err(FetchFailure::HttpStatus(status));
+    }
 
     if is_binary_content_type(&content_type) {
         return Err(FetchFailure::Request(aish_i18n::t(
@@ -345,6 +350,13 @@ fn is_redirect_status(status: StatusCode) -> bool {
     )
 }
 
+/// Whether `status` is a client (4xx) or server (5xx) error that must not be
+/// treated as a successful fetch: the response body is an error page, not
+/// content, so it must not be cached or analyzed by the secondary model.
+fn is_error_status(status: StatusCode) -> bool {
+    status.is_client_error() || status.is_server_error()
+}
+
 fn is_permitted_redirect(original: &Url, redirect_url: &Url) -> bool {
     if original.scheme() != redirect_url.scheme() || original.port() != redirect_url.port() {
         return false;
@@ -381,7 +393,7 @@ async fn read_limited_body(response: reqwest::Response) -> Result<Vec<u8>, Strin
     Ok(buffer)
 }
 
-fn status_text(status: StatusCode) -> &'static str {
+pub(crate) fn status_text(status: StatusCode) -> &'static str {
     status.canonical_reason().unwrap_or("")
 }
 
@@ -593,5 +605,26 @@ mod tests {
         assert_eq!(decode_html_entities("&amp;quot;"), "&quot;");
         assert_eq!(decode_html_entities("&amp;#39;"), "&#39;");
         assert_eq!(decode_html_entities("&amp;apos;"), "&apos;");
+    }
+
+    #[test]
+    fn is_error_status_classifies_4xx_and_5xx() {
+        assert!(is_error_status(StatusCode::NOT_FOUND));
+        assert!(is_error_status(StatusCode::GONE));
+        assert!(is_error_status(StatusCode::TOO_MANY_REQUESTS));
+        assert!(is_error_status(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(is_error_status(StatusCode::BAD_REQUEST));
+        assert!(is_error_status(StatusCode::FORBIDDEN));
+        assert!(is_error_status(StatusCode::BAD_GATEWAY));
+        assert!(is_error_status(StatusCode::SERVICE_UNAVAILABLE));
+    }
+
+    #[test]
+    fn is_error_status_rejects_success_and_redirect() {
+        assert!(!is_error_status(StatusCode::OK));
+        assert!(!is_error_status(StatusCode::MOVED_PERMANENTLY));
+        assert!(!is_error_status(StatusCode::FOUND));
+        assert!(!is_error_status(StatusCode::NOT_MODIFIED));
+        assert!(!is_error_status(StatusCode::PARTIAL_CONTENT));
     }
 }

--- a/crates/aish-tools/src/web_fetch/web_fetch.rs
+++ b/crates/aish-tools/src/web_fetch/web_fetch.rs
@@ -80,7 +80,6 @@ impl WebFetchTool {
     }
 }
 
-
 /// Build a failure `ToolResult` for an HTTP 4xx/5xx response.
 fn http_status_error(url: &str, status: StatusCode, duration_ms: u64) -> ToolResult {
     let args_map = HashMap::from([
@@ -272,18 +271,24 @@ impl Tool for WebFetchTool {
 mod tests {
     use super::*;
 
-
     #[test]
     fn http_status_error_returns_failure() {
         let result = http_status_error("https://example.com/missing", StatusCode::NOT_FOUND, 50);
         assert!(!result.ok, "4xx/5xx should return ok=false");
         assert_eq!(
-            result.meta.as_ref().and_then(|m| m.get("http_status")).and_then(|v| v.as_u64()),
+            result
+                .meta
+                .as_ref()
+                .and_then(|m| m.get("http_status"))
+                .and_then(|v| v.as_u64()),
             Some(404),
             "meta should contain http_status=404"
         );
         let meta = result.meta.as_ref().expect("meta should be present");
-        assert_eq!(meta.get("url").and_then(|v| v.as_str()), Some("https://example.com/missing"));
+        assert_eq!(
+            meta.get("url").and_then(|v| v.as_str()),
+            Some("https://example.com/missing")
+        );
         assert_eq!(meta.get("durationMs").and_then(|v| v.as_u64()), Some(50));
         assert!(
             result.output.contains("404"),
@@ -294,7 +299,11 @@ mod tests {
 
     #[test]
     fn http_status_error_covers_410_429_500() {
-        for code in [StatusCode::GONE, StatusCode::TOO_MANY_REQUESTS, StatusCode::INTERNAL_SERVER_ERROR] {
+        for code in [
+            StatusCode::GONE,
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ] {
             let result = http_status_error("https://example.com", code, 10);
             assert!(!result.ok, "{code} should return ok=false");
             let meta = result.meta.as_ref().expect("meta should be present");

--- a/crates/aish-tools/src/web_fetch/web_fetch.rs
+++ b/crates/aish-tools/src/web_fetch/web_fetch.rs
@@ -12,8 +12,8 @@ use reqwest::Url;
 use super::preapproved::is_preapproved_host;
 use super::prompt;
 use super::utils::{
-    fetch_url_content, format_redirect_message, make_secondary_model_prompt, truncate_for_model,
-    validate_and_normalize_url, FetchFailure, FetchedContent,
+    fetch_url_content, format_redirect_message, make_secondary_model_prompt, status_text,
+    truncate_for_model, validate_and_normalize_url, FetchFailure, FetchedContent,
 };
 
 const TOOL_NAME: &str = "WebFetch";
@@ -190,6 +190,22 @@ impl Tool for WebFetchTool {
                         })),
                     };
                 }
+                Err(FetchFailure::HttpStatus(status)) => {
+                    let args_map = HashMap::from([
+                        ("code".to_string(), status.as_u16().to_string()),
+                        ("status".to_string(), status_text(status).to_string()),
+                    ]);
+                    let message = aish_i18n::t_with_args("tools.web_fetch.http_error", &args_map);
+                    return ToolResult {
+                        ok: false,
+                        output: message,
+                        meta: Some(serde_json::json!({
+                            "url": url,
+                            "http_status": status.as_u16(),
+                            "durationMs": start.elapsed().as_millis() as u64,
+                        })),
+                    };
+                }
                 Err(FetchFailure::Blocked(message)) | Err(FetchFailure::Request(message)) => {
                     return ToolResult::error(message)
                 }
@@ -292,6 +308,44 @@ mod tests {
                     .to_ascii_lowercase()
                     .contains(&expected.to_ascii_lowercase()),
                 "expected fetched content to contain {expected:?}"
+            );
+        }
+    }
+
+    /// End-to-end test: web_fetch must return a structured failure with
+    /// `ok=false` and `http_status` in meta when the server responds with a
+    /// 4xx/5xx status. Uses httpbin.org/status/{code} which echoes the
+    /// requested status code. No LLM is invoked on the error path.
+    /// Run with: AISH_LIVE_WEBFETCH=1 cargo test -p aish-tools live_http_error -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore]
+    async fn live_http_error_returns_failure() {
+        if std::env::var("AISH_LIVE_WEBFETCH").ok().as_deref() != Some("1") {
+            eprintln!("set AISH_LIVE_WEBFETCH=1 to run this live network smoke test");
+            return;
+        }
+
+        let codes = [404u16, 410, 429, 500];
+        for code in codes {
+            let url = format!("https://httpbin.org/status/{code}");
+            let args = serde_json::json!({ "url": url, "prompt": "summarize" });
+            let tool = WebFetchTool::new("", "", "", Some(0.1), Some(256));
+            let result = tool.execute_async(args).await;
+
+            assert!(
+                !result.ok,
+                "HTTP {code} should return ok=false, got ok=true\noutput: {}",
+                result.output
+            );
+            let meta = result.meta.expect("HTTP error should include meta");
+            let http_status = meta
+                .get("http_status")
+                .and_then(|v| v.as_u64())
+                .expect("meta should contain http_status");
+            assert_eq!(http_status, code as u64, "http_status should be {code}");
+            println!(
+                "HTTP {code}: ok={} output={:?} meta={}",
+                result.ok, result.output, meta
             );
         }
     }

--- a/crates/aish-tools/src/web_fetch/web_fetch.rs
+++ b/crates/aish-tools/src/web_fetch/web_fetch.rs
@@ -7,7 +7,7 @@ use aish_llm::{
     ChatMessage, LlmResponse, LlmSession, PreflightResult, PreflightSecurityContext,
     SecurityPanelMode, StreamParser, Tool, ToolResult,
 };
-use reqwest::Url;
+use reqwest::{StatusCode, Url};
 
 use super::preapproved::is_preapproved_host;
 use super::prompt;
@@ -80,6 +80,24 @@ impl WebFetchTool {
     }
 }
 
+
+/// Build a failure `ToolResult` for an HTTP 4xx/5xx response.
+fn http_status_error(url: &str, status: StatusCode, duration_ms: u64) -> ToolResult {
+    let args_map = HashMap::from([
+        ("code".to_string(), status.as_u16().to_string()),
+        ("status".to_string(), status_text(status).to_string()),
+    ]);
+    let message = aish_i18n::t_with_args("tools.web_fetch.http_error", &args_map);
+    ToolResult {
+        ok: false,
+        output: message,
+        meta: Some(serde_json::json!({
+            "url": url,
+            "http_status": status.as_u16(),
+            "durationMs": duration_ms,
+        })),
+    }
+}
 impl Tool for WebFetchTool {
     fn name(&self) -> &str {
         TOOL_NAME
@@ -191,20 +209,7 @@ impl Tool for WebFetchTool {
                     };
                 }
                 Err(FetchFailure::HttpStatus(status)) => {
-                    let args_map = HashMap::from([
-                        ("code".to_string(), status.as_u16().to_string()),
-                        ("status".to_string(), status_text(status).to_string()),
-                    ]);
-                    let message = aish_i18n::t_with_args("tools.web_fetch.http_error", &args_map);
-                    return ToolResult {
-                        ok: false,
-                        output: message,
-                        meta: Some(serde_json::json!({
-                            "url": url,
-                            "http_status": status.as_u16(),
-                            "durationMs": start.elapsed().as_millis() as u64,
-                        })),
-                    };
+                    return http_status_error(url, status, start.elapsed().as_millis() as u64);
                 }
                 Err(FetchFailure::Blocked(message)) | Err(FetchFailure::Request(message)) => {
                     return ToolResult::error(message)
@@ -267,6 +272,39 @@ impl Tool for WebFetchTool {
 mod tests {
     use super::*;
 
+
+    #[test]
+    fn http_status_error_returns_failure() {
+        let result = http_status_error("https://example.com/missing", StatusCode::NOT_FOUND, 50);
+        assert!(!result.ok, "4xx/5xx should return ok=false");
+        assert_eq!(
+            result.meta.as_ref().and_then(|m| m.get("http_status")).and_then(|v| v.as_u64()),
+            Some(404),
+            "meta should contain http_status=404"
+        );
+        let meta = result.meta.as_ref().expect("meta should be present");
+        assert_eq!(meta.get("url").and_then(|v| v.as_str()), Some("https://example.com/missing"));
+        assert_eq!(meta.get("durationMs").and_then(|v| v.as_u64()), Some(50));
+        assert!(
+            result.output.contains("404"),
+            "output should mention the status code: got {}",
+            result.output
+        );
+    }
+
+    #[test]
+    fn http_status_error_covers_410_429_500() {
+        for code in [StatusCode::GONE, StatusCode::TOO_MANY_REQUESTS, StatusCode::INTERNAL_SERVER_ERROR] {
+            let result = http_status_error("https://example.com", code, 10);
+            assert!(!result.ok, "{code} should return ok=false");
+            let meta = result.meta.as_ref().expect("meta should be present");
+            assert_eq!(
+                meta.get("http_status").and_then(|v| v.as_u64()),
+                Some(code.as_u16() as u64),
+                "meta http_status should match {code}"
+            );
+        }
+    }
     #[tokio::test]
     #[ignore]
     async fn live_fetch_url() {


### PR DESCRIPTION
## Problem

`web_fetch` had no failure semantics for HTTP 4xx/5xx: it read the error page body, cached it, passed it to the secondary LLM model, and returned `ok=true`.

Fixes #450.

## Solution

Check the HTTP status code **before** reading the response body. On 4xx/5xx, return a structured failure (`ok=false`) with `http_status` in meta. The error page is never read, cached, or analyzed.

## Changes

- **`FetchFailure`**: new `HttpStatus(StatusCode)` variant
- **`fetch_url_content`**: `is_error_status` check before `read_limited_body` and `set_cached`
- **`execute_async`**: new `HttpStatus` match arm returns `ok=false` + meta with `http_status`
- **`is_error_status()`**: pure function, unit tested for 404/410/429/500
- **`status_text()`**: promoted to `pub(crate)` for reuse in `HttpStatus` arm
- **`prompt.rs`**: document 4xx/5xx failure semantics for the LLM
- **i18n**: new `http_error` key in `en-US` and `zh-CN`

## Verification

- `cargo clippy -p aish-tools --all-targets -- -D warnings`: zero warnings
- `cargo test -p aish-tools web_fetch`: 15 passed, 2 ignored, 0 failed
- `AISH_LIVE_WEBFETCH=1 cargo test live_http_error -- --ignored`: 404/410/429/500 all return `ok=false` with correct `http_status`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - WebFetch now reports HTTP 4xx and 5xx responses as failures with localized messages.
  - Failed requests include the HTTP status, request URL, and duration as metadata.
  - Error responses are handled before body processing or caching.
  - Redirect, success, and partial-content responses continue to be handled appropriately.

- **Documentation**
  - Updated WebFetch guidance to explain failure responses and available HTTP metadata.
  - Added English and Chinese messages for HTTP request failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->