### PR TITLE
Release v0.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.12] - 2026-09-03
+
+### Added
+
+- `/doctor` Shell Compatibility checker: identity, startup files, startup speed, environment inheritance (proxy values redacted), secret detection (set/unset only), PTY bash compatibility probe, and alias/function/completion counts. `aish doctor --json` and `/doctor --json` emit machine-readable results.
+- Live-session resource monitoring: `/live_sessions` shows CPU% and RSS per session; configurable alerts when a detached session exceeds CPU/RSS thresholds (`pty_resource_check_interval_secs` / `_cpu_percent` / `_rss_mb`). Killing a session now terminates the full worker process tree with pidfd-pinned SIGTERM then SIGKILL so recycled PIDs are not hit.
+- Long-term memory: confirm before store/forget, provenance, expiry/TTL, `/memory` (list / verify / forget), and a category-aware TTL policy with an explicit `permanent` flag.
+- `/audit export`: portable audit package (`audit.md` + `events.jsonl` + `manifest.json`) with `--until` and `--session` filters, SHA-256 hashes, and owner-only permissions.
+- System-level security policy: `/etc/aish/security_policy.yaml` takes full precedence over the user-level `~/.config/aish/security_policy.yaml`.
+
+### Changed
+
+- `glob` tool uses pruned DFS (skips `target` / `node_modules` / … at traversal time), a 60s wall-clock budget, Ctrl+C cancellation, and `spawn_blocking`. Cancellation returns partial results so the agent does not retry into another cancelled walk. Absolute patterns start at the longest wildcard-free prefix instead of scanning from `/`.
+- Session database (`sessions.db`) and its WAL/SHM siblings are created or tightened to owner-only `0600` on open.
+
+### Fixed
+
+- `web_fetch` returns a structured failure (`ok=false`, `http_status`) on HTTP 4xx/5xx instead of treating error pages as success, caching them, and sending them to the secondary LLM.
+- `/doctor` no longer hangs forever in the REPL: probe subprocesses are detached from the controlling TTY so interactive bash cannot SIGTTOU-stop itself. Probe stderr noise is a warning rather than a fatal baseline error, and API connectivity treats 401/403/404 as reachable (only 5xx and network errors fail that check).
+- Nested-confirm buffer truncation no longer panics on a UTF-8 character boundary (for example a large CJK MOTD inside nested SSH), and the kept tail is hard-capped.
+- Sub-agent fatal outcomes preserve already-completed tool results and a structured `error_category`, so the parent can continue without redoing finished work.
+- Main session now persists AI tool-call history, so a follow-up question can see what the AI just executed instead of misattributing those commands to the user.
+- Thinking-animation frames no longer swallow tracing log lines, so LLM retry warnings stay visible.
+- Ctrl+C now stops the sub-agent thinking animation thread; tool-result status lines no longer overlap leftover frames.
+
 ## [0.3.11] - 2026-08-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "aish-cli"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "aish-config"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "aish-context"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "aish-core",
  "serde",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "aish-core"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aish-hosts"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "aish-i18n"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "aish-llm"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "aish-context",
  "aish-core",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "aish-md-table"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "richrs",
  "unicode-width",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "aish-memory"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "aish-core",
  "chrono",
@@ -159,14 +159,14 @@ dependencies = [
 
 [[package]]
 name = "aish-prompts"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "dirs 5.0.1",
 ]
 
 [[package]]
 name = "aish-pty"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "aish-scripts"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "dirs 5.0.1",
  "regex",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "aish-security"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "libc",
  "regex",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "aish-session"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "aish-core",
  "chrono",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "aish-shell"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "aish-config",
  "aish-context",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "aish-skills"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "aish-tools"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "aish-ui"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "crossterm 0.28.1",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.11"
+version = "0.3.12"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.89"


### PR DESCRIPTION
## Summary
- Bump version to `0.3.12` (`Cargo.toml` / `Cargo.lock`)
- Add `CHANGELOG.md` section for 0.3.12 covering changes since 0.3.11

### Highlights
- **Added**: `/doctor` Shell Compatibility checker (plus `--json`); live-session CPU/RSS monitoring and process-tree kill; `/memory` with confirmation, provenance, TTL/`permanent`; `/audit export`; system-level `/etc/aish/security_policy.yaml`
- **Changed**: faster, cancellable `glob` (pruned DFS, 60s budget); `sessions.db` tightened to `0600`
- **Fixed**: `web_fetch` treats HTTP 4xx/5xx as failure; `/doctor` no longer hangs in REPL; nested-confirm UTF-8 truncation panic; sub-agent fatal preserves completed tools; main session keeps AI tool-call history; animation no longer swallows logs; Ctrl+C stops sub-agent thinking frames

## Local checks
- [x] `python3 packaging/scripts/release_metadata.py --expected-version 0.3.12`
- [x] `make ci-check`
- Note: `packaging/tests/test_resolve_release_pr.py` is not present in this tree (manual step skipped)

## Release prep
Please run **Release Preparation** with this PR number before merge:
```bash
gh workflow run release-preparation.yml \
  --repo AI-Shell-Team/aish \
  --ref main \
  -f pr_number=<PR_NUMBER>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added diagnostics, live-session resource monitoring, long-term memory, audit export, and system-level security policy precedence.
- **Improvements**
  - Updated glob traversal behavior and session database permissions.
- **Bug Fixes**
  - Improved HTTP error handling, `/doctor` reliability, UTF-8 truncation, sub-agent results, tool-call history, tracing visibility, and Ctrl+C animation cleanup.
- **Release**
  - Updated the application version to 0.3.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->