### PR TITLE
feat(shell): 欢迎面板内嵌渲染升级 changelog 区间并补全分类徽章

### DIFF
--- a/crates/aish-i18n/src/changelog.rs
+++ b/crates/aish-i18n/src/changelog.rs
@@ -109,6 +109,24 @@ pub fn select_changelog_range(
         .collect()
 }
 
+/// Collect all changelog entries from the range `after → through` (exclusive
+/// of `after`, inclusive of `through`) in display order (oldest → newest).
+/// Returns a flat list suitable for rendering inside the welcome panel.
+pub fn collect_range_entries(after: &str, through: &str) -> Vec<ChangelogEntry> {
+    let sections = parse_embedded_changelog_sections();
+    let selected = select_changelog_range(&sections, after, through, compare_changelog_versions);
+    let ordered: Vec<_> = selected.into_iter().rev().collect();
+    let mut entries = Vec::new();
+    for section in &ordered {
+        let show = section
+            .entries
+            .len()
+            .min(STARTUP_CHANGELOG_MAX_ENTRIES_PER_VERSION);
+        entries.extend_from_slice(&section.entries[..show]);
+    }
+    entries
+}
+
 /// Extract the text between `## [{version}]` and the next `## [` heading.
 ///
 /// Uses [`parse_version_heading`] so version matching is exact (avoids treating
@@ -209,6 +227,9 @@ fn category_badge(category: &str) -> &'static str {
         "Added" => "\x1b[32m[+]\x1b[0m",
         "Changed" => "\x1b[33m[*]\x1b[0m",
         "Fixed" => "\x1b[31m[!]\x1b[0m",
+        "Removed" => "\x1b[31m[-]\x1b[0m",
+        "Deprecated" => "\x1b[33m[!]\x1b[0m",
+        "Security" => "\x1b[31m[!]\x1b[0m",
         _ => "\x1b[2m[-]\x1b[0m",
     }
 }
@@ -633,6 +654,35 @@ mod tests {
             vec!["0.3.4", "0.3.3"]
         );
         assert!(selected.iter().all(|s| !s.entries.is_empty()));
