### PR TITLE
fix(skills): route registry search to explicit skill requests

### DIFF
--- a/crates/aish-shell/src/ai_handler.rs
+++ b/crates/aish-shell/src/ai_handler.rs
@@ -1051,15 +1051,27 @@ impl AiHandler {
             content.push_str("\n</available-skills>");
         }
 
-        // When auto_search is enabled, tell the AI it can search for new skills
-        // if none of the loaded skills match the user's request.
+        // When auto_search is enabled, inject registry routing rules: regular
+        // system tasks stay on the OS package-manager workflow; registry
+        // search is reserved for explicit skill requests or tasks that
+        // genuinely need a declarable skill capability.
         if self.auto_search {
             if !content.is_empty() {
                 content.push_str("\n\n");
             }
             content.push_str(
                 "<skill-marketplace>\n\
-If the user's request is NOT covered by any loaded skill above, follow this workflow:\n\
+ROUTING RULES (read before every turn):\n\
+- Regular system tasks (installing/upgrading/removing OS packages, checking\n\
+  software availability, downloading binaries, general shell work) MUST be\n\
+  handled with the normal OS workflow first: detect the OS and package\n\
+  manager (apt/dnf/pacman/flatpak/snap/...), then query authoritative\n\
+  sources. Do NOT call `skill_search` for them, even if a same-named skill\n\
+  might exist — a skill is NOT required to install ordinary software.\n\
+- Search the registry ONLY when the user explicitly asks for an AISH skill\n\
+  (e.g. \"find/install a skill for X\"), or the task genuinely needs a\n\
+  declarable skill capability and no loaded skill below covers it.\n\
+When a registry search IS warranted:\n\
 1. Call `skill_search` with keywords describing the user's need.\n\
 2. Call `ask_user` with the search results as options so the user can pick\n\
    which skill to install. Set each option's `value` to the skill's full ID\n\
@@ -2247,6 +2259,73 @@ mod tests {
             .contains("__AISH_TOOL_CONTEXT__"));
         assert!(context[2].text_content().unwrap().contains("[REDACTED]"));
         assert!(!context[2].text_content().unwrap().contains("SECRET_TOKEN"));
+    }
+
+    /// The marketplace injection must route ordinary system tasks to the OS
+    /// package-manager workflow instead of the skill registry (issue #456):
+    /// the prompt must forbid `skill_search` for regular installs and reserve
+    /// it for explicit skill requests.
+    #[test]
+    fn marketplace_prompt_forbids_registry_search_for_regular_tasks() {
+        let mut handler = test_handler();
+        handler.auto_search = true;
+        handler.inject_skills();
+        let content = handler
+            .context_manager
+            .knowledge_cache()
+            .get("skills")
+            .expect("skills knowledge injected")
+            .clone();
+
+        assert!(content.contains("<skill-marketplace>"));
+        assert!(content.contains("ROUTING RULES"));
+        assert!(
+            content.contains("Do NOT call `skill_search`"),
+            "regular system tasks must be routed away from skill_search"
+        );
+        assert!(
+            content.contains("ONLY when the user explicitly asks"),
+            "registry search must be reserved for explicit skill requests"
+        );
+        // The step-by-step workflow (search -> ask_user -> install -> vet)
+        // must survive the rewrite for the cases where a search IS warranted.
+        assert!(content.contains("`skill_search`"));
+        assert!(content.contains("`ask_user`"));
+        assert!(content.contains("`skill_install`"));
+        assert!(content.contains("`skill-vetter`"));
+    }
+
+    #[test]
+    fn marketplace_prompt_absent_when_auto_search_disabled() {
+        let mut handler = test_handler();
+        handler.auto_search = false;
+        handler.inject_skills();
+        let content = handler
+            .context_manager
+            .knowledge_cache()
+            .get("skills")
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            !content.contains("<skill-marketplace>"),
+            "auto_search=false must not inject the marketplace block"
+        );
+    }
+
+    #[test]
+    fn marketplace_prompt_absent_when_no_skills_and_auto_search_disabled() {
+        // Both injections empty -> no knowledge message at all.
+        let mut handler = test_handler();
+        handler.auto_search = false;
+        handler.inject_skills();
+        assert!(
+            handler
+                .context_manager
+                .knowledge_cache()
+                .get("skills")
+                .is_none_or(|c| c.is_empty()),
+            "empty content must not be injected"
+        );
     }
 
     #[test]

