### PR TITLE
fix(cli): PTY 附加零输出时回退 standalone 模式，避免空白屏

### DIFF
--- a/crates/aish-cli/src/main.rs
+++ b/crates/aish-cli/src/main.rs
@@ -1296,6 +1296,11 @@ fn run_pty_raw_attach(socket_path: &str, session_id: &str) -> bool {
     // scrollback (including the prompt) would never be displayed until
     // the user presses a key to generate new output.
     let mut initial_exit = false;
+    // Track whether any PTY output was actually received during scrollback
+    // replay. When the inner shell exits immediately without producing any
+    // output (e.g. PersistentPty::start failed before the welcome banner),
+    // we return false so the caller can fall back to standalone mode.
+    let mut had_output = false;
     if let Ok(events) = backend.drain_events() {
         for event in events {
             match event {
@@ -1303,6 +1308,7 @@ fn run_pty_raw_attach(socket_path: &str, session_id: &str) -> bool {
                     if !bytes.is_empty() {
                         let (clean, _cmds) = osc.process(&bytes);
                         if !clean.is_empty() {
+                            had_output = true;
                             // SAFETY: [Category 8 — FFI] `write()` to stdout.
                             // `stdout_fd` is valid; `clean` is a Vec whose
                             // buffer is valid for the duration of the call.
@@ -1331,9 +1337,13 @@ fn run_pty_raw_attach(socket_path: &str, session_id: &str) -> bool {
         unsafe {
             libc::tcsetattr(stdin_fd, libc::TCSANOW, &orig_termios);
         }
-        return true;
+        // If the inner shell exited without producing any output, the user
+        // saw a blank screen. Return false so the caller falls back to
+        // standalone mode and shows the welcome banner.
+        // When output was produced (banner/prompt visible), return true —
+        // the user already saw what they need and the session is done.
+        return had_output;
     }
-
     let mut stdin_buf = [0u8; 1024];
     // True when the inner shell sent ShellExiting (user typed `exit`/`logout`).
     // Distinguishes a true detach (Ctrl+Q — session still alive) from a shell

--- a/crates/aish-cli/src/main.rs
+++ b/crates/aish-cli/src/main.rs
@@ -1444,6 +1444,7 @@ fn run_pty_raw_attach(socket_path: &str, session_id: &str) -> bool {
                                 }
                                 let (clean, cmds) = osc.process(&bytes);
                                 if !clean.is_empty() {
+                                    had_output = true;
                                     // SAFETY: [Category 8 — FFI] `write()` to
                                     // stdout. `stdout_fd` is valid; `clean`
                                     // is a Vec whose buffer is valid.
@@ -1539,6 +1540,12 @@ fn run_pty_raw_attach(socket_path: &str, session_id: &str) -> bool {
     // sends EXIT_NOTICE which sets running=false — nothing to reattach to.
     if !shell_exited && backend.is_running() {
         eprintln!("\x1b[32m[aish] {}\x1b[0m", aish_i18n::t("cli.detach_hint"));
+    }
+    // The inner shell exited during the live loop: apply the same
+    // blank-screen rule as the initial drain — success only if output
+    // was actually shown, otherwise let the caller fall back.
+    if shell_exited {
+        return had_output;
     }
     true
 }


### PR DESCRIPTION
## Summary

- Problem: `run_pty_raw_attach` 在 scrollback 回放后收到内层 Shell 退出信号时无条件返回 `true`，即使回放期间没有收到任何 PTY 输出。内层 Shell 在产出欢迎横幅前就退出时（如 `PersistentPty::start` 失败、内层进程立即崩溃），用户看到空白屏，且调用方不会走 "Falling back to standalone shell" 回退。
- Changes: 回放期间跟踪 `had_output`；`ShellExiting` 分支返回 `had_output` 而非恒 `true`。零输出 → 返回 `false` → 回退 standalone 模式并显示欢迎横幅；有输出 → 行为不变。
- Related Issue: Closes #514

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Other

## Scope

- [x] Core shell / PTY
- [ ] AI agent / LLM
- [ ] Skills / Tools
- [ ] Security
- [ ] Configuration
- [x] CLI / Interface
- [ ] Packaging / Installation
- [ ] CI/CD
- [ ] Documentation

## User-visible Changes

- 内层 Shell 静默退出（零输出）时不再卡在空白屏：自动回退到 standalone Shell 并正常显示欢迎界面。有正常输出时的附加/退出行为完全不变。

## Compatibility

- Backward compatible? Yes（仅改变失败路径的返回值语义）
- Config changes? No

## Testing

- `cargo test -p aish-cli` 38 passed / 0 failed
- `cargo build --workspace` 通过；`cargo clippy -p aish-cli --all-targets -- -D warnings` 0 错误；`cargo fmt --all -- --check` clean
- 人工核验：`run_pty_raw_attach` 的三个调用点（`run_shell_continue` 会话选择器、`spawn_daemon_and_attach`、resume 路径）对 `false` 返回值均有既有 standalone 回退分支

## Checklist

- [x] Code follows project style
- [x] Tests added if needed（既有测试覆盖调用点语义，失败路径依赖 PTY 环境无法单测）
- [ ] Documentation updated if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal startup behavior when the backend is unavailable or the shell exits immediately.
  - The application now correctly detects when no terminal output was received during startup or live session handling.
  - When no visible output is produced, the application can fall back to standalone mode instead of displaying an unusable or blank session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->