### PR TITLE
fix: 升级更新内容汇总被瞬时启动吞掉的问题

### DIFF
--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -691,6 +691,10 @@ pub struct AishShell {
     /// Session-scoped approval memory shared with the LLM session. Kept on the
     /// shell so slash commands (e.g. `/forget-approvals`) can reset it.
     approval_memory: Arc<parking_lot::Mutex<aish_llm::ApprovalMemory>>,
+    /// Upgrade changelog marker version pending confirmation. Set when the
+    /// startup summary is displayed; committed to disk on the first real
+    /// user command so transient launches do not swallow the notes.
+    pending_changelog_marker: Option<String>,
 }
 
 impl AishShell {
@@ -2094,7 +2098,6 @@ impl AishShell {
         }
 
         // Note: event_callback is already set on the LlmSession before AiHandler takes ownership
-
         let version = env!("CARGO_PKG_VERSION").to_string();
 
         // After an upgrade, show the Keep-a-Changelog range once (omp-style),
@@ -2126,15 +2129,15 @@ impl AishShell {
 
         // Store full changelog in expand_history so Ctrl+O can show all entries
         // when the welcome panel truncates them with "and N more".
-        if let Some((_, plain, prev)) = upgrade_summary {
+        if let Some((_, ref plain, ref prev)) = upgrade_summary {
             let mut args = std::collections::HashMap::new();
-            args.insert("current".to_string(), prev);
+            args.insert("current".to_string(), prev.clone());
             args.insert("latest".to_string(), version.clone());
             let cl_title = aish_i18n::t_with_args("shell.welcome2.changelog_summary_title", &args);
             expand_history
                 .lock()
                 .unwrap()
-                .add(format!("[changelog] {cl_title}"), plain);
+                .add(format!("[changelog] {cl_title}"), plain.clone());
         } else if changelog.len() > 2 {
             let full_text = prompt::format_changelog_full(&version, &changelog);
             let cl_title = prompt::changelog_title(&version);
@@ -2143,6 +2146,10 @@ impl AishShell {
                 .unwrap()
                 .add(format!("[changelog] {}", cl_title), full_text);
         }
+
+        // The marker advances on the first real user command (see run loop),
+        // not here: a transient launch must not consume the upgrade notes.
+        let pending_changelog_marker = upgrade_summary.as_ref().map(|_| version.clone());
 
         // Initialize persistent PTY session
         let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
@@ -2215,6 +2222,7 @@ impl AishShell {
             ai_op_generation,
             expand_history,
             resource_monitor: crate::resource_monitor::Monitor::new(resource_thresholds),
+            pending_changelog_marker,
             last_resource_check: None,
             shared_recorder,
             inline_ai: None,
@@ -2539,6 +2547,13 @@ impl AishShell {
 
             if input.is_empty() {
                 continue;
+            }
+
+            // The user reached a real command: the upgrade changelog summary
+            // (if any) has now been on screen, so its marker can advance.
+            // Transient launches that exit before this point stay pending.
+            if let Some(v) = self.pending_changelog_marker.take() {
+                prompt::commit_last_changelog_version(&v);
             }
 
             // Add to history
@@ -3216,6 +3231,9 @@ impl AishShell {
             return;
         }
         self.echo_user_submitted_line(prompt, input);
+        if let Some(v) = self.pending_changelog_marker.take() {
+            prompt::commit_last_changelog_version(&v);
+        }
         rl.add_history_entry(input);
         self.state.history.push(input.to_string());
         if self.handle_special_command(input) {
@@ -3336,6 +3354,11 @@ impl AishShell {
         let input = line.trim();
         if input.is_empty() {
             return false;
+        }
+        // Popup-recovery submissions count as real interaction too: commit
+        // the pending upgrade-changelog marker exactly like the main loop.
+        if let Some(v) = self.pending_changelog_marker.take() {
+            prompt::commit_last_changelog_version(&v);
         }
         self.state.history.push(input.to_string());
         match input::classify_input(input) {

--- a/crates/aish-shell/src/prompt.rs
+++ b/crates/aish-shell/src/prompt.rs
@@ -186,6 +186,10 @@ fn last_changelog_version_path() -> PathBuf {
         .join("last-changelog-version")
 }
 
+/// Read and normalize the last-seen changelog version marker.
+///
+/// Returns the trimmed file content, or `None` when the marker is missing
+/// or blank (treated as a fresh install by the caller).
 fn read_last_changelog_version() -> Option<String> {
     let raw = std::fs::read_to_string(last_changelog_version_path()).ok()?;
     let trimmed = raw.trim();
@@ -196,6 +200,9 @@ fn read_last_changelog_version() -> Option<String> {
     }
 }
 
+/// Write the last-seen changelog version marker, creating the parent
+/// directory on demand. I/O errors are ignored: a missing or stale marker
+/// only affects changelog display, never shell operation.
 fn write_last_changelog_version(version: &str) {
     let path = last_changelog_version_path();
     if let Some(parent) = path.parent() {

--- a/crates/aish-shell/src/prompt.rs
+++ b/crates/aish-shell/src/prompt.rs
@@ -1153,6 +1153,11 @@ mod tests {
             .map(|s| s.trim().to_string())
     }
 
+    // These tests rely on `dirs::config_dir()` honoring `XDG_CONFIG_HOME`,
+    // which only holds on Linux/Redox. On macOS `config_dir()` returns
+    // `~/Library/Application Support` and ignores the env var, so the tests
+    // would touch the real user marker. CI runs tests on Linux only.
+    #[cfg(target_os = "linux")]
     #[test]
     fn test_startup_summary_does_not_advance_marker() {
         // A transient launch (display only) must leave the marker untouched
@@ -1172,6 +1177,7 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn test_commit_advances_marker() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1192,6 +1198,7 @@ mod tests {
         assert_eq!(read_marker(tmp.path()).as_deref(), Some("0.3.12"));
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn test_first_install_seeds_marker_without_summary() {
         // Fresh install: no marker → seed silently, never show a range.
@@ -1204,6 +1211,7 @@ mod tests {
         assert_eq!(read_marker(tmp.path()).as_deref(), Some("0.3.12"));
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn test_take_accepts_v_prefixed_inputs() {
         // Version strings may arrive with a leading 'v' (e.g. from update
@@ -1225,6 +1233,7 @@ mod tests {
         assert_eq!(read_marker(tmp.path()).as_deref(), Some("0.3.12"));
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn test_take_reseats_marker_ahead_of_current() {
         // Marker ahead of the binary (downgrade or corruption): reseat to

--- a/crates/aish-shell/src/prompt.rs
+++ b/crates/aish-shell/src/prompt.rs
@@ -204,17 +204,22 @@ fn write_last_changelog_version(version: &str) {
     let _ = std::fs::write(path, version.trim());
 }
 
-/// Consume the startup upgrade changelog for `current_version`.
+/// Load the startup upgrade changelog for `current_version`.
 ///
 /// Mimics omp: the first interactive launch after an upgrade shows notes from
-/// the embedded CHANGELOG for every version in `last_seen → current`. The
-/// marker then advances so steady-state launches keep the existing
-/// current-version welcome panel.
+/// the embedded CHANGELOG for every version in `last_seen → current`.
+///
+/// Loading alone does NOT advance the marker: transient launches (a quick
+/// exit, a fire-and-forget attach, or a formatting miss) must not swallow the
+/// summary. Call [`commit_last_changelog_version`] once the user actually
+/// interacts with the shell.
 ///
 /// Returns `(ansi_summary, plain_expand_text, previous_version)` when a range
 /// should be shown.
 pub fn take_startup_changelog_summary(current_version: &str) -> Option<(String, String, String)> {
     let current = current_version.strip_prefix('v').unwrap_or(current_version);
+    // First launch after a fresh install: seed the marker silently so the
+    // very first version seen is never reported as an upgrade.
     let last = match read_last_changelog_version() {
         Some(v) => v,
         None => {
@@ -234,13 +239,29 @@ pub fn take_startup_changelog_summary(current_version: &str) -> Option<(String, 
         return None;
     }
 
+    // No marker write here: the range is returned for display and the marker
+    // only advances when the shell records real user interaction.
     let summary = aish_i18n::changelog::format_changelog_range_summary(last_norm, current);
     let plain = aish_i18n::changelog::format_changelog_range_plain(last_norm, current);
-    write_last_changelog_version(current);
     match (summary, plain) {
         (Some(ansi), Some(text)) => Some((ansi, text, last_norm.to_string())),
-        _ => None,
+        // Nothing renderable for this range (e.g. missing CHANGELOG entries):
+        // reseat so the next launch does not retry an empty range forever.
+        _ => {
+            write_last_changelog_version(current);
+            None
+        }
     }
+}
+
+/// Advance the last-seen changelog marker to `version`.
+///
+/// Called from the REPL once the user submits a real command, so a launch
+/// that never reaches interaction (quick exit, Ctrl-D, attach probe) keeps
+/// the upgrade summary pending for the next launch.
+pub fn commit_last_changelog_version(version: &str) {
+    let current = version.strip_prefix('v').unwrap_or(version);
+    write_last_changelog_version(current);
 }
 
 /// Localized changelog title for the current version (e.g. "v0.3.4 更新内容").
@@ -1091,5 +1112,130 @@ mod tests {
 
         assert_eq!(item1_column, item2_column);
         assert_eq!(item1_column, item3_column);
+    }
+
+    // --- Startup changelog marker (consume/commit decoupling) ------------
+
+    /// Serialize tests that mutate the process-global `XDG_CONFIG_HOME`.
+    fn xdg_env_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
+            std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
+        &LOCK
+    }
+
+    /// Restore `XDG_CONFIG_HOME` on drop (including panic unwind).
+    struct XdgGuard {
+        prev: Option<std::ffi::OsString>,
+    }
+    impl XdgGuard {
+        fn set(dir: &std::path::Path) -> Self {
+            let prev = std::env::var_os("XDG_CONFIG_HOME");
+            std::env::set_var("XDG_CONFIG_HOME", dir);
+            Self { prev }
+        }
+    }
+    impl Drop for XdgGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+    }
+
+    fn marker_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("aish").join("last-changelog-version")
+    }
+
+    fn read_marker(dir: &std::path::Path) -> Option<String> {
+        std::fs::read_to_string(marker_path(dir))
+            .ok()
+            .map(|s| s.trim().to_string())
+    }
+
+    #[test]
+    fn test_startup_summary_does_not_advance_marker() {
+        // A transient launch (display only) must leave the marker untouched
+        // so the next launch still shows the upgrade notes.
+        let tmp = tempfile::tempdir().unwrap();
+        let _lock = xdg_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = XdgGuard::set(tmp.path());
+        std::fs::create_dir_all(marker_path(tmp.path()).parent().unwrap()).unwrap();
+        std::fs::write(marker_path(tmp.path()), "0.3.10").unwrap();
+
+        let summary = take_startup_changelog_summary("0.3.12");
+        assert!(summary.is_some(), "range 0.3.10 → 0.3.12 should render");
+        assert_eq!(
+            read_marker(tmp.path()).as_deref(),
+            Some("0.3.10"),
+            "display alone must not advance the marker"
+        );
+    }
+
+    #[test]
+    fn test_commit_advances_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _lock = xdg_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = XdgGuard::set(tmp.path());
+        std::fs::create_dir_all(marker_path(tmp.path()).parent().unwrap()).unwrap();
+        std::fs::write(marker_path(tmp.path()), "0.3.10").unwrap();
+
+        assert!(take_startup_changelog_summary("0.3.12").is_some());
+        assert_eq!(read_marker(tmp.path()).as_deref(), Some("0.3.10"));
+
+        // First real user command commits the pending version.
+        commit_last_changelog_version("0.3.12");
+        assert_eq!(read_marker(tmp.path()).as_deref(), Some("0.3.12"));
+
+        // Next launch is steady-state: no summary, marker untouched.
+        assert!(take_startup_changelog_summary("0.3.12").is_none());
+        assert_eq!(read_marker(tmp.path()).as_deref(), Some("0.3.12"));
+    }
+
+    #[test]
+    fn test_first_install_seeds_marker_without_summary() {
+        // Fresh install: no marker → seed silently, never show a range.
+        let tmp = tempfile::tempdir().unwrap();
+        let _lock = xdg_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = XdgGuard::set(tmp.path());
+        std::fs::create_dir_all(marker_path(tmp.path()).parent().unwrap()).unwrap();
+
+        assert!(take_startup_changelog_summary("0.3.12").is_none());
+        assert_eq!(read_marker(tmp.path()).as_deref(), Some("0.3.12"));
+    }
+
+    #[test]
+    fn test_take_accepts_v_prefixed_inputs() {
+        // Version strings may arrive with a leading 'v' (e.g. from update
+        // tooling); marker comparisons normalize the prefix on both sides.
+        let tmp = tempfile::tempdir().unwrap();
+        let _lock = xdg_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = XdgGuard::set(tmp.path());
+        std::fs::create_dir_all(marker_path(tmp.path()).parent().unwrap()).unwrap();
+        std::fs::write(marker_path(tmp.path()), "v0.3.10").unwrap();
+
+        let summary = take_startup_changelog_summary("v0.3.12");
+        assert!(summary.is_some());
+        assert_eq!(
+            read_marker(tmp.path()).as_deref(),
+            Some("v0.3.10"),
+            "take must not rewrite a v-prefixed marker"
+        );
+        commit_last_changelog_version("v0.3.12");
+        assert_eq!(read_marker(tmp.path()).as_deref(), Some("0.3.12"));
+    }
+
+    #[test]
+    fn test_take_reseats_marker_ahead_of_current() {
+        // Marker ahead of the binary (downgrade or corruption): reseat to
+        // current and never render a backwards range.
+        let tmp = tempfile::tempdir().unwrap();
+        let _lock = xdg_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = XdgGuard::set(tmp.path());
+        std::fs::create_dir_all(marker_path(tmp.path()).parent().unwrap()).unwrap();
+        std::fs::write(marker_path(tmp.path()), "9.9.9").unwrap();
+
+        assert!(take_startup_changelog_summary("0.3.12").is_none());
+        assert_eq!(read_marker(tmp.path()).as_deref(), Some("0.3.12"));
     }
 }


### PR DESCRIPTION
## Summary

- Problem: 升级后首次启动的更新内容汇总（如 "更新内容（0.3.11 → 0.3.12）" 面板）会被瞬时启动（验证性启动、秒退、Ctrl-D）永久吞掉，之后不再显示。根因是 `take_startup_changelog_summary` 在启动渲染汇总的同时写入 `~/.config/aish/last-changelog-version` marker，显示与消费耦合；次级问题：CHANGELOG 范围格式化为空时 marker 也被推进，内容丢失。
- Changes: 显示与消费解耦——`take_startup_changelog_summary` 成功路径不再写 marker（保留首次安装播种、marker 领先 reseat 语义；格式化失败 reseat 防空范围重试）；新增 `commit_last_changelog_version`；`AishShell` 增加 `pending_changelog_marker` 状态，在 REPL 主循环首个非空输入、slash popup 选中命令、popup 恢复 readline 提交三条真实交互路径上提交 marker。EOF/Ctrl-C/空行不提交，瞬时启动下次启动重新显示。
- Related Issue: #507（关联 #456）

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Other

## Scope

- [x] Core shell / PTY
- [ ] AI agent / LLM
- [ ] Skills / Tools
- [ ] Security
- [ ] Configuration
- [ ] CLI / Interface
- [ ] Packaging / Installation
- [ ] CI/CD
- [ ] Documentation

## User-visible Changes

- 升级后若首次启动只是瞬时启动（未真正使用），下次启动会重新显示更新内容汇总，不再永久丢失；用户提交第一条真实命令后汇总才被标记为已读。

## Compatibility

- Backward compatible? Yes。marker 文件格式与语义兼容；首次安装播种、marker 领先 reseat 行为不变。
- Config changes? No。

## Testing

- 5 个新单元测试（显示不推进 marker、commit 推进、首次安装播种不显示、v 前缀归一化、marker 领先 reseat），`XdgGuard` + 互斥锁隔离 XDG_CONFIG_HOME；`cargo test -p aish-shell -p aish-i18n` 全过（444+23）
- PTY 冒烟 4 场景：瞬时启动保持 marker 且显示汇总 / 再次瞬时启动仍显示 / 真实命令后 marker 推进 / 稳态启动不再显示范围汇总
- `cargo clippy -p aish-shell --all-targets -- -D warnings` 通过

Fixes #507

## Checklist

- [x] Code follows project style
- [x] Tests added if needed
- [ ] Documentation updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Upgrade summaries shown at startup are now recorded only after the first real command is submitted.
  - This tracking remains consistent when commands are submitted through recovery flows, including slash commands and file pop-ups.
  - Changelog version tracking now handles version prefixes and unusual version ranges more reliably.
  - Upgrade summaries continue to appear in expandable changelog history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->