### PR TITLE
feat(shell): slash 命令面板可搜索、按场景分组并展示命令可用状态

### DIFF
--- a/crates/aish-i18n/locales/de-DE.yaml
+++ b/crates/aish-i18n/locales/de-DE.yaml
@@ -194,8 +194,27 @@ shell:
     fork: "Aktuelle Sitzung abzweigen"
     sessions: "Sitzungsbaum anzeigen"
     rollback: "KI-Dateibearbeitungen dieser Sitzung prüfen und zurückrollen (edit_file/write_file)"
-    undo: "Letzte Dateiänderung dieser Sitzung rückgängig machen (edit_file/write_file)"
+    undo: "Letzte KI-Dateiänderung rückgängig machen (edit_file/write_file)"
     memory: "Langfristige Erinnerungen anzeigen, verifizieren oder löschen"
+
+  slash_group:
+    diagnostics: "Diagnose"
+    sessions: "Sitzungen"
+    model_settings: "Modell & Einstellungen"
+    skills: "Fähigkeiten"
+    files_memory: "Dateien & Erinnerungen"
+    record_share: "Aufnahme & Teilen"
+    security_audit: "Sicherheit & Audit"
+    exit: "Beenden"
+
+  slash_status:
+    reason_diagnose_no_failure: "Kein fehlgeschlagener Befehl zum Diagnostizieren"
+    reason_audit_disabled: "Audit-Speicher ist deaktiviert"
+    reason_undo_empty: "Keine Dateiänderungen zum Rückgängigmachen"
+    reason_pty_daemon_disabled: "PTY-Daemon ist nicht aktiviert"
+    undo_count: "{count} Änderung(en) rückgängig machbar"
+    plan_planning: "Planung"
+    plan_normal: "Normal"
 
   feedback:
     select_type: "Feedback-Typ auswählen"

--- a/crates/aish-i18n/locales/en-US.yaml
+++ b/crates/aish-i18n/locales/en-US.yaml
@@ -371,8 +371,27 @@ shell:
     fork: "Branch the current session"
     sessions: "Show the session tree"
     rollback: "Review and roll back AI file edits (edit_file/write_file) this session"
-    undo: "Undo the last file change (edit_file/write_file) this session"
+    undo: "Undo the most recent AI file edit (edit_file/write_file)"
     memory: "View, verify, or forget long-term memories"
+
+  slash_group:
+    diagnostics: "Diagnostics"
+    sessions: "Sessions"
+    model_settings: "Model & Settings"
+    skills: "Skills"
+    files_memory: "Files & Memory"
+    record_share: "Record & Share"
+    security_audit: "Security & Audit"
+    exit: "Exit"
+
+  slash_status:
+    reason_diagnose_no_failure: "No failed command to diagnose"
+    reason_audit_disabled: "Audit store is disabled"
+    reason_undo_empty: "No file changes to undo"
+    reason_pty_daemon_disabled: "PTY daemon is not enabled"
+    undo_count: "{count} file change(s) can be undone"
+    plan_planning: "Planning"
+    plan_normal: "Normal"
 
   record:
     started: "⏺ Recording started: {path}"

--- a/crates/aish-i18n/locales/es-ES.yaml
+++ b/crates/aish-i18n/locales/es-ES.yaml
@@ -194,8 +194,27 @@ shell:
     fork: "Bifurcar la sesión actual"
     sessions: "Mostrar el árbol de sesiones"
     rollback: "Revisar y revertir ediciones de archivo de la IA (edit_file/write_file) de esta sesión"
-    undo: "Deshacer el último cambio de archivo (edit_file/write_file) de esta sesión"
+    undo: "Deshacer la última edición de archivo de la IA (edit_file/write_file)"
     memory: "Ver, verificar u olvidar memorias a largo plazo"
+
+  slash_group:
+    diagnostics: "Diagnóstico"
+    sessions: "Sesiones"
+    model_settings: "Modelo y ajustes"
+    skills: "Habilidades"
+    files_memory: "Archivos y memoria"
+    record_share: "Grabar y compartir"
+    security_audit: "Seguridad y auditoría"
+    exit: "Salir"
+
+  slash_status:
+    reason_diagnose_no_failure: "No hay comando fallido que diagnosticar"
+    reason_audit_disabled: "El almacén de auditoría está deshabilitado"
+    reason_undo_empty: "No hay cambios de archivo que deshacer"
+    reason_pty_daemon_disabled: "El demonio PTY no está habilitado"
+    undo_count: "{count} cambio(s) se pueden deshacer"
+    plan_planning: "Planificando"
+    plan_normal: "Normal"
 
   feedback:
     select_type: "Seleccionar tipo de comentario"

--- a/crates/aish-i18n/locales/fr-FR.yaml
+++ b/crates/aish-i18n/locales/fr-FR.yaml
@@ -194,8 +194,27 @@ shell:
     fork: "Créer une branche de la session actuelle"
     sessions: "Afficher l'arborescence des sessions"
     rollback: "Examiner et annuler les modifications de fichier de l'IA (edit_file/write_file) cette session"
-    undo: "Annuler la dernière modification de fichier (edit_file/write_file) cette session"
+    undo: "Annuler la dernière modification de fichier par l'IA (edit_file/write_file)"
     memory: "Visualiser, vérifier ou oublier les mémoires"
+
+  slash_group:
+    diagnostics: "Diagnostic"
+    sessions: "Sessions"
+    model_settings: "Modèle et paramètres"
+    skills: "Compétences"
+    files_memory: "Fichiers et mémoire"
+    record_share: "Enregistrement et partage"
+    security_audit: "Sécurité et audit"
+    exit: "Quitter"
+
+  slash_status:
+    reason_diagnose_no_failure: "Aucune commande en échec à diagnostiquer"
+    reason_audit_disabled: "Le stockage d'audit est désactivé"
+    reason_undo_empty: "Aucune modification de fichier à annuler"
+    reason_pty_daemon_disabled: "Le démon PTY n'est pas activé"
+    undo_count: "{count} modification(s) annulable(s)"
+    plan_planning: "Planification"
+    plan_normal: "Normal"
 
   feedback:
     select_type: "Sélectionner le type de commentaire"

--- a/crates/aish-i18n/locales/ja-JP.yaml
+++ b/crates/aish-i18n/locales/ja-JP.yaml
@@ -194,8 +194,27 @@ shell:
     fork: "現在のセッションを分岐"
     sessions: "セッションツリーを表示"
     rollback: "このセッションの AI によるファイル編集を確認・ロールバック (edit_file/write_file)"
-    undo: "このセッションの最後のファイル変更を取り消す (edit_file/write_file)"
+    undo: "AIによる直近のファイル変更を取り消す (edit_file/write_file)"
     memory: "長期メモリの表示、検証、削除"
+
+  slash_group:
+    diagnostics: "診断"
+    sessions: "セッション"
+    model_settings: "モデルと設定"
+    skills: "スキル"
+    files_memory: "ファイルとメモリ"
+    record_share: "録画と共有"
+    security_audit: "セキュリティと監査"
+    exit: "終了"
+
+  slash_status:
+    reason_diagnose_no_failure: "診断する失敗コマンドがありません"
+    reason_audit_disabled: "監査ストアが無効です"
+    reason_undo_empty: "取り消すファイル変更がありません"
+    reason_pty_daemon_disabled: "PTY デーモンが有効ではありません"
+    undo_count: "取り消し可能 {count} 件"
+    plan_planning: "計画中"
+    plan_normal: "通常"
 
   feedback:
     select_type: "フィードバックの種類を選択"

--- a/crates/aish-i18n/locales/zh-CN.yaml
+++ b/crates/aish-i18n/locales/zh-CN.yaml
@@ -371,8 +371,27 @@ shell:
     fork: "分支当前会话"
     sessions: "显示会话树"
     rollback: "查看并回滚本次会话中 AI 的文件修改 (edit_file/write_file)"
-    undo: "撤销本次会话最后一次文件修改 (edit_file/write_file)"
+    undo: "撤销 AI 最近一次文件修改（edit_file/write_file）"
     memory: "查看、验证或删除长期记忆"