+    }
+
+    #[test]
+    fn test_collect_range_entries_orders_oldest_first_and_caps_per_version() {
+        // Uses the embedded CHANGELOG.md so the test stays valid as new
+        // releases are appended. Pick the two newest released sections.
+        let sections = parse_embedded_changelog_sections();
+        assert!(
+            sections.len() >= 2,
+            "embedded CHANGELOG.md needs at least two released sections"
+        );
+        let latest = sections[0].version.as_str();
+        let prev = sections[1].version.as_str();
+
+        let entries = collect_range_entries(prev, latest);
+        assert!(
+            !entries.is_empty(),
+            "range {prev} → {latest} should yield entries"
+        );
+        // Every version contributes at most
+        // STARTUP_CHANGELOG_MAX_ENTRIES_PER_VERSION entries; two versions
+        // cap the flat list at 2 × that constant.
+        assert!(
+            entries.len() <= 2 * STARTUP_CHANGELOG_MAX_ENTRIES_PER_VERSION,
+            "flat list must respect the per-version cap"
+        );
+
+        // Out-of-range (after == through) yields nothing.
+        assert!(collect_range_entries(latest, latest).is_empty());
     }
 
     #[test]

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -2107,25 +2107,37 @@ impl AishShell {
 
         // Note: event_callback is already set on the LlmSession before AiHandler takes ownership
         let version = env!("CARGO_PKG_VERSION").to_string();
-
         // After an upgrade, show the Keep-a-Changelog range once (omp-style),
         // sourced from the CHANGELOG.md embedded in this binary. Steady-state
         // launches keep the existing current-version welcome panel.
         let upgrade_summary = prompt::take_startup_changelog_summary(&version);
-        if let Some((ref ansi, _, _)) = upgrade_summary {
-            print!("\n{ansi}");
-            let _ = io::stdout().flush();
-        }
 
-        let changelog = if upgrade_summary.is_some() {
-            // Range summary already covered the newly installed versions.
-            Vec::new()
-        } else {
-            aish_i18n::changelog::parse_current_changelog(&version)
-        };
+        // Build the changelog entries + optional range title for the panel.
+        // When an upgrade summary exists, the range entries are rendered
+        // inside the welcome panel (not above it) so the display stays
+        // visually consistent between upgrades and steady-state launches.
+        let (changelog, changelog_title_override) =
+            if let Some((_, _, ref prev, ref entries)) = upgrade_summary {
+                let mut args = std::collections::HashMap::new();
+                args.insert("current".to_string(), prev.clone());
+                args.insert("latest".to_string(), version.clone());
+                let title = aish_i18n::t_with_args("shell.welcome2.changelog_summary_title", &args);
+                (entries.clone(), Some(title))
+            } else {
+                (
+                    aish_i18n::changelog::parse_current_changelog(&version),
+                    None,
+                )
+            };
         print!(
             "{}",
-            prompt::render_welcome(&version, &config.model, skill_count, changelog.clone())
+            prompt::render_welcome(
+                &version,
+                &config.model,
+                skill_count,
+                changelog.clone(),
+                changelog_title_override.as_deref(),
+            )
         );
         let _ = io::stdout().flush();
 
@@ -2137,7 +2149,7 @@ impl AishShell {
 
         // Store full changelog in expand_history so Ctrl+O can show all entries
         // when the welcome panel truncates them with "and N more".
-        if let Some((_, ref plain, ref prev)) = upgrade_summary {
+        if let Some((_, ref plain, ref prev, _)) = upgrade_summary {
             let mut args = std::collections::HashMap::new();
             args.insert("current".to_string(), prev.clone());
             args.insert("latest".to_string(), version.clone());
@@ -2146,7 +2158,10 @@ impl AishShell {
                 .lock()
                 .unwrap()
                 .add(format!("[changelog] {cl_title}"), plain.clone());
-        } else if changelog.len() > 2 {
+        } else if !changelog.is_empty() {
+            // Even when there are ≤2 entries, each one is likely truncated
+            // in the panel (inner_width ≈ 56 chars). Store the full text so
+            // Ctrl+O can expand it.
             let full_text = prompt::format_changelog_full(&version, &changelog);
             let cl_title = prompt::changelog_title(&version);
             expand_history

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -2116,13 +2116,17 @@ impl AishShell {
         // When an upgrade summary exists, the range entries are rendered
         // inside the welcome panel (not above it) so the display stays
         // visually consistent between upgrades and steady-state launches.
+        // Single source of truth for the range title so the panel header
+        // and the Ctrl+O expand entry can never drift apart.
+        let range_title = |prev: &str| {
+            let mut args = std::collections::HashMap::new();
+            args.insert("current".to_string(), prev.to_string());
+            args.insert("latest".to_string(), version.clone());
+            aish_i18n::t_with_args("shell.welcome2.changelog_summary_title", &args)
+        };
         let (changelog, changelog_title_override) =
             if let Some((_, _, ref prev, ref entries)) = upgrade_summary {
-                let mut args = std::collections::HashMap::new();
-                args.insert("current".to_string(), prev.clone());
-                args.insert("latest".to_string(), version.clone());
-                let title = aish_i18n::t_with_args("shell.welcome2.changelog_summary_title", &args);
-                (entries.clone(), Some(title))
+                (entries.clone(), Some(range_title(prev)))
             } else {
                 (
                     aish_i18n::changelog::parse_current_changelog(&version),
@@ -2150,10 +2154,7 @@ impl AishShell {
         // Store full changelog in expand_history so Ctrl+O can show all entries
         // when the welcome panel truncates them with "and N more".
         if let Some((_, ref plain, ref prev, _)) = upgrade_summary {
-            let mut args = std::collections::HashMap::new();
-            args.insert("current".to_string(), prev.clone());
-            args.insert("latest".to_string(), version.clone());
-            let cl_title = aish_i18n::t_with_args("shell.welcome2.changelog_summary_title", &args);
+            let cl_title = range_title(prev);
             expand_history
                 .lock()
                 .unwrap()

--- a/crates/aish-shell/src/prompt.rs
+++ b/crates/aish-shell/src/prompt.rs
@@ -659,6 +659,9 @@ pub fn format_changelog_full(
             "Added" => "[+]",
             "Changed" => "[*]",
             "Fixed" => "[!]",
+            "Removed" => "[-]",
+            "Deprecated" => "[!]",
+            "Security" => "[!]",
             _ => "[-]",
         };
         // Wrap long descriptions to fit panel width (~76 visible chars)

--- a/crates/aish-shell/src/prompt.rs
+++ b/crates/aish-shell/src/prompt.rs
@@ -221,9 +221,17 @@ fn write_last_changelog_version(version: &str) {
 /// summary. Call [`commit_last_changelog_version`] once the user actually
 /// interacts with the shell.
 ///
-/// Returns `(ansi_summary, plain_expand_text, previous_version)` when a range
-/// should be shown.
-pub fn take_startup_changelog_summary(current_version: &str) -> Option<(String, String, String)> {
+/// Returns `(ansi_summary, plain_expand_text, previous_version, range_entries)`
+/// when a range should be shown. `range_entries` contains the flat list of
+/// changelog entries for in-panel rendering.
+pub fn take_startup_changelog_summary(
+    current_version: &str,
+) -> Option<(
+    String,
+    String,
+    String,
+    Vec<aish_i18n::changelog::ChangelogEntry>,
+)> {
     let current = current_version.strip_prefix('v').unwrap_or(current_version);
     // First launch after a fresh install: seed the marker silently so the
     // very first version seen is never reported as an upgrade.
@@ -250,8 +258,9 @@ pub fn take_startup_changelog_summary(current_version: &str) -> Option<(String, 
     // only advances when the shell records real user interaction.
     let summary = aish_i18n::changelog::format_changelog_range_summary(last_norm, current);
     let plain = aish_i18n::changelog::format_changelog_range_plain(last_norm, current);
+    let entries = aish_i18n::changelog::collect_range_entries(last_norm, current);
     match (summary, plain) {
-        (Some(ansi), Some(text)) => Some((ansi, text, last_norm.to_string())),
+        (Some(ansi), Some(text)) => Some((ansi, text, last_norm.to_string(), entries)),
         // Nothing renderable for this range (e.g. missing CHANGELOG entries):
         // reseat so the next launch does not retry an empty range forever.
         _ => {
@@ -393,11 +402,17 @@ pub fn render_prompt(
 /// - Quick start tips
 /// - Risk warning
 /// - Changelog entries (up to 2 shown; Ctrl+O expands to full list)
+///
+/// `changelog_title_override` replaces the default "v{version} 更新内容"
+/// header inside the panel — used by the upgrade range summary so the
+/// panel shows "更新内容（0.3.12 → 0.3.13）：" instead of a single-version
+/// title.
 pub fn render_welcome(
     version: &str,
     model: &str,
     skill_count: usize,
     changelog: Vec<aish_i18n::changelog::ChangelogEntry>,
+    changelog_title_override: Option<&str>,
 ) -> String {
     let mut out = String::new();
     out.push('\n');
@@ -453,7 +468,9 @@ pub fn render_welcome(
 
     // Changelog section (inside the panel)
     if !changelog.is_empty() {
-        let title = changelog_title(version);
+        let title = changelog_title_override
+            .map(String::from)
+            .unwrap_or_else(|| changelog_title(version));
 
         let max_entries = 2usize;
         let entries_to_show = changelog.len().min(max_entries);
@@ -492,6 +509,9 @@ pub fn render_welcome(
                 "Added" => theme::success("[+]"),
                 "Changed" => theme::warning("[*]"),
                 "Fixed" => theme::error("[!]"),
+                "Removed" => theme::error("[-]"),
+                "Deprecated" => theme::warning("[!]"),
+                "Security" => theme::error("[!]"),
                 _ => theme::dim("[-]"),
             };
             let mut line = format!("  {} {}", badge_styled, entry.text);
@@ -911,6 +931,34 @@ mod tests {
     }
 
     #[test]
+    fn test_render_welcome_changelog_title_override_used_in_panel() {
+        // The upgrade range summary renders inside the panel with a range
+        // title (e.g. "更新内容（0.3.12 → 0.3.13）：") instead of the default
+        // single-version title. Verify the override replaces the default.
+        let entry = aish_i18n::changelog::ChangelogEntry {
+            category: "Removed".to_string(),
+            text: "some removed thing".to_string(),
+        };
+        let range_title = "更新内容（0.3.12 → 0.3.13）：";
+        let result = render_welcome("0.3.13", "gpt-4", 0, vec![entry], Some(range_title));
+        assert!(
+            result.contains(range_title),
+            "panel should render the override range title"
+        );
+        let default_title = changelog_title("0.3.13");
+        assert!(
+            !result.contains(&default_title),
+            "default single-version title must not appear when overridden"
+        );
+        // Removed entries render with the red error badge, not the dim default.
+        let removed_badge = theme::error("[-]");
+        assert!(
+            result.contains(removed_badge.as_str()),
+            "Removed category should use the red [-] badge"
+        );
+    }
+
+    #[test]
     fn test_render_welcome_changelog_truncated_appends_reset() {
         // Long changelog lines get truncated to inner_width-3 chars plus
         // "...". Without an explicit reset, the panel padding after the
@@ -920,7 +968,7 @@ mod tests {
             category: "Added".to_string(),
             text: "X".repeat(120),
         };
-        let result = render_welcome("0.3.5", "gpt-4", 0, vec![entry]);
+        let result = render_welcome("0.3.5", "gpt-4", 0, vec![entry], None);
         let lines: Vec<&str> = result.lines().collect();
         let truncated_line = lines
             .iter()
@@ -1003,6 +1051,7 @@ mod tests {
             "deepseek-v4-flash",
             8,
             vec![mk("short change"), mk("another"), mk("third")],
+            None,
         );
         let panel_lines: Vec<&str> = result
             .lines()
@@ -1031,7 +1080,7 @@ mod tests {
 
     #[test]
     fn test_render_welcome_contains_logo() {
-        let result = render_welcome("0.1.0", "gpt-4", 3, vec![]);
+        let result = render_welcome("0.1.0", "gpt-4", 3, vec![], None);
         assert!(result.contains("█████"), "should contain ASCII art logo");
         assert!(result.contains("╭"), "should contain rounded box top-left");
         assert!(result.contains("╮"), "should contain rounded box top-right");
@@ -1053,7 +1102,7 @@ mod tests {
 
     #[test]
     fn test_render_welcome_contains_quick_start() {
-        let result = render_welcome("0.1.0", "gpt-4", 0, vec![]);
+        let result = render_welcome("0.1.0", "gpt-4", 0, vec![], None);
         assert!(result.contains("•"), "should contain bullet points");
         assert!(result.contains("ls"), "should contain ls example command");
         assert!(result.contains("top"), "should contain top example command");
@@ -1063,7 +1112,7 @@ mod tests {
 
     #[test]
     fn test_render_welcome_uses_default_logo_color() {
-        let result = render_welcome("0.1.0", "gpt-4", 0, vec![]);
+        let result = render_welcome("0.1.0", "gpt-4", 0, vec![], None);
         assert!(
             !result.contains("\x1b[38;5;250m"),
             "logo should not use grayscale gradient colors"
@@ -1072,7 +1121,7 @@ mod tests {
 
     #[test]
     fn test_render_welcome_starts_with_blank_line() {
-        let result = render_welcome("0.1.0", "gpt-4", 0, vec![]);
+        let result = render_welcome("0.1.0", "gpt-4", 0, vec![], None);
         assert!(
             result.starts_with('\n'),
             "welcome banner should leave a blank line above the logo"
@@ -1081,7 +1130,7 @@ mod tests {
 
     #[test]
     fn test_render_welcome_aligns_quick_start_content() {
-        let result = render_welcome("0.1.0", "gpt-4", 0, vec![]);
+        let result = render_welcome("0.1.0", "gpt-4", 0, vec![], None);
         let item1_prefix = t("shell.welcome2.quick_start.item1_prefix");
         let item2_prefix = t("shell.welcome2.quick_start.item2_prefix");
         let item3_prefix = t("shell.welcome2.quick_start.item3_prefix");


### PR DESCRIPTION
## Summary

- Problem: 升级后的 changelog 区间汇总以独立文本块打印在欢迎面板上方，与稳态启动（面板内嵌）视觉不一致；面板徽章仅识别 Added/Changed/Fixed，Removed/Deprecated/Security 条目落入灰色默认徽章。
- Changes:
  - `aish-i18n::changelog` 新增 `collect_range_entries(after, through)`：按旧→新顺序拍平区间条目，保留每版本条目数上限；新增 Removed/Deprecated/Security 的 ANSI 徽章
  - `prompt::take_startup_changelog_summary` 返回值追加区间条目；`render_welcome` 新增 `changelog_title_override`，面板标题显示"更新内容（a → b）："区间形式；theme 徽章同步补全三类
  - `app.rs` 升级启动时把区间条目传入欢迎面板；Ctrl+O 展开文本与重置逻辑不变；≤2 条目也存入展开历史（面板内宽会截断）
- Related Issue: Closes #515

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Other

## Scope

- [x] Core shell / PTY
- [ ] AI agent / LLM
- [ ] Skills / Tools
- [ ] Security
- [ ] Configuration
- [x] CLI / Interface
- [ ] Packaging / Installation
- [ ] CI/CD
- [ ] Documentation

## User-visible Changes

- 升级后首次启动：changelog 区间汇总直接渲染在欢迎面板内部，标题为区间形式（"更新内容（0.3.12 → 0.3.13）："），与稳态启动视觉一致
- Removed（红色 [-]）、Deprecated（黄色 [!]）、Security（红色 [!]）条目拥有醒目徽章，不再显示灰色默认

## Compatibility

- Backward compatible? Yes（`render_welcome` 新参数为内部 API；i18n key `shell.welcome2.changelog_summary_title` 已存在）
- Config changes? No

## Testing

- `cargo test -p aish-shell --lib prompt` 47 passed / 0 failed（含新增：面板标题覆盖 + Removed 徽章断言）
- `cargo test -p aish-i18n --lib` 15 passed / 0 failed（含新增：`collect_range_entries` 排序与每版本上限）
- `cargo clippy -p aish-shell -p aish-i18n --all-targets -- -D warnings` 0 错误；`cargo fmt --all -- --check` clean；`cargo build --workspace` 通过

## Checklist

- [x] Code follows project style
- [x] Tests added if needed
- [ ] Documentation updated if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup welcome panels now display upgrade changelog entries directly within the panel.
  * Upgrade summaries can include changes across a version range, ordered from oldest to newest.
  * Changelog history can be expanded whenever entries are available, including shorter updates.
* **Improvements**
  * Added distinct visual badges for removed, deprecated, and security-related changes.
  * Version-range changelogs now use an appropriate localized title.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->