--- a/crates/aish-skills/src/registry/mod.rs
+++ b/crates/aish-skills/src/registry/mod.rs
@@ -144,6 +144,10 @@ pub struct SearchOutcome {
     pub results: Vec<RegistrySkill>,
     /// Per-registry failures (e.g. timeout, rate limit, DNS).
     pub errors: Vec<RegistrySearchError>,
+    /// Number of registries that completed a successful search (even when
+    /// they returned zero results). Callers use this to distinguish "every
+    /// registry failed" from "some registry legitimately found nothing".
+    pub succeeded: usize,
 }
 
 impl SearchOutcome {
@@ -219,9 +223,13 @@ impl RegistryManager {
     pub fn search_all_with_errors(&self, query: &str, limit: usize) -> SearchOutcome {
         let mut results = Vec::new();
         let mut errors = Vec::new();
+        let mut succeeded = 0usize;
         for adapter in &self.adapters {
             match adapter.search(query, limit) {
-                Ok(r) => results.extend(r),
+                Ok(r) => {
+                    succeeded += 1;
+                    results.extend(r);
+                }
                 Err(e) => {
                     tracing::warn!(
                         registry = adapter.name(),
@@ -237,7 +245,11 @@ impl RegistryManager {
         }
         results.sort_by_key(|s| std::cmp::Reverse(s.installs));
         results.truncate(limit);
-        SearchOutcome { results, errors }
+        SearchOutcome {
+            results,
+            errors,
+            succeeded,
+        }
     }
 
     /// Find a specific adapter by name.

--- a/crates/aish-tools/src/skill_registry/skill_registry.rs
+++ b/crates/aish-tools/src/skill_registry/skill_registry.rs
@@ -1,7 +1,8 @@
 //! LLM tools for searching and installing skills from registries.
 //!
-//! These tools enable the AI to auto-discover and install skills when a user's
-//! request doesn't match any loaded skill.
+//! These tools let the AI install skills ONLY on explicit user request or
+//! when a task genuinely needs a declarable skill capability — never as a
+//! substitute for ordinary OS package-manager work.
 
 use std::future::Future;
 use std::path::PathBuf;
@@ -22,7 +23,10 @@ use serde::{Deserialize, Serialize};
 
 /// Tool for searching skill registries.
 ///
-/// The AI calls this when the user's request doesn't match any loaded skill.
+/// The AI calls this ONLY when the user explicitly asks for an AISH skill or
+/// the task genuinely requires a declarable skill capability — never for
+/// ordinary system work like installing software through the OS package
+/// manager.
 pub struct SkillSearchTool {
     registries: Vec<RegistryConfig>,
     prompt: String,
@@ -104,7 +108,11 @@ impl Tool for SkillSearchTool {
 
     fn description(&self) -> &str {
         "Search skill registries for skills matching a query. \
-Use this when the user's request might be solvable by a skill that is not yet installed."
+Use this ONLY when the user explicitly asks for an AISH skill, or the task \
+genuinely requires a declarable skill capability that no loaded skill \
+provides. NEVER use it for ordinary system tasks such as installing, \
+upgrading, or looking up software via the OS package manager (apt/dnf/\
+pacman/flatpak/snap) or official download sources."
     }
 
     fn parameters(&self) -> serde_json::Value {
@@ -142,6 +150,31 @@ Use this when the user's request might be solvable by a skill that is not yet in
         let outcome = self.do_search(&search_args.query, search_args.limit);
         let error_registries: Vec<String> =
             outcome.errors.iter().map(|e| e.registry.clone()).collect();
+        // Failure semantics: every registry failed -> the search did not
+        // happen at all, so report failure (ok=false) and let the model
+        // degrade gracefully instead of mistaking it for "no matches".
+        // Partial failures with some results stay ok=true but keep the
+        // errors visible in output and meta; a genuinely empty result with
+        // no errors is a real "no matches" answer.
+        if outcome.results.is_empty() && !outcome.errors.is_empty() {
+            let mut output = String::from("Skill registry search failed for all registries:\n");
+            for e in &outcome.errors {
+                output.push_str(&format!("- {}: {}\n", e.registry, e.error));
+            }
+            output.push_str(
+                "Treat this as a transient failure, not as \"no skills found\". \
+You may retry once or continue the task without skills.",
+            );
+            return ToolResult {
+                ok: false,
+                output,
+                meta: Some(serde_json::json!({
+                    "count": 0,
+                    "query": search_args.query,
+                    "registry_errors": error_registries,
+                })),
+            };
+        }
         ToolResult {
             ok: true,
             output: Self::format_results(&outcome),
@@ -695,5 +728,122 @@ mod tests {
         // observe the reset so later installs re-prompt for review.
         assert!(handle.swap(false, std::sync::atomic::Ordering::SeqCst));
         assert!(!tool.auto_vet.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    /// Spawn a one-shot HTTP server on 127.0.0.1 that answers every request
+    /// with the given status and body, and return its base URL. Used to drive
+    /// the real skills.sh adapter against a local endpoint (no network).
+    fn spawn_local_registry(
+        status: u16,
+        body: &'static str,
+    ) -> (String, std::thread::JoinHandle<()>) {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf);
+                let resp = format!(
+                    "HTTP/1.1 {status} TEST\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(resp.as_bytes());
+                let _ = stream.flush();
+            }
+        });
+        (format!("http://{}", addr), handle)
+    }
+
+    fn search_registry_config(name: &str, url: &str) -> RegistryConfig {
+        RegistryConfig {
+            name: name.to_string(),
+            registry_type: "skills_sh".to_string(),
+            enabled: true,
+            url: url.to_string(),
+        }
+    }
+
+    fn search_args_json(query: &str) -> serde_json::Value {
+        serde_json::json!({ "query": query, "limit": 10 })
+    }
+
+    #[test]
+    fn all_registries_failing_reports_ok_false() {
+        // Registry returns HTTP 500: the search did not happen, so the tool
+        // must fail (ok=false) instead of pretending "no matches".
+        let (url, server) = spawn_local_registry(500, r#"{"error":"boom"}"#);
+        let tool = SkillSearchTool::new(vec![search_registry_config("broken", &url)]);
+
+        let result = tool.execute(search_args_json("lunacy install"));
+        server.join().expect("server thread");
+
+        assert!(!result.ok, "total registry failure must return ok=false");
+        assert!(result.output.contains("search failed"));
+        assert!(result.output.contains("broken"));
+        let meta = result.meta.expect("meta present");
+        assert_eq!(meta["count"], 0);
+        assert_eq!(meta["registry_errors"][0], "broken");
+    }
+
+    #[test]
+    fn partial_registry_failure_with_results_stays_ok_true() {
+        // One registry answers with a result, another is unreachable: the
+        // merged results are valid (ok=true) but the errors must stay visible.
+        let (good_url, good_server) = spawn_local_registry(
+            200,
+            r#"{"skills":[{"id":"a/b/lunacy-skill","name":"Lunacy Skill","installs":5,"source":"a/b"}]}"#,
+        );
+        let (bad_url, bad_server) = spawn_local_registry(500, r#"{"error":"boom"}"#);
+        let tool = SkillSearchTool::new(vec![
+            search_registry_config("good", &good_url),
+            search_registry_config("bad", &bad_url),
+        ]);
+
+        let result = tool.execute(search_args_json("lunacy"));
+        good_server.join().expect("good server thread");
+        bad_server.join().expect("bad server thread");
+
+        assert!(result.ok, "results from a working registry stay ok=true");
+        assert!(
+            result.output.contains("Found 1 skill(s)"),
+            "got: {}",
+            result.output
+        );
+        assert!(result.output.contains("Registry errors"));
+        assert!(result.output.contains("bad:"));
+        let meta = result.meta.expect("meta present");
+        assert_eq!(meta["count"], 1);
+        assert_eq!(meta["registry_errors"][0], "bad");
+    }
+
+    #[test]
+    fn empty_result_without_errors_is_ok_true_no_matches() {
+        // Registry answers 200 with zero skills: a genuine "no matches".
+        let (url, server) = spawn_local_registry(200, r#"{"skills":[]}"#);
+        let tool = SkillSearchTool::new(vec![search_registry_config("empty", &url)]);
+
+        let result = tool.execute(search_args_json("zzz-nonexistent"));
+        server.join().expect("server thread");
+
+        assert!(result.ok);
+        assert!(result.output.contains("No skills found"));
+        let meta = result.meta.expect("meta present");
+        assert_eq!(meta["count"], 0);
+        assert_eq!(meta["registry_errors"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn disabled_registries_fail_fast() {
+        let tool = SkillSearchTool::new(vec![RegistryConfig {
+            name: "off".to_string(),
+            registry_type: "skills_sh".to_string(),
+            enabled: false,
+            url: "http://127.0.0.1:9".to_string(),
+        }]);
+        let result = tool.execute(search_args_json("anything"));
+        assert!(!result.ok);
+        assert!(result.output.contains("No skill registries are enabled"));
     }
 }

--- a/crates/aish-tools/src/skill_registry/skill_registry.rs
+++ b/crates/aish-tools/src/skill_registry/skill_registry.rs
@@ -85,6 +85,14 @@ impl SkillSearchTool {
             }
             out.push_str("To install, use the skill_install tool with the skill ID.\n");
         }
+        if outcome.results.is_empty() {
+            if out.is_empty() {
+                out.push_str("No skills found matching the query, and no registry errors.");
+            } else {
+                out.push('\n');
+                out.push_str("No skills found among the registries that answered successfully.");
+            }
+        }
         if !outcome.errors.is_empty() {
             if !out.is_empty() {
                 out.push('\n');
@@ -93,9 +101,6 @@ impl SkillSearchTool {
             for e in &outcome.errors {
                 out.push_str(&format!("- {}: {}\n", e.registry, e.error));
             }
-        }
-        if out.is_empty() {
-            out.push_str("No skills found matching the query, and no registry errors.")
         }
         out
     }
@@ -150,13 +155,14 @@ pacman/flatpak/snap) or official download sources."
         let outcome = self.do_search(&search_args.query, search_args.limit);
         let error_registries: Vec<String> =
             outcome.errors.iter().map(|e| e.registry.clone()).collect();
-        // Failure semantics: every registry failed -> the search did not
-        // happen at all, so report failure (ok=false) and let the model
+        // Failure semantics: ok=false only when EVERY enabled registry
+        // failed — the search did not happen at all, so the model must
         // degrade gracefully instead of mistaking it for "no matches".
-        // Partial failures with some results stay ok=true but keep the
-        // errors visible in output and meta; a genuinely empty result with
-        // no errors is a real "no matches" answer.
-        if outcome.results.is_empty() && !outcome.errors.is_empty() {
+        // `outcome.succeeded` counts registries that completed a search
+        // (even with zero results); a success-plus-failure mix stays ok=true
+        // with the errors visible in output and meta, and a genuinely empty
+        // result with no errors is a real "no matches" answer.
+        if outcome.succeeded == 0 && !outcome.errors.is_empty() {
             let mut output = String::from("Skill registry search failed for all registries:\n");
             for e in &outcome.errors {
                 output.push_str(&format!("- {}: {}\n", e.registry, e.error));
@@ -832,6 +838,35 @@ mod tests {
         let meta = result.meta.expect("meta present");
         assert_eq!(meta["count"], 0);
         assert_eq!(meta["registry_errors"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn empty_success_plus_failure_stays_ok_true_no_matches() {
+        // Regression: one registry answers 200 with zero skills while
+        // another fails. A successful empty response is a real "no matches"
+        // from that registry, so the merged outcome must stay ok=true (with
+        // the failure visible), never masquerade as a total outage.
+        let (empty_url, empty_server) = spawn_local_registry(200, r#"{"skills":[]}"#);
+        let (bad_url, bad_server) = spawn_local_registry(500, r#"{"error":"boom"}"#);
+        let tool = SkillSearchTool::new(vec![
+            search_registry_config("empty-ok", &empty_url),
+            search_registry_config("bad", &bad_url),
+        ]);
+
+        let result = tool.execute(search_args_json("zzz-nonexistent"));
+        empty_server.join().expect("empty server thread");
+        bad_server.join().expect("bad server thread");
+
+        assert!(
+            result.ok,
+            "a successful empty registry response is not a total failure"
+        );
+        assert!(result.output.contains("No skills found"));
+        assert!(result.output.contains("Registry errors"));
+        assert!(result.output.contains("bad:"));
+        let meta = result.meta.expect("meta present");
+        assert_eq!(meta["count"], 0);
+        assert_eq!(meta["registry_errors"][0], "bad");
     }
 
     #[test]

--- a/crates/aish-tools/src/skill_registry/skill_registry.rs
+++ b/crates/aish-tools/src/skill_registry/skill_registry.rs
@@ -86,10 +86,9 @@ impl SkillSearchTool {
             out.push_str("To install, use the skill_install tool with the skill ID.\n");
         }
         if outcome.results.is_empty() {
-            if out.is_empty() {
+            if outcome.errors.is_empty() {
                 out.push_str("No skills found matching the query, and no registry errors.");
             } else {
-                out.push('\n');
                 out.push_str("No skills found among the registries that answered successfully.");
             }
         }
@@ -857,6 +856,10 @@ mod tests {
         empty_server.join().expect("empty server thread");
         bad_server.join().expect("bad server thread");
 
+        assert!(
+            !result.output.contains("no registry errors"),
+            "output must not claim 'no registry errors' while listing registry errors"
+        );
         assert!(
             result.ok,
             "a successful empty registry response is not a total failure"


### PR DESCRIPTION
Closes #456

## Summary

- Problem: 普通软件安装请求（如"帮我安装下 Lunacy"）会被引导先调用 `skill_search` 搜索 Skill registry，即使用户没有提出 Skill 需求；且 registry 部分失败时工具仍返回 `ok=true`，网络故障会被误读为"无匹配技能"。
- Changes:
  1. **系统提示词路由规则**（`aish-shell/src/ai_handler.rs`）：`<skill-marketplace>` 注入改写为 ROUTING RULES——普通系统任务（安装/升级/移除 OS 包、查询软件可用性、下载二进制）必须先走 OS 工作流（探测包管理器 apt/dnf/pacman/flatpak/snap，再查权威来源），禁止调用 `skill_search`；仅当用户明确要求 AISH skill 或任务确实需要可声明的 skill 能力且已加载 skill 未覆盖时才搜索。原 search → ask_user → install → skill-vetter 流程保留在"确需搜索"分支后。
  2. **工具描述收紧**（`aish-tools/src/skill_registry/skill_registry.rs`）：`skill_search` 的 `Tool::description()` 同步加入限制（NEVER 用于包管理器/官方下载源类系统任务），提示词 + 工具描述双保险。
  3. **搜索失败语义**（`skill_registry.rs` + `aish-skills/src/registry/mod.rs`）：`SearchOutcome` 新增 `succeeded` 计数（完成成功搜索的 registry 数，含零结果）；`ok=false` 仅当 `succeeded == 0` 且有错误（全部 registry 失败）；部分成功保持 `ok=true` 且错误在 output/meta 可见；`format_results` 在零结果但有 registry 失败时显式输出 "No skills found among the registries that answered successfully"，消除歧义。
- Related Issue: #456

## Change Type

- [x] Bug fix

## Scope

- [x] AI agent / LLM
- [x] Skills / Tools

## User-visible Changes

- 普通软件安装不再触发 skill registry 搜索，直接走 OS 包管理器工作流。
- 显式请求 skill 时：全部 registry 失败会得到明确的失败反馈（可重试/降级），不再伪装成"无匹配技能"；部分失败时错误对模型可见。

## Compatibility

- Backward compatible? Yes（工具名、参数、meta 字段均不变，仅语义修正）
- Config changes? No

## Testing

- `cargo fmt --all -- --check` / `cargo clippy --all-targets -- -D warnings` / `cargo test --workspace`（0 失败）。
- 新增/覆盖测试：marketplace 路由提示词 3 例；skill_search 6 例（全失败→ok=false、部分失败→ok=true、空结果→no matches、空成功+失败混合→ok=true【CodeRabbit 回归测试】、全禁用→fail-fast、auto-vet handle），本地 HTTP server 驱动真实 skills.sh adapter，无网络依赖。

## Checklist

- [x] Code follows project style
- [x] Tests added if needed
- [x] Documentation updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved skill marketplace search routing so standard operating-system package tasks avoid unnecessary skill searches.
  - Skill searches are now used for explicit skill requests or tasks requiring additional capabilities.
  - Improved search result messages to distinguish between no matches and registry failures, including partial failures.
  - Search results now more accurately reflect when registries respond successfully, even if they return no matching skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->