+
+  slash_group:
+    diagnostics: "诊断"
+    sessions: "会话"
+    model_settings: "模型与设置"
+    skills: "技能"
+    files_memory: "文件与记忆"
+    record_share: "录制与分享"
+    security_audit: "安全与审计"
+    exit: "退出"
+
+  slash_status:
+    reason_diagnose_no_failure: "没有可诊断的失败命令"
+    reason_audit_disabled: "审计存储未启用"
+    reason_undo_empty: "没有可撤销的文件修改"
+    reason_pty_daemon_disabled: "PTY 守护进程未启用"
+    undo_count: "可撤销 {count} 项"
+    plan_planning: "规划中"
+    plan_normal: "普通模式"
 
   record:
     started: "⏺ 录制已开始: {path}"

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -743,17 +743,31 @@ impl AishShell {
 
     /// Show inline slash command popup with real-time filtering.
     fn run_slash_input_session(&self, prompt: &str) -> aish_ui::SlashInputOutcome {
-        let commands: Vec<(String, String)> = crate::readline::SLASH_COMMANDS
+        let group_labels: Vec<String> = crate::readline::SlashGroup::ALL
             .iter()
-            .map(|(name, _desc)| {
-                let cmd = name
+            .map(|g| aish_i18n::t(&format!("shell.slash_group.{}", g.key())))
+            .collect();
+        let entries: Vec<aish_ui::SlashCommandEntry> = crate::readline::SLASH_COMMANDS
+            .iter()
+            .map(|c| {
+                let cmd = c
+                    .name
                     .strip_prefix('/')
                     .expect("slash commands must start with /");
-                let i18n_key = format!("shell.slash.{cmd}");
-                (name.to_string(), aish_i18n::t(&i18n_key))
+                aish_ui::SlashCommandEntry {
+                    name: c.name.to_string(),
+                    desc: aish_i18n::t(&format!("shell.slash.{cmd}")),
+                    keywords: c.keywords.iter().map(|s| s.to_string()).collect(),
+                    group_index: crate::readline::SlashGroup::ALL
+                        .iter()
+                        .position(|g| *g == c.group)
+                        .unwrap_or(0),
+                    fill_only: matches!(c.enter, crate::readline::EnterPolicy::Fill),
+                    status: Some(self.slash_command_status(c.name)),
+                }
             })
             .collect();
-        let session = aish_ui::SlashInputSession::new(commands, prompt.to_string());
+        let session = aish_ui::SlashInputSession::new(entries, group_labels, prompt.to_string());
         // When triggered by Tab on a `/` prefix, pre-fill the popup with
         // the text the user had already typed.
         let session = {
@@ -764,9 +778,71 @@ impl AishShell {
                 session.with_input(prefill)
             }
         };
-        match session.run() {
-            Ok(outcome) => outcome,
-            Err(_) => aish_ui::SlashInputOutcome::Cancelled,
+        session
+            .run()
+            .unwrap_or(aish_ui::SlashInputOutcome::Cancelled(String::new()))
+    }
+
+    /// Availability of one slash command right now. Unavailable commands
+    /// stay visible (greyed) with a localized reason instead of disappearing.
+    fn slash_command_status(&self, name: &str) -> aish_ui::SlashCommandStatus {
+        let disabled_reason: Option<String> = match name {
+            "/diagnose" if !self.state.can_correct_error => Some(aish_i18n::t(
+                "shell.slash_status.reason_diagnose_no_failure",
+            )),
+            "/audit" if self.audit_store.is_none() => {
+                Some(aish_i18n::t("shell.slash_status.reason_audit_disabled"))
+            }
+            "/undo" | "/rollback" => {
+                let count = self
+                    .snapshot_store
+                    .lock()
+                    .map(|store| store.history_len())
+                    .unwrap_or(0);
+                if count == 0 {
+                    Some(aish_i18n::t("shell.slash_status.reason_undo_empty"))
+                } else {
+                    // Enabled rows carry a live count instead of a reason.
+                    let mut args = std::collections::HashMap::new();
+                    args.insert("count".to_string(), count.to_string());
+                    let status_text =
+                        aish_i18n::t_with_args("shell.slash_status.undo_count", &args);
+                    return aish_ui::SlashCommandStatus {
+                        enabled: true,
+                        status_text,
+                        reason: String::new(),
+                    };
+                }
+            }
+            "/plan" => {
+                // Issue #473: the plan row shows the current mode live.
+                let phase = self.ai_handler.plan_phase();
+                let status_text = match phase {
+                    aish_core::types::PlanPhase::Planning => {
+                        aish_i18n::t("shell.slash_status.plan_planning")
+                    }
+                    aish_core::types::PlanPhase::Normal => {
+                        aish_i18n::t("shell.slash_status.plan_normal")
+                    }
+                };
+                return aish_ui::SlashCommandStatus {
+                    enabled: true,
+                    status_text,
+                    reason: String::new(),
+                };
+            }
+            "/live_sessions" | "/kill_live_sessions" if !self.config.pty_daemon_enabled => Some(
+                aish_i18n::t("shell.slash_status.reason_pty_daemon_disabled"),
+            ),
+            _ => None,
+        };
+        match disabled_reason {
+            Some(reason) => aish_ui::SlashCommandStatus {
+                enabled: false,
+                status_text: String::new(),
+                reason,
+            },
+            None => aish_ui::SlashCommandStatus::available(),
         }
     }
 
@@ -2516,12 +2592,28 @@ impl AishShell {
                             aish_ui::SlashInputOutcome::Command(cmd) => {
                                 self.apply_slash_popup_command(&mut rl, &prompt_str, &cmd);
                             }
+                            aish_ui::SlashInputOutcome::Fill(text) => {
+                                if self.read_line_after_slash_dismiss(&mut rl, &prompt_str, &text) {
+                                    break;
+                                }
+                            }
                             aish_ui::SlashInputOutcome::Dismissed(text) => {
                                 if self.read_line_after_slash_dismiss(&mut rl, &prompt_str, &text) {
                                     break;
                                 }
                             }
-                            aish_ui::SlashInputOutcome::Cancelled => {}
+                            aish_ui::SlashInputOutcome::Cancelled(restore) => {
+                                if !restore.is_empty()
+                                    && restore != "/"
+                                    && self.read_line_after_slash_dismiss(
+                                        &mut rl,
+                                        &prompt_str,
+                                        &restore,
+                                    )
+                                {
+                                    break;
+                                }
+                            }
                         }
                         continue;
                     }
@@ -3294,11 +3386,20 @@ impl AishShell {
                                 self.apply_slash_popup_command(rl, prompt, &cmd);
                                 return false;
                             }
+                            aish_ui::SlashInputOutcome::Fill(text) => {
+                                self.record_slash_popup_dismissed(&text);
+                                prefill = format!("{text} ");
+                            }
                             aish_ui::SlashInputOutcome::Dismissed(text) => {
                                 self.record_slash_popup_dismissed(&text);
                                 prefill = text;
                             }
-                            aish_ui::SlashInputOutcome::Cancelled => return false,
+                            aish_ui::SlashInputOutcome::Cancelled(restore) => {
+                                if restore.is_empty() || restore == "/" {
+                                    return false;
+                                }
+                                prefill = restore;
+                            }
                         }
                     } else {
                         crate::recorder::shared_record_output(&self.shared_recorder, "\r\n");
@@ -3344,10 +3445,18 @@ impl AishShell {
                                 self.apply_slash_popup_command(rl, prompt, &cmd);
                                 return false;
                             }
+                            aish_ui::SlashInputOutcome::Fill(text) => {
+                                prefill = format!("{text} ");
+                            }
                             aish_ui::SlashInputOutcome::Dismissed(text) => {
                                 prefill = text;
                             }
-                            aish_ui::SlashInputOutcome::Cancelled => return false,
+                            aish_ui::SlashInputOutcome::Cancelled(restore) => {
+                                if restore.is_empty() || restore == "/" {
+                                    return false;
+                                }
+                                prefill = restore;
+                            }
                         }
                     } else {
                         crate::recorder::shared_record_output(&self.shared_recorder, "\r\n");

--- a/crates/aish-shell/src/app.rs
+++ b/crates/aish-shell/src/app.rs
@@ -2593,7 +2593,12 @@ impl AishShell {
                                 self.apply_slash_popup_command(&mut rl, &prompt_str, &cmd);
                             }
                             aish_ui::SlashInputOutcome::Fill(text) => {
-                                if self.read_line_after_slash_dismiss(&mut rl, &prompt_str, &text) {
+                                // Fill returns the bare command; the trailing
+                                // space separates it from arguments the user
+                                // types next.
+                                let filled = format!("{text} ");
+                                if self.read_line_after_slash_dismiss(&mut rl, &prompt_str, &filled)
+                                {
                                     break;
                                 }
                             }

--- a/crates/aish-shell/src/completion.rs
+++ b/crates/aish-shell/src/completion.rs
@@ -113,10 +113,10 @@ fn complete_slash_command(before_cursor: &str) -> Vec<Pair> {
     let query = before_cursor.to_lowercase();
     crate::readline::SLASH_COMMANDS
         .iter()
-        .filter(|(name, _)| name.to_lowercase().starts_with(&query))
-        .map(|(name, _)| Pair {
-            display: (*name).to_string(),
-            replacement: (*name).to_string(),
+        .filter(|c| c.name.to_lowercase().starts_with(&query))
+        .map(|c| Pair {
+            display: c.name.to_string(),
+            replacement: c.name.to_string(),
         })
         .collect()
 }

--- a/crates/aish-shell/src/input.rs
+++ b/crates/aish-shell/src/input.rs
@@ -23,7 +23,7 @@ pub fn classify_input(input: &str) -> InputIntent {
         && trimmed.split_whitespace().next().is_some_and(|cmd| {
             crate::readline::SLASH_COMMANDS
                 .iter()
-                .any(|(name, _)| *name == cmd)
+                .any(|c| c.name == cmd)
         })
     {
         return InputIntent::SpecialCommand;

--- a/crates/aish-shell/src/readline.rs
+++ b/crates/aish-shell/src/readline.rs
@@ -20,53 +20,241 @@ use aish_pty::readline_tab::clamp_pos;
 use crate::autosuggest::AutoSuggest;
 use crate::completion::CompletionEngine;
 
-/// Slash commands with descriptions for popup completion.
-pub const SLASH_COMMANDS: &[(&str, &str)] = &[
-    ("/help", "Show help information"),
-    ("/model", "Show or switch AI model"),
-    ("/setup", "Open setup wizard"),
-    ("/setting", "Open interactive settings panel"),
-    ("/plan", "Plan mode control"),
-    ("/token", "Show token usage"),
-    ("/resume", "Resume previous session"),
-    ("/feedback", "Submit feedback"),
-    ("/record", "Record terminal session (start/stop)"),
-    ("/quit", "Exit AI Shell"),
-    ("/doctor", "Run system diagnostics"),
-    ("/diagnose", "Read-only diagnosis for last failed command"),
-    ("/status", "Show system environment status"),
-    ("/live_sessions", "List live PTY sessions"),
-    ("/kill_live_sessions", "Kill live PTY session(s) by ID"),
-    (
-        "/audit",
-        "Query audit log or export audit package (who/when/what/AI suggestion/confirm)",
-    ),
-    (
-        "/forget-approvals",
-        "Clear remembered command approvals (this session)",
-    ),
-    (
-        "/skill",
-        "Browse, install, trust, verify skills; manage registries",
-    ),
-    ("/export", "Export current session to Markdown"),
-    (
-        "/fork",
-        "Branch the current session into a new one (copied context)",
-    ),
-    ("/sessions", "Show the session tree (roots + forks)"),
-    (
-        "/undo",
-        "Undo the last file change (edit_file/write_file) this session",
-    ),
-    (
-        "/rollback",
-        "Review and roll back AI file edits (edit_file/write_file) this session",
-    ),
-    (
-        "/memory",
-        "View, verify, or forget long-term memories (list/verify/forget/clear-expired)",
-    ),
+/// Group a slash command belongs to in the popup panel. Groups render as
+/// headers and fix the display order regardless of locale.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlashGroup {
+    Diagnostics,
+    Sessions,
+    ModelSettings,
+    Skills,
+    FilesMemory,
+    RecordShare,
+    SecurityAudit,
+    Exit,
+}
+
+impl SlashGroup {
+    /// All groups in popup display order.
+    pub const ALL: [SlashGroup; 8] = [
+        SlashGroup::Diagnostics,
+        SlashGroup::Sessions,
+        SlashGroup::ModelSettings,
+        SlashGroup::Skills,
+        SlashGroup::FilesMemory,
+        SlashGroup::RecordShare,
+        SlashGroup::SecurityAudit,
+        SlashGroup::Exit,
+    ];
+
+    /// i18n key suffix under `shell.slash_group.`.
+    pub fn key(&self) -> &'static str {
+        match self {
+            SlashGroup::Diagnostics => "diagnostics",
+            SlashGroup::Sessions => "sessions",
+            SlashGroup::ModelSettings => "model_settings",
+            SlashGroup::Skills => "skills",
+            SlashGroup::FilesMemory => "files_memory",
+            SlashGroup::RecordShare => "record_share",
+            SlashGroup::SecurityAudit => "security_audit",
+            SlashGroup::Exit => "exit",
+        }
+    }
+}
+
+/// What Enter does when a command is picked from the popup without extra
+/// arguments typed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnterPolicy {
+    /// Bare call is safe: run the command as typed.
+    Execute,
+    /// Bare call needs args, opens a picker, or is destructive: only fill
+    /// the input line and let the user confirm with a second Enter.
+    Fill,
+}
+
+/// Metadata for one built-in slash command shown in the popup panel.
+#[derive(Debug, Clone, Copy)]
+pub struct SlashCommandMeta {
+    pub name: &'static str,
+    /// English fallback description (popup renders the i18n one).
+    pub desc: &'static str,
+    pub group: SlashGroup,
+    /// Extra fuzzy-search terms: English aliases + scenario words.
+    pub keywords: &'static [&'static str],
+    pub enter: EnterPolicy,
+}
+
+/// Slash commands with metadata for the searchable grouped popup.
+pub const SLASH_COMMANDS: &[SlashCommandMeta] = &[
+    SlashCommandMeta {
+        name: "/help",
+        desc: "Show help information",
+        group: SlashGroup::Diagnostics,
+        keywords: &["help", "usage"],
+        enter: EnterPolicy::Execute,
+    },
+    SlashCommandMeta {
+        name: "/doctor",
+        desc: "Run system diagnostics",
+        group: SlashGroup::Diagnostics,
+        keywords: &["doctor", "health"],
+        enter: EnterPolicy::Execute,
+    },
+    SlashCommandMeta {
+        name: "/diagnose",
+        desc: "Read-only diagnosis for last failed command",
+        group: SlashGroup::Diagnostics,
+        keywords: &["diagnose", "troubleshoot", "error"],
+        enter: EnterPolicy::Execute,
+    },
+    SlashCommandMeta {
+        name: "/status",
+        desc: "Show system environment status",
+        group: SlashGroup::Diagnostics,
+        keywords: &["status", "env"],
+        enter: EnterPolicy::Execute,
+    },
+    SlashCommandMeta {
+        name: "/resume",
+        desc: "Resume previous session",
+        group: SlashGroup::Sessions,
+        keywords: &["resume", "continue", "history"],
+        enter: EnterPolicy::Fill,
+    },
+    SlashCommandMeta {
+        name: "/sessions",
+        desc: "Show the session tree (roots + forks)",
+        group: SlashGroup::Sessions,
+        keywords: &["sessions", "tree"],
+        enter: EnterPolicy::Execute,
+    },
+    SlashCommandMeta {
+        name: "/fork",
+        desc: "Branch the current session into a new one (copied context)",
+        group: SlashGroup::Sessions,
+        keywords: &["fork", "branch", "copy"],
+        enter: EnterPolicy::Execute,
+    },
+    SlashCommandMeta {
+        name: "/live_sessions",
+        desc: "List live PTY sessions",
+        group: SlashGroup::Sessions,
+        keywords: &["live", "pty", "active"],
+        enter: EnterPolicy::Execute,
+    },
+    SlashCommandMeta {
+        name: "/kill_live_sessions",
+        desc: "Kill live PTY session(s) by ID",
+        group: SlashGroup::Sessions,
+        keywords: &["kill", "terminate", "pty"],
+        enter: EnterPolicy::Fill,
+    },
+    SlashCommandMeta {
+        name: "/model",
+        desc: "Show or switch AI model",
+        group: SlashGroup::ModelSettings,
+        keywords: &["model", "llm", "switch"],
+        enter: EnterPolicy::Fill,
+    },
+    SlashCommandMeta {
+        name: "/setting",
+        desc: "Open interactive settings panel",
+        group: SlashGroup::ModelSettings,
+        keywords: &["setting", "config", "preference"],
+        enter: EnterPolicy::Execute,
+    },
+    SlashCommandMeta {
+        name: "/setup",
+        desc: "Open setup wizard",
+        group: SlashGroup::ModelSettings,
+        keywords: &["setup", "wizard", "init"],
+        enter: EnterPolicy::Execute,
+    },
+    SlashCommandMeta {
+        name: "/token",
+        desc: "Show token usage",
+        group: SlashGroup::ModelSettings,
+        keywords: &["token", "usage", "cost"],
+        enter: EnterPolicy::Execute,
+    },
+    SlashCommandMeta {
+        name: "/plan",
+        desc: "Plan mode control",
+        group: SlashGroup::ModelSettings,
+        keywords: &["plan", "mode"],
+        enter: EnterPolicy::Execute,
+    },
+    SlashCommandMeta {
+        name: "/skill",
+        desc: "Browse, install, trust, verify skills; manage registries",
+        group: SlashGroup::Skills,
+        keywords: &["skill", "plugin", "market"],
+        enter: EnterPolicy::Fill,
+    },
+    SlashCommandMeta {
+        name: "/undo",
+        desc: "Undo the most recent AI file edit (edit_file/write_file)",
+        group: SlashGroup::FilesMemory,
+        keywords: &["undo", "revert"],
+        enter: EnterPolicy::Fill,
+    },
+    SlashCommandMeta {
+        name: "/rollback",
+        desc: "Review and roll back AI file edits (edit_file/write_file) this session",
+        group: SlashGroup::FilesMemory,
+        keywords: &["rollback", "revert", "restore"],
+        enter: EnterPolicy::Fill,
+    },
+    SlashCommandMeta {
+        name: "/memory",
+        desc: "View, verify, or forget long-term memories (list/verify/forget/clear-expired)",
+        group: SlashGroup::FilesMemory,
+        keywords: &["memory", "recall", "forget"],
+        enter: EnterPolicy::Fill,
+    },
+    SlashCommandMeta {
+        name: "/record",
+        desc: "Record terminal session (start/stop)",
+        group: SlashGroup::RecordShare,
+        keywords: &["record", "capture", "asciinema"],
+        enter: EnterPolicy::Fill,
+    },
+    SlashCommandMeta {
+        name: "/export",
+        desc: "Export current session to Markdown",
+        group: SlashGroup::RecordShare,
+        keywords: &["export", "markdown", "save"],
+        enter: EnterPolicy::Execute,
+    },
+    SlashCommandMeta {
+        name: "/feedback",
+        desc: "Submit feedback",
+        group: SlashGroup::RecordShare,
+        keywords: &["feedback", "report", "issue"],
+        enter: EnterPolicy::Execute,
+    },
+    SlashCommandMeta {
+        name: "/audit",
+        desc: "Query audit log or export audit package (who/when/what/AI suggestion/confirm)",
+        group: SlashGroup::SecurityAudit,
+        keywords: &["audit", "log", "trace"],
+        enter: EnterPolicy::Fill,
+    },
+    SlashCommandMeta {
+        name: "/forget-approvals",
+        desc: "Clear remembered command approvals (this session)",
+        group: SlashGroup::SecurityAudit,
+        keywords: &["forget", "approvals", "reset"],
+        enter: EnterPolicy::Fill,
+    },
+    SlashCommandMeta {
+        name: "/quit",
+        desc: "Exit AI Shell",
+        group: SlashGroup::Exit,
+        keywords: &["quit", "exit", "close"],
+        enter: EnterPolicy::Fill,
+    },
 ];
 
 // ---------------------------------------------------------------------------
@@ -216,7 +404,7 @@ impl ConditionalEventHandler for TabCompletionHandler {
             let query = before.to_lowercase();
             if SLASH_COMMANDS
                 .iter()
-                .any(|(name, _)| name.to_lowercase().starts_with(&query))
+                .any(|c| c.name.to_lowercase().starts_with(&query))
             {
                 set_slash_prefill(before.to_string());
                 SLASH_REQUESTED.store(true, Ordering::SeqCst);
@@ -842,16 +1030,16 @@ mod tests {
 
     #[test]
     fn test_slash_commands_format() {
-        for (cmd, desc) in SLASH_COMMANDS {
+        for cmd in SLASH_COMMANDS {
             assert!(
-                cmd.starts_with('/'),
+                cmd.name.starts_with('/'),
                 "slash command must start with /: {}",
-                cmd
+                cmd.name
             );
             assert!(
-                !desc.is_empty(),
+                !cmd.desc.is_empty(),
                 "description must not be empty for {}",
-                cmd
+                cmd.name
             );
         }
         assert_eq!(SLASH_COMMANDS.len(), 24);
@@ -863,13 +1051,14 @@ mod tests {
         // translation, not the raw key. Regression: a slash command once
         // rendered its raw i18n key in the popup (shell.slash.<cmd> missing).
         aish_i18n::set_locale("en-US");
-        for (name, _desc) in SLASH_COMMANDS {
-            let cmd = name.trim_start_matches('/');
-            let key = format!("shell.slash.{cmd}");
+        for cmd in SLASH_COMMANDS {
+            let name = cmd.name.trim_start_matches('/');
+            let key = format!("shell.slash.{name}");
             let translated = aish_i18n::t(&key);
             assert_ne!(
                 translated, key,
-                "missing i18n key {key} for slash command {name}"
+                "missing i18n key {key} for slash command {}",
+                cmd.name
             );
         }
     }

--- a/crates/aish-shell/tests/slash_popup_commands.rs
+++ b/crates/aish-shell/tests/slash_popup_commands.rs
@@ -1,30 +1,54 @@
 //! Integration tests: slash popup behavior against `readline::SLASH_COMMANDS`.
 
-use aish_shell::readline::SLASH_COMMANDS;
-use aish_ui::{SlashInputOutcome, SlashInputSession};
+use aish_shell::readline::{EnterPolicy, SlashGroup, SLASH_COMMANDS};
+use aish_ui::{SlashCommandEntry, SlashInputOutcome, SlashInputSession};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 
 fn key(code: KeyCode) -> Event {
     Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
 }
 
+/// Build a fully-enabled popup session from the real command table.
 fn session_with(input: &str) -> SlashInputSession {
-    let commands: Vec<(String, String)> = SLASH_COMMANDS
+    let group_labels: Vec<String> = SlashGroup::ALL
         .iter()
-        .map(|(name, desc)| (name.to_string(), desc.to_string()))
+        .map(|g| format!("group:{}", g.key()))
         .collect();
-    SlashInputSession::new(commands, "aish> ".to_string()).with_input(input)
+    let entries: Vec<SlashCommandEntry> = SLASH_COMMANDS
+        .iter()
+        .map(|c| SlashCommandEntry {
+            name: c.name.to_string(),
+            desc: format!("{} description", c.name),
+            keywords: c.keywords.iter().map(|s| s.to_string()).collect(),
+            group_index: SlashGroup::ALL
+                .iter()
+                .position(|g| *g == c.group)
+                .unwrap_or(0),
+            fill_only: matches!(c.enter, EnterPolicy::Fill),
+            status: None,
+        })
+        .collect();
+    SlashInputSession::new(entries, group_labels, "aish> ".to_string()).with_input(input)
 }
 
 #[test]
 fn each_builtin_command_enter_executes() {
-    for (name, _) in SLASH_COMMANDS {
-        let mut session = session_with(name);
-        assert_eq!(
-            session.dispatch_event(key(KeyCode::Enter)),
-            Some(SlashInputOutcome::Command(name.to_string())),
-            "Enter on {name}",
-        );
+    for c in SLASH_COMMANDS {
+        let mut session = session_with(c.name);
+        match session.dispatch_event(key(KeyCode::Enter)) {
+            Some(SlashInputOutcome::Command(text)) => {
+                assert_eq!(text, c.name, "Enter on {}", c.name);
+            }
+            Some(SlashInputOutcome::Fill(text)) => {
+                assert!(
+                    matches!(c.enter, EnterPolicy::Fill),
+                    "unexpected Fill for {}",
+                    c.name
+                );
+                assert_eq!(text, c.name);
+            }
+            other => panic!("Enter on {} produced {:?}", c.name, other),
+        }
     }
 }
 
@@ -38,14 +62,62 @@ fn slash_commands_have_i18n_descriptions() {
     const LOCALES: &[&str] = &["en-US", "zh-CN", "de-DE", "es-ES", "fr-FR", "ja-JP"];
     for locale in LOCALES {
         aish_i18n::set_locale(locale);
-        for (name, _) in SLASH_COMMANDS {
-            let cmd = name.strip_prefix('/').expect("slash command");
+        for c in SLASH_COMMANDS {
+            let cmd = c.name.strip_prefix('/').expect("slash command");
             let key = format!("shell.slash.{cmd}");
             let translated = aish_i18n::t(&key);
             assert_ne!(
                 translated, key,
-                "missing i18n entry for slash command {name} (key: {key}) in locale {locale}"
+                "missing i18n entry for slash command {} (key: {key}) in locale {locale}",
+                c.name
             );
         }
+    }
+}
+
+#[test]
+fn group_labels_and_status_reasons_have_i18n_entries() {
+    const LOCALES: &[&str] = &["en-US", "zh-CN", "de-DE", "es-ES", "fr-FR", "ja-JP"];
+    for locale in LOCALES {
+        aish_i18n::set_locale(locale);
+        for g in SlashGroup::ALL {
+            let key = format!("shell.slash_group.{}", g.key());
+            assert_ne!(
+                aish_i18n::t(&key),
+                key,
+                "missing i18n group entry {key} in locale {locale}"
+            );
+        }
+        for key_suffix in [
+            "reason_diagnose_no_failure",
+            "reason_audit_disabled",
+            "reason_undo_empty",
+            "reason_pty_daemon_disabled",
+            "undo_count",
+            "plan_planning",
+            "plan_normal",
+        ] {
+            let key = format!("shell.slash_status.{key_suffix}");
+            assert_ne!(
+                aish_i18n::t(&key),
+                key,
+                "missing i18n status entry {key} in locale {locale}"
+            );
+        }
+    }
+}
+
+#[test]
+fn undo_count_placeholder_substitutes_in_all_locales() {
+    const LOCALES: &[&str] = &["en-US", "zh-CN", "de-DE", "es-ES", "fr-FR", "ja-JP"];
+    for locale in LOCALES {
+        aish_i18n::set_locale(locale);
+        let mut args = std::collections::HashMap::new();
+        args.insert("count".to_string(), "3".to_string());
+        let text = aish_i18n::t_with_args("shell.slash_status.undo_count", &args);
+        assert!(
+            text.contains('3') && !text.contains("{count}"),
+            "undo_count placeholder not substituted in {locale}: {text}"
+        );
     }
 }

--- a/crates/aish-shell/tests/slash_popup_commands.rs
+++ b/crates/aish-shell/tests/slash_popup_commands.rs
@@ -37,6 +37,11 @@ fn each_builtin_command_enter_executes() {
         let mut session = session_with(c.name);
         match session.dispatch_event(key(KeyCode::Enter)) {
             Some(SlashInputOutcome::Command(text)) => {
+                assert!(
+                    matches!(c.enter, EnterPolicy::Execute),
+                    "unexpected Command for {}",
+                    c.name
+                );
                 assert_eq!(text, c.name, "Enter on {}", c.name);
             }
             Some(SlashInputOutcome::Fill(text)) => {

--- a/crates/aish-ui/src/file_mention.rs
+++ b/crates/aish-ui/src/file_mention.rs
@@ -25,8 +25,9 @@ use ratatui::{
 };
 
 use crate::slash_input::{
-    drain_pending_events, longest_common_prefix, open_inline_terminal, strip_ansi, RawModeGuard,
+    drain_pending_events, longest_common_prefix, open_inline_terminal, RawModeGuard,
 };
+use crate::text::strip_ansi_escapes;
 
 /// Outcome of the file-mention session.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -103,7 +104,7 @@ impl FileMentionSession {
     pub fn new(cwd: &Path, prompt: String, prefix: String) -> Self {
         let candidates = scan_files(cwd);
         let mut session = Self {
-            prompt: strip_ansi(&prompt),
+            prompt: strip_ansi_escapes(&prompt),
             prefix,
             query: String::new(),
             cursor: 0,
@@ -504,7 +505,7 @@ fn scan_dir(
 /// of `target` (case-insensitive). Matching is case-insensitive; exact-case
 /// matches, contiguous runs, and word-start positions score higher, while
 /// longer targets are penalized so specific short paths win.
-pub(crate) fn fuzzy_score(query: &str, target: &str) -> Option<i64> {
+pub fn fuzzy_score(query: &str, target: &str) -> Option<i64> {
     if query.is_empty() {
         return Some(0);
     }

--- a/crates/aish-ui/src/lib.rs
+++ b/crates/aish-ui/src/lib.rs
@@ -12,7 +12,7 @@ mod util;
 
 pub use choice::{ChoiceOutcome, ChoicePanel};
 pub use expand::ExpandPanel;
-pub use file_mention::{FileMentionOutcome, FileMentionSession};
+pub use file_mention::{fuzzy_score, FileMentionOutcome, FileMentionSession};
 pub use history::{HistoryOutcome, HistoryPanel, HistoryRecord};
 pub use runtime::{PanelComponent, PanelError, PanelEvent, PanelOutcome, PanelRuntime};
 pub use select::{SearchSelectItem, SearchSelectOutcome, SearchSelectPanel};
@@ -20,6 +20,8 @@ pub use settings_ui::{
     SettingsCategoryInfo, SettingsItem, SettingsOutcome, SettingsPanel, SettingsValueKind,
 };
 pub use skill_ui::{SkillCategoryInfo, SkillItem, SkillItemKind, SkillOutcome, SkillPanel};
-pub use slash_input::{SlashInputOutcome, SlashInputSession};
+pub use slash_input::{
+    SlashCommandEntry, SlashCommandStatus, SlashInputOutcome, SlashInputSession,
+};
 pub use text::strip_ansi_escapes;
 pub use util::{padded_area, truncate_line, truncate_str, unicode_width_ch, PANEL_PADDING_X};

--- a/crates/aish-ui/src/slash_input.rs
+++ b/crates/aish-ui/src/slash_input.rs
@@ -251,7 +251,9 @@ impl SlashInputSession {
             return;
         }
         // Fuzzy match against name + localized description + keywords; keep
-        // only subsequence hits and rank them by best score.
+        // only subsequence hits and rank them by best score. Ties break by
+        // registration order. Groups may interleave; display_rows renders
+        // each group header once at its first occurrence.
         let mut scored: Vec<(i64, usize)> = self
             .entries
             .iter()
@@ -518,7 +520,10 @@ impl SlashInputSession {
     /// before the first command of each new group.
     fn display_rows(&self) -> Vec<DisplayRow> {
         let mut rows = Vec::with_capacity(self.filtered.len() + self.group_labels.len());
-        let mut last_group: Option<usize> = None;
+        // Score order may interleave groups; render each header exactly once,
+        // at the group's first occurrence, so a group is never split by a
+        // repeated header row.
+        let mut rendered_groups: Vec<usize> = Vec::with_capacity(self.group_labels.len());
         for &idx in &self.filtered {
             let entry = &self.entries[idx];
             let Some(label) = self.group_labels.get(entry.group_index) else {
@@ -529,9 +534,9 @@ impl SlashInputSession {
                 rows.push(DisplayRow::Command(idx));
                 continue;
             }
-            if last_group != Some(entry.group_index) {
+            if !rendered_groups.contains(&entry.group_index) {
                 rows.push(DisplayRow::Header(entry.group_index));
-                last_group = Some(entry.group_index);
+                rendered_groups.push(entry.group_index);
             }
             rows.push(DisplayRow::Command(idx));
         }
@@ -1057,6 +1062,33 @@ mod tests {
         assert_eq!(
             session.filtered.first().map(|&i| commands[i].name.as_str()),
             Some("/setting")
+        );
+    }
+
+    #[test]
+    fn display_rows_render_each_group_header_once() {
+        // Score order may interleave groups; each header renders exactly
+        // once at the group's first occurrence — never repeated mid-list.
+        let mut g0 = entry("/aaa", 0);
+        g0.desc = "zzz match".into();
+        let mut g1 = entry("/zzz", 1);
+        g1.desc = "aaa match".into();
+        let commands = vec![g0, g1];
+        let mut session =
+            SlashInputSession::new(commands, vec!["G0".into(), "G1".into()], "aish> ".into());
+        // Simulate a search whose score order interleaves groups: g1 first.
+        session.input = "/match".into();
+        session.cursor = session.input.len();
+        session.filtered = vec![1, 0];
+        let rows = session.display_rows();
+        assert_eq!(
+            rows,
+            vec![
+                DisplayRow::Header(1),
+                DisplayRow::Command(1),
+                DisplayRow::Header(0),
+                DisplayRow::Command(0),
+            ]
         );
     }
 

--- a/crates/aish-ui/src/slash_input.rs
+++ b/crates/aish-ui/src/slash_input.rs
@@ -1,5 +1,10 @@
 use std::io::{self, Write};
 
+use crate::file_mention::fuzzy_score;
+use crate::text::strip_ansi_escapes;
+use crate::util::truncate_str;
+use unicode_width::UnicodeWidthStr;
+
 use crossterm::{
     cursor, event,
     event::{Event, KeyCode, KeyEventKind, KeyModifiers},
@@ -17,24 +22,114 @@ use ratatui::{
 /// Outcome of the slash input session.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SlashInputOutcome {
-    /// User selected a slash command (e.g. "/model gpt-4").
+    /// User selected a slash command to run as typed (e.g. "/help").
     Command(String),
+    /// User picked a command that must not run bare (needs arguments, opens
+    /// a picker, or is destructive): fill the readline with "cmd " and let
+    /// the user confirm with a second Enter.
+    Fill(String),
     /// Input no longer matches any command; return to normal readline with this text.
     Dismissed(String),
-    /// User pressed Esc; cancel and return to empty readline.
-    Cancelled,
+    /// User pressed Esc (or emptied the input): restore this text in the
+    /// readline. Empty string means discard and return to a fresh prompt.
+    Cancelled(String),
 }
 
 const MAX_VISIBLE_COMMANDS: usize = 8;
 const MAX_PANEL_HEIGHT: u16 = 10;
 
-/// Inline slash command autocomplete popup.
-///
-/// Renders the shell prompt + input on the first line, and a filtered
-/// command list below it — no focus mode switching, typing and popup
-/// navigation work simultaneously.
+/// One renderable row in the popup list: a group header or a command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DisplayRow {
+    Header(usize),
+    Command(usize),
+}
+
+/// Availability status shown next to a command row. Unavailable commands
+/// stay visible (greyed) with the reason and an enable hint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlashCommandStatus {
+    /// Whether the command can run right now.
+    pub enabled: bool,
+    /// Short state word (e.g. "unavailable") rendered before the reason.
+    pub status_text: String,
+    /// Why it is unavailable, rendered as a suffix on the row.
+    pub reason: String,
+}
+
+impl SlashCommandStatus {
+    /// Default available status; the row renders the description only.
+    pub fn available() -> Self {
+        Self {
+            enabled: true,
+            status_text: String::new(),
+            reason: String::new(),
+        }
+    }
+}
+
+/// One popup row: command name, localized description, and popup metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlashCommandEntry {
+    /// Command with leading "/", e.g. "/help".
+    pub name: String,
+    /// Localized description (already translated by the caller).
+    pub desc: String,
+    /// Extra fuzzy-search terms (English aliases + scenario words).
+    pub keywords: Vec<String>,
+    /// Index into the caller's group-label list; rows sort by (group, name).
+    pub group_index: usize,
+    /// True when Enter must fill instead of execute (Fill policy).
+    pub fill_only: bool,
+    /// Availability status; commands without one are always available.
+    pub status: Option<SlashCommandStatus>,
+}
+
+impl SlashCommandEntry {
+    /// Best fuzzy score across name, description, and keywords. A positive
+    /// score requires a word-initial or consecutive bonus to outweigh the
+    /// position/length penalties, which filters scattered trivial matches.
+    /// Single-char ASCII queries fall back to plain name-prefix matching so
+    /// Tab prefix extension behaves exactly like the old prefix filter
+    /// (fuzzy on one letter matches too many scattered name hits); CJK and
+    /// other non-ASCII single chars use the full fuzzy path because they only
+    /// ever match via descriptions/keywords. From two chars on, descriptions
+    /// and keywords always join the fuzzy match.
+    fn best_score(&self, query: &str) -> Option<i64> {
+        let mut chars = query.chars();
+        let is_single_char = chars.next().is_some() && chars.next().is_none();
+        if is_single_char && query.chars().all(|c| c.is_ascii_alphanumeric()) {
+            let ch = query.chars().next().expect("non-empty");
+            let lower = ch.to_ascii_lowercase();
+            return if self
+                .name
+                .trim_start_matches('/')
+                .to_lowercase()
+                .starts_with(lower)
+            {
+                Some(1)
+            } else {
+                None
+            };
+        }
+        let name = fuzzy_score(query, &self.name);
+        let desc = fuzzy_score(query, &self.desc);
+        let kw = self
+            .keywords
+            .iter()
+            .filter_map(|k| fuzzy_score(query, k))
+            .max();
+        name.into_iter()
+            .chain(desc)
+            .chain(kw)
+            .filter(|s| *s > 0)
+            .max()
+    }
+}
 pub struct SlashInputSession {
-    commands: Vec<(String, String)>,
+    entries: Vec<SlashCommandEntry>,
+    /// Group header labels by group index; empty label = no header row.
+    group_labels: Vec<String>,
     prompt: String,
     input: String,
     cursor: usize,
@@ -43,13 +138,25 @@ pub struct SlashInputSession {
 }
 
 impl SlashInputSession {
-    pub fn new(commands: Vec<(String, String)>, prompt: String) -> Self {
+    /// Build a session. Rows sort by (group_index, name) so the popup order
+    /// is stable regardless of locale; empty group labels hide headers.
+    pub fn new(
+        mut entries: Vec<SlashCommandEntry>,
+        group_labels: Vec<String>,
+        prompt: String,
+    ) -> Self {
+        entries.sort_by(|a, b| {
+            a.group_index
+                .cmp(&b.group_index)
+                .then_with(|| a.name.cmp(&b.name))
+        });
         // Strip ANSI escape codes — ratatui renders via its own style system
-        let prompt = strip_ansi(&prompt);
-        let mut filtered = Vec::with_capacity(commands.len());
-        filtered.extend(0..commands.len());
+        let prompt = strip_ansi_escapes(&prompt);
+        let mut filtered = Vec::with_capacity(entries.len());
+        filtered.extend(0..entries.len());
         Self {
-            commands,
+            entries,
+            group_labels,
             prompt,
             input: String::from("/"),
             cursor: 1,
@@ -132,25 +239,27 @@ impl SlashInputSession {
             None => &self.input,
         }
     }
-
     fn update_filtered(&mut self) {
         if self.should_hide_command_list() {
             self.filtered.clear();
             return;
         }
-        let query = self.command_query().to_lowercase();
-        if query.is_empty() || !query.starts_with('/') {
-            self.filtered.clear();
+        let query = self.command_query().trim_start_matches('/').to_lowercase();
+        if query.is_empty() {
+            self.filtered = (0..self.entries.len()).collect();
             self.selected = 0;
             return;
         }
-        self.filtered = self
-            .commands
+        // Fuzzy match against name + localized description + keywords; keep
+        // only subsequence hits and rank them by best score.
+        let mut scored: Vec<(i64, usize)> = self
+            .entries
             .iter()
             .enumerate()
-            .filter(|(_, (name, _))| name.to_lowercase().starts_with(&query))
-            .map(|(i, _)| i)
+            .filter_map(|(i, e)| e.best_score(&query).map(|s| (s, i)))
             .collect();
+        scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+        self.filtered = scored.into_iter().map(|(_, i)| i).collect();
         self.selected = 0;
         self.clamp_selected();
     }
@@ -172,15 +281,13 @@ impl SlashInputSession {
         }
     }
 
-    /// Whether the current input is still a prefix of any command name.
+    /// Whether the current input is still a fuzzy match for any command.
     fn has_command_prefix(&self) -> bool {
-        let query = self.command_query().to_lowercase();
-        if query.is_empty() || !query.starts_with('/') {
-            return false;
+        let query = self.command_query().trim_start_matches('/').to_lowercase();
+        if query.is_empty() {
+            return true;
         }
-        self.commands
-            .iter()
-            .any(|(name, _)| name.to_lowercase().starts_with(&query))
+        self.entries.iter().any(|e| e.best_score(&query).is_some())
     }
 
     /// True when input is an exact command followed by a space (Tab completion or typed).
@@ -190,7 +297,7 @@ impl SlashInputSession {
             return false;
         };
         let command_name = &self.input[..space_idx];
-        self.commands.iter().any(|(name, _)| name == command_name)
+        self.entries.iter().any(|e| e.name == command_name)
     }
 
     /// True when the user has started typing arguments (not just a trailing space).
@@ -205,31 +312,45 @@ impl SlashInputSession {
         format!("{command_name} ")
     }
 
-    /// Name of the currently highlighted command in the filtered list.
-    fn selected_command_name(&self) -> Option<&str> {
+    /// Entry of the currently highlighted command in the filtered list.
+    fn selected_entry(&self) -> Option<&SlashCommandEntry> {
         self.filtered
             .get(self.selected)
-            .map(|&idx| self.commands[idx].0.as_str())
+            .map(|&idx| &self.entries[idx])
     }
 
-    /// Enter: exact command match executes; otherwise accept the highlighted item.
+    /// Enter: exact Execute command runs; exact Fill command fills; the
+    /// highlighted row decides otherwise. Disabled commands do nothing
+    /// (popup stays open so the user can read the enable hint).
     fn handle_submit(&mut self) -> Option<SlashInputOutcome> {
         let trimmed = self.input.trim();
         let first_word = trimmed.split_whitespace().next().unwrap_or("");
-        let exact_match = self
-            .commands
+        let exact = self
+            .entries
             .iter()
-            .any(|(name, _)| first_word == name || trimmed == name);
-        if exact_match {
-            return Some(SlashInputOutcome::Command(trimmed.to_string()));
+            .find(|e| first_word == e.name || trimmed == e.name);
+        if let Some(entry) = exact {
+            return self.outcome_for(entry, trimmed);
         }
         if !self.filtered.is_empty() {
-            let Some(command) = self.selected_command_name().map(str::to_string) else {
+            let Some(entry) = self.selected_entry() else {
                 return Some(SlashInputOutcome::Dismissed(self.input.clone()));
             };
-            return Some(SlashInputOutcome::Command(command));
+            return self.outcome_for(entry, &entry.name);
         }
         Some(SlashInputOutcome::Dismissed(self.input.clone()))
+    }
+
+    /// Command/Fill/no-op for one picked entry. Disabled entries never run.
+    fn outcome_for(&self, entry: &SlashCommandEntry, text: &str) -> Option<SlashInputOutcome> {
+        if entry.status.as_ref().is_some_and(|s| !s.enabled) {
+            return None;
+        }
+        Some(if entry.fill_only {
+            SlashInputOutcome::Fill(entry.name.clone())
+        } else {
+            SlashInputOutcome::Command(text.to_string())
+        })
     }
 
     /// Tab: extend shared prefix, or complete the highlighted command and dismiss.
@@ -238,7 +359,7 @@ impl SlashInputSession {
             return None;
         }
         if self.filtered.len() == 1 {
-            let command = self.selected_command_name()?.to_string();
+            let command = self.selected_entry()?.name.clone();
             let completed = Self::format_command_with_trailing_space(&command);
             return Some(SlashInputOutcome::Dismissed(completed));
         }
@@ -246,7 +367,7 @@ impl SlashInputSession {
         let names: Vec<&str> = self
             .filtered
             .iter()
-            .map(|&idx| self.commands[idx].0.as_str())
+            .map(|&idx| self.entries[idx].name.as_str())
             .collect();
         let lcp = longest_common_prefix(&names);
         let query = self.command_query();
@@ -256,7 +377,7 @@ impl SlashInputSession {
             return None;
         }
 
-        let command = self.selected_command_name()?.to_string();
+        let command = self.selected_entry()?.name.clone();
         let completed = Self::format_command_with_trailing_space(&command);
         Some(SlashInputOutcome::Dismissed(completed))
     }
@@ -268,9 +389,9 @@ impl SlashInputSession {
             return None;
         }
 
-        // Ctrl+C always cancels
+        // Ctrl+C discards everything: restore to a fresh prompt.
         if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
-            return Some(SlashInputOutcome::Cancelled);
+            return Some(SlashInputOutcome::Cancelled(String::new()));
         }
 
         match key.code {
@@ -301,7 +422,7 @@ impl SlashInputSession {
                     self.cursor = prev;
                     self.update_filtered();
                     if self.input.is_empty() {
-                        return Some(SlashInputOutcome::Cancelled);
+                        return Some(SlashInputOutcome::Cancelled(self.input.clone()));
                     }
                     if !self.has_command_prefix() {
                         return Some(SlashInputOutcome::Dismissed(self.input.clone()));
@@ -351,7 +472,7 @@ impl SlashInputSession {
                 }
                 None
             }
-            KeyCode::Esc => Some(SlashInputOutcome::Cancelled),
+            KeyCode::Esc => Some(SlashInputOutcome::Cancelled(self.input.clone())),
             _ => None,
         }
     }
@@ -393,55 +514,147 @@ impl SlashInputSession {
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
     }
 
+    /// Expand filtered command indexes into rows, inserting a group header
+    /// before the first command of each new group.
+    fn display_rows(&self) -> Vec<DisplayRow> {
+        let mut rows = Vec::with_capacity(self.filtered.len() + self.group_labels.len());
+        let mut last_group: Option<usize> = None;
+        for &idx in &self.filtered {
+            let entry = &self.entries[idx];
+            let Some(label) = self.group_labels.get(entry.group_index) else {
+                rows.push(DisplayRow::Command(idx));
+                continue;
+            };
+            if label.is_empty() {
+                rows.push(DisplayRow::Command(idx));
+                continue;
+            }
+            if last_group != Some(entry.group_index) {
+                rows.push(DisplayRow::Header(entry.group_index));
+                last_group = Some(entry.group_index);
+            }
+            rows.push(DisplayRow::Command(idx));
+        }
+        rows
+    }
+
+    /// Build the spans for one command row: marker, name, description, and
+    /// (when unavailable) the status suffix — all truncated to the width.
+    /// Name and description use separate spans so the DarkGray description
+    /// keeps visual contrast against the bright selected name.
+    fn command_row(&self, idx: usize, is_selected: bool, width: usize) -> Line<'static> {
+        let entry = &self.entries[idx];
+        let disabled = entry.status.as_ref().is_some_and(|s| !s.enabled);
+        let marker = if is_selected { "▸ " } else { "  " };
+        let marker_style = if is_selected {
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+        let name_style = if disabled {
+            Style::default().fg(Color::DarkGray)
+        } else if is_selected {
+            Style::default()
+                .fg(Color::LightCyan)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::White)
+        };
+        let mut name = String::from(entry.name.as_str());
+        name.push_str("  ");
+        let mut desc = entry.desc.clone();
+        let status = entry.status.as_ref();
+        if let Some(status) = status.filter(|s| !s.status_text.is_empty()) {
+            desc.push_str(&format!("  [{}]", status.status_text));
+        }
+        if disabled {
+            let status = status.expect("disabled implies a status");
+            if !status.reason.is_empty() {
+                desc.push_str(&format!(" — {}", status.reason));
+            }
+        }
+        let marker_width = marker.width();
+        let name = truncate_str(&name, width.saturating_sub(marker_width));
+        let desc_budget = width
+            .saturating_sub(marker_width)
+            .saturating_sub(name.width());
+        let desc = truncate_str(&desc, desc_budget);
+
+        let desc_style = if disabled {
+            Style::default().fg(Color::DarkGray)
+        } else if is_selected {
+            Style::default().fg(Color::Gray)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+
+        Line::from(vec![
+            Span::styled(marker.to_string(), marker_style),
+            Span::styled(name, name_style),
+            Span::styled(desc, desc_style),
+        ])
+    }
+
     fn render_command_list(&self, frame: &mut ratatui::Frame<'_>, area: Rect) {
         if self.filtered.is_empty() || area.height == 0 {
             return;
         }
 
         let max_visible = area.height as usize;
-        let scroll = self.scroll_offset(max_visible);
-        let end = (scroll + max_visible).min(self.filtered.len());
-        let lines: Vec<Line> = self.filtered[scroll..end]
+        let width = area.width as usize;
+        let rows = self.display_rows();
+        let scroll = self.scroll_offset(&rows, max_visible);
+        let end = (scroll + max_visible).min(rows.len());
+        let header_style = Style::default().fg(Color::DarkGray);
+        let lines: Vec<Line> = rows[scroll..end]
             .iter()
-            .enumerate()
-            .map(|(row, &cmd_idx)| {
-                let absolute_row = scroll + row;
-                let (name, desc) = &self.commands[cmd_idx];
-                let is_selected = absolute_row == self.selected;
-                let marker = if is_selected { "▸ " } else { "  " };
-                let marker_style = if is_selected {
-                    Style::default()
-                        .fg(Color::Cyan)
-                        .add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default().fg(Color::DarkGray)
-                };
-                let name_style = if is_selected {
-                    Style::default()
-                        .fg(Color::LightCyan)
-                        .add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default().fg(Color::White)
-                };
-                let desc_style = Style::default().fg(Color::DarkGray);
-
-                Line::from(vec![
-                    Span::styled(marker, marker_style),
-                    Span::styled(name, name_style),
-                    Span::styled(format!("  {desc}"), desc_style),
-                ])
+            .map(|row| match row {
+                DisplayRow::Header(g) => {
+                    let label = self.group_labels.get(*g).map(String::as_str).unwrap_or("");
+                    Line::from(Span::styled(
+                        truncate_str(&format!("── {label}"), width),
+                        header_style,
+                    ))
+                }
+                DisplayRow::Command(idx) => {
+                    let is_selected = self.selected_command() == Some(*idx);
+                    self.command_row(*idx, is_selected, width)
+                }
             })
             .collect();
 
         frame.render_widget(Paragraph::new(lines), area);
     }
 
-    fn scroll_offset(&self, max_visible: usize) -> usize {
-        if self.selected >= max_visible {
-            self.selected - max_visible + 1
-        } else {
-            0
+    /// Index (into `entries`) of the currently highlighted command.
+    fn selected_command(&self) -> Option<usize> {
+        self.filtered.get(self.selected).copied()
+    }
+
+    /// Row position (within `display_rows`) of the selected command.
+    fn selected_command_row(&self) -> Option<usize> {
+        let target = self.selected_command()?;
+        self.display_rows()
+            .iter()
+            .position(|r| matches!(r, DisplayRow::Command(i) if *i == target))
+    }
+
+    /// First visible row index so the selected command stays on screen.
+    /// A header at the window top would be an orphan row, so scroll past it.
+    fn scroll_offset(&self, rows: &[DisplayRow], max_visible: usize) -> usize {
+        let Some(sel_row) = self.selected_command_row() else {
+            return 0;
+        };
+        if sel_row < max_visible {
+            return 0;
         }
+        let mut start = sel_row + 1 - max_visible;
+        if matches!(rows.get(start), Some(DisplayRow::Header(_))) {
+            start += 1;
+        }
+        start.min(rows.len().saturating_sub(max_visible))
     }
 }
 
@@ -502,45 +715,6 @@ pub(crate) fn longest_common_prefix(names: &[&str]) -> String {
     prefix
 }
 
-/// Strip ANSI CSI/OSC escape sequences from a string.
-pub(crate) fn strip_ansi(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    while let Some(ch) = chars.next() {
-        if ch == '\x1b' {
-            match chars.peek() {
-                Some('[') => {
-                    chars.next();
-                    // CSI: skip until final byte (0x40..=0x7E)
-                    while let Some(&c) = chars.peek() {
-                        chars.next();
-                        if ('\x40'..='\x7e').contains(&c) {
-                            break;
-                        }
-                    }
-                }
-                Some(']') => {
-                    chars.next();
-                    // OSC: skip until BEL or ST
-                    while let Some(c) = chars.next() {
-                        if c == '\x07' {
-                            break;
-                        }
-                        if c == '\x1b' && chars.peek() == Some(&'\\') {
-                            chars.next();
-                            break;
-                        }
-                    }
-                }
-                _ => {}
-            }
-        } else {
-            out.push(ch);
-        }
-    }
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -550,36 +724,60 @@ mod tests {
         Event::Key(KeyEvent::new(code, mods))
     }
 
-    fn sample_commands() -> Vec<(String, String)> {
+    fn entry(name: &str, group_index: usize) -> SlashCommandEntry {
+        SlashCommandEntry {
+            name: name.to_string(),
+            desc: format!("{name} description"),
+            keywords: Vec::new(),
+            group_index,
+            fill_only: false,
+            status: None,
+        }
+    }
+
+    fn fill_entry(name: &str, group_index: usize) -> SlashCommandEntry {
+        let mut e = entry(name, group_index);
+        e.fill_only = true;
+        e
+    }
+
+    fn disabled_entry(name: &str, group_index: usize, reason: &str) -> SlashCommandEntry {
+        let mut e = entry(name, group_index);
+        e.status = Some(SlashCommandStatus {
+            enabled: false,
+            status_text: String::new(),
+            reason: reason.to_string(),
+        });
+        e
+    }
+
+    fn sample_commands() -> Vec<SlashCommandEntry> {
         vec![
-            ("/help".into(), "Show help".into()),
-            ("/model".into(), "Switch model".into()),
-            ("/quit".into(), "Exit".into()),
+            entry("/help", 0),
+            fill_entry("/model", 1),
+            fill_entry("/quit", 1),
         ]
     }
 
-    fn all_slash_commands() -> Vec<(String, String)> {
+    fn all_slash_commands() -> Vec<SlashCommandEntry> {
         vec![
-            ("/help".into(), "Show help information".into()),
-            ("/model".into(), "Show or switch AI model".into()),
-            ("/setup".into(), "Open setup wizard".into()),
-            ("/setting".into(), "Open interactive settings panel".into()),
-            ("/plan".into(), "Plan mode control".into()),
-            ("/token".into(), "Show token usage".into()),
-            ("/resume".into(), "Resume previous session".into()),
-            ("/feedback".into(), "Submit feedback".into()),
-            (
-                "/record".into(),
-                "Record terminal session (start/stop)".into(),
-            ),
-            ("/quit".into(), "Exit AI Shell".into()),
-            ("/doctor".into(), "Run system diagnostics".into()),
-            ("/status".into(), "Show system environment status".into()),
+            entry("/help", 0),
+            entry("/model", 1),
+            entry("/setup", 1),
+            entry("/setting", 1),
+            entry("/plan", 2),
+            entry("/token", 3),
+            fill_entry("/resume", 4),
+            entry("/feedback", 5),
+            entry("/record", 5),
+            entry("/quit", 6),
+            entry("/doctor", 7),
+            entry("/status", 7),
         ]
     }
 
-    fn session_with_commands(input: &str, commands: &[(String, String)]) -> SlashInputSession {
-        let mut session = SlashInputSession::new(commands.to_vec(), "aish> ".into());
+    fn session_with_commands(input: &str, commands: &[SlashCommandEntry]) -> SlashInputSession {
+        let mut session = SlashInputSession::new(commands.to_vec(), Vec::new(), "aish> ".into());
         session.input = input.to_string();
         session.cursor = input.len();
         session.update_filtered();
@@ -609,11 +807,22 @@ mod tests {
     }
 
     #[test]
-    fn enter_on_exact_command_executes_as_typed() {
+    fn enter_on_exact_fill_command_fills() {
         let mut session = session_with_input("/quit");
         assert_eq!(
             session.handle_event(key(KeyCode::Enter, KeyModifiers::NONE)),
-            Some(SlashInputOutcome::Command("/quit".into()))
+            Some(SlashInputOutcome::Fill("/quit".into()))
+        );
+    }
+
+    #[test]
+    fn enter_on_ambiguous_fill_prefix_fills_highlighted() {
+        let commands = all_slash_commands();
+        let mut session = session_with_commands("/r", &commands);
+        // /resume sorts before /record within group 4 and is fill-only.
+        assert_eq!(
+            session.handle_event(key(KeyCode::Enter, KeyModifiers::NONE)),
+            Some(SlashInputOutcome::Fill("/resume".into()))
         );
     }
 
@@ -639,7 +848,6 @@ mod tests {
     fn tab_at_shared_prefix_completes_highlighted() {
         let commands = all_slash_commands();
         let mut session = session_with_commands("/re", &commands);
-        // /resume precedes /record in SLASH_COMMANDS; selected defaults to 0.
         assert_eq!(
             session.handle_event(key(KeyCode::Tab, KeyModifiers::NONE)),
             Some(SlashInputOutcome::Dismissed("/resume ".into()))
@@ -695,12 +903,18 @@ mod tests {
     #[test]
     fn enter_executes_each_exact_command() {
         let commands = all_slash_commands();
-        for (name, _) in &commands {
-            let mut session = session_with_commands(name, &commands);
+        for c in &commands {
+            let mut session = session_with_commands(&c.name, &commands);
+            let expected = if c.fill_only {
+                SlashInputOutcome::Fill(c.name.clone())
+            } else {
+                SlashInputOutcome::Command(c.name.clone())
+            };
             assert_eq!(
                 session.handle_event(key(KeyCode::Enter, KeyModifiers::NONE)),
-                Some(SlashInputOutcome::Command(name.clone())),
-                "Enter on {name}",
+                Some(expected),
+                "Enter on {}",
+                c.name,
             );
         }
     }
@@ -708,8 +922,8 @@ mod tests {
     #[test]
     fn trailing_space_hides_list_for_each_command() {
         let commands = all_slash_commands();
-        for (name, _) in &commands {
-            let input = format!("{name} ");
+        for c in &commands {
+            let input = format!("{} ", c.name);
             let session = session_with_commands(&input, &commands);
             assert!(
                 session.filtered.is_empty(),
@@ -718,24 +932,13 @@ mod tests {
         }
     }
 
-    #[test]
-    fn enter_on_ambiguous_prefix_executes_highlighted() {
-        let commands = all_slash_commands();
-        let mut session = session_with_commands("/r", &commands);
-        // /resume precedes /record; default highlight is the first match.
-        assert_eq!(
-            session.handle_event(key(KeyCode::Enter, KeyModifiers::NONE)),
-            Some(SlashInputOutcome::Command("/resume".into()))
-        );
-    }
-
     /// Regression: typing `/se`, navigating Down to `/setting`, then pressing
     /// Enter must execute `/setting` — not dismiss with the partial `/se`.
     #[test]
     fn enter_after_down_arrow_executes_selected_command() {
         let commands = all_slash_commands();
         let mut session = session_with_commands("/se", &commands);
-        // /se matches /setup (selected=0) and /setting (selected=1).
+        // Fuzzy ranks /setting first for "/se".
         session.handle_event(key(KeyCode::Down, KeyModifiers::NONE));
         assert_eq!(
             session.handle_event(key(KeyCode::Enter, KeyModifiers::NONE)),
@@ -763,7 +966,97 @@ mod tests {
         let mut session = session_with_input("/");
         assert_eq!(
             session.handle_event(key(KeyCode::Backspace, KeyModifiers::NONE)),
-            Some(SlashInputOutcome::Cancelled)
+            Some(SlashInputOutcome::Cancelled(String::new()))
+        );
+    }
+
+    #[test]
+    fn esc_cancels_with_input_for_restore() {
+        let mut session = session_with_input("/hel");
+        assert_eq!(
+            session.handle_event(key(KeyCode::Esc, KeyModifiers::NONE)),
+            Some(SlashInputOutcome::Cancelled("/hel".into()))
+        );
+    }
+
+    #[test]
+    fn ctrl_c_cancels_with_empty_restore() {
+        let mut session = session_with_input("/hel");
+        assert_eq!(
+            session.handle_event(key(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+            Some(SlashInputOutcome::Cancelled(String::new()))
+        );
+    }
+
+    #[test]
+    fn disabled_command_enter_is_noop() {
+        let commands = vec![disabled_entry("/live", 0, "daemon off"), entry("/help", 0)];
+        let mut session = session_with_commands("/live", &commands);
+        assert_eq!(
+            session.handle_event(key(KeyCode::Enter, KeyModifiers::NONE)),
+            None
+        );
+        // Still open: dismissing requires Esc.
+        assert_eq!(
+            session.handle_event(key(KeyCode::Esc, KeyModifiers::NONE)),
+            Some(SlashInputOutcome::Cancelled("/live".into()))
+        );
+    }
+
+    #[test]
+    fn group_headers_render_between_groups() {
+        let commands = vec![entry("/alpha", 0), entry("/beta", 1), entry("/gamma", 1)];
+        let mut session =
+            SlashInputSession::new(commands, vec!["G0".into(), "G1".into()], "aish> ".into());
+        session.input = "/".into();
+        session.cursor = 1;
+        session.update_filtered();
+        let rows = session.display_rows();
+        assert_eq!(
+            rows,
+            vec![
+                DisplayRow::Header(0),
+                DisplayRow::Command(0),
+                DisplayRow::Header(1),
+                DisplayRow::Command(1),
+                DisplayRow::Command(2),
+            ]
+        );
+    }
+
+    #[test]
+    fn description_query_matches_command() {
+        let mut help = entry("/help", 0);
+        help.desc = "Show help information".into();
+        let commands = vec![help, entry("/model", 1)];
+        let session = session_with_commands("/information", &commands);
+        assert_eq!(
+            session
+                .filtered
+                .first()
+                .map(|&i| session.entries[i].name.as_str()),
+            Some("/help")
+        );
+    }
+
+    #[test]
+    fn keyword_query_matches_command() {
+        let mut doctor = entry("/doctor", 0);
+        doctor.keywords = vec!["diagnose".into()];
+        // new() sorts by (group, name): /doctor precedes /help.
+        let commands = vec![doctor, entry("/help", 0)];
+        let session = session_with_commands("/diagnose", &commands);
+        assert_eq!(session.filtered, vec![0]);
+    }
+
+    #[test]
+    fn fuzzy_ranks_prefix_above_scattered_subsequence() {
+        let commands = all_slash_commands();
+        let session = session_with_commands("/se", &commands);
+        // /setting and /setup match; the word-initial /setting wins.
+        assert_eq!(
+            session.filtered.first().map(|&i| commands[i].name.as_str()),
+            Some("/setting")
         );
     }
 
@@ -800,12 +1093,5 @@ mod tests {
             session.handle_event(key(KeyCode::Tab, KeyModifiers::NONE)),
             Some(SlashInputOutcome::Dismissed("/resume ".into()))
         );
-    }
-
-    #[test]
-    fn description_only_query_does_not_match() {
-        let commands = all_slash_commands();
-        let session = session_with_commands("/show", &commands);
-        assert!(session.filtered.is_empty());
     }
 }

--- a/crates/aish-ui/src/slash_input.rs
+++ b/crates/aish-ui/src/slash_input.rs
@@ -1071,23 +1071,27 @@ mod tests {
         // once at the group's first occurrence — never repeated mid-list.
         let mut g0 = entry("/aaa", 0);
         g0.desc = "zzz match".into();
+        let g0b = entry("/bbb", 0);
         let mut g1 = entry("/zzz", 1);
         g1.desc = "aaa match".into();
-        let commands = vec![g0, g1];
+        let commands = vec![g0, g1, g0b];
         let mut session =
             SlashInputSession::new(commands, vec!["G0".into(), "G1".into()], "aish> ".into());
-        // Simulate a search whose score order interleaves groups: g1 first.
+        // Score order interleaves non-adjacent rows of the same group:
+        // g0, g1, then g0 again — the old last-group check re-rendered
+        // Header(0) at the tail. new() sorted entries, so /bbb is index 1.
         session.input = "/match".into();
         session.cursor = session.input.len();
-        session.filtered = vec![1, 0];
+        session.filtered = vec![0, 2, 1];
         let rows = session.display_rows();
         assert_eq!(
             rows,
             vec![
-                DisplayRow::Header(1),
-                DisplayRow::Command(1),
                 DisplayRow::Header(0),
                 DisplayRow::Command(0),
+                DisplayRow::Header(1),
+                DisplayRow::Command(2),
+                DisplayRow::Command(1),
             ]
         );
     }


### PR DESCRIPTION
Closes #473

## 概述

Slash 命令面板升级为**可搜索、按场景分组、带实时可用状态**的命令选择器，覆盖 issue #473 全部验收点。

## 主要变更

### 可搜索
- 模糊匹配命令名称、本地化描述与新增关键词（如 `/诊断` 中文可命中 `/diagnose`），复用 `file_mention::fuzzy_score`
- 按最佳得分排序，同分按注册序稳定
- 单字符 ASCII 查询退回名称前缀匹配，保持既有 Tab 前缀补全语义不受模糊打分污染

### 分组
- `SLASH_COMMANDS` 从 `(name, desc)` 元组升级为 `SlashCommandMeta`（name/desc/group/keywords/enter），新增 `SlashGroup` 8 组（诊断/会话/模型与设置/技能/文件与记忆/录制与分享/安全与审计/退出）
- 面板按 (组, 名称) 稳定排序，组间渲染 `── 组名` 分隔标题（i18n）；滚动窗口顶为组标题时自动跳过防孤行

### 状态标记
不可用命令置灰保留在面板中并附原因，不再消失：
- `/diagnose` — 无可诊断失败命令
- `/audit` — 审计存储未启用
- `/live_sessions` `/kill_live_sessions` — PTY 守护进程未启用
- `/undo` `/rollback` — 无可撤销修改时置灰；有则显示 `[可撤销 N 项]` 实时计数
- `/plan` — 显示当前模式 `[规划中]`/`[普通模式]`

### Enter 策略
新增 `EnterPolicy::{Execute, Fill}`：裸调用需要参数/打开选择器/破坏性的 11 条命令（`/quit` `/model` `/resume` `/undo` 等）Enter 仅回填输入行，二次 Enter 确认；Esc 恢复原输入、Ctrl+C 清空。

### 其他
- 选中行恢复三段配色（marker/name/desc 分 span），修复选中与未选中区分不明显
- `/undo` 描述更正为「撤销 AI 最近一次文件修改」——快照仅由 AI 工具链（edit_file/write_file）记录，不含用户手动 shell 编辑
- 6 locale 新增 `shell.slash_group.*`（8 键）与 `shell.slash_status.*`（7 键）

## 测试

- `cargo fmt --all -- --check`、`cargo clippy --all-targets -- -D warnings`（pinned 1.95.0）通过
- `cargo test --workspace` 2024 passed / 0 failed
- WeTTY 真机验证：分组渲染、置灰原因、中文模糊命中、Fill 二次确认、Esc/Ctrl+C 行为、`/plan` 状态切换、`/undo` 计数显示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Redesigned the slash-command popup with grouped commands, fuzzy search, keywords, and clearer descriptions.
  - Added availability indicators and reasons for unavailable commands.
  - Commands can now fill the input without executing, while preserving or restoring typed text when closing the popup.
  - Added localized slash-command group labels and status messages across supported languages.
  - Clarified the `/undo` description to specify the latest AI file edit.

- **Bug Fixes**
  - Improved handling of disabled commands and cancellation behavior in the slash-command interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->