### PR TITLE
fix(shell): include tool name and scope in completion rows

### DIFF
--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -1321,6 +1321,10 @@ impl AishShell {
         let sub_agent_animation_ref = sub_agent_animation.clone();
         let ai_op_generation = Arc::new(std::sync::atomic::AtomicU64::new(0));
         let ai_op_generation_cb = ai_op_generation.clone();
+        // Stable per-spawn ordinals (#1, #2, …) so interleaved sub-agent
+        // tool rows pair deterministically with their start rows.
+        let spawn_ordinals = crate::llm_event_ui::new_shared_spawn_ordinals();
+        let spawn_ordinals_ref = spawn_ordinals.clone();
 
         // Shared history of collapsed bash outputs for Ctrl+O browsing.
         let expand_history = Arc::new(Mutex::new(crate::expand_history::ExpandHistory::new()));
@@ -1471,7 +1475,8 @@ impl AishShell {
                     LlmEventType::OpEnd => {
                         // Operation ends — stop animation and show timing
                         sub_agent_active_count_ref.store(0, Ordering::SeqCst);
-                        sub_agent_animation_ref.stop();
+                        // New parent turn: restart spawn numbering at #1.
+                        crate::llm_event_ui::reset_spawn_ordinals(&spawn_ordinals_ref);
                         animation_ref.stop();
                         let ttft = *ttft_value_ref.lock().unwrap();
                         if ttft >= 0.1 {
@@ -1749,6 +1754,7 @@ impl AishShell {
                                         &ctx,
                                         name,
                                         &args_preview,
+                                        &spawn_ordinals_ref,
                                     )
                                 } else {
                                     format!(
@@ -1932,7 +1938,10 @@ impl AishShell {
                         // indent) so Start/End rows pair deterministically.
                         {
                             let mut status_line = crate::llm_event_ui::format_tool_end_line(
-                                &event, end_tool, tool_ok,
+                                &event,
+                                end_tool,
+                                tool_ok,
+                                &spawn_ordinals_ref,
                             );
                             // Truncate to the terminal width (ANSI-aware) so
                             // long tool names stay on one line on narrow

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -1927,23 +1927,22 @@ impl AishShell {
                                 }
                             }
                         }
-                        // Always print completion indicator with box bottom corner.
+                        // Always print completion indicator with box bottom
+                        // corner. Include the tool name (and sub-agent child
+                        // indent) so Start/End rows pair deterministically.
                         {
-                            let status_line = if tool_ok {
-                                format!(
-                                    "{} {} {}",
-                                    theme::dim(theme::TOOL_BOX_BOT),
-                                    theme::success(theme::ICON_SUCCESS),
-                                    theme::dim("done")
-                                )
-                            } else {
-                                format!(
-                                    "{} {} {}",
-                                    theme::dim(theme::TOOL_BOX_BOT),
-                                    theme::error(theme::ICON_ERROR),
-                                    theme::dim("failed")
-                                )
-                            };
+                            let mut status_line = crate::llm_event_ui::format_tool_end_line(
+                                &event, end_tool, tool_ok,
+                            );
+                            // Truncate to the terminal width (ANSI-aware) so
+                            // long tool names stay on one line on narrow
+                            // terminals instead of wrapping.
+                            let max_cols = crossterm::terminal::size()
+                                .map(|(cols, _)| cols as usize)
+                                .unwrap_or(80);
+                            if max_cols > 0 {
+                                status_line = truncate_ansi_display_width(&status_line, max_cols);
+                            }
                             crate::recorder::shared_record_output(
                                 &shared_recorder_cb,
                                 &format!("{}\n", status_line),

--- a/crates/aish-shell/src/llm_event_ui.rs
+++ b/crates/aish-shell/src/llm_event_ui.rs
@@ -1,5 +1,8 @@
 //! Helpers for rendering sub-agent LLM events in the shell TUI (AC-11).
 
+use std::collections::HashMap;
+use std::sync::Mutex;
+
 use aish_core::LlmEvent;
 
 /// Parsed sub-agent metadata from an [`LlmEvent`] `data` payload.
@@ -63,6 +66,82 @@ pub fn sub_agent_child_indent(depth: u32) -> String {
     }
 }
 
+/// Ordinals assigned to sub-agent spawns as their events are first observed.
+///
+/// When multiple sub-agents run concurrently (the parent LLM may emit several
+/// `Agent` calls in one response), same-depth agents running the same tool
+/// would otherwise render identical start/end rows. Once a second spawn has
+/// been observed, every row rendered afterwards carries a stable `#N` tag so
+/// rows pair deterministically with their spawn. Note the streaming limit:
+/// the first spawn's start row may render before the second spawn registers,
+/// so it stays untagged — its end row (which always renders after every
+/// spawn of the batch is registered) is tagged instead.
+#[derive(Default)]
+pub struct SpawnOrdinalRegistry {
+    next: u32,
+    ordinals: HashMap<String, u32>,
+}
+
+impl SpawnOrdinalRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the 1-based ordinal for `spawn_id`, assigning the next one on
+    /// first sight.
+    fn ordinal_for(&mut self, spawn_id: &str) -> u32 {
+        let next = &mut self.next;
+        *self
+            .ordinals
+            .entry(spawn_id.to_string())
+            .or_insert_with(|| {
+                *next += 1;
+                *next
+            })
+    }
+
+    fn total(&self) -> u32 {
+        self.ordinals.len() as u32
+    }
+}
+
+/// Thread-safe handle to a [`SpawnOrdinalRegistry`] owned by the shell session.
+pub type SharedSpawnOrdinals = std::sync::Arc<Mutex<SpawnOrdinalRegistry>>;
+
+/// Create a fresh empty registry handle (one per REPL lifetime).
+pub fn new_shared_spawn_ordinals() -> SharedSpawnOrdinals {
+    std::sync::Arc::new(Mutex::new(SpawnOrdinalRegistry::new()))
+}
+
+/// Drop all observed ordinals (call when a parent turn ends so the next turn
+/// starts numbering at `#1` again).
+pub fn reset_spawn_ordinals(registry: &SharedSpawnOrdinals) {
+    *registry.lock().unwrap_or_else(|e| e.into_inner()) = SpawnOrdinalRegistry::new();
+}
+
+/// Scope tag (`#1`, `#2`) for `ctx`, or an empty string while only one spawn
+/// has been observed.
+fn spawn_scope_tag(ctx: &SubAgentContext, registry: &SharedSpawnOrdinals) -> String {
+    let mut guard = registry.lock().unwrap_or_else(|e| e.into_inner());
+    let ordinal = guard.ordinal_for(&ctx.spawn_id);
+    if guard.total() > 1 {
+        format!("#{}", ordinal)
+    } else {
+        String::new()
+    }
+}
+
+/// Human-readable sub-agent scope prefix (`explore#1 `) for tool rows; empty
+/// while only one spawn exists.
+fn sub_agent_scope_prefix(ctx: &SubAgentContext, registry: &SharedSpawnOrdinals) -> String {
+    let tag = spawn_scope_tag(ctx, registry);
+    if tag.is_empty() {
+        String::new()
+    } else {
+        format!("{}{} ", ctx.agent_type, tag)
+    }
+}
+
 pub fn sub_agent_thinking_prefix(ctx: &SubAgentContext) -> String {
     format!("{}{} · ", sub_agent_indent(ctx.depth), ctx.agent_type)
 }
@@ -76,10 +155,16 @@ pub fn format_sub_agent_thinking_line(ctx: &SubAgentContext, status: &str) -> St
     )
 }
 
-pub fn format_sub_agent_tool_line(ctx: &SubAgentContext, name: &str, args_preview: &str) -> String {
+pub fn format_sub_agent_tool_line(
+    ctx: &SubAgentContext,
+    name: &str,
+    args_preview: &str,
+    registry: &SharedSpawnOrdinals,
+) -> String {
     format!(
-        "{}{} {} {}",
+        "{}{}{} {} {}",
         sub_agent_child_indent(ctx.depth),
+        sub_agent_scope_prefix(ctx, registry),
         crate::theme::accent(crate::theme::TOOL_PREFIX),
         crate::theme::accent(name),
         crate::theme::muted(&format!("({})", args_preview))
@@ -125,12 +210,19 @@ pub fn format_main_tool_end_line(name: &str, ok: bool) -> String {
 
 /// Format a tool completion line for a sub-agent event.
 ///
-/// Keeps the child indent used by the sub-agent start line so Start/End
+/// Keeps the child indent used by the sub-agent start line and appends the
+/// spawn scope tag once several sub-agents are active, so Start/End rows
 /// pair deterministically under the agent branch.
-pub fn format_sub_agent_tool_end_line(ctx: &SubAgentContext, name: &str, ok: bool) -> String {
+pub fn format_sub_agent_tool_end_line(
+    ctx: &SubAgentContext,
+    name: &str,
+    ok: bool,
+    registry: &SharedSpawnOrdinals,
+) -> String {
     format!(
-        "{}{}",
+        "{}{}{}",
         sub_agent_child_indent(ctx.depth),
+        sub_agent_scope_prefix(ctx, registry),
         format_tool_end_body(name, ok)
     )
 }
@@ -138,10 +230,15 @@ pub fn format_sub_agent_tool_end_line(ctx: &SubAgentContext, name: &str, ok: boo
 /// Format the completion line for a `ToolExecutionEnd` event.
 ///
 /// Dispatches on sub-agent context so completion rows preserve the same
-/// indentation as their start rows.
-pub fn format_tool_end_line(event: &LlmEvent, name: &str, ok: bool) -> String {
+/// indentation (and spawn scope tag) as their start rows.
+pub fn format_tool_end_line(
+    event: &LlmEvent,
+    name: &str,
+    ok: bool,
+    registry: &SharedSpawnOrdinals,
+) -> String {
     match sub_agent_context(event) {
-        Some(ctx) => format_sub_agent_tool_end_line(&ctx, name, ok),
+        Some(ctx) => format_sub_agent_tool_end_line(&ctx, name, ok, registry),
         None => format_main_tool_end_line(name, ok),
     }
 }
@@ -241,12 +338,13 @@ mod tests {
 
     #[test]
     fn sub_agent_tool_end_line_preserves_child_indent() {
+        let registry = new_shared_spawn_ordinals();
         let ctx = SubAgentContext {
             agent_type: "explore".into(),
             depth: 1,
             spawn_id: "id".into(),
         };
-        let line = format_sub_agent_tool_end_line(&ctx, "grep", true);
+        let line = format_sub_agent_tool_end_line(&ctx, "grep", true, &registry);
         // Child indent (4 spaces) matches the sub-agent start line.
         assert!(line.starts_with("    "));
         assert!(!line.contains("└─"));
@@ -257,13 +355,14 @@ mod tests {
 
     #[test]
     fn format_tool_end_line_dispatches_on_sub_agent_context() {
+        let registry = new_shared_spawn_ordinals();
         let main = LlmEvent {
             event_type: LlmEventType::ToolExecutionEnd,
             data: serde_json::json!({"tool_name": "glob"}),
             timestamp: 0.0,
             metadata: None,
         };
-        let line = format_tool_end_line(&main, "glob", true);
+        let line = format_tool_end_line(&main, "glob", true, &registry);
         assert!(line.contains("╰─"));
         assert!(line.contains("glob"));
 
@@ -271,7 +370,7 @@ mod tests {
             LlmEventType::ToolExecutionEnd,
             serde_json::json!({"tool_name": "glob"}),
         );
-        let line = format_tool_end_line(&sub, "glob", true);
+        let line = format_tool_end_line(&sub, "glob", true, &registry);
         assert!(line.starts_with("    "));
         assert!(line.contains("glob"));
         assert!(!line.contains("╰─"));
@@ -289,12 +388,13 @@ mod tests {
 
     #[test]
     fn format_sub_agent_tool_line_uses_child_indent_without_agent_prefix() {
+        let registry = new_shared_spawn_ordinals();
         let ctx = SubAgentContext {
             agent_type: "plan".into(),
             depth: 1,
             spawn_id: "id".into(),
         };
-        let line = format_sub_agent_tool_line(&ctx, "grep", "pattern=x");
+        let line = format_sub_agent_tool_line(&ctx, "grep", "pattern=x", &registry);
         assert!(line.starts_with("    "));
         assert!(line.contains("❯"));
         assert!(line.contains("grep"));
@@ -313,5 +413,83 @@ mod tests {
         assert!(indented.starts_with("    line1"));
         assert!(indented.contains("\n    line2"));
         assert!(!indented.contains("└─"));
+    }
+
+    // --- spawn scope tags (parallel sub-agent disambiguation) ---
+
+    #[test]
+    fn single_spawn_rows_carry_no_scope_tag() {
+        let registry = new_shared_spawn_ordinals();
+        let start = sub_agent_event(
+            LlmEventType::ToolExecutionStart,
+            serde_json::json!({"tool_name": "grep"}),
+        );
+        let ctx = sub_agent_context(&start).unwrap();
+        let start_line = format_sub_agent_tool_line(&ctx, "grep", "pattern=x", &registry);
+        assert!(!start_line.contains("explore#"), "{start_line}");
+        let end_line = format_sub_agent_tool_end_line(&ctx, "grep", true, &registry);
+        assert!(!end_line.contains("explore#"), "{end_line}");
+    }
+
+    #[test]
+    fn parallel_same_name_spawns_pair_via_distinct_scope_tags() {
+        let registry = new_shared_spawn_ordinals();
+        let first = sub_agent_event(
+            LlmEventType::ToolExecutionStart,
+            serde_json::json!({"spawn_id": "spawn-a", "tool_name": "grep"}),
+        );
+        let second = sub_agent_event(
+            LlmEventType::ToolExecutionStart,
+            serde_json::json!({"spawn_id": "spawn-b", "tool_name": "grep"}),
+        );
+        let ctx_a = sub_agent_context(&first).unwrap();
+        let ctx_b = sub_agent_context(&second).unwrap();
+
+        // Streaming order: spawn-a's start row renders before spawn-b is
+        // registered, so it carries no tag; spawn-b's does. Once both
+        // spawns are known every later row (including both end rows) is
+        // tagged, so each spawn still pairs to exactly one distinct end row.
+        let start_a = format_sub_agent_tool_line(&ctx_a, "grep", "pattern=a", &registry);
+        let start_b = format_sub_agent_tool_line(&ctx_b, "grep", "pattern=b", &registry);
+        assert!(!start_a.contains("explore#"), "{start_a}");
+        assert!(start_b.contains("explore#2 "), "{start_b}");
+
+        // End order may be reversed (concurrent completion): each end row
+        // carries its own stable tag.
+        let end_b = format_sub_agent_tool_end_line(&ctx_b, "grep", true, &registry);
+        let end_a = format_sub_agent_tool_end_line(&ctx_a, "grep", false, &registry);
+        assert!(end_b.contains("explore#2 "), "{end_b}");
+        assert!(end_b.contains("done"));
+        assert!(end_a.contains("explore#1 "), "{end_a}");
+        assert!(end_a.contains("failed"));
+    }
+
+    #[test]
+    fn reset_spawn_ordinals_restores_single_spawn_behavior() {
+        let registry = new_shared_spawn_ordinals();
+        let first = sub_agent_event(
+            LlmEventType::ToolExecutionStart,
+            serde_json::json!({"spawn_id": "spawn-a", "tool_name": "grep"}),
+        );
+        let second = sub_agent_event(
+            LlmEventType::ToolExecutionStart,
+            serde_json::json!({"spawn_id": "spawn-b", "tool_name": "grep"}),
+        );
+        let ctx_a = sub_agent_context(&first).unwrap();
+        let ctx_b = sub_agent_context(&second).unwrap();
+        // Two spawns observed before the reset.
+        format_sub_agent_tool_line(&ctx_a, "grep", "p", &registry);
+        assert!(format_sub_agent_tool_line(&ctx_b, "grep", "p", &registry).contains("explore#2 "));
+
+        reset_spawn_ordinals(&registry);
+        // After the reset a single fresh spawn must not be tagged: the next
+        // turn starts numbering from scratch.
+        let fresh = sub_agent_event(
+            LlmEventType::ToolExecutionStart,
+            serde_json::json!({"spawn_id": "spawn-c", "tool_name": "grep"}),
+        );
+        let ctx_c = sub_agent_context(&fresh).unwrap();
+        let line = format_sub_agent_tool_line(&ctx_c, "grep", "p", &registry);
+        assert!(!line.contains("explore#"), "{line}");
     }
 }

--- a/crates/aish-shell/src/llm_event_ui.rs
+++ b/crates/aish-shell/src/llm_event_ui.rs
@@ -95,6 +95,57 @@ pub fn indent_sub_agent_output_block(ctx: &SubAgentContext, block: &str) -> Stri
         .join("\n")
 }
 
+/// Icon + tool name + status shared by all completion-row variants.
+fn format_tool_end_body(name: &str, ok: bool) -> String {
+    let status = if ok { "done" } else { "failed" };
+    let icon = if ok {
+        crate::theme::success(crate::theme::ICON_SUCCESS)
+    } else {
+        crate::theme::error(crate::theme::ICON_ERROR)
+    };
+    format!(
+        "{} {} {}",
+        icon,
+        crate::theme::accent(name),
+        crate::theme::dim(status)
+    )
+}
+
+/// Format a tool completion line for the main session.
+///
+/// Mirrors the start line (`╭─ ❯ tool (args)`) so start/end rows pair by
+/// tool name instead of showing a bare `done`/`failed`.
+pub fn format_main_tool_end_line(name: &str, ok: bool) -> String {
+    format!(
+        "{} {}",
+        crate::theme::dim(crate::theme::TOOL_BOX_BOT),
+        format_tool_end_body(name, ok)
+    )
+}
+
+/// Format a tool completion line for a sub-agent event.
+///
+/// Keeps the child indent used by the sub-agent start line so Start/End
+/// pair deterministically under the agent branch.
+pub fn format_sub_agent_tool_end_line(ctx: &SubAgentContext, name: &str, ok: bool) -> String {
+    format!(
+        "{}{}",
+        sub_agent_child_indent(ctx.depth),
+        format_tool_end_body(name, ok)
+    )
+}
+
+/// Format the completion line for a `ToolExecutionEnd` event.
+///
+/// Dispatches on sub-agent context so completion rows preserve the same
+/// indentation as their start rows.
+pub fn format_tool_end_line(event: &LlmEvent, name: &str, ok: bool) -> String {
+    match sub_agent_context(event) {
+        Some(ctx) => format_sub_agent_tool_end_line(&ctx, name, ok),
+        None => format_main_tool_end_line(name, ok),
+    }
+}
+
 pub fn print_sub_agent_generation_start(event: &LlmEvent) {
     if let Some(ctx) = sub_agent_context(event) {
         let status = aish_i18n::t("shell.sub_agent.thinking");
@@ -112,6 +163,7 @@ pub fn sub_agent_thinking_animation_prefix(event: &LlmEvent) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::theme;
     use aish_core::LlmEventType;
 
     fn sub_agent_event(event_type: LlmEventType, extra: serde_json::Value) -> LlmEvent {
@@ -169,6 +221,60 @@ mod tests {
             serde_json::json!({"tool_name": "glob"}),
         );
         assert!(!is_parent_agent_spawn_tool_event(&sub));
+    }
+
+    #[test]
+    fn main_tool_end_line_pairs_with_start_line() {
+        let ok = format_main_tool_end_line("glob", true);
+        assert!(ok.contains("╰─"));
+        assert!(ok.contains(theme::ICON_SUCCESS));
+        assert!(ok.contains("glob"));
+        assert!(ok.contains("done"));
+        assert!(!ok.contains("failed"));
+
+        let failed = format_main_tool_end_line("bash", false);
+        assert!(failed.contains(theme::ICON_ERROR));
+        assert!(failed.contains("bash"));
+        assert!(failed.contains("failed"));
+        assert!(!failed.contains("done"));
+    }
+
+    #[test]
+    fn sub_agent_tool_end_line_preserves_child_indent() {
+        let ctx = SubAgentContext {
+            agent_type: "explore".into(),
+            depth: 1,
+            spawn_id: "id".into(),
+        };
+        let line = format_sub_agent_tool_end_line(&ctx, "grep", true);
+        // Child indent (4 spaces) matches the sub-agent start line.
+        assert!(line.starts_with("    "));
+        assert!(!line.contains("└─"));
+        assert!(line.contains(theme::ICON_SUCCESS));
+        assert!(line.contains("grep"));
+        assert!(line.contains("done"));
+    }
+
+    #[test]
+    fn format_tool_end_line_dispatches_on_sub_agent_context() {
+        let main = LlmEvent {
+            event_type: LlmEventType::ToolExecutionEnd,
+            data: serde_json::json!({"tool_name": "glob"}),
+            timestamp: 0.0,
+            metadata: None,
+        };
+        let line = format_tool_end_line(&main, "glob", true);
+        assert!(line.contains("╰─"));
+        assert!(line.contains("glob"));
+
+        let sub = sub_agent_event(
+            LlmEventType::ToolExecutionEnd,
+            serde_json::json!({"tool_name": "glob"}),
+        );
+        let line = format_tool_end_line(&sub, "glob", true);
+        assert!(line.starts_with("    "));
+        assert!(line.contains("glob"));
+        assert!(!line.contains("╰─"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #484

## Summary

- Problem: `ToolExecutionEnd` rendered a bare `╰─ ✔ done` / `╰─ ✘ failed` indicator; when skills, sub-agents and the main session ran tools consecutively or interleaved, identical end rows could not be paired with their start rows. Parallel same-type sub-agents were additionally indistinguishable from each other.
- Changes:
  - `crates/aish-shell/src/llm_event_ui.rs`: new `format_tool_end_line` dispatcher (`format_main_tool_end_line` / `format_sub_agent_tool_end_line` share `format_tool_end_body`); main rows render as `╰─ ✔ <tool_name> done`; sub-agent rows keep the same 4-space child indent as their start rows. Added an injected `SpawnOrdinalRegistry` (`SharedSpawnOrdinals`): each spawn registers a 1-based ordinal, and when a turn has ≥2 spawns, sub-agent tool Start/End rows carry a stable `explore#N ` scope tag so parallel same-type spawns pair unambiguously. A single spawn renders with no tag (zero noise); the registry resets on parent turn end (`OpEnd`) so the next turn numbers from 1 again. Streaming note: a first spawn's Start row may render before a second spawn registers (no tag possible), but its End row is always tagged once the turn ends with ≥2 spawns, so every end line pairs deterministically.
  - `crates/aish-shell/src/app.rs`: owns the `SharedSpawnOrdinals`, passes it into the sub-agent row formatters, and resets it on `OpEnd`; `ToolExecutionEnd` status line built via `format_tool_end_line`; rows truncated to terminal width (ANSI-aware).
- Related Issue: #484

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Other

## Scope

- [ ] Core shell / PTY
- [x] AI agent / LLM
- [ ] Skills / Tools
- [ ] Security
- [ ] Configuration
- [ ] CLI / Interface
- [ ] Packaging / Installation
- [ ] CI/CD
- [ ] Documentation

## User-visible Changes

- Tool completion rows now show which tool finished: `╰─ ✔ bash done` instead of `╰─ ✔ done`.
- Sub-agent tool rows use the same child indent for Start and End, pairing deterministically under the agent branch.
- When a turn runs multiple (especially parallel) sub-agents, their tool rows carry stable scope tags:

```
  └─ explore · 思考中
  └─ explore · 思考中
    ❯ glob (crates/**/*.toml)          ← spawn #1 start (rendered before #2 registered)
    explore#2 ❯ glob (crates/**/*.toml) ← spawn #2 start
    explore#2 ✔ glob done               ← end lines always tagged → pairable
    explore#1 ✔ glob done
  ╰─ ✔ Agent done
```

- A single sub-agent spawn in a turn renders exactly as before — no tag noise.

## Compatibility

- Backward compatible? Yes — single-spawn and main-session rendering is unchanged in shape; new tags only appear when a turn has ≥2 spawns.
- Config changes? No.

## Testing

- `cargo test -p aish-shell --lib`: 451 passed, incl. 3 new scope-tag tests (`single_spawn_rows_carry_no_scope_tag`, `parallel_same_name_spawns_pair_via_distinct_scope_tags`, `reset_spawn_ordinals_restores_single_spawn_behavior`)
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- End-to-end PTY smoke against a scripted provider (single + two sequential + two parallel `explore` spawns): start/end rows pair, parallel end lines carry distinct `explore#N` tags, single-spawn rows show no tag

## Result

Before:
```
╰─ ✔ done
╰─ ✔ done
```

After:
```
╰─ ✔ bash done
    explore#2 ✔ glob done
    explore#1 ✔ glob done
╰─ ✔ Agent done
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pairing of tool start and completion rows when multiple same-depth sub-agents run the same tool concurrently.
  * Added distinct sub-agent identifiers when needed to make interleaved tool activity easier to follow.
  * Spawn numbering now resets for each parent operation, preventing stale identifiers across turns.

* **Tests**
  * Added coverage for concurrent sub-agent activity, single-spawn display behavior, and per-turn numbering resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->