### PR TITLE
Release v0.3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.13] - 2026-09-04
 
 ### Removed
 
-- System-level security policy: `/etc/aish/security_policy.yaml` is no longer read; the user-level `~/.config/aish/security_policy.yaml` (auto-seeded from the shipped template when missing) is the sole source of security settings. Administrators who relied on a system-wide policy must migrate its content to each user's policy file. The uninstaller still removes leftover `/etc/aish` from older installers.
+- System-level security policy: `/etc/aish/security_policy.yaml` is no longer read; the user-level `~/.config/aish/security_policy.yaml` (auto-seeded from the shipped template when missing) is the sole source of security settings. Administrators who relied on a system-wide policy must migrate its content to each user's policy file. On upgrade, if the user-level file is missing and a leftover `/etc/aish/security_policy.yaml` exists, its content is copied to the user-level path instead of being silently discarded. The uninstaller still removes leftover `/etc/aish` from older installers.
+
+### Fixed
+
+- After an upgrade, the Keep-a-Changelog startup summary is no longer consumed by a flash start (version probe, immediate quit, Ctrl-D, or a daemon-attach race). The `last-changelog-version` marker is only advanced after the user actually uses the shell, so the next real session still shows the notes.
 
 ## [0.3.12] - 2026-09-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "aish-cli"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "aish-config"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "aish-context"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "aish-core",
  "serde",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "aish-core"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aish-hosts"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "aish-i18n"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "aish-llm"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "aish-context",
  "aish-core",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "aish-md-table"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "richrs",
  "unicode-width",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "aish-memory"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "aish-core",
  "chrono",
@@ -159,14 +159,14 @@ dependencies = [
 
 [[package]]
 name = "aish-prompts"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "dirs 5.0.1",
 ]
 
 [[package]]
 name = "aish-pty"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "aish-scripts"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "dirs 5.0.1",
  "regex",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "aish-security"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "libc",
  "regex",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "aish-session"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "aish-core",
  "chrono",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "aish-shell"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "aish-config",
  "aish-context",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "aish-skills"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "aish-core",
  "dirs 5.0.1",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "aish-tools"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "aish-config",
  "aish-core",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "aish-ui"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "crossterm 0.28.1",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.89"


### PR DESCRIPTION
## Summary
- Bump version to `0.3.13` (`Cargo.toml` / `Cargo.lock`)
- Add `CHANGELOG.md` section for 0.3.13 covering changes since 0.3.12

### Highlights
- **Removed**: system-level `/etc/aish/security_policy.yaml` is no longer read; user-level policy is the sole source. On upgrade, a leftover system file is copied to the user path when the user file is missing
- **Fixed**: upgrade changelog summary is no longer consumed by a flash start; the marker advances only after the user actually uses the shell

## Local checks
- [x] `python3 packaging/scripts/release_metadata.py --expected-version 0.3.13`
- [x] `make format-check` / `make lint`
- [x] `make test` (one `aish-pty` completion timing assertion flaked locally, passed on retry; packaging smoke passed)

## Release prep
Please run **Release Preparation** with this PR number before merge:
```bash
gh workflow run release-preparation.yml \
  --repo AI-Shell-Team/aish \
  --ref main \
  -f pr_number=<PR_NUMBER>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 0.3.13 released on September 4, 2026.

* **Bug Fixes**
  * Startup summaries are no longer marked as viewed during brief or non-interactive launches.
  * Existing system security policies are now migrated to the user-level location when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->